### PR TITLE
Corrected spelling in node text.

### DIFF
--- a/ILSpy/TreeNodes/Analyzer/AnalyzedPropertyOverridesTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzedPropertyOverridesTreeNode.cs
@@ -28,7 +28,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 
 		public override object Text
 		{
-			get { return "Overriden By"; }
+			get { return "Overridden By"; }
 		}
 
 		public override object Icon

--- a/ILSpy/TreeNodes/Analyzer/AnalyzerMethodOverridesTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzerMethodOverridesTreeNode.cs
@@ -31,7 +31,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 
 		public override object Text
 		{
-			get { return "Overriden By"; }
+			get { return "Overridden By"; }
 		}
 
 		public override object Icon


### PR DESCRIPTION
'overriden' -> 'overridden'
