### PR TITLE
Fixed #650 - C++ switch over `char`/`long` values crashes ILSpy

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/TypeAnalysis.cs
+++ b/ICSharpCode.Decompiler/ILAst/TypeAnalysis.cs
@@ -1266,6 +1266,16 @@ namespace ICSharpCode.Decompiler.ILAst
 					return TypeCode.Double;
 				case MetadataType.String:
 					return TypeCode.String;
+				case MetadataType.RequiredModifier:
+				case MetadataType.OptionalModifier:
+					TypeReference modifier = ((IModifierType)type).ModifierType;
+					switch (modifier.FullName) {
+						case "System.Runtime.CompilerServices.IsSignUnspecifiedByte":
+							return TypeCode.SByte;
+						case "System.Runtime.CompilerServices.IsLong":
+							return TypeCode.Int32;
+					}
+					goto default;
 				default:
 					return TypeCode.Object;
 			}


### PR DESCRIPTION
SByte is chosen because ElementType is set to SByte