### PR TITLE
Allow System.Runtime for System Type Lookups (Issue 435)

### DIFF
--- a/Mono.Cecil/Mono.Cecil/TypeSystem.cs
+++ b/Mono.Cecil/Mono.Cecil/TypeSystem.cs
@@ -114,12 +114,13 @@ namespace Mono.Cecil {
 					return corlib;
 
 				const string mscorlib = "mscorlib";
+				const string systemruntime = "System.Runtime";
 
 				var references = module.AssemblyReferences;
 
 				for (int i = 0; i < references.Count; i++) {
 					var reference = references [i];
-					if (reference.Name == mscorlib)
+					if (reference.Name == mscorlib || reference.Name == systemruntime)
 						return corlib = reference;
 				}
 


### PR DESCRIPTION
ILSpy is incorrectly adding a reference to mscorlib when it is not part of the assembly manifest. This is due to its assumption that all BCL primitive types exist in mscorlib.
