### PR TITLE
Handle switch cases in the form 'default: case x:'

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/ILAstTypes.cs
+++ b/ICSharpCode.Decompiler/ILAst/ILAstTypes.cs
@@ -519,16 +519,32 @@ namespace ICSharpCode.Decompiler.ILAst
 	{
 		public class CaseBlock: ILBlock
 		{
-			public List<int> Values;  // null for the default case
+			internal bool _IsDefault;
+			public List<int> Values;
+
+			public bool IsDefault {
+				get {
+					return _IsDefault || (Values == null) || (Values.Count == 0);
+				}
+				set {
+					if ((Values == null) || (Values.Count == 0)) {
+						if (!value)
+							throw new Exception("This case has no values so it must be default");
+					}
+
+					_IsDefault = value;
+				}
+			}
 			
 			public override void WriteTo(ITextOutput output)
 			{
+				if (IsDefault)
+					output.WriteLine("default:");
+
 				if (this.Values != null) {
 					foreach (int i in this.Values) {
 						output.WriteLine("case {0}:", i);
 					}
-				} else {
-					output.WriteLine("default:");
 				}
 				output.Indent();
 				base.WriteTo(output);


### PR DESCRIPTION
This introduces a simple fixup pass after ILSwitch nodes are constructed that identifies scenarios where the right form for a switch case is 'default: case x: case y: ...'. It then folds the default case into the case it normally jumps to.

As a result, to tell whether a case block is default you now check case.IsDefault instead of checking to see if it has any values.

This makes it possible for decompiled code involving switches to not need gotos in some scenarios, like in the following simple test case:

```csharp
using System;

public static class Program {
    public static int DBF;

    internal static void ApplyState () {
        if (false) {
        } else {
            Console.WriteLine("Entered");

            int func;

            switch (DBF) {
                default:
                case 0:
                    Console.WriteLine("Default case");
                    func = 0;
                    break;
                case 1:
                    Console.WriteLine("case 1");
                    func = 1;
                    break;
                case 2:
                    Console.WriteLine("case 2");
                    func = 2;
                    break;
                case 3:
                    Console.WriteLine("case 3");
                    func = 3;
                    break;
            }

            Console.WriteLine("Tail");
        }

        Console.WriteLine("Exited");
    }

    public static void Main (string[] args) {
        DBF = 0;
        ApplyState();
        DBF = 2;
    }
}
```