### PR TITLE
add tooltip on typetreenode and methodtreenode

### DIFF
--- a/ILSpy/TreeNodes/ILSpyTreeNode.cs
+++ b/ILSpy/TreeNodes/ILSpyTreeNode.cs
@@ -190,5 +190,5 @@ namespace ICSharpCode.ILSpy.TreeNodes
 					return System.Windows.SystemColors.GrayTextBrush;
 			}
 		}
-	}
+    }
 }

--- a/ILSpy/TreeNodes/MethodTreeNode.cs
+++ b/ILSpy/TreeNodes/MethodTreeNode.cs
@@ -18,6 +18,8 @@
 
 using System;
 using System.Text;
+using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Media;
 
 using ICSharpCode.Decompiler;
@@ -151,5 +153,25 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		{
 			get { return method; }
 		}
-	}
+
+        TextBlock tooltip;
+
+        public override object ToolTip
+        {
+            get
+            {
+                if (tooltip == null)
+                {
+                    tooltip = new TextBlock();
+                    tooltip.Inlines.Add(new Bold(new Run("Type: ")));
+                    tooltip.Inlines.Add(new Run(this.MethodDefinition.DeclaringType.FullName));
+                    tooltip.Inlines.Add(new LineBreak());
+                    tooltip.Inlines.Add(new Bold(new Run("Assembly: ")));
+                    tooltip.Inlines.Add(new Run(this.MethodDefinition.Module.Assembly.FullName));
+                }
+
+                return tooltip;
+            }
+        }
+    }
 }

--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -19,6 +19,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Media;
 
 using ICSharpCode.Decompiler;
@@ -200,5 +202,22 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		MemberReference IMemberTreeNode.Member {
 			get { return type; }
 		}
-	}
+
+        TextBlock tooltip;
+
+        public override object ToolTip
+        {
+            get
+            {
+                if (tooltip == null)
+                {
+                    tooltip = new TextBlock();
+                    tooltip.Inlines.Add(new Bold(new Run("Assembly: ")));
+                    tooltip.Inlines.Add(new Run(this.TypeDefinition.Module.Assembly.FullName));
+                }
+
+                return tooltip;
+            }
+        }
+    }
 }


### PR DESCRIPTION
on "heavy" Assembly or Types, you didn't see where you are (because navigation jump to an assembly then to another). Just move your mouse over selected node (type or method actually) in order to see assembly name on type or type and assembly on methods.

