### PR TITLE
Fix a NullReferenceException: Modules can exist without an Assembly

### DIFF
--- a/ICSharpCode.Decompiler/Disassembler/MethodBodyDisassembler.cs
+++ b/ICSharpCode.Decompiler/Disassembler/MethodBodyDisassembler.cs
@@ -54,8 +54,8 @@ namespace ICSharpCode.Decompiler.Disassembler
 			output.WriteLine("// Method begins at RVA 0x{0:x4}", method.RVA);
 			output.WriteLine("// Code size {0} (0x{0:x})", body.CodeSize);
 			output.WriteLine(".maxstack {0}", body.MaxStackSize);
-			if (method.DeclaringType.Module.Assembly.EntryPoint == method)
-				output.WriteLine (".entrypoint");
+            if (method.DeclaringType.Module.Assembly != null && method.DeclaringType.Module.Assembly.EntryPoint == method)
+                output.WriteLine (".entrypoint");
 			
 			if (method.Body.HasVariables) {
 				output.Write(".locals ");


### PR DESCRIPTION
"method.DeclaringType.Module.Assembly.EntryPoint"
causes a NullReferenceException as Assembly == null.
This change first checks if Module.Assembly != null.

A module without Assembly can be created by 
assemblyBuilder.DefineDynamicModule("modulName", "filename.dll", true);
