### PR TITLE
Ui improve pane experience

### DIFF
--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -872,10 +872,40 @@ namespace ICSharpCode.ILSpy
 		}
 		
 		#region Top/Bottom Pane management
+
+		/// <summary>
+		///   When grid is resized using splitter, row height value could become greater than 1.
+		///   As result, when a new pane is shown, both textView and pane could become very small.
+		///   This method normalizes two rows and ensures that height is less then 1.
+		/// </summary>
+		void NormalizePaneRowHeightValues(RowDefinition pane1Row, RowDefinition pane2Row)
+		{
+			var pane1Height = pane1Row.Height;
+			var pane2Height = pane2Row.Height;
+
+			//only star height values are normalized.
+			if (!pane1Height.IsStar || !pane2Height.IsStar)
+			{
+				return;
+			}
+
+			var totalHeight = pane1Height.Value + pane2Height.Value;
+			if (totalHeight == 0)
+			{
+				return;
+			}
+
+			pane1Row.Height = new GridLength(pane1Height.Value / totalHeight, GridUnitType.Star);
+			pane2Row.Height = new GridLength(pane2Height.Value / totalHeight, GridUnitType.Star);
+		}
+
 		public void ShowInTopPane(string title, object content)
 		{
 			topPaneRow.MinHeight = 100;
 			if (sessionSettings.TopPaneSplitterPosition > 0 && sessionSettings.TopPaneSplitterPosition < 1) {
+				//Ensure all 3 blocks are in fair conditions
+				NormalizePaneRowHeightValues(bottomPaneRow, textViewRow);
+
 				textViewRow.Height = new GridLength(1 - sessionSettings.TopPaneSplitterPosition, GridUnitType.Star);
 				topPaneRow.Height = new GridLength(sessionSettings.TopPaneSplitterPosition, GridUnitType.Star);
 			}
@@ -906,6 +936,9 @@ namespace ICSharpCode.ILSpy
 		{
 			bottomPaneRow.MinHeight = 100;
 			if (sessionSettings.BottomPaneSplitterPosition > 0 && sessionSettings.BottomPaneSplitterPosition < 1) {
+				//Ensure all 3 blocks are in fair conditions
+				NormalizePaneRowHeightValues(topPaneRow, textViewRow);
+
 				textViewRow.Height = new GridLength(1 - sessionSettings.BottomPaneSplitterPosition, GridUnitType.Star);
 				bottomPaneRow.Height = new GridLength(sessionSettings.BottomPaneSplitterPosition, GridUnitType.Star);
 			}

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -849,7 +849,7 @@ namespace ICSharpCode.ILSpy
 			sessionSettings.WindowBounds = this.RestoreBounds;
 			sessionSettings.SplitterPosition = leftColumn.Width.Value / (leftColumn.Width.Value + rightColumn.Width.Value);
 			if (topPane.Visibility == Visibility.Visible)
-				sessionSettings.BottomPaneSplitterPosition = topPaneRow.Height.Value / (topPaneRow.Height.Value + textViewRow.Height.Value);
+				sessionSettings.TopPaneSplitterPosition = topPaneRow.Height.Value / (topPaneRow.Height.Value + textViewRow.Height.Value);
 			if (bottomPane.Visibility == Visibility.Visible)
 				sessionSettings.BottomPaneSplitterPosition = bottomPaneRow.Height.Value / (bottomPaneRow.Height.Value + textViewRow.Height.Value);
 			sessionSettings.Save();


### PR DESCRIPTION
Fixed two issues.
The first issue is just a typo and top panel size was not saved on tool close.

The second issue leaded to the small pane size when it's displayed. Consider the following scenario:
- You open the `Source code` and the `Search panel`. After that you use a grid resizer and make the panels the same height. Resizer assigned heights `250*` and `250*`. Yes, resizer assigns values greater than 1.
- You open the `Analyze` panel. Tool finds from the settings that the bottom pane ratio comparing to the source code is `0.5`. As result, heights become the following:
  - top pane: `250*`
  - text view: `0.5*`
  - bottom pane: `0.5*`

Obviously, the top pane became a "Godzilla", while rest panels took their minimum.

In order to avoid such issues, I run normalization and ensure that all heights are less then 1 before a new pane is opened.
