### PR TITLE
Support for BamlRecordType.TypeSerializerInfo in bamlreader

### DIFF
--- a/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
+++ b/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
@@ -488,6 +488,9 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 				case BamlRecordType.PresentationOptionsAttribute:
 					this.ReadPresentationOptionsAttribute();
 					break;
+				case BamlRecordType.TypeSerializerInfo:
+					this.ReadTypeInfo();
+					break;
 				default:
 					throw new NotImplementedException("UnsupportedNode: " + currentType);
 			}
@@ -526,6 +529,7 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 				case BamlRecordType.TypeInfo:
 				case BamlRecordType.AttributeInfo:
 				case BamlRecordType.StringInfo:
+				case BamlRecordType.TypeSerializerInfo:
 					bytesToSkip = reader.ReadCompressedInt32();
 					break;
 			}


### PR DESCRIPTION
We faced a situation when csc submits TypeSerializerInfo into the baml being generated. ILSpy doesn't support it so it fails to decompile the baml. From the MSFT source code the binary layout for TypeSerializedInfo is the same as for TypeInfo, so i just added TypeSerializerInfo handling the same way it was done for TypeInfo.