### PR TITLE
Portable settings file

### DIFF
--- a/ILSpy/ILSpySettings.cs
+++ b/ILSpy/ILSpySettings.cs
@@ -115,6 +115,9 @@ namespace ICSharpCode.ILSpy
 		
 		static string GetConfigFile()
 		{
+			string localPath = Path.Combine(Path.GetDirectoryName(typeof(MainWindow).Assembly.Location), "ILSpy.xml");
+			if (File.Exists(localPath))
+				return localPath;
 			return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ICSharpCode\\ILSpy.xml");
 		}
 		


### PR DESCRIPTION
A small change that allows ILSpy to run self-contained, I thought some other people may find it useful. This simply checks if a settings file exists in the same directory as the executable and, if so, uses that instead of ApplicationData.