### PR TITLE
Update ILSpy to show assembly version in the assembly tree view

### DIFF
--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -85,6 +85,20 @@ namespace ICSharpCode.ILSpy
 			get { return shortName; }
 		}
 		
+		public string Text
+		{
+			get
+			{
+				if (IsLoaded) {
+					return String.Format("{0}, {1}", ShortName, AssemblyDefinition.Name.Version);
+				}
+				else
+				{
+					return ShortName;
+				}
+			}
+		}
+		
 		public bool IsLoaded {
 			get { return assemblyTask.IsCompleted; }
 		}

--- a/ILSpy/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyTreeNode.cs
@@ -63,7 +63,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override object Text
 		{
-			get { return HighlightSearchMatch(assembly.ShortName); }
+			get { return HighlightSearchMatch(assembly.Text); }
 		}
 
 		public override object Icon


### PR DESCRIPTION
Today the Assembly tree view in ILSpy only show assembly name. If different version of the same dlls are included, they appear the same and is confusing. You have to click the entry and check the details on the right panel. That happens a lot when work with both .Net 3.5 and 4.0/4.5.

The change is to include dll version in the name.
