### PR TITLE
Display a reference to a module's global type.

### DIFF
--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -291,6 +291,11 @@ namespace ICSharpCode.ILSpy
 				base.DecompileAssembly(assembly, output, options);
 				output.WriteLine();
 				ModuleDefinition mainModule = assembly.ModuleDefinition;
+				if (mainModule.Types.Count > 0) {
+					output.Write("// Global type: ");
+					output.WriteReference(mainModule.Types[0].FullName, mainModule.Types[0]);
+					output.WriteLine();
+				}
 				if (mainModule.EntryPoint != null) {
 					output.Write("// Entry point: ");
 					output.WriteReference(mainModule.EntryPoint.DeclaringType.FullName + "." + mainModule.EntryPoint.Name, mainModule.EntryPoint);

--- a/ILSpy/VB/VBLanguage.cs
+++ b/ILSpy/VB/VBLanguage.cs
@@ -80,6 +80,11 @@ namespace ICSharpCode.ILSpy.VB
 				base.DecompileAssembly(assembly, output, options);
 				output.WriteLine();
 				ModuleDefinition mainModule = assembly.ModuleDefinition;
+				if (mainModule.Types.Count > 0) {
+					output.Write("// Global type: ");
+					output.WriteReference(mainModule.Types[0].FullName, mainModule.Types[0]);
+					output.WriteLine();
+				}
 				if (mainModule.EntryPoint != null) {
 					output.Write("' Entry point: ");
 					output.WriteReference(mainModule.EntryPoint.DeclaringType.FullName + "." + mainModule.EntryPoint.Name, mainModule.EntryPoint);


### PR DESCRIPTION
Global types are used as assembly initializers; they contain global methods (e.g. in VB), and may be used by obfuscators. They can also be renamed so they are hard to find (default name is "&lt;Module&gt;").