### PR TITLE
Issue #225 and Random Enhancement.

### DIFF
--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -280,7 +280,7 @@ namespace ICSharpCode.ILSpy
 				}
 				if (!found) {
 					AvalonEditTextOutput output = new AvalonEditTextOutput();
-					output.Write("Cannot find " + args.NavigateTo );
+					output.Write(string.Format("Cannot find '{0}' in command line specified assemblies.", args.NavigateTo ));
 					decompilerTextView.ShowText(output);
 				}
 			}


### PR DESCRIPTION
I've implemented the ability to specifying a library with /navigateTo: to be selected when starting up.

I noticed that the text of the 'Cannot find' was slightly misleading since it only looked at the assemblies loaded from the command line but did not specify that was the only place looked. Updated the text for clarity.
