### PR TITLE
Add ellipses to menu items

### DIFF
--- a/ILSpy/Commands/OpenCommand.cs
+++ b/ILSpy/Commands/OpenCommand.cs
@@ -22,7 +22,7 @@ using System.Windows.Input;
 namespace ICSharpCode.ILSpy
 {
 	[ExportToolbarCommand(ToolTip = "Open", ToolbarIcon = "Images/Open.png", ToolbarCategory = "Open", ToolbarOrder = 0)]
-	[ExportMainMenuCommand(Menu = "_File", MenuIcon = "Images/Open.png", MenuCategory = "Open", MenuOrder = 0)]
+	[ExportMainMenuCommand(Menu = "_File", Header = "_Open...", MenuIcon = "Images/Open.png", MenuCategory = "Open", MenuOrder = 0)]
 	sealed class OpenCommand : CommandWrapper
 	{
 		public OpenCommand()

--- a/ILSpy/Commands/OpenFromGacCommand.cs
+++ b/ILSpy/Commands/OpenFromGacCommand.cs
@@ -20,7 +20,7 @@ using System;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = "_File", Header = "Open from _GAC", MenuIcon = "Images/AssemblyListGAC.png", MenuCategory = "Open", MenuOrder = 1)]
+	[ExportMainMenuCommand(Menu = "_File", Header = "Open from _GAC...", MenuIcon = "Images/AssemblyListGAC.png", MenuCategory = "Open", MenuOrder = 1)]
 	sealed class OpenFromGacCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/OpenListCommand.cs
+++ b/ILSpy/Commands/OpenListCommand.cs
@@ -20,7 +20,7 @@ using System;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = "_File", Header = "Open _List", MenuIcon = "Images/AssemblyList.png", MenuCategory = "Open", MenuOrder = 1.7)]
+	[ExportMainMenuCommand(Menu = "_File", Header = "Open _List...", MenuIcon = "Images/AssemblyList.png", MenuCategory = "Open", MenuOrder = 1.7)]
 	sealed class OpenListCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/RefreshCommand.cs
+++ b/ILSpy/Commands/RefreshCommand.cs
@@ -22,7 +22,7 @@ using System.Windows.Input;
 namespace ICSharpCode.ILSpy
 {
 	[ExportToolbarCommand(ToolTip = "Reload all assemblies", ToolbarIcon = "Images/Refresh.png", ToolbarCategory = "Open", ToolbarOrder = 2)]
-	[ExportMainMenuCommand(Menu = "_File", Header = "Reload", MenuIcon = "Images/Refresh.png", MenuCategory = "Open", MenuOrder = 2)]
+	[ExportMainMenuCommand(Menu = "_File", Header = "_Reload", MenuIcon = "Images/Refresh.png", MenuCategory = "Open", MenuOrder = 2)]
 	sealed class RefreshCommand : CommandWrapper
 	{
 		public RefreshCommand()

--- a/ILSpy/Options/OptionsDialog.xaml.cs
+++ b/ILSpy/Options/OptionsDialog.xaml.cs
@@ -89,7 +89,7 @@ namespace ICSharpCode.ILSpy.Options
 		public int Order { get; set; }
 	}
 	
-	[ExportMainMenuCommand(Menu = "_View", Header = "_Options", MenuCategory = "Options", MenuOrder = 999)]
+	[ExportMainMenuCommand(Menu = "_View", Header = "_Options...", MenuCategory = "Options", MenuOrder = 999)]
 	sealed class ShowOptionsCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/SearchPane.cs
+++ b/ILSpy/SearchPane.cs
@@ -293,7 +293,7 @@ namespace ICSharpCode.ILSpy
 		}
 	}
 
-	[ExportMainMenuCommand(Menu = "_View", Header = "_Search", MenuIcon = "Images/Find.png", MenuCategory = "ShowPane", MenuOrder = 100)]
+	[ExportMainMenuCommand(Menu = "_View", Header = "_Search...", MenuIcon = "Images/Find.png", MenuCategory = "ShowPane", MenuOrder = 100)]
 	[ExportToolbarCommand(ToolTip = "Search (Ctrl+Shift+F or Ctrl+E)", ToolbarIcon = "Images/Find.png", ToolbarCategory = "View", ToolbarOrder = 100)]
 	sealed class ShowSearchCommand : CommandWrapper
 	{


### PR DESCRIPTION
The following menu items now have an ellipses (...) because they open a
new dialog:

File -> Open...
File -> Open from GAC...
File -> Open List...
View -> Search...
View -> Options...