### PR TITLE
Add reference to _this_ and _base_ keywords in ctor initializer

### DIFF
--- a/ICSharpCode.Decompiler/Ast/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Ast/TextTokenWriter.cs
@@ -188,6 +188,15 @@ namespace ICSharpCode.Decompiler.Ast
 		
 		public override void WriteKeyword(Role role, string keyword)
 		{
+			//To make reference for 'this' and 'base' keywords in the ClassName():this() expression
+			if (role == ConstructorInitializer.ThisKeywordRole || role == ConstructorInitializer.BaseKeywordRole) {
+				var reference = GetCurrentMemberReference();
+				if (reference != null) {
+					output.WriteReference(keyword, reference);
+					return;
+				}
+			}
+
 			output.Write(keyword);
 		}
 		


### PR DESCRIPTION
I've found that significant improvement could be applied to the ILSpy. Consider the following code:
![image](https://cloud.githubusercontent.com/assets/1074182/17279785/9c74ae02-5786-11e6-800a-c2106e52acca.png)

Unfortunately, the `base` and `this` words near the constructors are not clickable. 
I've extended code to make them clickable. They will point to appropriate ctor definition.
That will hugely simplify the code navigation.

P.S. I've created issue in NRefactory project ([#519](https://github.com/icsharpcode/NRefactory/issues/519)), but later realized that it's a pure ILSpy issue.