### PR TITLE
Context aware search results

### DIFF
--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -140,12 +140,14 @@
     <Compile Include="Languages\Language.cs" />
     <Compile Include="Images\Images.cs" />
     <Compile Include="Languages\Languages.cs" />
+    <Compile Include="Levenstein.cs" />
     <Compile Include="LoadedAssembly.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="NavigationHistory.cs" />
     <Compile Include="NavigationState.cs" />
     <Compile Include="Commands\OpenCommand.cs" />
     <Compile Include="Commands\OpenFromGacCommand.cs" />
+    <Compile Include="ObservableSortedList.cs" />
     <Compile Include="OpenFromGacDialog.xaml.cs">
       <DependentUpon>OpenFromGacDialog.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/ILSpy/Levenstein.cs
+++ b/ILSpy/Levenstein.cs
@@ -1,0 +1,180 @@
+#region Copyright
+/*
+ * The original .NET implementation of the SimMetrics library is taken from the Java
+ * source and converted to NET using the Microsoft Java converter.
+ * It is notclear who made the initial convertion to .NET.
+ * 
+ * This updated version has started with the 1.0 .NET release of SimMetrics and used
+ * FxCop (http://www.gotdotnet.com/team/fxcop/) to highlight areas where changes needed 
+ * to be made to the converted code.
+ * 
+ * this version with updates Copyright (c) 2006 Chris Parkinson.
+ * 
+ * For any queries on the .NET version please contact me through the 
+ * sourceforge web address.
+ * 
+ * SimMetrics - SimMetrics is a java library of Similarity or Distance
+ * Metrics, e.g. Levenshtein Distance, that provide float based similarity
+ * measures between string Data. All metrics return consistant measures
+ * rather than unbounded similarity scores.
+ *
+ * Copyright (C) 2005 Sam Chapman - Open Source Release v1.1
+ *
+ * Please Feel free to contact me about this library, I would appreciate
+ * knowing quickly what you wish to use it for and any criticisms/comments
+ * upon the SimMetric library.
+ *
+ * email:       s.chapman@dcs.shef.ac.uk
+ * www:         http://www.dcs.shef.ac.uk/~sam/
+ * www:         http://www.dcs.shef.ac.uk/~sam/stringmetrics.html
+ *
+ * address:     Sam Chapman,
+ *              Department of Computer Science,
+ *              University of Sheffield,
+ *              Sheffield,
+ *              S. Yorks,
+ *              S1 4DP
+ *              United Kingdom,
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+#endregion
+
+namespace SimMetricsMetricUtilities {
+    using System;
+
+    /// <summary>
+    /// levenstein implements the levenstein distance function.
+    /// </summary>
+    sealed public class Levenstein {
+        const int defaultPerfectMatchScore = 1;
+        const int defaultMismatchScore = 0;
+
+        static int Min(int a, int b, int c)
+        {
+            return Math.Min(a, Math.Min(b, c));
+        }
+
+        /// <summary>
+        /// a constant for calculating the estimated timing cost.
+        /// </summary>
+        const double estimatedTimingConstant = 0.00018F;
+
+        /// <summary>
+        /// gets the similarity of the two strings using levenstein distance.
+        /// </summary>
+        /// <param name="firstWord">first word</param>
+        /// <param name="secondWord">second word</param>
+        /// <returns>a value between 0-1 of the similarity</returns>
+        public int GetSimilarity(string firstWord, string secondWord) {
+            if ((firstWord != null) && (secondWord != null)) {
+                int levensteinDistance = GetUnnormalisedSimilarity(firstWord, secondWord);
+                int maxLen = firstWord.Length;
+                if (maxLen < secondWord.Length) {
+                    maxLen = secondWord.Length;
+                }
+                if (maxLen == defaultMismatchScore) {
+                    return defaultPerfectMatchScore;
+                }
+                else {
+                    return defaultPerfectMatchScore - levensteinDistance / maxLen;
+                }
+            }
+            return defaultMismatchScore;
+        }
+
+        /// <summary>
+        /// gets the estimated time in milliseconds it takes to perform a similarity timing.
+        /// </summary>
+        /// <param name="firstWord"></param>                                                  
+        /// <param name="secondWord"></param>
+        /// <returns>the estimated time in milliseconds taken to perform the similarity measure</returns>
+        public double GetSimilarityTimingEstimated(string firstWord, string secondWord) {
+            if ((firstWord != null) && (secondWord != null)) {
+                int firstLength = firstWord.Length;
+                int secondLength = secondWord.Length;
+                return firstLength * secondLength * estimatedTimingConstant;
+            }
+            return defaultMismatchScore;
+        }
+
+        /// <summary> 
+        /// gets the un-normalised similarity measure of the metric for the given strings.</summary>
+        /// <param name="firstWord"></param>
+        /// <param name="secondWord"></param>
+        /// <returns> returns the score of the similarity measure (un-normalised)</returns>
+        /// <remarks>
+        /// <p/>
+        /// Copy character from string1 over to string2 (cost 0)
+        /// Delete a character in string1 (cost 1)
+        /// Insert a character in string2 (cost 1)
+        /// Substitute one character for another (cost 1)
+        /// <p/>
+        /// D(i-1,j-1) + d(si,tj) //subst/copy
+        /// D(i,j) = min D(i-1,j)+1 //insert
+        /// D(i,j-1)+1 //delete
+        /// <p/>
+        /// d(i,j) is a function whereby d(c,d)=0 if c=d, 1 else.
+        /// </remarks>
+        public int GetUnnormalisedSimilarity(string firstWord, string secondWord) {
+            if ((firstWord != null) && (secondWord != null)) {
+                // Step 1
+                var a = firstWord.ToCharArray();
+                var b = secondWord.ToCharArray();
+                int n = firstWord.Length;
+                int m = secondWord.Length;
+                if (n == 0) {
+                    return m;
+                }
+                if (m == 0) {
+                    return n;
+                }
+
+                int[][] d = new int[n + 1][];
+                for (int i = 0; i < n + 1; i++) {
+                    d[i] = new int[m + 1];
+                }
+
+                // Step 2
+                for (int i = 0; i <= n; i++) {
+                    d[i][0] = i;
+                }
+                for (int j = 0; j <= m; j++) {
+                    d[0][j] = j;
+                }
+
+                // Step 3
+                for (int i = 1; i <= n; i++) {
+                    // Step 4
+                    for (int j = 1; j <= m; j++) {
+                        // Step 5
+                        int cost = GetCost(a, i - 1, b, j - 1);
+                        // Step 6
+                        d[i][j] = Min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + cost);
+                    }
+                }
+
+                // Step 7
+                return d[n][m];
+            }
+            return 0;
+        }
+
+        static int GetCost(char[] firstWord, int p1, char[] secondWord, int p2)
+        {
+            return firstWord[p1] == secondWord[p2] ? 1 : 0;
+        }
+    }
+}

--- a/ILSpy/ObservableSortedList.cs
+++ b/ILSpy/ObservableSortedList.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace WpfCrutches
+{
+    /// <summary>
+    ///     Implements an observable collection which maintains its items in sorted order. In particular, items remain sorted
+    ///     when changes are made to their properties: they are reordered automatically when necessary to keep them sorted.</summary>
+    /// <remarks>
+    ///     <para>This class currently requires <typeparamref name="T" /> to be a reference type. This is because a couple of
+    ///     methods operate on the basis of reference equality instead of the comparison used for sorting. As implemented,
+    ///     their behaviour for value types would be somewhat unexpected.</para>
+    ///     <para>The INotifyCollectionChange interface is fairly complicated and relatively poorly documented (see
+    ///     http://stackoverflow.com/a/5883947/33080 for example), increasing the likelihood of bugs. And there are currently
+    ///     no unit tests. There could well be bugs in this code.</para></remarks>
+    public class ObservableSortedList<T> : IList<T>,
+        INotifyPropertyChanged,
+        INotifyCollectionChanged
+        where T : class, INotifyPropertyChanged
+    {
+        private List<T> _list;
+        private IComparer<T> _comparer;
+
+        /// <summary>Gets the number of items stored in this collection.</summary>
+        public int Count { get { return _list.Count; } }
+        /// <summary>Returns false.</summary>
+        public bool IsReadOnly { get { return false; } }
+
+        /// <summary>
+        ///     Constructor.</summary>
+        /// <remarks>
+        ///     Certain serialization libraries require a parameterless constructor.</remarks>
+        public ObservableSortedList() : this(4) { }
+
+        /// <summary>Constructor.</summary>
+        public ObservableSortedList(int capacity = 4, IComparer<T> comparer = null)
+        {
+            _list = new List<T>(capacity);
+            _comparer = comparer ?? Comparer<T>.Default;
+        }
+
+        /// <summary>Constructor.</summary>
+        public ObservableSortedList(IEnumerable<T> items, IComparer<T> comparer = null)
+        {
+            _list = new List<T>(items);
+            _comparer = comparer ?? Comparer<T>.Default;
+            _list.Sort(_comparer);
+            foreach (var item in _list)
+                item.PropertyChanged += ItemPropertyChanged;
+        }
+
+        /// <summary>Removes all items from this collection.</summary>
+        public void Clear()
+        {
+            foreach (var item in _list)
+                item.PropertyChanged -= ItemPropertyChanged;
+            _list.Clear();
+            collectionChanged_Reset();
+            propertyChanged("Count");
+        }
+
+        /// <summary>
+        ///     Adds an item to this collection, ensuring that it ends up at the correct place according to the sort order.</summary>
+        public void Add(T item)
+        {
+            int i = _list.BinarySearch(item, _comparer);
+            if (i < 0)
+                i = ~i;
+            else
+                do i++; while (i < _list.Count && _comparer.Compare(_list[i], item) == 0);
+
+            _list.Insert(i, item);
+            item.PropertyChanged += ItemPropertyChanged;
+            collectionChanged_Added(item, i);
+            propertyChanged("Count");
+        }
+
+        /// <summary>Not supported on a sorted collection.</summary>
+        public void Insert(int index, T item)
+        {
+            throw new InvalidOperationException("Cannot insert an item at an arbitrary index into a ObservableSortedList.");
+        }
+
+        /// <summary>Removes the specified item, returning true if found or false otherwise.</summary>
+        public bool Remove(T item)
+        {
+            int i = IndexOf(item);
+            if (i < 0) return false;
+            _list.RemoveAt(i);
+            collectionChanged_Removed(item, i);
+            propertyChanged("Count");
+            return true;
+        }
+
+        /// <summary>Removes the specified item.</summary>
+        public void RemoveAt(int index)
+        {
+            var item = _list[index];
+            _list.RemoveAt(index);
+            collectionChanged_Removed(item, index);
+            propertyChanged("Count");
+        }
+
+        /// <summary>Gets the item at the specified index. Does not support setting.</summary>
+        public T this[int index]
+        {
+            get { return _list[index]; }
+            set { throw new InvalidOperationException("Cannot set an item at an arbitrary index in a ObservableSortedList."); }
+        }
+
+        /// <summary>
+        ///     Gets the index of the specified item, or -1 if not found. Only reference equality matches are considered.</summary>
+        /// <remarks>
+        ///     Binary search is used to make the operation more efficient.</remarks>
+        public int IndexOf(T item)
+        {
+            int i = _list.BinarySearch(item, _comparer);
+            if (i < 0) return -1;
+            if (object.ReferenceEquals(_list[i], item)) return i;
+            // Search downwards
+            for (int s = i - 1; s >= 0 && _comparer.Compare(_list[s], item) == 0; s--)
+                if (object.ReferenceEquals(_list[s], item))
+                    return s;
+            // Search upwards
+            for (int s = i + 1; s < _list.Count && _comparer.Compare(_list[s], item) == 0; s++)
+                if (object.ReferenceEquals(_list[s], item))
+                    return s;
+            // Not found
+            return -1;
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether the specified item is contained in this collection.</summary>
+        /// <remarks>
+        ///     Uses binary search to make the operation more efficient.</remarks>
+        public bool Contains(T item)
+        {
+            return IndexOf(item) >= 0;
+        }
+
+        /// <summary>Copies all items to the specified array.</summary>
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            _list.CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>Enumerates all items in sorted order.</summary>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _list.GetEnumerator();
+        }
+
+        /// <summary>Triggered whenever the <see cref="Count" /> property changes as a result of adding/removing items.</summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        ///     Triggered whenever items are added/removed, and also whenever they are reordered due to item property changes.</summary>
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        private void propertyChanged(string name)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(name));
+        }
+
+        private void collectionChanged_Reset()
+        {
+            if (CollectionChanged != null)
+                CollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        private void collectionChanged_Added(T item, int index)
+        {
+            if (CollectionChanged != null)
+                CollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
+        }
+
+        private void collectionChanged_Removed(T item, int index)
+        {
+            if (CollectionChanged != null)
+                CollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+        }
+
+        private void collectionChanged_Moved(T item, int oldIndex, int newIndex)
+        {
+            if (CollectionChanged != null)
+                CollectionChanged(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, item, newIndex, oldIndex));
+        }
+
+        private void ItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            var item = (T)sender;
+            int oldIndex = _list.IndexOf(item);
+
+            // See if item should now be sorted to a different position
+            if (Count <= 1 || (oldIndex == 0 || _comparer.Compare(_list[oldIndex - 1], item) <= 0)
+                && (oldIndex == Count - 1 || _comparer.Compare(item, _list[oldIndex + 1]) <= 0))
+                return;
+
+            // Find where it should be inserted 
+            _list.RemoveAt(oldIndex);
+            int newIndex = _list.BinarySearch(item, _comparer);
+            if (newIndex < 0)
+                newIndex = ~newIndex;
+            else
+                do newIndex++; while (newIndex < _list.Count && _comparer.Compare(_list[newIndex], item) == 0);
+
+            _list.Insert(newIndex, item);
+            collectionChanged_Moved(item, oldIndex, newIndex);
+        }
+    }
+}
+


### PR DESCRIPTION
Something I find ILSpy has been missing is a context aware search, the search results are largely irrelevant. By using a ObservableSortedList and a string edit distance algorithm we can get search results that better capture our intention.

I pulled in an existing ObservableSortedList (from the web) and the Levenstein distance (from simmetrics, I scrapped to double, string indexing and abstractions, it just makes it unnecessarily slow) as prof of concept. If any of these implementations are not OK, please take into consideration, adding a feature like this. I find it to be a much more direct approach to get at what you want.

This works by simply prioritizing the edit distance over the sort order, feel free to fiddle with the controls but I wanted to illustrate how I think search results could be further improved.

As you'l surly notice, this implementation has some quirks to it, I simplified to the problem to get the idea across initially, this code will run but it will not work with multi-term searches or search types not based on the `.Name` property.
