### PR TITLE
Annotate closure variable references

### DIFF
--- a/ICSharpCode.Decompiler/Ast/Transforms/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler/Ast/Transforms/DelegateConstruction.cs
@@ -428,7 +428,7 @@ namespace ICSharpCode.Decompiler.Ast.Transforms
 						MemberReferenceExpression mre = (MemberReferenceExpression)identExpr.Parent;
 						AstNode replacement;
 						if (dict.TryGetValue(mre.Annotation<FieldReference>().ResolveWithinSameModule(), out replacement)) {
-							mre.ReplaceWith(replacement.Clone());
+							mre.ReplaceWith(replacement.Clone().CopyAnnotationsFrom(replacement));
 						}
 					}
 				}


### PR DESCRIPTION
Currently the generated ILVariable annotation for closure variables is not propagated through the references.
This patch fixes it.
