### PR TITLE
Allow Reflexil integration

### DIFF
--- a/ILSpy/AssemblyList.cs
+++ b/ILSpy/AssemblyList.cs
@@ -145,6 +145,29 @@ namespace ICSharpCode.ILSpy
 			}
 			return newAsm;
 		}
+
+		/// <summary>
+		/// Replace the assembly object model from a crafted stream, without disk I/O
+		/// Returns null if it is not already loaded.
+		/// </summary>
+		public LoadedAssembly HotReplaceAssembly(string file, Stream stream)
+		{
+			App.Current.Dispatcher.VerifyAccess();
+			file = Path.GetFullPath(file);
+
+			var target = this.assemblies.FirstOrDefault(asm => file.Equals(asm.FileName, StringComparison.OrdinalIgnoreCase));
+			if (target == null)
+				return null;
+
+			var index = this.assemblies.IndexOf(target);
+			var newAsm = new LoadedAssembly(this, file, stream);
+			lock (assemblies)
+			{
+				this.assemblies.Remove(target);
+				this.assemblies.Insert(index, newAsm);
+			}
+			return newAsm;
+		}
 		
 		public void Unload(LoadedAssembly assembly)
 		{

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -35,7 +35,7 @@ namespace ICSharpCode.ILSpy
 		readonly string fileName;
 		readonly string shortName;
 		
-		public LoadedAssembly(AssemblyList assemblyList, string fileName)
+		public LoadedAssembly(AssemblyList assemblyList, string fileName, Stream stream = null)
 		{
 			if (assemblyList == null)
 				throw new ArgumentNullException("assemblyList");
@@ -44,7 +44,7 @@ namespace ICSharpCode.ILSpy
 			this.assemblyList = assemblyList;
 			this.fileName = fileName;
 			
-			this.assemblyTask = Task.Factory.StartNew<ModuleDefinition>(LoadAssembly); // requires that this.fileName is set
+			this.assemblyTask = Task.Factory.StartNew<ModuleDefinition>(LoadAssembly, stream); // requires that this.fileName is set
 			this.shortName = Path.GetFileNameWithoutExtension(fileName);
 		}
 		
@@ -93,12 +93,26 @@ namespace ICSharpCode.ILSpy
 			get { return assemblyTask.IsFaulted; }
 		}
 		
-		ModuleDefinition LoadAssembly()
+		ModuleDefinition LoadAssembly(object state)
 		{
+			var stream = state as Stream;
+			ModuleDefinition module;
+
 			// runs on background thread
 			ReaderParameters p = new ReaderParameters();
 			p.AssemblyResolver = new MyAssemblyResolver(this);
-			ModuleDefinition module = ModuleDefinition.ReadModule(fileName, p);
+
+			if (stream != null)
+			{
+				// Read the module from a precrafted stream
+				module = ModuleDefinition.ReadModule(stream, p);
+			}
+			else
+			{
+				// Read the module from disk (by default)
+				module = ModuleDefinition.ReadModule(fileName, p);
+			}
+
 			if (DecompilerSettingsPanel.CurrentDecompilerSettings.UseDebugSymbols) {
 				try {
 					LoadSymbols(module);

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -481,7 +481,8 @@ namespace ICSharpCode.ILSpy
 		}
 		
 		#region Node Selection
-		internal void SelectNode(SharpTreeNode obj)
+
+		public void SelectNode(SharpTreeNode obj)
 		{
 			if (obj != null) {
 				if (!obj.AncestorsAndSelf().Any(node => node.IsHidden)) {
@@ -500,7 +501,7 @@ namespace ICSharpCode.ILSpy
 		/// <summary>
 		/// Retrieves a node using the .ToString() representations of its ancestors.
 		/// </summary>
-		SharpTreeNode FindNodeByPath(string[] path, bool returnBestMatch)
+		public SharpTreeNode FindNodeByPath(string[] path, bool returnBestMatch)
 		{
 			if (path == null)
 				return null;
@@ -522,7 +523,7 @@ namespace ICSharpCode.ILSpy
 		/// <summary>
 		/// Gets the .ToString() representation of the node's ancestors.
 		/// </summary>
-		string[] GetPathForNode(SharpTreeNode node)
+		public string[] GetPathForNode(SharpTreeNode node)
 		{
 			if (node == null)
 				return null;

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -639,6 +639,9 @@ namespace ICSharpCode.ILSpy
 		void TreeView_SelectionChanged(object sender, SelectionChangedEventArgs e)
 		{
 			DecompileSelectedNodes();
+
+			if (SelectionChanged != null)
+				SelectionChanged(sender, e);
 		}
 		
 		Task decompilationTask;
@@ -689,7 +692,9 @@ namespace ICSharpCode.ILSpy
 				return sessionSettings.FilterSettings.Language;
 			}
 		}
-		
+
+		public event SelectionChangedEventHandler SelectionChanged;
+
 		public IEnumerable<ILSpyTreeNode> SelectedNodes {
 			get {
 				return treeView.GetTopLevelSelection().OfType<ILSpyTreeNode>();

--- a/ILSpy/TreeNodes/AssemblyReferenceTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyReferenceTreeNode.cs
@@ -25,7 +25,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 	/// <summary>
 	/// Node within assembly reference list.
 	/// </summary>
-	sealed class AssemblyReferenceTreeNode : ILSpyTreeNode
+	public sealed class AssemblyReferenceTreeNode : ILSpyTreeNode
 	{
 		readonly AssemblyNameReference r;
 		readonly AssemblyTreeNode parentAssembly;
@@ -39,6 +39,11 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			this.r = r;
 			this.parentAssembly = parentAssembly;
 			this.LazyLoading = true;
+		}
+
+		public AssemblyNameReference AssemblyNameReference
+		{
+			get { return r; }
 		}
 		
 		public override object Text {


### PR DESCRIPTION
When writing an ILSpy plugin (in my case Reflexil), it is very useful to:

- know when the selected node(s) is changed, so that the plugin can react in sync with the user selection. You already consume SelectionChanged from the TreeView, so we can easily forward this with a SelectionChanged event directly exposed by the MainWindow.

- use the AssemblyReferenceTreeNode node and its AssemblyNameReference object. In my case, Reflexil is able to deal with such objects.

- Hot replace an assembly from stream so that ILSpy and Reflexil can exchange data, without the need to share the same Mono.Cecil implementation.

Regards
S.L.