### PR TITLE
Search as command line argument

### DIFF
--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -27,6 +27,7 @@ namespace ICSharpCode.ILSpy
 		public List<string> AssembliesToLoad = new List<string>();
 		public bool? SingleInstance;
 		public string NavigateTo;
+		public string Search;
 		public string Language;
 		public bool NoActivate;
 		
@@ -42,6 +43,8 @@ namespace ICSharpCode.ILSpy
 						this.SingleInstance = false;
 					else if (arg.StartsWith("/navigateTo:", StringComparison.OrdinalIgnoreCase))
 						this.NavigateTo = arg.Substring("/navigateTo:".Length);
+					else if (arg.StartsWith("/search:", StringComparison.OrdinalIgnoreCase))
+						this.Search = arg.Substring("/search:".Length);
 					else if (arg.StartsWith("/language:", StringComparison.OrdinalIgnoreCase))
 						this.Language = arg.Substring("/language:".Length);
 					else if (arg.Equals("/noActivate", StringComparison.OrdinalIgnoreCase))

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -295,6 +295,11 @@ namespace ICSharpCode.ILSpy
 				// Select the newly loaded assembly
 				JumpToReference(commandLineLoadedAssemblies[0].ModuleDefinition);
 			}
+			if (args.Search != null)
+			{
+				SearchPane.Instance.SearchTerm = args.Search;
+				SearchPane.Instance.Show();
+			}
 			commandLineLoadedAssemblies.Clear(); // clear references once we don't need them anymore
 		}
 		


### PR DESCRIPTION
This adds a new command line argument "/search:keyword", which will open the search pane with the given keyword.