### PR TITLE
Missing null check causes abend

### DIFF
--- a/NRefactory/ICSharpCode.NRefactory.CSharp/Analysis/ControlFlow.cs
+++ b/NRefactory/ICSharpCode.NRefactory.CSharp/Analysis/ControlFlow.cs
@@ -436,7 +436,7 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 						}
 					}
 				}
-				if (constant.IsCompileTimeConstant && sectionMatchedByConstant == null)
+				if (constant !=null && constant.IsCompileTimeConstant && sectionMatchedByConstant == null)
 					sectionMatchedByConstant = defaultSection;
 				
 				int gotoCaseOrDefaultInOuterScope = gotoCaseOrDefault.Count;


### PR DESCRIPTION
The latest NRefactory version has a missing null check which can cause an abend.
