### PR TITLE
Add support for the read-only properties decompilation

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
@@ -25,6 +25,7 @@ using ICSharpCode.Decompiler.CSharp.Syntax.PatternMatching;
 using ICSharpCode.Decompiler.CSharp.TypeSystem;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.Decompiler.CSharp.Analysis;
+using ICSharpCode.Decompiler.Semantics;
 using Mono.Cecil;
 
 namespace ICSharpCode.Decompiler.CSharp.Transforms
@@ -59,7 +60,19 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			}
 			return node;
 		}
-		
+
+		public override AstNode VisitConstructorDeclaration(ConstructorDeclaration constructorDeclaration)
+		{
+			if (context.Settings.AutomaticProperties)
+			{
+				AstNode result = TrasnformConstructorDeclarationForReadOnlyProperties(constructorDeclaration);
+				if (result != null)
+					return result;
+			}
+
+			return base.VisitConstructorDeclaration(constructorDeclaration);
+		}
+
 		public override AstNode VisitExpressionStatement(ExpressionStatement expressionStatement)
 		{
 			AstNode result;
@@ -115,6 +128,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 		{
 			if (context.Settings.AutomaticProperties) {
 				AstNode result = TransformAutomaticProperties(propertyDeclaration);
+				if (result != null)
+					return result;
+
+				result = TransformAutomaticReadOnlyProperties(propertyDeclaration);
 				if (result != null)
 					return result;
 			}
@@ -1003,7 +1020,116 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			// Since the property instance is not changed, we can continue in the visitor as usual, so return null
 			return null;
 		}
-		
+
+		static readonly PropertyDeclaration automaticReadOnlyPropertyPattern = new PropertyDeclaration
+		{
+			Attributes = { new Repeat(new AnyNode()) },
+			Modifiers = Modifiers.Any,
+			ReturnType = new AnyNode(),
+			PrivateImplementationType = new OptionalNode(new AnyNode()),
+			Name = Pattern.AnyString,
+			Getter = new Accessor
+			{
+				Attributes = { new Repeat(new AnyNode()) },
+				Modifiers = Modifiers.Any,
+				Body = new BlockStatement {
+					new ReturnStatement {
+						Expression = new MemberReferenceExpression(new ThisReferenceExpression(), Pattern.AnyString)
+							.WithName("fieldReference")
+					}
+				}
+			},
+			Setter = Accessor.Null
+		};
+
+		PropertyDeclaration TransformAutomaticReadOnlyProperties(PropertyDeclaration propertyNode)
+		{
+			var property = propertyNode.GetSymbol() as IProperty;
+			if (property == null || property.Getter == null || property.Setter != null)
+				return null;
+
+			if (!property.Getter.IsCompilerGenerated())
+				return null;
+
+			Match m = automaticReadOnlyPropertyPattern.Match(propertyNode);
+			if (m.Success)
+			{
+				var field = m.Get<AstNode>("fieldReference").Single().GetSymbol() as IField;
+				if (field == null)
+					return null;
+
+				if (field.IsCompilerGenerated() && field.DeclaringType.Equals(property.DeclaringType))
+				{
+					RemoveCompilerGeneratedAttribute(propertyNode.Getter.Attributes);
+					propertyNode.Getter.Body = null;
+				}
+			}
+			// Since the property instance is not changed, we can continue in the visitor as usual, so return null
+			return null;
+		}
+
+		static readonly ExpressionStatement automaticReadOnlyPropertyInitializationPattern = new ExpressionStatement
+		{
+			Expression = new AssignmentExpression
+			{
+				Left = new MemberReferenceExpression
+					{
+						MemberName = Pattern.AnyString,
+						Target = new ThisReferenceExpression()
+					}
+					.WithName("memberRef"),
+
+				Right = new AnyNodeOrNull(),
+				Operator = AssignmentOperatorType.Assign
+			}
+		};
+
+		ConstructorDeclaration TrasnformConstructorDeclarationForReadOnlyProperties(ConstructorDeclaration constructor)
+		{
+			var declaringType = (constructor.GetSymbol() as IMember)?.DeclaringType;
+			if (declaringType == null)
+				return null;
+
+			foreach (var expressionStatement in constructor.Body.Children.OfType<ExpressionStatement>())
+			{
+				var match = automaticReadOnlyPropertyInitializationPattern.Match(expressionStatement);
+				if (!match.Success)
+					continue;
+
+				var memberReference = match.Get<MemberReferenceExpression>("memberRef").Single();
+
+				var field = declaringType.GetFields(f => f.Name.Equals(memberReference.MemberName, StringComparison.Ordinal)).FirstOrDefault();
+				if (field == null || !field.IsCompilerGenerated() || !field.IsReadOnly)
+					continue;
+
+				string mangledName = field.Name;
+
+				//The compiler generated name has the following format: <FIELDNAME>k__BackingField
+				//We should extract the FIELDNAME, because it corresponds to the property name.
+
+				const string manglePrefix = "<";
+				const string mangleSuffix = ">k__BackingField";
+
+				if (!mangledName.StartsWith(manglePrefix, StringComparison.Ordinal) || !mangledName.EndsWith(mangleSuffix, StringComparison.Ordinal))
+					continue;
+
+				string propertyName = mangledName.Substring(manglePrefix.Length, mangledName.Length - manglePrefix.Length - mangleSuffix.Length);
+				var property = declaringType.GetProperties(p => p.Name.Equals(propertyName, StringComparison.Ordinal)).FirstOrDefault();
+
+				if (property == null)
+					continue;
+
+				//Create a new reference expression to reference property instead of field.
+				var propertyReference = new MemberReferenceExpression(new ThisReferenceExpression(), propertyName);
+				propertyReference.AddAnnotation(new MemberResolveResult(new ThisResolveResult(declaringType), property));
+
+				memberReference.ReplaceWith(propertyReference);
+			}
+
+			// Since the constructor instance is not changed, we can continue in the visitor as usual, so return null
+			return null;
+		}
+
 		void RemoveCompilerGeneratedAttribute(AstNodeCollection<AttributeSection> attributeSections)
 		{
 			foreach (AttributeSection section in attributeSections) {

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -8,6 +8,7 @@
 		<CheckBox IsChecked="{Binding AsyncAwait}">Decompile async methods (async/await)</CheckBox>
 		<CheckBox IsChecked="{Binding QueryExpressions}" IsEnabled="{Binding AnonymousMethods}">Decompile query expressions</CheckBox>
 		<CheckBox IsChecked="{Binding ExpressionTrees}">Decompile expression trees</CheckBox>
+		<CheckBox IsChecked="{Binding AutomaticProperties}">Decompile automatic properties</CheckBox>
 		<CheckBox IsChecked="{Binding UseDebugSymbols}">Use variable names from debug symbols, if available</CheckBox>
 		<CheckBox IsChecked="{Binding ShowXmlDocumentation}">Show XML documentation in decompiled code</CheckBox>
 		<CheckBox IsChecked="{Binding FoldBraces}">Enable folding on all blocks in braces</CheckBox>

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml.cs
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml.cs
@@ -53,6 +53,7 @@ namespace ICSharpCode.ILSpy.Options
 			s.AnonymousMethods = (bool?)e.Attribute("anonymousMethods") ?? s.AnonymousMethods;
 			s.YieldReturn = (bool?)e.Attribute("yieldReturn") ?? s.YieldReturn;
 			s.AsyncAwait = (bool?)e.Attribute("asyncAwait") ?? s.AsyncAwait;
+			s.AutomaticProperties = (bool?) e.Attribute("automaticProperties") ?? s.AutomaticProperties;
 			s.QueryExpressions = (bool?)e.Attribute("queryExpressions") ?? s.QueryExpressions;
 			s.ExpressionTrees = (bool?)e.Attribute("expressionTrees") ?? s.ExpressionTrees;
 			s.UseDebugSymbols = (bool?)e.Attribute("useDebugSymbols") ?? s.UseDebugSymbols;
@@ -68,6 +69,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("anonymousMethods", s.AnonymousMethods);
 			section.SetAttributeValue("yieldReturn", s.YieldReturn);
 			section.SetAttributeValue("asyncAwait", s.AsyncAwait);
+			section.SetAttributeValue("automaticProperties", s.AutomaticProperties);
 			section.SetAttributeValue("queryExpressions", s.QueryExpressions);
 			section.SetAttributeValue("expressionTrees", s.ExpressionTrees);
 			section.SetAttributeValue("useDebugSymbols", s.UseDebugSymbols);


### PR DESCRIPTION
Add support for the get-only properties decompilation. It's a rework of the #734. It fixes issues which were present in that version of PR (e.g. doesn't fail if you select property only).

Let me know if you have any concerns regarding the implementation. I've tried to make patterns as strict as possible (I'd say even overstrict ).

I intentionally haven't introduced a standalone setting for this feature for 2 reasons:
1. Read-only properties are just a kind of properties, they are still auto-properties.
2. If you enable auto-properties, but disable read-only properties, you will not have compiler generated fields for properties - [this](https://github.com/icsharpcode/ILSpy/blob/bdfc3903e11031e2403f2ef426ec6f83a621c10c/ICSharpCode.Decompiler/Ast/AstBuilder.cs#L99) code removes them. It would require extra-logic to separate fields which belong to R/W and R/O properties.

BTW, I looked for the place to put tests, however wasn't able to find it (I don't see similar tests, just some test classes). Does this project have tests? 😟 