### PR TITLE
Added word wrapping

### DIFF
--- a/ILSpy/Options/DisplaySettings.cs
+++ b/ILSpy/Options/DisplaySettings.cs
@@ -96,12 +96,27 @@ namespace ICSharpCode.ILSpy.Options
 			}
 		}
 
-		public void CopyValues(DisplaySettings s)
+        bool enableWordWrap;
+
+        public bool EnableWordWrap
+        {
+            get { return enableWordWrap; }
+            set
+            {
+                if (enableWordWrap != value) {
+                    enableWordWrap = value;
+                    OnPropertyChanged("EnableWordWrap");
+                }
+            }
+        }
+
+        public void CopyValues(DisplaySettings s)
 		{
 			this.SelectedFont = s.selectedFont;
 			this.SelectedFontSize = s.selectedFontSize;
 			this.ShowLineNumbers = s.showLineNumbers;
 			this.ShowMetadataTokens = s.showMetadataTokens;
+            this.EnableWordWrap = s.enableWordWrap;
 		}
 	}
 }

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -61,6 +61,7 @@
 			<StackPanel Margin="3">
 				<CheckBox IsChecked="{Binding ShowLineNumbers}">Show line numbers</CheckBox>
 				<CheckBox IsChecked="{Binding ShowMetadataTokens}">Show metadata tokens</CheckBox>
+                <CheckBox IsChecked="{Binding EnableWordWrap}">Enable word wrap</CheckBox>
 			</StackPanel>
 		</GroupBox>
 	</Grid>

--- a/ILSpy/Options/DisplaySettingsPanel.xaml.cs
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml.cs
@@ -101,6 +101,7 @@ namespace ICSharpCode.ILSpy.Options
 			s.SelectedFontSize = (double?)e.Attribute("FontSize") ?? 10.0 * 4 / 3;
 			s.ShowLineNumbers = (bool?)e.Attribute("ShowLineNumbers") ?? false;
 			s.ShowMetadataTokens = (bool?) e.Attribute("ShowMetadataTokens") ?? false;
+		    s.EnableWordWrap = (bool?)e.Attribute("EnableWordWrap") ?? false;
 			
 			return s;
 		}
@@ -116,6 +117,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("FontSize", s.SelectedFontSize);
 			section.SetAttributeValue("ShowLineNumbers", s.ShowLineNumbers);
 			section.SetAttributeValue("ShowMetadataTokens", s.ShowMetadataTokens);
+            section.SetAttributeValue("EnableWordWrap", s.EnableWordWrap);
 			
 			XElement existingElement = root.Element("DisplaySettings");
 			if (existingElement != null)

--- a/ILSpy/TextView/DecompilerTextView.cs
+++ b/ILSpy/TextView/DecompilerTextView.cs
@@ -97,8 +97,9 @@ namespace ICSharpCode.ILSpy.TextView
 			textEditor.TextArea.TextView.MouseDown += TextViewMouseDown;
 			textEditor.SetBinding(Control.FontFamilyProperty, new Binding { Source = DisplaySettingsPanel.CurrentDisplaySettings, Path = new PropertyPath("SelectedFont") });
 			textEditor.SetBinding(Control.FontSizeProperty, new Binding { Source = DisplaySettingsPanel.CurrentDisplaySettings, Path = new PropertyPath("SelectedFontSize") });
-			
-			textMarkerService = new TextMarkerService(textEditor.TextArea.TextView);
+            textEditor.SetBinding(TextEditor.WordWrapProperty, new Binding { Source = DisplaySettingsPanel.CurrentDisplaySettings, Path = new PropertyPath("EnableWordWrap") });
+
+            textMarkerService = new TextMarkerService(textEditor.TextArea.TextView);
 			textEditor.TextArea.TextView.BackgroundRenderers.Add(textMarkerService);
 			textEditor.TextArea.TextView.LineTransformers.Add(textMarkerService);
 			textEditor.ShowLineNumbers = true;


### PR DESCRIPTION
For those of us on small monitors or who just dislike horizontal scrollbars, this adds an 'Enable word wrap' option to the Display settings, which causes the decompilation view to wrap if enabled.