### PR TITLE
Fix object initializer

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="DataFlowTest.cs" />
     <Compile Include="TestCases\Correctness\LINQRaytracer.cs" />
+    <Compile Include="TestCases\ILPretty\ObjectInitializer.cs" />
     <Compile Include="TestCases\Pretty\DelegateConstruction.cs" />
     <Compile Include="Helpers\CodeAssert.cs" />
     <Compile Include="Helpers\SdkUtility.cs" />
@@ -121,6 +122,7 @@
 
   <ItemGroup>
     <None Include="TestCases\ILPretty\Issue646.il" />
+    <None Include="TestCases\ILPretty\ObjectInitializer.il" />
     <None Include="TestCases\Pretty\HelloWorld.il">
       <DependentUpon>HelloWorld.cs</DependentUpon>
     </None>

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -41,6 +41,12 @@ namespace ICSharpCode.Decompiler.Tests
 		{
 			Run();
 		}
+
+		[Test]
+		public void ObjectInitializer()
+		{
+			Run();
+		}
 		
 		void Run([CallerMemberName] string testName = null)
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/ObjectInitializer.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/ObjectInitializer.cs
@@ -1,0 +1,35 @@
+﻿// ILSpyBugs.Program
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace ILSpyBugs
+{
+	internal class Program
+	{
+		private static void Main(string[] args)
+		{
+		}
+
+		private static HttpResponseMessage Aaa(Image image, string fileName)
+		{
+			MemoryStream memoryStream = new MemoryStream();
+			image.Save(memoryStream, ImageFormat.Jpeg);
+			memoryStream.Close();
+			MemoryStream memoryStream2 = new MemoryStream(memoryStream.ToArray());
+			return new HttpResponseMessage {
+				Content = new StreamContent(memoryStream2) {
+					Headers =  {
+						ContentDisposition = new ContentDispositionHeaderValue("aaa") {
+							FileName = fileName
+						},
+						ContentType = new MediaTypeHeaderValue("bbb"),
+						ContentLength = new long?(memoryStream2.Length)
+					}
+				}
+			};
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/ObjectInitializer.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/ObjectInitializer.il
@@ -1,0 +1,103 @@
+﻿.assembly ILSpyBugs
+{
+	
+	.hash algorithm 0x00008004 // SHA1
+	.ver 1:0:0:0
+}
+
+.module ILSpyBugs.exe
+// MVID: {BAB92FF9-8191-4D51-9A72-CD3EE83B18CD}
+.corflags 0x00020003 // ILOnly, Required32Bit, Preferred32Bit
+
+
+.class private auto ansi beforefieldinit ILSpyBugs.Program
+	extends [mscorlib]System.Object
+{
+
+.method private hidebysig static 
+	void Main (
+		string[] args
+	) cil managed 
+{
+	// Method begins at RVA 0x2050
+	// Code size 8 (0x8)
+	.maxstack 8
+	.entrypoint
+	IL_0000: nop
+	IL_0007: ret
+}
+
+.method private hidebysig static 
+	class [System.Net.Http]System.Net.Http.HttpResponseMessage Aaa(
+		class [System.Drawing]System.Drawing.Image image,
+		string fileName
+	) cil managed 
+{
+	// Method begins at RVA 0x49c4
+	// Code size 155 (0x9b)
+	.maxstack 3
+	.locals init (
+		[0] class [mscorlib]System.IO.MemoryStream,
+		[1] class [mscorlib]System.IO.MemoryStream
+	)
+
+	IL_0000: newobj instance void [mscorlib]System.IO.MemoryStream::.ctor()
+	IL_0005: stloc.0
+	IL_0006: ldarg.0
+	IL_0007: ldloc.0
+	IL_0008: call class [System.Drawing]System.Drawing.Imaging.ImageFormat [System.Drawing]System.Drawing.Imaging.ImageFormat::get_Jpeg()
+	IL_000d: callvirt instance void [System.Drawing]System.Drawing.Image::Save(class [mscorlib]System.IO.Stream, class [System.Drawing]System.Drawing.Imaging.ImageFormat)
+	IL_0012: ldloc.0
+	IL_0013: callvirt instance void [mscorlib]System.IO.Stream::Close()
+	IL_0018: ldloc.0
+	IL_0019: callvirt instance uint8[] [mscorlib]System.IO.MemoryStream::ToArray()
+	IL_001e: newobj instance void [mscorlib]System.IO.MemoryStream::.ctor(uint8[])
+	IL_0023: stloc.1
+	IL_0024: newobj instance void [System.Net.Http]System.Net.Http.HttpResponseMessage::.ctor()
+	IL_0029: dup
+	IL_002a: ldloc.1
+	IL_002b: newobj instance void [System.Net.Http]System.Net.Http.StreamContent::.ctor(class [mscorlib]System.IO.Stream)
+	IL_0030: callvirt instance void [System.Net.Http]System.Net.Http.HttpResponseMessage::set_Content(class [System.Net.Http]System.Net.Http.HttpContent)
+	IL_0035: dup
+	IL_0036: callvirt instance class [System.Net.Http]System.Net.Http.HttpContent [System.Net.Http]System.Net.Http.HttpResponseMessage::get_Content()
+	IL_003b: callvirt instance class [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders [System.Net.Http]System.Net.Http.HttpContent::get_Headers()
+	IL_0040: ldstr "aaa"
+	IL_0045: newobj instance void [System.Net.Http]System.Net.Http.Headers.ContentDispositionHeaderValue::.ctor(string)
+	IL_004a: callvirt instance void [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders::set_ContentDisposition(class [System.Net.Http]System.Net.Http.Headers.ContentDispositionHeaderValue)
+	IL_004f: dup
+	IL_0050: callvirt instance class [System.Net.Http]System.Net.Http.HttpContent [System.Net.Http]System.Net.Http.HttpResponseMessage::get_Content()
+	IL_0055: callvirt instance class [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders [System.Net.Http]System.Net.Http.HttpContent::get_Headers()
+	IL_005a: callvirt instance class [System.Net.Http]System.Net.Http.Headers.ContentDispositionHeaderValue [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders::get_ContentDisposition()
+	IL_005f: ldarg.1
+	IL_0060: callvirt instance void [System.Net.Http]System.Net.Http.Headers.ContentDispositionHeaderValue::set_FileName(string)
+	IL_0065: dup
+	IL_0066: callvirt instance class [System.Net.Http]System.Net.Http.HttpContent [System.Net.Http]System.Net.Http.HttpResponseMessage::get_Content()
+	IL_006b: callvirt instance class [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders [System.Net.Http]System.Net.Http.HttpContent::get_Headers()
+	IL_0070: ldstr "bbb"
+	IL_0075: newobj instance void [System.Net.Http]System.Net.Http.Headers.MediaTypeHeaderValue::.ctor(string)
+	IL_007a: callvirt instance void [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders::set_ContentType(class [System.Net.Http]System.Net.Http.Headers.MediaTypeHeaderValue)
+	IL_007f: dup
+	IL_0080: callvirt instance class [System.Net.Http]System.Net.Http.HttpContent [System.Net.Http]System.Net.Http.HttpResponseMessage::get_Content()
+	IL_0085: callvirt instance class [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders [System.Net.Http]System.Net.Http.HttpContent::get_Headers()
+	IL_008a: ldloc.1
+	IL_008b: callvirt instance int64 [mscorlib]System.IO.Stream::get_Length()
+	IL_0090: newobj instance void valuetype [mscorlib]System.Nullable`1<int64>::.ctor(!0)
+	IL_0095: callvirt instance void [System.Net.Http]System.Net.Http.Headers.HttpContentHeaders::set_ContentLength(valuetype [mscorlib]System.Nullable`1<int64>)
+	IL_009a: ret
+}
+
+
+.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x20d5
+		// Code size 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [mscorlib]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	}
+
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
@@ -231,6 +231,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		private bool CheckSetter(ILInstruction inst, string propertyName, ILInstruction onObject)
 		{
+			if (!(inst is CallInstruction setterInst))
+				return false;
+			if (!setterInst.Method.Name.StartsWith("set_"))
+				return false;
 			// inst: callvirt set...(callvirt get...(callvirt get_Content(ldloc obj)), newobj)
 			// propertyName: Content
 			// onObject: ldloc obj

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
@@ -43,6 +43,66 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		bool DoTransform(Block body, int pos)
 		{
 			ILInstruction inst = body.Instructions[pos];
+			
+			// Match callvirt set_Content(ldloc obj, newobj)
+			if (inst is CallInstruction callInst) {
+				(var kind, var path, var values, var targetVariable) = AccessPathElement.GetAccessPath(callInst, null, new Dictionary<ILVariable, (int Index, ILInstruction Value)>());
+				if (kind != AccessPathKind.Setter)
+					return false;
+				string propertyName = callInst.Method.FullName.Replace("set", "");
+				int initializerItemsCount = 0;
+				while (pos + initializerItemsCount + 1 < body.Instructions.Count
+					&& CheckSetter(body.Instructions[pos + initializerItemsCount + 1], propertyName, callInst.Arguments[0])) {
+					initializerItemsCount++;
+				}
+				if (initializerItemsCount == 0)
+					return false;
+				Block initializerBlock = new Block(BlockType.ObjectInitializer);
+				IType instType = null;
+				switch (callInst.Arguments[1]) {
+					case NewObj newObjInst:
+						instType = newObjInst.Method.DeclaringType;
+						break;
+					case DefaultValue defaultVal:
+						instType = defaultVal.Type;
+						break;
+					case Block existingInitializer:
+						if (existingInitializer.Type == BlockType.CollectionInitializer || existingInitializer.Type == BlockType.ObjectInitializer) {
+							initializerBlock = existingInitializer;
+							var value = ((StLoc)initializerBlock.Instructions[0]).Value;
+							if (value is NewObj no)
+								instType = no.Method.DeclaringType;
+							else
+								instType = ((DefaultValue)value).Type;
+							break;
+						}
+						return false;
+					default:
+						return false;
+				}
+				var finalSlot = context.Function.RegisterVariable(VariableKind.InitializerTarget, instType);
+				initializerBlock.FinalInstruction = new LdLoc(finalSlot);
+				initializerBlock.Instructions.Add(new StLoc(finalSlot, callInst.Arguments[1].Clone()));
+
+				for (int i = 1; i <= initializerItemsCount; i++) {
+					CallInstruction c = body.Instructions[i + pos].Clone() as CallInstruction;
+					foreach (CallInstruction call in c.Descendants.OfType<CallInstruction>()) {
+						if (call.Method.FullName.Replace("get", "").Equals(propertyName)) {
+							// callvirt get_Content(ldloc obj)
+							if (SpecialToString(callInst.Arguments[0]).Equals(SpecialToString(callInst.Arguments[0]))) {
+								call.ReplaceWith(new LdLoc(finalSlot));
+							}
+						}
+					}
+					initializerBlock.Instructions.Add(c);
+				}
+
+				callInst.Arguments[1].ReplaceWith(initializerBlock);
+				body.Instructions.RemoveRange(pos + 1, initializerItemsCount);
+				ILInlining.InlineIfPossible(body, pos, context);
+				return true;
+			}
+
 			// Match stloc(v, newobj)
 			if (inst.MatchStLoc(out var v, out var initInst) && (v.Kind == VariableKind.Local || v.Kind == VariableKind.StackSlot)) {
 				Block initializerBlock = null;
@@ -160,6 +220,28 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				default:
 					return false;
 			}
+		}
+
+		private string SpecialToString(ILInstruction instruction)
+		{
+			var output = new PlainTextOutput();
+			instruction.WriteTo(output, new ILAstWritingOptions());
+			return output.ToString();
+		}
+
+		private bool CheckSetter(ILInstruction inst, string propertyName, ILInstruction onObject)
+		{
+			// inst: callvirt set...(callvirt get...(callvirt get_Content(ldloc obj)), newobj)
+			// propertyName: Content
+			// onObject: ldloc obj
+			foreach (CallInstruction callInst in inst.Descendants.OfType<CallInstruction>()) {
+				if (callInst.Method.FullName.Replace("get", "").Equals(propertyName)) {
+					// callvirt get_Content(ldloc obj)
+					if (SpecialToString(callInst.Arguments[0]).Equals(SpecialToString(onObject)))
+						return true;
+				}
+			}
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Before:
```
return new HttpResponseMessage
{
	Content = new StreamContent(memoryStream2),
	Content = 
	{
		Headers = 
		{
			ContentDisposition = new ContentDispositionHeaderValue("aaa"),
			ContentDisposition = 
			{
				FileName = fileName
			},
			ContentType = new MediaTypeHeaderValue("bbb"),
			ContentLength = new long?(memoryStream2.Length)
		}
	}
};
```
I had to use an IL test as I could not find code which reproduces that issue.
Feedback please...