### PR TITLE
Fix for Issue #99 - Field nodes should be ordered as per decompile output

### DIFF
--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -99,7 +99,14 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			foreach (TypeDefinition nestedType in type.NestedTypes.OrderBy(m => m.Name)) {
 				this.Children.Add(new TypeTreeNode(nestedType, parentAssemblyNode));
 			}
-			foreach (FieldDefinition field in type.Fields.OrderBy(m => m.Name)) {
+
+			foreach (FieldDefinition field in type.Fields.Where(m => m.IsLiteral).OrderBy(m => m.Name)) {
+				this.Children.Add(new FieldTreeNode(field));
+			}
+			foreach (FieldDefinition field in type.Fields.Where(m => m.IsInitOnly).OrderBy(m => m.Name)) {
+				this.Children.Add(new FieldTreeNode(field));
+			}
+			foreach (FieldDefinition field in type.Fields.Where(m => !(m.IsLiteral || m.IsInitOnly)).OrderBy(m => m.Name)) {
 				this.Children.Add(new FieldTreeNode(field));
 			}
 			


### PR DESCRIPTION
Tree nodes for fields should be ordered consistent with the type decompile output.
- **Literal**  - aka _const_.
- **InitOnly** - aka _readonly_.
- **Field** - fields that do not fall into the previous 2 categories.

https://github.com/icsharpcode/ILSpy/issues#issue/99
