### PR TITLE
add checked blocks only after variables have been declared

### DIFF
--- a/ICSharpCode.Decompiler/Ast/Transforms/TransformationPipeline.cs
+++ b/ICSharpCode.Decompiler/Ast/Transforms/TransformationPipeline.cs
@@ -37,8 +37,8 @@ namespace ICSharpCode.Decompiler.Ast.Transforms
 				new PatternStatementTransform(context),
 				new ReplaceMethodCallsWithOperators(context),
 				new IntroduceUnsafeModifier(),
-				new AddCheckedBlocks(),
 				new DeclareVariables(context), // should run after most transforms that modify statements
+				new AddCheckedBlocks(),
 				new ConvertConstructorCallIntoInitializer(), // must run after DeclareVariables
 				new DecimalConstantTransform(),
 				new IntroduceUsingDeclarations(context),


### PR DESCRIPTION
Before this patch, variable num3 in the code below would end up undeclared:

``` csharp
using System.Diagnostics;

static class VariablesOutsideCheckedBlock
{
    static void Test(int i)
    {
        checked
        {
            var num1 = 42*i;
            Trace.WriteLine(num1);
            var num2 = 42 * i;
            Trace.WriteLine(num2);
        }
        unchecked
        {
            var num3 = 42*i;
            Trace.WriteLine(num3);
        }
    }
}
```
