### PR TITLE
Fix #220

### DIFF
--- a/ICSharpCode.Decompiler/Ast/TextOutputFormatter.cs
+++ b/ICSharpCode.Decompiler/Ast/TextOutputFormatter.cs
@@ -84,8 +84,8 @@ namespace ICSharpCode.Decompiler.Ast
 		{
 			AstNode node = nodeStack.Peek();
 			MemberReference memberRef = node.Annotation<MemberReference>();
-			if ((node.Parent is ObjectCreateExpression) ||
-				(memberRef == null && node.Role == Roles.TargetExpression && node.Parent is InvocationExpression))
+			if ((node.Role == Roles.Type && node.Parent is ObjectCreateExpression) ||
+				(memberRef == null && node.Role == Roles.TargetExpression && (node.Parent is InvocationExpression || node.Parent is ObjectCreateExpression)))
 			{
 				memberRef = node.Parent.Annotation<MemberReference>();
 			}


### PR DESCRIPTION
Link constructor calls to constructor rather than type + add link for constructor calls to this() and base()
