### PR TITLE
Work around #723 by eating all symbols during loading.

### DIFF
--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -128,9 +128,7 @@ namespace ICSharpCode.ILSpy
 			if (DecompilerSettingsPanel.CurrentDecompilerSettings.UseDebugSymbols) {
 				try {
 					LoadSymbols(module);
-				} catch (IOException) {
-				} catch (UnauthorizedAccessException) {
-				} catch (InvalidOperationException) {
+				} catch {
 					// ignore any errors during symbol loading
 				}
 			}


### PR DESCRIPTION
This patch allows assemblies with portable PDBs to be loaded.
Obviously CECIL should be fixed, but this get's IlSpy working again in the meantime.