### PR TITLE
Annotate VariableInitializers with ILVariable when possible

### DIFF
--- a/ICSharpCode.Decompiler/Ast/AstMethodBodyBuilder.cs
+++ b/ICSharpCode.Decompiler/Ast/AstMethodBodyBuilder.cs
@@ -128,6 +128,7 @@ namespace ICSharpCode.Decompiler.Ast
 				else
 					type = AstBuilder.ConvertType(v.Type);
 				var newVarDecl = new VariableDeclarationStatement(type, v.Name);
+				newVarDecl.Variables.Single().AddAnnotation(v);
 				astBlock.Statements.InsertBefore(insertionPoint, newVarDecl);
 			}
 			


### PR DESCRIPTION
VariableInitializers should be annotated with their ILVariable when possible.
