### PR TITLE
BamlDecompiler: Correctly qualify types in nested {x:Static} extensions

### DIFF
--- a/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
+++ b/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
@@ -868,11 +868,7 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 			switch (x) {
 				case 0x25a:
 					// StaticExtension
-					object resource = this.GetResourceName(valueIdentifier);
-					if (resource is ResourceName)
-						value = this.GetStaticExtension(((ResourceName)resource).Name);
-					else if (resource is PropertyDeclaration)
-						value = this.GetStaticExtension(FormatPropertyDeclaration(((PropertyDeclaration)resource), true, false, false));
+					value = this.GetStaticExtension(this.GetResourceName(valueIdentifier));
 					break;
 				case 0x25b: // StaticResource
 				case 0xbd: // DynamicResource
@@ -883,7 +879,7 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 					else if (isStaticType)
 					{
 						TypeDeclaration extensionDeclaration = this.GetTypeDeclaration(extensionIdentifier);
-						value = GetExtension(extensionDeclaration, GetStaticExtension(GetResourceName(valueIdentifier).ToString()));
+						value = GetExtension(extensionDeclaration, GetStaticExtension(GetResourceName(valueIdentifier)));
 					}
 					else
 					{
@@ -1449,15 +1445,7 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 			if (isValueType)
 				resource = GetTypeExtension(typeIdentifier);
 			else if (isStaticType) {
-				object name = GetResourceName(typeIdentifier);
-				if (name == null)
-					resource = null;
-				else if (name is ResourceName)
-					resource = GetStaticExtension(((ResourceName)name).Name);
-				else if (name is PropertyDeclaration)
-					resource = GetStaticExtension(FormatPropertyDeclaration(((PropertyDeclaration)name), true, false, false));
-				else
-					throw new InvalidOperationException("Invalid resource: " + name.GetType());
+				resource = GetStaticExtension(GetResourceName(typeIdentifier));
 			} else {
 				resource = this.stringTable[typeIdentifier];
 			}
@@ -1473,8 +1461,18 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 			return String.Format("{{TemplateBinding {0}}}", FormatPropertyDeclaration(propertyDeclaration, true, false, false));
 		}
 
-		string GetStaticExtension(string name)
+		string GetStaticExtension(object resource)
 		{
+			if (resource == null)
+				return null;
+			string name;
+			if (resource is ResourceName)
+				name = ((ResourceName)resource).Name;
+			else if (resource is PropertyDeclaration)
+				name = this.FormatPropertyDeclaration(((PropertyDeclaration)resource), true, false, false);
+			else
+				throw new InvalidOperationException("Invalid resource: " + resource.GetType());
+
 			string prefix = this.LookupPrefix(XmlPIMapping.XamlNamespace, false);
 			if (String.IsNullOrEmpty(prefix))
 				return String.Format("{{Static {0}}}", name);

--- a/ILSpy.BamlDecompiler/Tests/Cases/CustomControl.cs
+++ b/ILSpy.BamlDecompiler/Tests/Cases/CustomControl.cs
@@ -10,6 +10,8 @@ namespace ILSpy.BamlDecompiler.Tests.Cases
 {
 	public class CustomControl : ContentControl
 	{
+		public static string SimpleProperty = "Hi!";
+
 		public static readonly DependencyProperty CustomNameProperty = DependencyProperty.RegisterAttached("CustomName", typeof(string), typeof(CustomControl));
 		
 		public static string GetCustomName(DependencyObject target)

--- a/ILSpy.BamlDecompiler/Tests/Cases/NamespacePrefix.xaml
+++ b/ILSpy.BamlDecompiler/Tests/Cases/NamespacePrefix.xaml
@@ -1,4 +1,4 @@
-﻿<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:cc="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases">
+﻿<Grid xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:cc="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases">
 	<cc:CustomControl>
 		<cc:CustomControl.Style>
 			<Style />
@@ -6,7 +6,7 @@
 		<Grid.Row>0</Grid.Row>
 		<cc:CustomControl.CustomName>Custom1</cc:CustomControl.CustomName>
 	</cc:CustomControl>
-	<Label>
+	<Label ToolTip="{DynamicResource {x:Static cc:CustomControl.SimpleProperty}}">
 		<Label.Style>
 			<Style />
 		</Label.Style>


### PR DESCRIPTION
Includes formerly-failing test case.

This is completely unrelated to all of my other pull requests, but this bug has been bothering me for a while.
