### PR TITLE
FIX #675. Decompile empty async void methods

### DIFF
--- a/ICSharpCode.Decompiler/ILAst/StateRange.cs
+++ b/ICSharpCode.Decompiler/ILAst/StateRange.cs
@@ -273,14 +273,23 @@ namespace ICSharpCode.Decompiler.ILAst
 		{
 			if (pos > 0 && body[pos - 1] is ILLabel) {
 				pos--;
-			} else {
-				// ensure that the first element at body[pos] is a label:
-				ILLabel newLabel = new ILLabel();
-				newLabel.Name = "YieldReturnEntryPoint";
-				ranges[newLabel] = ranges[body[pos]]; // give the label the range of the instruction at body[pos]
-				body.Insert(pos, newLabel);
-				bodyLength++;
+				return; // label found
 			}
+
+			// ensure that the first element at body[pos] is a label:
+			ILLabel newLabel = new ILLabel();
+			newLabel.Name = "YieldReturnEntryPoint";
+
+			ILExpression expr = pos == 1 && body.Count == 1 ? body[0] as ILExpression : null;
+			if (expr != null && expr.Code == ILCode.Leave && expr.Operand is ILLabel) {
+				ranges[newLabel] = ranges[(ILLabel)expr.Operand];
+				pos = 0;
+			} else {
+				ranges[newLabel] = ranges[body[pos]]; // give the label the range of the instruction at body[pos]
+			}
+
+			body.Insert(pos, newLabel);
+			bodyLength++;
 		}
 		
 		public LabelRangeMapping CreateLabelRangeMapping(List<ILNode> body, int pos, int bodyLength)

--- a/ICSharpCode.Decompiler/Tests/Async.cs
+++ b/ICSharpCode.Decompiler/Tests/Async.cs
@@ -37,6 +37,10 @@ public class Async
 		Console.WriteLine("No Await");
 	}
 	
+	public async void EmptyVoidMethod()
+	{
+	}
+	
 	public async void AwaitYield()
 	{
 		await Task.Yield();


### PR DESCRIPTION
This resolves issue https://github.com/icsharpcode/ILSpy/issues/675 by checking if ast matches to very specific case