### PR TITLE
Improved local variable inlining

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/ILInlining.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILInlining.cs
@@ -231,6 +231,16 @@ namespace ICSharpCode.Decompiler.ILAst
 					return false;
 			}
 		}
+
+		/// <summary>
+		/// Gets whether 'expressionBeingMoved' can be inlined into 'expr'.
+		/// </summary>
+		public bool CanInlineInto(ILExpression expr, ILVariable v, ILExpression expressionBeingMoved)
+		{
+			ILExpression parent;
+			int pos;
+			return FindLoadInNext(expr, v, expressionBeingMoved, out parent, out pos) == true;
+		}
 		
 		/// <summary>
 		/// Finds the position to inline to.


### PR DESCRIPTION
This removes temporary local variables generated by the C# compiler for instance method calls on immutable value type values. For example `DateTime.Now.ToString()` generates a temporary local variable because the result of `get_Now()` has to be stored somewhere before `ToString()` can be called.
