### PR TITLE
Fix for handler blocks ending at method body end

### DIFF
--- a/ICSharpCode.Decompiler/Disassembler/ILStructure.cs
+++ b/ICSharpCode.Decompiler/Disassembler/ILStructure.cs
@@ -92,7 +92,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 				AddNestedStructure(new ILStructure(ILStructureType.Try, eh.TryStart.Offset, eh.TryEnd.Offset, eh));
 				if (eh.HandlerType == ExceptionHandlerType.Filter)
 					AddNestedStructure(new ILStructure(ILStructureType.Filter, eh.FilterStart.Offset, eh.FilterEnd.Offset, eh));
-				AddNestedStructure(new ILStructure(ILStructureType.Handler, eh.HandlerStart.Offset, eh.HandlerEnd.Offset, eh));
+				AddNestedStructure(new ILStructure(ILStructureType.Handler, eh.HandlerStart.Offset, eh.HandlerEnd == null ? body.CodeSize : eh.HandlerEnd.Offset, eh));
 			}
 			// Very simple loop detection: look for backward branches
 			List<KeyValuePair<Instruction, Instruction>> allBranches = FindAllBranches(body);

--- a/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILAstBuilder.cs
@@ -567,8 +567,9 @@ namespace Decompiler
 					int startIndex;
 					for (startIndex = 0; body[startIndex].Offset != eh.HandlerStart.Offset; startIndex++);
 					int endInclusiveIndex;
-					// Note that the end(exclusiove) instruction may not necessarly be in our body
-					for (endInclusiveIndex = 0; body[endInclusiveIndex].Next.Offset != eh.HandlerEnd.Offset; endInclusiveIndex++);
+					if (eh.HandlerEnd == null) endInclusiveIndex = body.Count - 1;
+					// Note that the end(exclusive) instruction may not necessarly be in our body
+					else for (endInclusiveIndex = 0; body[endInclusiveIndex].Next.Offset != eh.HandlerEnd.Offset; endInclusiveIndex++);
 					int count = 1 + endInclusiveIndex - startIndex;
 					HashSet<ExceptionHandler> nestedEHs = new HashSet<ExceptionHandler>(ehs.Where(e => (eh.HandlerStart.Offset <= e.TryStart.Offset && e.TryEnd.Offset < eh.HandlerEnd.Offset) || (eh.HandlerStart.Offset < e.TryStart.Offset && e.TryEnd.Offset <= eh.HandlerEnd.Offset)));
 					ehs.ExceptWith(nestedEHs);


### PR DESCRIPTION
This fixes IL display and C# decompilation of methods that end with a `endfinally` instruction.
This happens when a method ends with a `throw` encapsulated in a `using` block.
Minimal code to reproduce:

```
static void ThrowFinally()
{
    try
    {
        throw null;
    }
    finally
    {
        GC.KeepAlive(null);
    }
}
```
