### PR TITLE
Fixing SendMessage API example

### DIFF
--- a/doc/Command Line.txt
+++ b/doc/Command Line.txt
@@ -43,7 +43,7 @@ WM_COPYDATA (SendMessage API):
     That is, by sending this message:
         ILSpy:
         C:\Assembly.dll
-        /navigateTo T:Type
+        /navigateTo:T:Type
     The target ILSpy instance will open C:\Assembly.dll and navigate to the specified type.
     
     ILSpy will return TRUE (1) if it handles the message, and FALSE (0) otherwise.


### PR DESCRIPTION
missing colon in the documentation between the option and the tag! 

I effectively made sure the colon is mandatory when using the WM_COPYDATA API by testing it in my [Hawkeye2](https://github.com/odalet/Hawkeye2) project makes use of this API [here](https://github.com/odalet/Hawkeye2/blob/master/src/Plugins/Hawkeye.DecompilePlugin/ilspy/ILSpyController.cs).

Hope this helps
