### PR TITLE
Add a new "Used By" analyzer node on types

### DIFF
--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -194,6 +194,7 @@
     <Compile Include="TreeNodes\Analyzer\AnalyzedTypeInstantiationsTreeNode.cs" />
     <Compile Include="TreeNodes\Analyzer\AnalyzedTypeTreeNode.cs" />
     <Compile Include="TreeNodes\Analyzer\AnalyzedEventAccessorTreeNode.cs" />
+    <Compile Include="TreeNodes\Analyzer\AnalyzedTypeUsedByTreeNode.cs" />
     <Compile Include="TreeNodes\Analyzer\AnalyzedVirtualMethodUsedByTreeNode.cs" />
     <Compile Include="TreeNodes\Analyzer\AnalyzerEntityTreeNode.cs" />
     <Compile Include="TreeNodes\Analyzer\AnalyzerSearchTreeNode.cs" />

--- a/ILSpy/TreeNodes/Analyzer/AnalyzedTypeTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzedTypeTreeNode.cs
@@ -54,6 +54,9 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 			if (AnalyzedTypeInstantiationsTreeNode.CanShow(analyzedType))
 				this.Children.Add(new AnalyzedTypeInstantiationsTreeNode(analyzedType));
 
+			if (AnalyzedTypeUsedByTreeNode.CanShow(analyzedType))
+				this.Children.Add(new AnalyzedTypeUsedByTreeNode(analyzedType));
+
 			if (AnalyzedTypeExposedByTreeNode.CanShow(analyzedType))
 				this.Children.Add(new AnalyzedTypeExposedByTreeNode(analyzedType));
 

--- a/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
@@ -22,7 +22,6 @@ using System.Linq;
 using System.Threading;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using TypeDefinition = Mono.Cecil.TypeDefinition;
 
 namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 {
@@ -159,7 +158,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 
 		private bool IsUsedInCustomAttribute(CustomAttribute attribute)
 		{
-			// No need search in custom attribe, ILSpy already provide an "Applied To" search.
+			// No need search in custom attribute, ILSpy already provide an "Applied To" search.
 			return false;
 		}
 

--- a/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
@@ -71,9 +71,9 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 		{
 			var property = method.DeclaringType.Properties.FirstOrDefault(p => p.GetMethod == method || p.SetMethod == method);
 			if (property != null)
-				return new AnalyzedPropertyTreeNode(property) {Language = Language};
+				return new AnalyzedPropertyTreeNode(property) { Language = Language };
 
-			return new AnalyzedMethodTreeNode(method) {Language = Language};
+			return new AnalyzedMethodTreeNode(method) { Language = Language };
 		}
 
 		private bool IsUsedInTypeReferences(IEnumerable<TypeReference> types)
@@ -93,9 +93,9 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 		private bool IsUsedInTypeDefinition(TypeDefinition type)
 		{
 			return IsUsedInTypeReference(type)
-			       || TypeMatches(type.BaseType)
+				   || TypeMatches(type.BaseType)
 				   || IsUsedInTypeReferences(type.Interfaces)
-			       || IsUsedInCustomAttributes(type.CustomAttributes);
+				   || IsUsedInCustomAttributes(type.CustomAttributes);
 		}
 
 		private bool IsUsedInFieldReference(FieldReference field)
@@ -122,12 +122,12 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 				   || TypeMatches(method.ReturnType)
 				   || IsUsedInMethodParameters(method.Parameters);
 		}
-		
+
 		private bool IsUsedInMethodDefinition(MethodDefinition method)
 		{
 			return IsUsedInMethodReference(method)
-			       || IsUsedInMethodBody(method.Body)
-			       || IsUsedInCustomAttributes(method.CustomAttributes);
+				   || IsUsedInMethodBody(method.Body)
+				   || IsUsedInCustomAttributes(method.CustomAttributes);
 		}
 
 		private bool IsUsedInMethodBody(MethodBody body)
@@ -148,7 +148,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 		private bool IsUsedInMethodParameter(ParameterDefinition parameter)
 		{
 			return TypeMatches(parameter.ParameterType)
-			       || IsUsedInCustomAttributes(parameter.CustomAttributes);
+				   || IsUsedInCustomAttributes(parameter.CustomAttributes);
 		}
 
 		private bool IsUsedInCustomAttributes(IEnumerable<CustomAttribute> attributes)
@@ -161,7 +161,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 			// No need search in custom attribe, ILSpy already provide an "Applied To" search.
 			return false;
 		}
-	
+
 		private bool TypeMatches(TypeReference tref)
 		{
 			return tref != null && analyzedType.ToString() == tref.ToString();

--- a/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
@@ -48,6 +48,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 			var analyzer = new ScopedWhereUsedAnalyzer<AnalyzerTreeNode>(analyzedType, FindTypeUsage);
 			return analyzer.PerformAnalysis(ct)
 				.Cast<AnalyzerEntityTreeNode>()
+				.Where(n => n.Member.DeclaringType != analyzedType)
 				.Distinct(new AnalyzerEntityTreeNodeComparer())
 				.OrderBy(n => n.Text);
 		}
@@ -100,7 +101,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 
 		private bool IsUsedInFieldReference(FieldReference field)
 		{
-			if (field == null || field.DeclaringType == analyzedType)
+			if (field == null)
 				return false;
 
 			return TypeMatches(field.DeclaringType)
@@ -115,7 +116,7 @@ namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
 
 		private bool IsUsedInMethodReference(MethodReference method)
 		{
-			if (method == null || method.DeclaringType == analyzedType)
+			if (method == null)
 				return false;
 
 			return TypeMatches(method.DeclaringType)

--- a/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
+++ b/ILSpy/TreeNodes/Analyzer/AnalyzedTypeUsedByTreeNode.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using TypeDefinition = Mono.Cecil.TypeDefinition;
+
+namespace ICSharpCode.ILSpy.TreeNodes.Analyzer
+{
+	internal sealed class AnalyzedTypeUsedByTreeNode : AnalyzerSearchTreeNode
+	{
+		private readonly TypeDefinition analyzedType;
+
+		public AnalyzedTypeUsedByTreeNode(TypeDefinition analyzedType)
+		{
+			if (analyzedType == null)
+				throw new ArgumentNullException("analyzedType");
+
+			this.analyzedType = analyzedType;
+		}
+
+		public override object Text
+		{
+			get { return "Used By"; }
+		}
+
+		protected override IEnumerable<AnalyzerTreeNode> FetchChildren(CancellationToken ct)
+		{
+			var analyzer = new ScopedWhereUsedAnalyzer<AnalyzerTreeNode>(analyzedType, FindTypeUsage);
+			return analyzer.PerformAnalysis(ct)
+				.Cast<AnalyzerEntityTreeNode>()
+				.Distinct(new AnalyzerEntityTreeNodeComparer())
+				.OrderBy(n => n.Text);
+		}
+
+		private IEnumerable<AnalyzerEntityTreeNode> FindTypeUsage(TypeDefinition type)
+		{
+			if (type == analyzedType)
+				yield break;
+
+			if (IsUsedInTypeDefinition(type))
+				yield return new AnalyzedTypeTreeNode(type) { Language = Language };
+
+			foreach (var field in type.Fields.Where(IsUsedInFieldDefinition))
+				yield return new AnalyzedFieldTreeNode(field) { Language = Language };
+
+			foreach (var method in type.Methods.Where(IsUsedInMethodDefinition))
+				yield return HandleSpecialMethodNode(method);
+		}
+
+		private AnalyzerEntityTreeNode HandleSpecialMethodNode(MethodDefinition method)
+		{
+			var property = method.DeclaringType.Properties.FirstOrDefault(p => p.GetMethod == method || p.SetMethod == method);
+			if (property != null)
+				return new AnalyzedPropertyTreeNode(property) {Language = Language};
+
+			return new AnalyzedMethodTreeNode(method) {Language = Language};
+		}
+
+		private bool IsUsedInTypeReferences(IEnumerable<TypeReference> types)
+		{
+			return types.Any(IsUsedInTypeReference);
+		}
+
+		private bool IsUsedInTypeReference(TypeReference type)
+		{
+			if (type == null)
+				return false;
+
+			return TypeMatches(type.DeclaringType)
+				|| TypeMatches(type);
+		}
+
+		private bool IsUsedInTypeDefinition(TypeDefinition type)
+		{
+			return IsUsedInTypeReference(type)
+			       || TypeMatches(type.BaseType)
+				   || IsUsedInTypeReferences(type.Interfaces)
+			       || IsUsedInCustomAttributes(type.CustomAttributes);
+		}
+
+		private bool IsUsedInFieldReference(FieldReference field)
+		{
+			if (field == null || field.DeclaringType == analyzedType)
+				return false;
+
+			return TypeMatches(field.DeclaringType)
+				|| TypeMatches(field.FieldType);
+		}
+
+		private bool IsUsedInFieldDefinition(FieldDefinition field)
+		{
+			return IsUsedInFieldReference(field)
+				   || IsUsedInCustomAttributes(field.CustomAttributes);
+		}
+
+		private bool IsUsedInMethodReference(MethodReference method)
+		{
+			if (method == null || method.DeclaringType == analyzedType)
+				return false;
+
+			return TypeMatches(method.DeclaringType)
+				   || TypeMatches(method.ReturnType)
+				   || IsUsedInMethodParameters(method.Parameters);
+		}
+		
+		private bool IsUsedInMethodDefinition(MethodDefinition method)
+		{
+			return IsUsedInMethodReference(method)
+			       || IsUsedInMethodBody(method.Body)
+			       || IsUsedInCustomAttributes(method.CustomAttributes);
+		}
+
+		private bool IsUsedInMethodBody(MethodBody body)
+		{
+			if (body == null)
+				return false;
+
+			return body.Instructions.Select(ins => ins.Operand as TypeReference).Any(IsUsedInTypeReference)
+				|| body.Instructions.Select(ins => ins.Operand as MethodReference).Any(IsUsedInMethodReference)
+				|| body.Instructions.Select(ins => ins.Operand as FieldReference).Any(IsUsedInFieldReference);
+		}
+
+		private bool IsUsedInMethodParameters(IEnumerable<ParameterDefinition> parameters)
+		{
+			return parameters.Any(IsUsedInMethodParameter);
+		}
+
+		private bool IsUsedInMethodParameter(ParameterDefinition parameter)
+		{
+			return TypeMatches(parameter.ParameterType)
+			       || IsUsedInCustomAttributes(parameter.CustomAttributes);
+		}
+
+		private bool IsUsedInCustomAttributes(IEnumerable<CustomAttribute> attributes)
+		{
+			return attributes.Any(IsUsedInCustomAttribute);
+		}
+
+		private bool IsUsedInCustomAttribute(CustomAttribute attribute)
+		{
+			// No need search in custom attribe, ILSpy already provide an "Applied To" search.
+			return false;
+		}
+	
+		private bool TypeMatches(TypeReference tref)
+		{
+			return tref != null && analyzedType.ToString() == tref.ToString();
+		}
+
+		public static bool CanShow(TypeDefinition type)
+		{
+			return type != null;
+		}
+	}
+
+	internal class AnalyzerEntityTreeNodeComparer : IEqualityComparer<AnalyzerEntityTreeNode>
+	{
+		public bool Equals(AnalyzerEntityTreeNode x, AnalyzerEntityTreeNode y)
+		{
+			return x.Member == y.Member;
+		}
+
+		public int GetHashCode(AnalyzerEntityTreeNode node)
+		{
+			return node.Member.GetHashCode();
+		}
+	}
+
+}


### PR DESCRIPTION
The "Used By" analyzer node on types, is very handy to quickly find type references.

This PR is an implementation for that in ILSpy:
![ilspy](https://cloud.githubusercontent.com/assets/638167/5505689/8928b5e2-8793-11e4-8d34-8ccf9e995fff.PNG)

Here is the Reflector output on the same assembly list:
![reflector](https://cloud.githubusercontent.com/assets/638167/5505691/8ee55ecc-8793-11e4-9d3b-c47d769cb180.PNG)

Seb

