### PR TITLE
Update AssemblyList.cs

### DIFF
--- a/ILSpy/AssemblyList.cs
+++ b/ILSpy/AssemblyList.cs
@@ -141,7 +141,7 @@ namespace ICSharpCode.ILSpy
 		
 		/// <summary>
 		/// Opens an assembly from disk.
-		/// Returns the existing assembly node if it is already loaded.
+		/// Returns the newly loaded or reloaded (to capture any changes) assembly
 		/// </summary>
 		public LoadedAssembly OpenAssembly(string file, bool isAutoLoaded=false)
 		{
@@ -151,7 +151,10 @@ namespace ICSharpCode.ILSpy
 			
 			foreach (LoadedAssembly asm in this.assemblies) {
 				if (file.Equals(asm.FileName, StringComparison.OrdinalIgnoreCase))
-					return asm;
+				{
+					this.assemblies.Remove(asm);
+                    			break;
+				}
 			}
 			
 			var newAsm = new LoadedAssembly(this, file);


### PR DESCRIPTION
Often I am editing an Assembly and subsequently inspecting it in ILSpy. It is very frustrating when my changes do not show up after I open the assembly via the menu. Currently I have to remove the existing assembly and then load it again from the menu. So many unnecessary clicks. Most users are not going to reload an assembly already in the list and if they do they very much should expect it to reflect the current version in the path. This ensures that happens.