### PR TITLE
Adapt size of ResourceStringTable/ResourceObjectTable on resize of...

### DIFF
--- a/ILSpy/Controls/ResourceObjectTable.xaml.cs
+++ b/ILSpy/Controls/ResourceObjectTable.xaml.cs
@@ -30,17 +30,25 @@ namespace ICSharpCode.ILSpy.Controls
 	/// </summary>
 	public partial class ResourceObjectTable : UserControl
 	{
-		public ResourceObjectTable(IEnumerable resources,Size maxSize)
-		{
+    public ResourceObjectTable(IEnumerable resources, ContentPresenter contentPresenter)
+    {
 			InitializeComponent();
 			// set size to fit decompiler window
-			// TODO: there should be a more transparent way to do this
-			Width = maxSize.Width;
-			MaxHeight = maxSize.Height;
-			resourceListView.ItemsSource = resources;
-		}
-		
-		void ExecuteCopy(object sender, ExecutedRoutedEventArgs args)
+      contentPresenter.SizeChanged += OnParentSizeChanged;
+      Width = contentPresenter.ActualWidth - 45;
+      MaxHeight = contentPresenter.ActualHeight;
+      resourceListView.ItemsSource = resources;
+    }
+
+    private void OnParentSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+      if (e.WidthChanged)
+        Width = e.NewSize.Width - 45;
+      if (e.HeightChanged)
+        MaxHeight = e.NewSize.Height;
+    }
+    
+    void ExecuteCopy(object sender, ExecutedRoutedEventArgs args)
 		{
 		  StringBuilder sb = new StringBuilder();
 		  foreach (var item in resourceListView.SelectedItems)

--- a/ILSpy/Controls/ResourceStringTable.xaml.cs
+++ b/ILSpy/Controls/ResourceStringTable.xaml.cs
@@ -30,15 +30,23 @@ namespace ICSharpCode.ILSpy.Controls
 	/// </summary>
 	public partial class ResourceStringTable : UserControl
 	{
-		public ResourceStringTable(IEnumerable strings,Size maxSize)
-		{
+    public ResourceStringTable(IEnumerable strings, ContentPresenter contentPresenter)
+    {
 			InitializeComponent();
 			// set size to fit decompiler window
-			// TODO: there should be a more transparent way to do this
-			Width = maxSize.Width;
-			MaxHeight = maxSize.Height;
-			resourceListView.ItemsSource = strings;
-		}
+      contentPresenter.SizeChanged += OnParentSizeChanged;
+      Width = contentPresenter.ActualWidth - 45;
+      MaxHeight = contentPresenter.ActualHeight;
+      resourceListView.ItemsSource = strings;
+    }
+
+    private void OnParentSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+      if (e.WidthChanged)
+			  Width = e.NewSize.Width - 45;
+      if (e.HeightChanged)
+        MaxHeight = e.NewSize.Height;
+    }
 		
 		void ExecuteCopy(object sender, ExecutedRoutedEventArgs args)
 		{

--- a/ILSpy/TreeNodes/ResourceNodes/ResourcesFileTreeNode.cs
+++ b/ILSpy/TreeNodes/ResourceNodes/ResourcesFileTreeNode.cs
@@ -121,9 +121,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				if (null != smartOutput) {
 					smartOutput.AddUIElement(
 						delegate {
-							return new ResourceStringTable(stringTableEntries,
-								new System.Windows.Size(MainWindow.Instance.mainPane.ActualWidth - 45,
-														MainWindow.Instance.mainPane.ActualHeight));
+							return new ResourceStringTable(stringTableEntries, MainWindow.Instance.mainPane);
 						}
 					);
 				}
@@ -135,9 +133,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				if (null != smartOutput) {
 					smartOutput.AddUIElement(
 						delegate {
-							return new ResourceObjectTable(otherEntries,
-								new System.Windows.Size(MainWindow.Instance.mainPane.ActualWidth - 45,
-														MainWindow.Instance.mainPane.ActualHeight));
+							return new ResourceObjectTable(otherEntries, MainWindow.Instance.mainPane);
 						}
 					);
 				}


### PR DESCRIPTION
... ILSpy MainWindow.

Today the size is defined in creation of those tables. If the main window is resized the tables size will stay as it is.