### PR TITLE
Fix NullReferenceException reported in #393 and #386

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/TypeAnalysis.cs
+++ b/ICSharpCode.Decompiler/ILAst/TypeAnalysis.cs
@@ -539,6 +539,8 @@ namespace ICSharpCode.Decompiler.ILAst
 						if (forceInferChildren)
 							InferTypeForExpression(expr.Arguments[1], typeSystem.Int32);
 						TypeReference type = NumericPromotion(InferTypeForExpression(expr.Arguments[0], null));
+            if (null == type)
+              return null;
 						TypeReference expectedInputType = null;
 						switch (type.MetadataType) {
 							case MetadataType.Int32:


### PR DESCRIPTION
This fixes the NullReferenceException but not the failed TypeInference for SHR. 
The later seems to be caused by temporary variables, which are created in the transformation to C# and do not contain type information, in conjunction with the dup statement.
The code from #393 will produce the following IL:

```
    .locals init (
        [0] int32 valuePos,
        [1] bool CS$4$0000
    )

    IL_0000: nop
    IL_0001: ldc.i4.1
    IL_0002: stloc.0
    IL_0003: ldc.i4.s 42
    IL_0005: ldloc.0
    IL_0006: dup
    IL_0007: ldc.i4.1
    IL_0008: add
    IL_0009: stloc.0
    IL_000a: ldc.i4.s 31
    IL_000c: and
    IL_000d: shr
    IL_000e: ldc.i4.0
    IL_000f: ceq
    IL_0011: ldc.i4.0
    IL_0012: ceq
    IL_0014: stloc.1
    IL_0015: ldloc.1
    IL_0016: brtrue.s IL_001a

    IL_0018: br.s IL_001a

    IL_001a: ret
```

The transformed code just before TypeInference = ILAst (after SplitToMovableBlocks):

```
valuePos_02 : int32
arg_0D_0 [generated]
expr_06 [generated]
valuePos_09 : int32

Block_0:
stloc(valuePos_02, ldc.i4(1))
arg_0D_0 = ldc.i4(42)
expr_06 = ldloc(valuePos_02)
stloc(valuePos_09, add(expr_06, ldc.i4(1)))
brtrue(IL_1A, ceq(ceq(shr(arg_0D_0, and(expr_06, ldc.i4(31))), ldc.i4(0)), ldc.i4(0)))
br(IL_1A)

IL_1A:
ret()
```

The variable arg_0D_0 does not contain type information so TypeInference fails. I'm not sure whether the error is the missing type information or the tree transformation placing arg_0D_0 instead of ldc.i4(42) as first argument of shr.
