### PR TITLE
Small fix to prevent missing treenode image for explicit interfaces

### DIFF
--- a/ILSpy/TreeNodes/MethodTreeNode.cs
+++ b/ILSpy/TreeNodes/MethodTreeNode.cs
@@ -118,6 +118,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				case MethodAttributes.FamORAssem:
 					return AccessOverlayIcon.Protected;
 				case MethodAttributes.Private:
+				case MethodAttributes.ReuseSlot:
 					return AccessOverlayIcon.Private;
 				default:
 					throw new NotSupportedException();


### PR DESCRIPTION
The IL header of the method:

.method privatescope hidebysig newslot virtual final instance void IModuleDictionaryInitialization.InitializeModuleDictionary(class [Microsoft.Scripting]Microsoft.Scripting.CodeContext) cil managed
{
  .override [Microsoft.Scripting]Microsoft.Scripting.IModuleDictionaryInitialization::InitializeModuleDictionary
