### PR TITLE
Write last access time

### DIFF
--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -255,6 +255,7 @@ namespace ICSharpCode.ILSpy
 			}
 			if (file != null) {
 				var loaded = assemblyList.OpenAssembly(file, true);
+				File.SetLastAccessTime(file, DateTime.Now);
 				return loaded;
 			} else {
 				return null;


### PR DESCRIPTION
In order to let devs beeing able to check if their assembly have been decompiled, I make ILSpy write the last access time. Decompiling could be checked by a tool like [this.](https://github.com/WoniMK7/dotnetSecure)
What do you think of this idea ?