### PR TITLE
Allow scrolling in high resource rows

### DIFF
--- a/ILSpy/Controls/ResourceStringTable.xaml
+++ b/ILSpy/Controls/ResourceStringTable.xaml
@@ -36,6 +36,7 @@
 			  Foreground="Black"
 				  Grid.Row="1"
 				  AlternationCount="2"
+				  ScrollViewer.CanContentScroll="False"
 				  ItemContainerStyle="{StaticResource alternatingWithBinding}">
 		<ListView.View>
 			<GridView AllowsColumnReorder="False">


### PR DESCRIPTION
Allow grid listview with resource tables to scroll items that are higher then the listview rows.