### PR TITLE
Add an "Open in ILSpy" option to the context menu in the code window.

### DIFF
--- a/ILSpy.AddIn/ILSpyAddIn.vsct
+++ b/ILSpy.AddIn/ILSpyAddIn.vsct
@@ -47,6 +47,10 @@
       <Group guid="guidILSpyAddInCmdSet" id="OpenILSpyProjGroup" priority="0x0200">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
       </Group>
+
+      <Group guid="guidILSpyAddInCmdSet" id="OpenILSpyCodeItemGroup" priority="0x0200">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
+      </Group>
     </Groups>
     
     <!--Buttons section. -->
@@ -74,6 +78,14 @@
         <Icon guid="guidImages" id="bmpLogo" />
         <Strings>
           <ButtonText>Open output in ILSpy</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="guidILSpyAddInCmdSet" id="cmdidOpenCodeItemInILSpy" priority="0x0600" type="Button">
+        <Parent guid="guidILSpyAddInCmdSet" id="OpenILSpyCodeItemGroup" />
+        <Icon guid="guidImages" id="bmpLogo" />
+        <Strings>
+          <ButtonText>Open code in ILSpy</ButtonText>
         </Strings>
       </Button>
 
@@ -114,9 +126,11 @@
       <IDSymbol name="OpenILSpyGroup" value="0x1010" />
       <IDSymbol name="OpenILSpyRefGroup" value="0x1020" />
       <IDSymbol name="OpenILSpyProjGroup" value="0x1030" />
+      <IDSymbol name="OpenILSpyCodeItemGroup" value="0x1040" />
       <IDSymbol name="cmdidOpenILSpy" value="0x0100" />
       <IDSymbol name="cmdidOpenReferenceInILSpy" value="0x0200" />
       <IDSymbol name="cmdidOpenProjectOutputInILSpy" value="0x0300" />
+      <IDSymbol name="cmdidOpenCodeItemInILSpy" value="0x0400" />
     </GuidSymbol>
      
     <GuidSymbol name="guidImages" value="{2f654db9-4641-4638-9937-27c6202b2a6a}" >

--- a/ILSpy.AddIn/PkgCmdID.cs
+++ b/ILSpy.AddIn/PkgCmdID.cs
@@ -9,5 +9,6 @@ namespace ICSharpCode.ILSpy.AddIn
 		public const uint cmdidOpenILSpy = 0x100;
 		public const uint cmdidOpenReferenceInILSpy = 0x200;
 		public const uint cmdidOpenProjectOutputInILSpy = 0x300;
+		public const uint cmdidOpenCodeItemInILSpy = 0x0400;
 	};
 }

--- a/ILSpy.AddIn/Utils.cs
+++ b/ILSpy.AddIn/Utils.cs
@@ -74,6 +74,10 @@ namespace ICSharpCode.ILSpy.AddIn
 
 		static void AppendArgument(StringBuilder b, string arg)
 		{
+			if (arg == null) {
+				return;
+			}
+
 			if (arg.Length > 0 && arg.IndexOfAny(charsNeedingQuoting) < 0) {
 				b.Append(arg);
 			} else {


### PR DESCRIPTION
Addresses #694. Supports methods, enums, delegates, properties, interfaces, events and classes.

Changes (only) to ILSpy.AddIn project:
add: code window context menu item "Open code in ILSpy"
add: OpenCodeItemInILSpyCallback does the work, using Visual Studio code model to interrogate source at selection point
change: add additional argument support to OpenAssemblyInILSpy (to support "/navigateTo")

Tested by running the AddIn via Debug > Start New Instance.
Using Visual Studio Pro 2013 for development and testing.

TODO: disambiguate overloaded methods by number and type of parameters

(Note: I have used C# and git for a long time, but I am new to GitHub and open source contributions. Please be gentle ...)