### PR TITLE
Fixed Address Of Field Output

### DIFF
--- a/NRefactory/ICSharpCode.NRefactory.CSharp/Ast/Expressions/DirectionExpression.cs
+++ b/NRefactory/ICSharpCode.NRefactory.CSharp/Ast/Expressions/DirectionExpression.cs
@@ -38,7 +38,7 @@ namespace ICSharpCode.NRefactory.CSharp
 	/// </summary>
 	public class DirectionExpression : Expression
 	{
-		public readonly static TokenRole RefKeywordRole = new TokenRole ("ref");
+		public readonly static TokenRole RefKeywordRole = new TokenRole ("&");
 		public readonly static TokenRole OutKeywordRole = new TokenRole ("out");
 		
 		public FieldDirection FieldDirection {

--- a/NRefactory/ICSharpCode.NRefactory.CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/NRefactory/ICSharpCode.NRefactory.CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -738,14 +738,14 @@ namespace ICSharpCode.NRefactory.CSharp
 			switch (directionExpression.FieldDirection) {
 				case FieldDirection.Out:
 					WriteKeyword(DirectionExpression.OutKeywordRole);
+					Space();
 					break;
 				case FieldDirection.Ref:
-					WriteKeyword(DirectionExpression.RefKeywordRole);
+					WriteToken(DirectionExpression.RefKeywordRole);
 					break;
 				default:
 					throw new NotSupportedException ("Invalid value for FieldDirection");
 			}
-			Space();
 			directionExpression.Expression.AcceptVisitor(this);
 			
 			EndNode(directionExpression);


### PR DESCRIPTION
This fixes this output:
```
            fixed (int *ptr = ref _field)  // Syntax error!
                *ptr = 10;
```

... to this output...
```
            fixed (int *ptr = &_field) // Correct!
                *ptr = 10;
```
