### PR TITLE
Don't add seperator after first context menu entry

### DIFF
--- a/ILSpy/ContextMenuEntry.cs
+++ b/ILSpy/ContextMenuEntry.cs
@@ -159,11 +159,11 @@ namespace ICSharpCode.ILSpy
 		{
 			menu = new ContextMenu();
 			foreach (var category in entries.OrderBy(c => c.Metadata.Order).GroupBy(c => c.Metadata.Category)) {
-				bool needSeparatorForCategory = true;
+				bool needSeparatorForCategory = menu.Items.Count > 0;
 				foreach (var entryPair in category) {
 					IContextMenuEntry entry = entryPair.Value;
 					if (entry.IsVisible(context)) {
-						if (needSeparatorForCategory && menu.Items.Count > 0) {
+						if (needSeparatorForCategory) {
 							menu.Items.Add(new Separator());
 							needSeparatorForCategory = false;
 						}


### PR DESCRIPTION
Currently a seperator is insert in context menu between the first 2 entries of the first category. This pull request fixes the behaviour so that a seperator is insert before every category but the first.
