### PR TITLE
Decompiler can now introduce `var` variable declarations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _ReSharper*/
 *.patch
 /packages
 *.ide/
+/.vs/config/applicationhost.config

--- a/ICSharpCode.Decompiler/Ast/Transforms/TransformationPipeline.cs
+++ b/ICSharpCode.Decompiler/Ast/Transforms/TransformationPipeline.cs
@@ -45,7 +45,8 @@ namespace ICSharpCode.Decompiler.Ast.Transforms
 				new IntroduceExtensionMethods(context), // must run after IntroduceUsingDeclarations
 				new IntroduceQueryExpressions(context), // must run after IntroduceExtensionMethods
 				new CombineQueryExpressions(context),
-				new FlattenSwitchBlocks(), 
+				new FlattenSwitchBlocks(),
+				new UseVarKeywordTransform(context.Settings)
 			};
 		}
 		

--- a/ICSharpCode.Decompiler/Ast/Transforms/UseVarKeywordTransform.cs
+++ b/ICSharpCode.Decompiler/Ast/Transforms/UseVarKeywordTransform.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ICSharpCode.NRefactory.CSharp;
+using ICSharpCode.NRefactory.PatternMatching;
+
+namespace ICSharpCode.Decompiler.Ast.Transforms
+{
+	class UseVarKeywordTransform : DepthFirstAstVisitor, IAstTransform
+	{
+		private readonly DecompilerSettings settings;
+
+		public UseVarKeywordTransform(DecompilerSettings settings)
+		{
+			this.settings = settings;
+		}
+
+		public override void VisitVariableDeclarationStatement(VariableDeclarationStatement variableDeclarationStatement)
+		{
+			if (variableDeclarationStatement.Variables.Count != 1 || variableDeclarationStatement.Type.IsVar()) return;
+			var variable = variableDeclarationStatement.Variables.Single();
+			if (variable.Initializer.IsNull) return; // has to have an initializer
+
+			var useVar = false;
+			switch (settings.UseVar) {
+				case VarKeywordUsage.WhenTypeIsEvident:
+					useVar = IsTypeEvident(variableDeclarationStatement.Type, variable.Initializer);
+					break;
+				case VarKeywordUsage.WhenTypeIsEvidentOrLong:
+					useVar = IsLongName(variableDeclarationStatement.Type) || IsTypeEvident(variableDeclarationStatement.Type, variable.Initializer);
+					break;
+				case VarKeywordUsage.Always:
+					useVar = true;
+					break;
+				default:
+					break;
+			}
+
+			if(useVar) variableDeclarationStatement.Type = new SimpleType("var");
+
+			base.VisitVariableDeclarationStatement(variableDeclarationStatement);
+		}
+
+		bool IsLongName(AstType type) => type.StartLocation.Column + 15 < type.EndLocation.Column;
+
+		bool IsTypeEvident(AstType type, Expression initializer)
+		{
+			if (initializer is IdentifierExpression) return true; // you know types of your locals
+			if (initializer is InvocationExpression) { // SOMETYPE variable = SOMETYPE.method123(ahoj, ahoj);
+				var target = ((InvocationExpression)initializer).Target;
+				do {
+					if (target is TypeReferenceExpression && ((INode)type).Match(((TypeReferenceExpression)target).Type).Success) {
+						return true;
+					} else if (target is MemberReferenceExpression && ((MemberReferenceExpression)target).TypeArguments.Any(a => ((INode)type).Match(a).Success)) {
+						return true;
+					}
+
+					if (target is MemberReferenceExpression) {
+						target = ((MemberReferenceExpression)target).Target;
+					} else target = null;
+				} while (target != null);
+			}
+			if (initializer is CastExpression) {
+				if (((INode)type).Match(((CastExpression)initializer).Type).Success) return true;
+			}
+			if (initializer is AsExpression) {
+				if (((INode)type).Match(((AsExpression)initializer).Type).Success) return true;
+			}
+			return false;
+		}
+
+
+		public void Run(AstNode compilationUnit)
+		{
+			if (settings.UseVar == VarKeywordUsage.Never) return;
+			compilationUnit.AcceptVisitor(this);
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/Ast/Transforms/UseVarKeywordTransform.cs
+++ b/ICSharpCode.Decompiler/Ast/Transforms/UseVarKeywordTransform.cs
@@ -30,10 +30,10 @@ namespace ICSharpCode.Decompiler.Ast.Transforms
 			var useVar = false;
 			switch (settings.UseVar) {
 				case VarKeywordUsage.WhenTypeIsEvident:
-					useVar = IsTypeEvident(type, variable.Initializer);
+					useVar = type.StartLocation.Column + 6 < type.EndLocation.Column && IsTypeEvident(type, variable.Initializer);
 					break;
 				case VarKeywordUsage.WhenTypeIsEvidentOrLong:
-					useVar = IsLongName(type) || IsTypeEvident(type, variable.Initializer);
+					useVar = type.StartLocation.Column + 6 < type.EndLocation.Column && IsLongName(type) || IsTypeEvident(type, variable.Initializer);
 					break;
 				case VarKeywordUsage.Always:
 					useVar = true;

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -266,6 +266,18 @@ namespace ICSharpCode.Decompiler
 				}
 			}
 		}
+
+		VarKeywordUsage useVar = VarKeywordUsage.WhenTypeIsEvidentOrLong;
+
+		public VarKeywordUsage UseVar {
+			get { return useVar; }
+			set {
+				if(value != useVar) {
+					useVar = value;
+					OnPropertyChanged(nameof(UseVar));
+				}
+			}
+		}
 		
 		#region Options to aid VB decompilation
 		bool introduceIncrementAndDecrement = true;
@@ -352,5 +364,13 @@ namespace ICSharpCode.Decompiler
 			settings.PropertyChanged = null;
 			return settings;
 		}
+	}
+
+	public enum VarKeywordUsage
+	{
+		Never,
+		WhenTypeIsEvident,
+		WhenTypeIsEvidentOrLong,
+		Always,
 	}
 }

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Ast\Transforms\PushNegation.cs" />
     <Compile Include="Ast\Transforms\TransformationPipeline.cs" />
     <Compile Include="Ast\Transforms\PatternStatementTransform.cs" />
+    <Compile Include="Ast\Transforms\UseVarKeywordTransform.cs" />
     <Compile Include="Ast\TypesHierarchyHelpers.cs" />
     <Compile Include="CecilExtensions.cs" />
     <Compile Include="CodeMappings.cs" />

--- a/ICSharpCode.Decompiler/Tests/DecompilerTestBase.cs
+++ b/ICSharpCode.Decompiler/Tests/DecompilerTestBase.cs
@@ -49,7 +49,7 @@ namespace ICSharpCode.Decompiler.Tests
 			var code = RemoveIgnorableLines(File.ReadLines(fileName));
 			AssemblyDefinition assembly = CompileLegacy(code, optimize, useDebug, compilerVersion);
 
-			AstBuilder decompiler = new AstBuilder(new DecompilerContext(assembly.MainModule));
+			AstBuilder decompiler = new AstBuilder(new DecompilerContext(assembly.MainModule) { Settings = new DecompilerSettings() { UseVar = VarKeywordUsage.Never } });
 			decompiler.AddAssembly(assembly);
 			new Helpers.RemoveCompilerAttribute().Run(decompiler.SyntaxTree);
 

--- a/ICSharpCode.Decompiler/Tests/FSharpPatterns/TestHelpers.cs
+++ b/ICSharpCode.Decompiler/Tests/FSharpPatterns/TestHelpers.cs
@@ -61,7 +61,7 @@ namespace ICSharpCode.Decompiler.Tests.FSharpPatterns
 			try
 			{
 				try { module.ReadSymbols(); } catch { }
-				AstBuilder decompiler = new AstBuilder(new DecompilerContext(module));
+				AstBuilder decompiler = new AstBuilder(new DecompilerContext(module) { Settings = new DecompilerSettings() { UseVar = VarKeywordUsage.Never } });
 				decompiler.AddAssembly(module);
 				new Helpers.RemoveCompilerAttribute().Run(decompiler.SyntaxTree);
 				StringWriter output = new StringWriter();

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -1,7 +1,17 @@
 ﻿<UserControl x:Class="ICSharpCode.ILSpy.Options.DecompilerSettingsPanel"
              x:ClassModifier="internal"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:System="clr-namespace:System;assembly=mscorlib"
+			 xmlns:Decompiler="clr-namespace:ICSharpCode.Decompiler;assembly=ICSharpCode.Decompiler">
+	<UserControl.Resources>
+		<ObjectDataProvider x:Key="dataFromEnum" MethodName="GetValues"
+                            ObjectType="{x:Type System:Enum}">
+			<ObjectDataProvider.MethodParameters>
+				<x:Type TypeName="Decompiler:VarKeywordUsage"/>
+			</ObjectDataProvider.MethodParameters>
+		</ObjectDataProvider>
+	</UserControl.Resources>
 	<StackPanel Margin="10">
 		<CheckBox IsChecked="{Binding AnonymousMethods}">Decompile anonymous methods/lambdas</CheckBox>
 		<CheckBox IsChecked="{Binding YieldReturn}">Decompile enumerators (yield return)</CheckBox>
@@ -11,5 +21,9 @@
 		<CheckBox IsChecked="{Binding UseDebugSymbols}">Use variable names from debug symbols, if available</CheckBox>
 		<CheckBox IsChecked="{Binding ShowXmlDocumentation}">Show XML documentation in decompiled code</CheckBox>
 		<CheckBox IsChecked="{Binding FoldBraces}">Enable folding on all blocks in braces</CheckBox>
+		<StackPanel Orientation="Horizontal">
+			<Label Content="Use 'var' keyword" />
+			<ComboBox SelectedValue="{Binding UseVar, Mode=TwoWay}" ItemsSource="{Binding Source={StaticResource dataFromEnum}}"></ComboBox>
+		</StackPanel>
 	</StackPanel>
 </UserControl>

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml.cs
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml.cs
@@ -59,6 +59,8 @@ namespace ICSharpCode.ILSpy.Options
 			s.UseDebugSymbols = (bool?)e.Attribute("useDebugSymbols") ?? s.UseDebugSymbols;
 			s.ShowXmlDocumentation = (bool?)e.Attribute("xmlDoc") ?? s.ShowXmlDocumentation;
 			s.FoldBraces = (bool?)e.Attribute("foldBraces") ?? s.FoldBraces;
+			VarKeywordUsage useVar;
+			if (Enum.TryParse(e.Attribute("useVar")?.Value, true, out useVar)) s.UseVar = useVar;
 			return s;
 		}
 		
@@ -74,6 +76,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("useDebugSymbols", s.UseDebugSymbols);
 			section.SetAttributeValue("xmlDoc", s.ShowXmlDocumentation);
 			section.SetAttributeValue("foldBraces", s.FoldBraces);
+			section.SetAttributeValue("useVar", s.UseVar);
 			
 			XElement existingElement = root.Element("DecompilerSettings");
 			if (existingElement != null)


### PR DESCRIPTION
The behavior can turned on/off in DecompilerSettings. You can also use `var` only if the type name is already used on the line or if it's long (hardcoded 15 chars).
