### PR TITLE
Fix await calls not getting decompiled correctly

### DIFF
--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -198,8 +198,8 @@ namespace ICSharpCode.Decompiler.Tests
 			RunCS(options: options);
 		}
 
-		[Test, Ignore("Run() method cannot be fully decompiled.")]
-		public void Async([ValueSource("defaultOptions")] CompilerOptions options)
+		[Test]
+		public void Async([Values(CompilerOptions.None, CompilerOptions.Optimize)] CompilerOptions options)
 		{
 			RunCS(options: options);
 		}

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -814,7 +814,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			if (block.Instructions[pos].MatchStFld(out target, out field, out value)) {
 				if (!target.MatchLdThis())
 					return false;
-				if (!field.Equals(stateField))
+				if (!field.MemberDefinition.Equals(stateField.MemberDefinition))
 					return false;
 				if (!(value.MatchLdcI4(initialState) || value.MatchLdLoc(m1Var)))
 					return false;

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -774,14 +774,14 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				return false;
 			if (!target.MatchLdThis())
 				return false;
-			if (field.MemberDefinition != awaiterField)
+			if (!field.MemberDefinition.Equals(awaiterField.MemberDefinition))
 				return false;
 			pos++;
 
 			// stfld awaiterField(ldloc this, default.value)
 			if (block.Instructions[pos].MatchStFld(out target, out field, out value)
 				&& target.MatchLdThis()
-				&& field.MemberDefinition == awaiterField
+				&& field.MemberDefinition.Equals(awaiterField.MemberDefinition)
 				&& value.OpCode == OpCode.DefaultValue)
 			{
 				pos++;

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -774,14 +774,14 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				return false;
 			if (!target.MatchLdThis())
 				return false;
-			if (!field.MemberDefinition.Equals(awaiterField.MemberDefinition))
+			if (!field.Equals(awaiterField))
 				return false;
 			pos++;
 
 			// stfld awaiterField(ldloc this, default.value)
 			if (block.Instructions[pos].MatchStFld(out target, out field, out value)
 				&& target.MatchLdThis()
-				&& field.MemberDefinition.Equals(awaiterField.MemberDefinition)
+				&& field.Equals(awaiterField)
 				&& value.OpCode == OpCode.DefaultValue)
 			{
 				pos++;

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -789,10 +789,9 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				// {stloc V_6(default.value System.Runtime.CompilerServices.TaskAwaiter)}
 				// {stobj System.Runtime.CompilerServices.TaskAwaiter`1[[System.Int32]](ldflda <>u__$awaiter4(ldloc this), ldloc V_6) at IL_0163}
 				if (block.Instructions[pos].MatchStLoc(out var variable, out value) && value.OpCode == OpCode.DefaultValue
-					&& block.Instructions[pos + 1].MatchStObj(out var target2, out var value2, out var type)
-					&& value2.MatchLdLoc(variable) // ldloc V_6
-					&& target2.MatchLdFlda(out var targetInst, out var loadField) // ldflda <>u__$awaiter4(ldloc this)
-					&& loadField.Equals(awaiterField)) {
+					&& block.Instructions[pos + 1].MatchStFld(out target, out field, out value)
+					&& field.Equals(awaiterField)
+					&& value.MatchLdLoc(variable)) {
 					pos += 2;
 				}
 			}


### PR DESCRIPTION
Original:
```
using System;
using System.Collections.Generic;
using System.Linq;
using System.Text;
using System.Threading.Tasks;

namespace ILSpyBugs
{
	class Class1
	{
		private static async Task<T> RequestResultAsync<T>()
		{
			return await Task.Run(async delegate {
				return default(T);
			});
		}
	}
}
```
Was decompiled to:
```
// ILSpyBugs.Class1
using System;
using System.Runtime.CompilerServices;
using System.Threading.Tasks;

internal class Class1
{
	private static async Task<T> RequestResultAsync<T>()
	{
		TaskAwaiter<T> taskAwaiter = Task.Run<T>((Func<Task<T>>)(() => default(T))).GetAwaiter();
		if (!taskAwaiter.IsCompleted)
		{
			await taskAwaiter;
			TaskAwaiter<T> taskAwaiter2 = default(TaskAwaiter<T>);
			taskAwaiter = taskAwaiter2;
			int num;
			int num2 = num = -1;
		}
		return taskAwaiter.GetResult();
	}
}
```
Now gets decompiled to:
```
// ILSpyBugs.Class1
using System;
using System.Threading.Tasks;

internal class Class1
{
	private static async Task<T> RequestResultAsync<T>()
	{
		return await Task.Run<T>((Func<Task<T>>)(() => default(T)));
	}
}
```