### PR TITLE
Make ArrayCreateExpression have an explictly defined ArraySpecification

### DIFF
--- a/ICSharpCode.Decompiler/Ast/AstBuilder.cs
+++ b/ICSharpCode.Decompiler/Ast/AstBuilder.cs
@@ -1481,6 +1481,7 @@ namespace ICSharpCode.Decompiler.Ast
 				ArrayType arrayType = argument.Type as ArrayType;
 				return new ArrayCreateExpression {
 					Type = ConvertType(arrayType != null ? arrayType.ElementType : argument.Type),
+					ArraySpecifier = new ArraySpecifier(arrayType.Rank),
 					Initializer = arrayInit
 				};
 			} else if (argument.Value is CustomAttributeArgument) {

--- a/ICSharpCode.Decompiler/Ast/AstMethodBodyBuilder.cs
+++ b/ICSharpCode.Decompiler/Ast/AstMethodBodyBuilder.cs
@@ -358,10 +358,11 @@ namespace ICSharpCode.Decompiler.Ast
 							ct.ArraySpecifiers.MoveTo(ace.AdditionalArraySpecifiers);
 						}
 						if (byteCode.Code == ILCode.InitArray) {
+							ace.ArraySpecifier = new ArraySpecifier(1);
 							ace.Initializer = new ArrayInitializerExpression();
 							ace.Initializer.Elements.AddRange(args);
 						} else {
-							ace.Arguments.Add(arg1);
+							ace.ArraySpecifier = new ArrayDimensionsSpecifier(new[] { arg1 });
 						}
 						return ace;
 					}
@@ -377,7 +378,7 @@ namespace ICSharpCode.Decompiler.Ast
 							ace.Initializer = new ArrayInitializerExpression();
 							var first = ace.AdditionalArraySpecifiers.First();
 							first.Remove();
-							ace.Arguments.AddRange(Enumerable.Repeat(0, first.Dimensions).Select(i => new EmptyExpression()));
+							ace.ArraySpecifier = new ArraySpecifier(first.Dimensions);
 						}
 						var newArgs = new List<Expression>();
 						foreach (var arrayDimension in arrayType.Dimensions.Skip(1).Reverse())
@@ -698,10 +699,11 @@ namespace ICSharpCode.Decompiler.Ast
 							ComposedType ct = AstBuilder.ConvertType((ArrayType)declaringType) as ComposedType;
 							if (ct != null && ct.ArraySpecifiers.Count >= 1) {
 								var ace = new Ast.ArrayCreateExpression();
-								ct.ArraySpecifiers.First().Remove();
+								var first = ct.ArraySpecifiers.First();
+								first.Remove();
+								ace.ArraySpecifier = new ArrayDimensionsSpecifier(args);
 								ct.ArraySpecifiers.MoveTo(ace.AdditionalArraySpecifiers);
 								ace.Type = ct;
-								ace.Arguments.AddRange(args);
 								return ace;
 							}
 						}

--- a/ICSharpCode.Decompiler/Tests/InitializerTests.cs
+++ b/ICSharpCode.Decompiler/Tests/InitializerTests.cs
@@ -459,7 +459,7 @@ public class InitializerTests
 
 	public void MultidimensionalInit()
 	{
-		int[,] expr_09 = new int[, ]
+		int[,] expr_09 = new int[,]
 		{
 
 	        {
@@ -580,7 +580,7 @@ public class InitializerTests
 	{
 		int[][,] array = new int[][,]
 		{
-	        new int[, ]
+	        new int[,]
 	            {
 
 	                {
@@ -612,7 +612,7 @@ public class InitializerTests
 					}
 
 	            },
-	        new int[, ]
+	        new int[,]
 	            {
 
 	                {
@@ -644,7 +644,7 @@ public class InitializerTests
 					}
 
 	            },
-	        new int[, ]
+	        new int[,]
 	            {
 
 	                {
@@ -675,7 +675,7 @@ public class InitializerTests
 						0
 					}
 	            },
-	        new int[, ]
+	        new int[,]
 	            {
 
 	                {
@@ -714,7 +714,7 @@ public class InitializerTests
 	{
 		int[][,,] array = new int[][,,]
 		{
-			new int[, , ]
+			new int[,,]
 			{
 				{
 					{
@@ -752,7 +752,7 @@ public class InitializerTests
 				}
 			},
 
-			new int[, , ]
+			new int[,,]
 			{
 				{
 					{

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/ComposedType.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/ComposedType.cs
@@ -121,8 +121,37 @@ namespace ICSharpCode.NRefactory.CSharp
 	/// </summary>
 	public class ArraySpecifier : AstNode
 	{
-		public override NodeType NodeType {
-			get {
+		public static new readonly ArraySpecifier Null = new NullArraySpecifier();
+		class NullArraySpecifier : ArraySpecifier
+		{
+			public override bool IsNull
+			{
+				get
+				{
+					return true;
+				}
+			}
+
+			public NullArraySpecifier()
+				: base(1)
+			{
+			}
+
+			public override S AcceptVisitor<T, S>(IAstVisitor<T, S> visitor, T data)
+			{
+				return default(S);
+			}
+
+			protected internal override bool DoMatch(AstNode other, PatternMatching.Match match)
+			{
+				return other == null || other.IsNull;
+			}
+		}
+
+		public override NodeType NodeType
+		{
+			get
+			{
 				return NodeType.Unknown;
 			}
 		}
@@ -173,6 +202,27 @@ namespace ICSharpCode.NRefactory.CSharp
 		public override string ToString()
 		{
 			return "[" + new string(',', this.Dimensions - 1) + "]";
+		}
+	}
+
+	public class ArrayDimensionsSpecifier : ArraySpecifier
+	{
+		public ArrayDimensionsSpecifier() { }
+
+		public ArrayDimensionsSpecifier(IList<Expression> dimensions) 
+			: base(dimensions.Count)
+		{
+			this.Arguments.AddRange(dimensions);
+		}
+
+		public AstNodeCollection<Expression> Arguments
+		{
+			get { return GetChildrenByRole(Roles.Argument); }
+		}
+
+		public override S AcceptVisitor<T, S>(IAstVisitor<T, S> visitor, T data)
+		{
+			return visitor.VisitArrayDimensionsSpecifier(this, data);
 		}
 	}
 }

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/DepthFirstAstVisitor.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/DepthFirstAstVisitor.cs
@@ -579,6 +579,11 @@ namespace ICSharpCode.NRefactory.CSharp
 		{
 			return VisitChildren (arraySpecifier, data);
 		}
+
+		public virtual S VisitArrayDimensionsSpecifier(ArrayDimensionsSpecifier arrayDimensionsSpecifier, T data)
+		{
+			return VisitChildren(arrayDimensionsSpecifier, data);
+		}
 		
 		public virtual S VisitNamedArgumentExpression (NamedArgumentExpression namedArgumentExpression, T data)
 		{

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/Expressions/ArrayCreateExpression.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/Expressions/ArrayCreateExpression.cs
@@ -8,6 +8,7 @@ namespace ICSharpCode.NRefactory.CSharp
 	/// </summary>
 	public class ArrayCreateExpression : Expression
 	{
+		public readonly static Role<ArraySpecifier> ArraySpecifierRole = new Role<ArraySpecifier>("ArraySpecifierRole", ArraySpecifier.Null);
 		public readonly static Role<ArraySpecifier> AdditionalArraySpecifierRole = new Role<ArraySpecifier>("AdditionalArraySpecifier");
 		public readonly static Role<ArrayInitializerExpression> InitializerRole = new Role<ArrayInitializerExpression>("Initializer", ArrayInitializerExpression.Null);
 		
@@ -16,8 +17,10 @@ namespace ICSharpCode.NRefactory.CSharp
 			set { SetChildByRole (Roles.Type, value); }
 		}
 		
-		public AstNodeCollection<Expression> Arguments {
-			get { return GetChildrenByRole (Roles.Argument); }
+		public ArraySpecifier ArraySpecifier
+		{
+			get { return GetChildByRole(ArraySpecifierRole); }
+			set { SetChildByRole(ArraySpecifierRole, value); }
 		}
 		
 		/// <summary>
@@ -41,7 +44,7 @@ namespace ICSharpCode.NRefactory.CSharp
 		protected internal override bool DoMatch(AstNode other, PatternMatching.Match match)
 		{
 			ArrayCreateExpression o = other as ArrayCreateExpression;
-			return o != null && this.Type.DoMatch(o.Type, match) && this.Arguments.DoMatch(o.Arguments, match) && this.AdditionalArraySpecifiers.DoMatch(o.AdditionalArraySpecifiers, match) && this.Initializer.DoMatch(o.Initializer, match);
+			return o != null && this.Type.DoMatch(o.Type, match) && this.ArraySpecifier.DoMatch(o.ArraySpecifier, match) && this.AdditionalArraySpecifiers.DoMatch(o.AdditionalArraySpecifiers, match) && this.Initializer.DoMatch(o.Initializer, match);
 		}
 	}
 }

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/IAstVisitor.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/IAstVisitor.cs
@@ -118,6 +118,7 @@ namespace ICSharpCode.NRefactory.CSharp
 		S VisitMemberType(MemberType memberType, T data);
 		S VisitComposedType(ComposedType composedType, T data);
 		S VisitArraySpecifier(ArraySpecifier arraySpecifier, T data);
+		S VisitArrayDimensionsSpecifier(ArrayDimensionsSpecifier arrayDimensionsSpecifier, T data);
 		S VisitPrimitiveType(PrimitiveType primitiveType, T data);
 		
 		S VisitComment(Comment comment, T data);

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/NotImplementedAstVisitor.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/Ast/NotImplementedAstVisitor.cs
@@ -491,7 +491,12 @@ namespace ICSharpCode.NRefactory.CSharp
 		{
 			throw new NotImplementedException();
 		}
-		
+
+		public virtual S VisitArrayDimensionsSpecifier(ArrayDimensionsSpecifier arrayDimensionsSpecifier, T data)
+		{
+			throw new NotImplementedException();
+		}
+
 		public virtual S VisitPrimitiveType(PrimitiveType primitiveType, T data)
 		{
 			throw new NotImplementedException();

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/OutputVisitor/OutputVisitor.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/OutputVisitor/OutputVisitor.cs
@@ -498,7 +498,7 @@ namespace ICSharpCode.NRefactory.CSharp
 			StartNode(arrayCreateExpression);
 			WriteKeyword("new");
 			arrayCreateExpression.Type.AcceptVisitor(this, data);
-			WriteCommaSeparatedListInBrackets(arrayCreateExpression.Arguments);
+			arrayCreateExpression.ArraySpecifier.AcceptVisitor(this, data);
 			foreach (var specifier in arrayCreateExpression.AdditionalArraySpecifiers)
 				specifier.AcceptVisitor(this, data);
 			arrayCreateExpression.Initializer.AcceptVisitor(this, data);
@@ -2134,6 +2134,13 @@ namespace ICSharpCode.NRefactory.CSharp
 			}
 			WriteToken("]", ArraySpecifier.Roles.RBracket);
 			return EndNode(arraySpecifier);
+		}
+
+		public virtual object VisitArrayDimensionsSpecifier(ArrayDimensionsSpecifier arrayDimensionsSpecifier, object data)
+		{
+			StartNode(arrayDimensionsSpecifier);
+			WriteCommaSeparatedListInBrackets(arrayDimensionsSpecifier.Arguments);
+			return EndNode(arrayDimensionsSpecifier);
 		}
 		
 		public object VisitPrimitiveType(PrimitiveType primitiveType, object data)

--- a/NRefactory/ICSharpCode.NRefactory/CSharp/Parser/CSharpParser.cs
+++ b/NRefactory/ICSharpCode.NRefactory/CSharp/Parser/CSharpParser.cs
@@ -2259,12 +2259,17 @@ namespace ICSharpCode.NRefactory.CSharp
 				if (location != null)
 					result.AddChild (new CSharpTokenNode (Convert (location [0]), 1), ArrayCreateExpression.Roles.LBracket);
 				if (arrayCreationExpression.Arguments != null) {
-					var commaLocations = LocationsBag.GetLocations (arrayCreationExpression.Arguments);
+					var specifier = new ArrayDimensionsSpecifier();
+					result.ArraySpecifier = specifier;
+					var commaLocations = LocationsBag.GetLocations(arrayCreationExpression.Arguments);
 					for (int i = 0; i < arrayCreationExpression.Arguments.Count; i++) {
-						result.AddChild ((Expression)arrayCreationExpression.Arguments [i].Accept (this), ArrayCreateExpression.Roles.Argument);
+						specifier.AddChild((Expression)arrayCreationExpression.Arguments[i].Accept(this), ArrayCreateExpression.Roles.Argument);
 						if (commaLocations != null && i > 0)
-							result.AddChild (new CSharpTokenNode (Convert (commaLocations [commaLocations.Count - i]), 1), ArrayCreateExpression.Roles.Comma);
+							specifier.AddChild(new CSharpTokenNode(Convert(commaLocations[commaLocations.Count - i]), 1), ArrayCreateExpression.Roles.Comma);
 					}
+				} else
+				{
+					result.ArraySpecifier = new ArraySpecifier(arrayCreationExpression.Rank.Dimension);
 				}
 				var next = arrayCreationExpression.Rank.Next;
 				while (next != null) {


### PR DESCRIPTION
This rejiggers ArrayCreateExpression to have an explicitly defined ArraySpecification, instead of assuming based on the Arguments, as mentioned in the review on #240.  This mainly fixes some formatting issues with the creation of multi-dimensional arrays.

May also fix a bug in the CSharpParser, where it doesn't create a correct (valid, round-trippable) Ast when defining the dimensions implicitly with an array initializer.

Major Issue:
- I don't (currently) know how to test CSharpParser, so I have no idea if that code change works or not.  I noodled it a bit and it looks good to me.  Can anyone give me a hint on how one goes about testing that thing?
