### PR TITLE
Tests: Reuse decompiler roundtrip assertion code

### DIFF
--- a/ICSharpCode.Decompiler/Tests/Helpers/CodeAssert.cs
+++ b/ICSharpCode.Decompiler/Tests/Helpers/CodeAssert.cs
@@ -104,7 +104,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 		private static IEnumerable<string> NormalizeAndSplitCode(string input)
 		{
-			return input.Split(new[] { "\r\n", "\n\r", "\n", "\r" }, StringSplitOptions.None);
+			return input.Split(new[] { "\r\n", "\n\r", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries);
 		}
 	}
 }


### PR DESCRIPTION
This contains no functional changes, except that
it will ignore blank lines when comparing code.

This reduces duplicate code, and will make it
easier to add assertions for Roslyn compilers.
This is required for #503 (which is still in progress)
