### PR TITLE
Initializer

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="TestCases\Correctness\Using.cs" />
     <Compile Include="TestCases\ILPretty\Issue379.cs" />
     <Compile Include="TestCases\Pretty\FixProxyCalls.cs" />
+    <Compile Include="TestCases\Pretty\InitializerTests.cs" />
     <None Include="TestCases\ILPretty\Issue646.cs" />
     <Compile Include="TestCases\Pretty\Async.cs" />
     <Compile Include="TestCases\Pretty\CheckedUnchecked.cs" />

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -189,6 +189,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public void InitializerTests([ValueSource("defaultOptions")] CompilerOptions cscOptions)
+		{
+			Run(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public void FixProxyCalls([Values(CompilerOptions.None, CompilerOptions.Optimize, CompilerOptions.UseRoslyn)] CompilerOptions cscOptions)
 		{
 			Run(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public class InitializerTests
+	{
+		public class C
+		{
+			public int Z;
+			public S Y;
+			public List<S> L;
+		}
+
+		public struct S
+		{
+			public int A;
+			public int B;
+
+			public S(int a)
+			{
+				this.A = a;
+				this.B = 0;
+			}
+		}
+
+		public static C TestCall(int a, C c)
+		{
+			return c;
+		}
+
+		public C Test()
+		{
+			C c = new C();
+			c.L = new List<S>();
+			c.L.Add(new S(1));
+			return c;
+		}
+
+		public C Test2()
+		{
+			C c = new C();
+			c.Z = 1;
+			c.Z = 2;
+			return c;
+		}
+
+		public C Test3()
+		{
+			C c = new C();
+			c.Y = new S(1);
+			c.Y.A = 2;
+			return c;
+		}
+
+		public C Test3b()
+		{
+			return InitializerTests.TestCall(0, new C {
+				Z = 1,
+				Y =  {
+					A = 2
+				}
+			});
+		}
+
+		public C Test4()
+		{
+			C c = new C();
+			c.Y.A = 1;
+			c.Y.B = 3;
+			c.Z = 2;
+			return c;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -338,7 +338,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			InitializerTests.X(InitializerTests.Y(), new Data {
 				MoreData = {
 					a = MyEnum.a,
-					[2] = (Data)null
+					[2] = null
 				}
 			});
 		}
@@ -348,11 +348,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			InitializerTests.X(InitializerTests.Y(), new Data {
 				MoreData = {
 					a = MyEnum.a,
-					[GetInt()] = {
+					[InitializerTests.GetInt()] = {
 						a = MyEnum.b,
-						FieldList = { MyEnum2.c },
-						[GetInt(), GetString()] = new Data(),
-						[2] = (Data)null
+						FieldList = {
+							MyEnum2.c
+						},
+						[InitializerTests.GetInt(), InitializerTests.GetString()] = new Data(),
+						[2] = null
 					}
 				}
 			});
@@ -397,7 +399,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void NotAStructInitializer_DefaultConstructor()
 		{
-			StructData structData = new StructData();
+			StructData structData = default(StructData);
 			structData.Field = 1;
 			structData.Property = 2;
 			InitializerTests.X(InitializerTests.Y(), structData);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -17,11 +17,15 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
 	public class InitializerTests
 	{
+		#region Types and helpers
 		public class C
 		{
 			public int Z;
@@ -41,10 +45,102 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		private enum MyEnum
+		{
+			a = 0,
+			b = 1
+		}
+
+		private enum MyEnum2
+		{
+			c = 0,
+			d = 1
+		}
+
+		private class Data
+		{
+			public List<MyEnum2> FieldList = new List<MyEnum2>();
+			public MyEnum a {
+				get;
+				set;
+			}
+			public MyEnum b {
+				get;
+				set;
+			}
+			public List<MyEnum2> PropertyList {
+				get;
+				set;
+			}
+
+			public Data MoreData {
+				get;
+				set;
+			}
+
+			public StructData NestedStruct {
+				get;
+				set;
+			}
+
+			public Data this[int i] {
+				get {
+					return null;
+				}
+				set {
+				}
+			}
+
+			public Data this[int i, string j] {
+				get {
+					return null;
+				}
+				set {
+				}
+			}
+		}
+
+		private struct StructData
+		{
+			public int Field;
+			public int Property {
+				get;
+				set;
+			}
+
+			public Data MoreData {
+				get;
+				set;
+			}
+
+			public StructData(int initialValue)
+			{
+				this = default(StructData);
+				this.Field = initialValue;
+				this.Property = initialValue;
+			}
+		}
+
+		// Helper methods used to ensure initializers used within expressions work correctly
+		private static void X(object a, object b)
+		{
+		}
+
+		private static object Y()
+		{
+			return null;
+		}
+
+		public static void TestCall(int a, Thread thread)
+		{
+
+		}
+
 		public static C TestCall(int a, C c)
 		{
 			return c;
 		}
+		#endregion
 
 		public C Test1()
 		{
@@ -83,7 +179,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return InitializerTests.TestCall(0, new C {
 				Z = 1,
-				Y =  {
+				Y = {
 					A = 2
 				}
 			});
@@ -96,6 +192,279 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			c.Z = 2;
 			c.Y.B = 3;
 			return c;
+		}
+
+
+		public static void CollectionInitializerList()
+		{
+			InitializerTests.X(InitializerTests.Y(), new List<int> {
+				1,
+				2,
+				3
+			});
+		}
+
+		public static object RecursiveCollectionInitializer()
+		{
+			List<object> list = new List<object>();
+			list.Add(list);
+			return list;
+		}
+
+		public static void CollectionInitializerDictionary()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Dictionary<string, int> {
+			{
+				"First",
+				1
+			},
+			{
+				"Second",
+				2
+			},
+			{
+				"Third",
+				3
+			}
+		  });
+		}
+
+		public static void CollectionInitializerDictionaryWithEnumTypes()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Dictionary<MyEnum, MyEnum2> {
+			{
+				MyEnum.a,
+				MyEnum2.c
+			},
+			{
+				MyEnum.b,
+				MyEnum2.d
+			}
+		  });
+		}
+
+		public static void NotACollectionInitializer()
+		{
+			List<int> list = new List<int>();
+			list.Add(1);
+			list.Add(2);
+			list.Add(3);
+			InitializerTests.X(InitializerTests.Y(), list);
+		}
+
+		public static void ObjectInitializer()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				a = MyEnum.a
+			});
+		}
+
+		public static void NotAnObjectInitializer()
+		{
+			Data data = new Data();
+			data.a = MyEnum.a;
+			InitializerTests.X(InitializerTests.Y(), data);
+		}
+
+		public static void ObjectInitializerAssignCollectionToField()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				a = MyEnum.a,
+				FieldList = new List<MyEnum2> {
+					MyEnum2.c,
+					MyEnum2.d
+				}
+			});
+		}
+
+		public static void ObjectInitializerAddToCollectionInField()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				a = MyEnum.a,
+				FieldList = {
+					MyEnum2.c,
+					MyEnum2.d
+				}
+			});
+		}
+
+		public static void ObjectInitializerAssignCollectionToProperty()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				a = MyEnum.a,
+				PropertyList = new List<MyEnum2> {
+					MyEnum2.c,
+					MyEnum2.d
+				}
+			});
+		}
+
+		public static void ObjectInitializerAddToCollectionInProperty()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				a = MyEnum.a,
+				PropertyList = {
+					MyEnum2.c,
+					MyEnum2.d
+				}
+			});
+		}
+
+		public static void ObjectInitializerWithInitializationOfNestedObjects()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				MoreData = {
+					a = MyEnum.a,
+					MoreData = {
+						a = MyEnum.b
+					}
+				}
+			});
+		}
+
+		private static int GetInt()
+		{
+			return 1;
+		}
+
+		private static string GetString()
+		{
+			return "Test";
+		}
+
+#if !LEGACY_CSC
+		public static void SimpleDictInitializer()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				MoreData = {
+					a = MyEnum.a,
+					[2] = (Data)null
+				}
+			});
+		}
+
+		public static void MixedObjectAndDictInitializer()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				MoreData = {
+					a = MyEnum.a,
+					[GetInt()] = {
+						a = MyEnum.b,
+						FieldList = { MyEnum2.c },
+						[GetInt(), GetString()] = new Data(),
+						[2] = (Data)null
+					}
+				}
+			});
+		}
+#endif
+
+		public static void ObjectInitializerWithInitializationOfDeeplyNestedObjects()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				a = MyEnum.b,
+				MoreData = {
+				  a = MyEnum.a,
+				  MoreData = {
+						MoreData = {
+							MoreData = {
+								MoreData = {
+									MoreData = {
+										MoreData = {
+											a = MyEnum.b
+										}
+									}
+								}
+							}
+						}
+					}
+			  }
+			});
+		}
+
+		public static void CollectionInitializerInsideObjectInitializers()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				MoreData = new Data {
+					a = MyEnum.a,
+					b = MyEnum.b,
+					PropertyList = {
+						MyEnum2.c
+					}
+				}
+			});
+		}
+
+		public static void NotAStructInitializer_DefaultConstructor()
+		{
+			StructData structData = new StructData();
+			structData.Field = 1;
+			structData.Property = 2;
+			InitializerTests.X(InitializerTests.Y(), structData);
+		}
+
+		public static void StructInitializer_DefaultConstructor()
+		{
+			InitializerTests.X(InitializerTests.Y(), new StructData {
+				Field = 1,
+				Property = 2
+			});
+		}
+
+		public static void NotAStructInitializer_ExplicitConstructor()
+		{
+			StructData structData = new StructData(0);
+			structData.Field = 1;
+			structData.Property = 2;
+			InitializerTests.X(InitializerTests.Y(), structData);
+		}
+
+		public static void StructInitializer_ExplicitConstructor()
+		{
+			InitializerTests.X(InitializerTests.Y(), new StructData(0) {
+				Field = 1,
+				Property = 2
+			});
+		}
+
+		public static void StructInitializerWithInitializationOfNestedObjects()
+		{
+			InitializerTests.X(InitializerTests.Y(), new StructData {
+				MoreData = {
+					a = MyEnum.a,
+					FieldList = {
+						MyEnum2.c,
+						MyEnum2.d
+					}
+				}
+			});
+		}
+
+		public static void StructInitializerWithinObjectInitializer()
+		{
+			InitializerTests.X(InitializerTests.Y(), new Data {
+				NestedStruct = new StructData(2) {
+					Field = 1,
+					Property = 2
+				}
+			});
+		}
+
+		public static void Bug270_NestedInitialisers()
+		{
+			NumberFormatInfo[] source = null;
+
+			InitializerTests.TestCall(0, new Thread(InitializerTests.Bug270_NestedInitialisers) {
+				Priority = ThreadPriority.BelowNormal,
+				CurrentCulture = new CultureInfo(0) {
+					DateTimeFormat = new DateTimeFormatInfo {
+						ShortDatePattern = "ddmmyy"
+					},
+					NumberFormat = (from format in source
+									where format.CurrencySymbol == "$"
+									select format).First()
+				}
+			});
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -46,12 +46,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return c;
 		}
 
-		public C Test()
+		public C Test1()
 		{
 			C c = new C();
 			c.L = new List<S>();
 			c.L.Add(new S(1));
 			return c;
+		}
+
+		public C Test1Alternative()
+		{
+			return InitializerTests.TestCall(1, new C {
+				L = new List<S> {
+					new S(1)
+				}
+			});
 		}
 
 		public C Test2()
@@ -84,8 +93,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			C c = new C();
 			c.Y.A = 1;
-			c.Y.B = 3;
 			c.Z = 2;
+			c.Y.B = 3;
 			return c;
 		}
 	}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -98,6 +99,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				set {
 				}
 			}
+
+			public event EventHandler TestEvent;
 		}
 
 		private struct StructData
@@ -263,6 +266,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			Data data = new Data();
 			data.a = MyEnum.a;
+			InitializerTests.X(InitializerTests.Y(), data);
+		}
+
+		public static void NotAnObjectInitializerWithEvent()
+		{
+			Data data = new Data();
+			data.TestEvent += delegate(object sender, EventArgs e) {
+				Console.WriteLine();
+			};
 			InitializerTests.X(InitializerTests.Y(), data);
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
@@ -1,0 +1,245 @@
+
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Copyright (c) Microsoft Corporation. Alle Rechte vorbehalten.
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly '0zopdghu'
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+  .permissionset reqmin
+             = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module '0zopdghu.dll'
+// MVID: {56C873AC-FD1E-4808-A65A-845BA0A3C2B7}
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x032A0000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested public beforefieldinit C
+         extends [mscorlib]System.Object
+  {
+    .field public int32 Z
+    .field public valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S Y
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> L
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method C::.ctor
+
+  } // end of class C
+
+  .class sequential ansi sealed nested public beforefieldinit S
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 A
+    .field public int32 B
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 a) cil managed
+    {
+      // Code size       16 (0x10)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ldarg.0
+      IL_0002:  ldarg.1
+      IL_0003:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+      IL_0008:  ldarg.0
+      IL_0009:  ldc.i4.0
+      IL_000a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+      IL_000f:  ret
+    } // end of method S::.ctor
+
+  } // end of class S
+
+  .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          TestCall(int32 a,
+                   class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C c) cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method InitializerTests::TestCall
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test() cil managed
+  {
+    // Code size       42 (0x2a)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000d:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0012:  ldloc.0
+    IL_0013:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0018:  ldc.i4.1
+    IL_0019:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_001e:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_0023:  nop
+    IL_0024:  ldloc.0
+    IL_0025:  stloc.1
+    IL_0026:  br.s       IL_0028
+
+    IL_0028:  ldloc.1
+    IL_0029:  ret
+  } // end of method InitializerTests::Test
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test2() cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000e:  ldloc.0
+    IL_000f:  ldc.i4.2
+    IL_0010:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0015:  ldloc.0
+    IL_0016:  stloc.1
+    IL_0017:  br.s       IL_0019
+
+    IL_0019:  ldloc.1
+    IL_001a:  ret
+  } // end of method InitializerTests::Test2
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3() cil managed
+  {
+    // Code size       37 (0x25)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_000e:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0013:  ldloc.0
+    IL_0014:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0019:  ldc.i4.2
+    IL_001a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001f:  ldloc.0
+    IL_0020:  stloc.1
+    IL_0021:  br.s       IL_0023
+
+    IL_0023:  ldloc.1
+    IL_0024:  ret
+  } // end of method InitializerTests::Test3
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3b() cil managed
+  {
+    // Code size       38 (0x26)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.0
+    IL_0002:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  ldc.i4.1
+    IL_000a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000f:  ldloc.0
+    IL_0010:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0015:  ldc.i4.2
+    IL_0016:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001b:  ldloc.0
+    IL_001c:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_0021:  stloc.1
+    IL_0022:  br.s       IL_0024
+
+    IL_0024:  ldloc.1
+    IL_0025:  ret
+  } // end of method InitializerTests::Test3b
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test4() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_000d:  ldc.i4.1
+    IL_000e:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_0013:  ldloc.0
+    IL_0014:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0019:  ldc.i4.3
+    IL_001a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+    IL_001f:  ldloc.0
+    IL_0020:  ldc.i4.2
+    IL_0021:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0026:  ldloc.0
+    IL_0027:  stloc.1
+    IL_0028:  br.s       IL_002a
+
+    IL_002a:  ldloc.1
+    IL_002b:  ret
+  } // end of method InitializerTests::Test4
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method InitializerTests::.ctor
+
+} // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************
+// Warnung: Win32-Ressourcendatei "../../../TestCases/Pretty\InitializerTests.res" wurde erstellt.

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
@@ -10,7 +10,7 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly '0meyjl4r'
+.assembly umgm00go
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
@@ -20,15 +20,15 @@
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module '0meyjl4r.dll'
-// MVID: {DBAD72F7-978F-407F-9C77-44D3E99CD8AD}
+.module umgm00go.dll
+// MVID: {8C42504A-ACC6-453C-81BA-626AB6649E25}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02FE0000
+// Image base: 0x02AE0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
@@ -15,25 +15,25 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly xws4p1nr
+.assembly n0iwoj0v
 {
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                              63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .permissionset reqmin
              = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module xws4p1nr.dll
-// MVID: {D353AAAB-C54F-4C62-88DC-E9FF995570BA}
+.module n0iwoj0v.dll
+// MVID: {04AC1961-FA71-4E8B-A77B-45FF217A617C}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x002F0000
+// Image base: 0x009A0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -102,6 +102,7 @@
   {
     .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
     .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> FieldList
+    .field private class [mscorlib]System.EventHandler TestEvent
     .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<a>k__BackingField'
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<b>k__BackingField'
@@ -311,6 +312,86 @@
       IL_0001:  ret
     } // end of method Data::set_Item
 
+    .method public hidebysig specialname 
+            instance void  add_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      // Code size       48 (0x30)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2,
+               bool V_3)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Combine(class [mscorlib]System.Delegate,
+                                                                                              class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  ceq
+      IL_0028:  ldc.i4.0
+      IL_0029:  ceq
+      IL_002b:  stloc.3
+      IL_002c:  ldloc.3
+      IL_002d:  brtrue.s   IL_0007
+
+      IL_002f:  ret
+    } // end of method Data::add_TestEvent
+
+    .method public hidebysig specialname 
+            instance void  remove_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      // Code size       48 (0x30)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2,
+               bool V_3)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Remove(class [mscorlib]System.Delegate,
+                                                                                             class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  ceq
+      IL_0028:  ldc.i4.0
+      IL_0029:  ceq
+      IL_002b:  stloc.3
+      IL_002c:  ldloc.3
+      IL_002d:  brtrue.s   IL_0007
+
+      IL_002f:  ret
+    } // end of method Data::remove_TestEvent
+
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
     {
@@ -325,6 +406,11 @@
       IL_0012:  ret
     } // end of method Data::.ctor
 
+    .event [mscorlib]System.EventHandler TestEvent
+    {
+      .removeon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::remove_TestEvent(class [mscorlib]System.EventHandler)
+      .addon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+    } // end of event Data::TestEvent
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
             a()
     {
@@ -334,33 +420,33 @@
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
             b()
     {
-      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
       .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_b()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
     } // end of property Data::b
     .property instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>
             PropertyList()
     {
-      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
       .get instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
     } // end of property Data::PropertyList
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             MoreData()
     {
-      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
       .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
     } // end of property Data::MoreData
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
             NestedStruct()
     {
-      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
       .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
     } // end of property Data::NestedStruct
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             Item(int32)
     {
-      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
       .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
                                                                                                        class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
     } // end of property Data::Item
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             Item(int32,
@@ -459,8 +545,8 @@
 
     .property instance int32 Property()
     {
-      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
       .get instance int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_Property()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
     } // end of property StructData::Property
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             MoreData()
@@ -470,7 +556,9 @@
     } // end of property StructData::MoreData
   } // end of class StructData
 
-  .field private static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> 'CS$<>9__CachedAnonymousMethodDelegate1a'
+  .field private static class [mscorlib]System.EventHandler 'CS$<>9__CachedAnonymousMethodDelegate8'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> 'CS$<>9__CachedAnonymousMethodDelegate1c'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method private hidebysig static void  X(object a,
                                            object b) cil managed
@@ -866,6 +954,37 @@
     IL_001a:  nop
     IL_001b:  ret
   } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializerWithEvent() cil managed
+  {
+    // Code size       58 (0x3a)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate8'
+    IL_000d:  brtrue.s   IL_0022
+
+    IL_000f:  ldnull
+    IL_0010:  ldftn      void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<NotAnObjectInitializerWithEvent>b__7'(object,
+                                                                                                                                      class [mscorlib]System.EventArgs)
+    IL_0016:  newobj     instance void [mscorlib]System.EventHandler::.ctor(object,
+                                                                            native int)
+    IL_001b:  stsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate8'
+    IL_0020:  br.s       IL_0022
+
+    IL_0022:  ldsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate8'
+    IL_0027:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+    IL_002c:  nop
+    IL_002d:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0032:  ldloc.0
+    IL_0033:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0038:  nop
+    IL_0039:  ret
+  } // end of method InitializerTests::NotAnObjectInitializerWithEvent
 
   .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
   {
@@ -1329,17 +1448,17 @@
     IL_003f:  nop
     IL_0040:  ldloc.2
     IL_0041:  ldloc.0
-    IL_0042:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0042:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1c'
     IL_0047:  brtrue.s   IL_005c
 
     IL_0049:  ldnull
-    IL_004a:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_004a:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<Bug270_NestedInitialisers>b__1b'(class [mscorlib]System.Globalization.NumberFormatInfo)
     IL_0050:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
                                                                                                                                         native int)
-    IL_0055:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0055:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1c'
     IL_005a:  br.s       IL_005c
 
-    IL_005c:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_005c:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1c'
     IL_0061:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                          class [mscorlib]System.Func`2<!!0,bool>)
     IL_0066:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
@@ -1365,7 +1484,18 @@
     IL_0006:  ret
   } // end of method InitializerTests::.ctor
 
-  .method private hidebysig static bool  '<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+  .method private hidebysig static void  '<NotAnObjectInitializerWithEvent>b__7'(object sender,
+                                                                                 class [mscorlib]System.EventArgs e) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  call       void [mscorlib]System.Console::WriteLine()
+    IL_0005:  nop
+    IL_0006:  ret
+  } // end of method InitializerTests::'<NotAnObjectInitializerWithEvent>b__7'
+
+  .method private hidebysig static bool  '<Bug270_NestedInitialisers>b__1b'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       21 (0x15)
@@ -1381,7 +1511,7 @@
 
     IL_0013:  ldloc.0
     IL_0014:  ret
-  } // end of method InitializerTests::'<Bug270_NestedInitialisers>b__19'
+  } // end of method InitializerTests::'<Bug270_NestedInitialisers>b__1b'
 
 } // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
@@ -10,25 +10,30 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly umgm00go
+.assembly extern System.Core
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly xws4p1nr
+{
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                              63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .permissionset reqmin
              = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module umgm00go.dll
-// MVID: {8C42504A-ACC6-453C-81BA-626AB6649E25}
+.module xws4p1nr.dll
+// MVID: {D353AAAB-C54F-4C62-88DC-E9FF995570BA}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02AE0000
+// Image base: 0x002F0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -75,6 +80,430 @@
     } // end of method S::.ctor
 
   } // end of class S
+
+  .class auto ansi sealed nested private MyEnum
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum a = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum b = int32(0x00000001)
+  } // end of class MyEnum
+
+  .class auto ansi sealed nested private MyEnum2
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 c = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 d = int32(0x00000001)
+  } // end of class MyEnum2
+
+  .class auto ansi nested private beforefieldinit Data
+         extends [mscorlib]System.Object
+  {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> FieldList
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<a>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<b>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> '<PropertyList>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData '<NestedStruct>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_a() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method Data::get_a
+
+    .method public hidebysig specialname 
+            instance void  set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_a
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_b() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method Data::get_b
+
+    .method public hidebysig specialname 
+            instance void  set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_b
+
+    .method public hidebysig specialname 
+            instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 
+            get_PropertyList() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method Data::get_PropertyList
+
+    .method public hidebysig specialname 
+            instance void  set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_PropertyList
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method Data::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_MoreData
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 
+            get_NestedStruct() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method Data::get_NestedStruct
+
+    .method public hidebysig specialname 
+            instance void  set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_NestedStruct
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+      IL_0000:  nop
+      IL_0001:  ldnull
+      IL_0002:  stloc.0
+      IL_0003:  br.s       IL_0005
+
+      IL_0005:  ldloc.0
+      IL_0006:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i,
+                     string j) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+      IL_0000:  nop
+      IL_0001:  ldnull
+      IL_0002:  stloc.0
+      IL_0003:  br.s       IL_0005
+
+      IL_0005:  ldloc.0
+      IL_0006:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    string j,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       19 (0x13)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+      IL_0006:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+      IL_000b:  ldarg.0
+      IL_000c:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0011:  nop
+      IL_0012:  ret
+    } // end of method Data::.ctor
+
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            a()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_a()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    } // end of property Data::a
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            b()
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_b()
+    } // end of property Data::b
+    .property instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>
+            PropertyList()
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+      .get instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    } // end of property Data::PropertyList
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::MoreData
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+            NestedStruct()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    } // end of property Data::NestedStruct
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32)
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::Item
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32,
+                 string)
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       string,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32,
+                                                                                                                                                                            string)
+    } // end of property Data::Item
+  } // end of class Data
+
+  .class sequential ansi sealed nested private beforefieldinit StructData
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 Field
+    .field private int32 '<Property>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance int32  get_Property() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (int32 V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method StructData::get_Property
+
+    .method public hidebysig specialname 
+            instance void  set_Property(int32 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_Property
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       11 (0xb)
+      .maxstack  1
+      .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0006:  stloc.0
+      IL_0007:  br.s       IL_0009
+
+      IL_0009:  ldloc.0
+      IL_000a:  ret
+    } // end of method StructData::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_MoreData
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 initialValue) cil managed
+    {
+      // Code size       24 (0x18)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ldarg.0
+      IL_0002:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+      IL_0008:  ldarg.0
+      IL_0009:  ldarg.1
+      IL_000a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+      IL_000f:  ldarg.0
+      IL_0010:  ldarg.1
+      IL_0011:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+      IL_0016:  nop
+      IL_0017:  ret
+    } // end of method StructData::.ctor
+
+    .property instance int32 Property()
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+      .get instance int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_Property()
+    } // end of property StructData::Property
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property StructData::MoreData
+  } // end of class StructData
+
+  .field private static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> 'CS$<>9__CachedAnonymousMethodDelegate1a'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method private hidebysig static void  X(object a,
+                                           object b) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method InitializerTests::X
+
+  .method private hidebysig static object 
+          Y() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (object V_0)
+    IL_0000:  nop
+    IL_0001:  ldnull
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method InitializerTests::Y
+
+  .method public hidebysig static void  TestCall(int32 a,
+                                                 class [mscorlib]System.Threading.Thread thread) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method InitializerTests::TestCall
 
   .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           TestCall(int32 a,
@@ -258,6 +687,674 @@
     IL_002b:  ret
   } // end of method InitializerTests::Test4
 
+  .method public hidebysig static void  CollectionInitializerList() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  ldc.i4.2
+    IL_0016:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001b:  nop
+    IL_001c:  ldloc.0
+    IL_001d:  ldc.i4.3
+    IL_001e:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0023:  nop
+    IL_0024:  ldloc.0
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::CollectionInitializerList
+
+  .method public hidebysig static object 
+          RecursiveCollectionInitializer() cil managed
+  {
+    // Code size       21 (0x15)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<object> V_0,
+             object V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<object>::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<object>::Add(!0)
+    IL_000e:  nop
+    IL_000f:  ldloc.0
+    IL_0010:  stloc.1
+    IL_0011:  br.s       IL_0013
+
+    IL_0013:  ldloc.1
+    IL_0014:  ret
+  } // end of method InitializerTests::RecursiveCollectionInitializer
+
+  .method public hidebysig static void  CollectionInitializerDictionary() cil managed
+  {
+    // Code size       59 (0x3b)
+    .maxstack  4
+    .locals init (class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32> V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldstr      "First"
+    IL_0012:  ldc.i4.1
+    IL_0013:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0018:  nop
+    IL_0019:  ldloc.0
+    IL_001a:  ldstr      "Second"
+    IL_001f:  ldc.i4.2
+    IL_0020:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0025:  nop
+    IL_0026:  ldloc.0
+    IL_0027:  ldstr      "Third"
+    IL_002c:  ldc.i4.3
+    IL_002d:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0032:  nop
+    IL_0033:  ldloc.0
+    IL_0034:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0039:  nop
+    IL_003a:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionary
+
+  .method public hidebysig static void  CollectionInitializerDictionaryWithEnumTypes() cil managed
+  {
+    // Code size       38 (0x26)
+    .maxstack  4
+    .locals init (class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  ldc.i4.0
+    IL_000f:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_0014:  nop
+    IL_0015:  ldloc.0
+    IL_0016:  ldc.i4.1
+    IL_0017:  ldc.i4.1
+    IL_0018:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_001d:  nop
+    IL_001e:  ldloc.0
+    IL_001f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0024:  nop
+    IL_0025:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionaryWithEnumTypes
+
+  .method public hidebysig static void  NotACollectionInitializer() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_000e:  nop
+    IL_000f:  ldloc.0
+    IL_0010:  ldc.i4.2
+    IL_0011:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0016:  nop
+    IL_0017:  ldloc.0
+    IL_0018:  ldc.i4.3
+    IL_0019:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001e:  nop
+    IL_001f:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0024:  ldloc.0
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::NotACollectionInitializer
+
+  .method public hidebysig static void  ObjectInitializer() cil managed
+  {
+    // Code size       28 (0x1c)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_001a:  nop
+    IL_001b:  ret
+  } // end of method InitializerTests::ObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializer() cil managed
+  {
+    // Code size       28 (0x1c)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.0
+    IL_0009:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_000e:  nop
+    IL_000f:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0014:  ldloc.0
+    IL_0015:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_001a:  nop
+    IL_001b:  ret
+  } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
+  {
+    // Code size       57 (0x39)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_1)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_001a:  stloc.1
+    IL_001b:  ldloc.1
+    IL_001c:  ldc.i4.0
+    IL_001d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0022:  nop
+    IL_0023:  ldloc.1
+    IL_0024:  ldc.i4.1
+    IL_0025:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002a:  nop
+    IL_002b:  ldloc.1
+    IL_002c:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0031:  ldloc.0
+    IL_0032:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0037:  nop
+    IL_0038:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToField
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInField() cil managed
+  {
+    // Code size       54 (0x36)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0020:  nop
+    IL_0021:  ldloc.0
+    IL_0022:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0027:  ldc.i4.1
+    IL_0028:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002d:  nop
+    IL_002e:  ldloc.0
+    IL_002f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0034:  nop
+    IL_0035:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInField
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToProperty() cil managed
+  {
+    // Code size       58 (0x3a)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_1)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_001a:  stloc.1
+    IL_001b:  ldloc.1
+    IL_001c:  ldc.i4.0
+    IL_001d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0022:  nop
+    IL_0023:  ldloc.1
+    IL_0024:  ldc.i4.1
+    IL_0025:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002a:  nop
+    IL_002b:  ldloc.1
+    IL_002c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+    IL_0031:  nop
+    IL_0032:  ldloc.0
+    IL_0033:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0038:  nop
+    IL_0039:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToProperty
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInProperty() cil managed
+  {
+    // Code size       54 (0x36)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0020:  nop
+    IL_0021:  ldloc.0
+    IL_0022:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0027:  ldc.i4.1
+    IL_0028:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002d:  nop
+    IL_002e:  ldloc.0
+    IL_002f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0034:  nop
+    IL_0035:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInProperty
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       51 (0x33)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0012:  ldc.i4.0
+    IL_0013:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0018:  nop
+    IL_0019:  ldloc.0
+    IL_001a:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001f:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0024:  ldc.i4.1
+    IL_0025:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_002a:  nop
+    IL_002b:  ldloc.0
+    IL_002c:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0031:  nop
+    IL_0032:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfNestedObjects
+
+  .method private hidebysig static int32 
+          GetInt() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (int32 V_0)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.1
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method InitializerTests::GetInt
+
+  .method private hidebysig static string 
+          GetString() cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "Test"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method InitializerTests::GetString
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfDeeplyNestedObjects() cil managed
+  {
+    // Code size       84 (0x54)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldc.i4.1
+    IL_000e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0013:  nop
+    IL_0014:  ldloc.0
+    IL_0015:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0020:  nop
+    IL_0021:  ldloc.0
+    IL_0022:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0027:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_002c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0031:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0036:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_003b:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0040:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0045:  ldc.i4.1
+    IL_0046:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_004b:  nop
+    IL_004c:  ldloc.0
+    IL_004d:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0052:  nop
+    IL_0053:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfDeeplyNestedObjects
+
+  .method public hidebysig static void  CollectionInitializerInsideObjectInitializers() cil managed
+  {
+    // Code size       63 (0x3f)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_1)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0012:  stloc.1
+    IL_0013:  ldloc.1
+    IL_0014:  ldc.i4.0
+    IL_0015:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001a:  nop
+    IL_001b:  ldloc.1
+    IL_001c:  ldc.i4.1
+    IL_001d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0022:  nop
+    IL_0023:  ldloc.1
+    IL_0024:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0029:  ldc.i4.0
+    IL_002a:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002f:  nop
+    IL_0030:  ldloc.1
+    IL_0031:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0036:  nop
+    IL_0037:  ldloc.0
+    IL_0038:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_003d:  nop
+    IL_003e:  ret
+  } // end of method InitializerTests::CollectionInitializerInsideObjectInitializers
+
+  .method public hidebysig static void  NotAStructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  ldloca.s   V_0
+    IL_0003:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0009:  ldloca.s   V_0
+    IL_000b:  ldc.i4.1
+    IL_000c:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0011:  ldloca.s   V_0
+    IL_0013:  ldc.i4.2
+    IL_0014:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0019:  nop
+    IL_001a:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001f:  ldloc.0
+    IL_0020:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::NotAStructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  StructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  ldloca.s   V_0
+    IL_0008:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000e:  ldloca.s   V_0
+    IL_0010:  ldc.i4.1
+    IL_0011:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0016:  ldloca.s   V_0
+    IL_0018:  ldc.i4.2
+    IL_0019:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001e:  nop
+    IL_001f:  ldloc.0
+    IL_0020:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::StructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  NotAStructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       45 (0x2d)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  ldloca.s   V_0
+    IL_0003:  ldc.i4.0
+    IL_0004:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0009:  nop
+    IL_000a:  ldloca.s   V_0
+    IL_000c:  ldc.i4.1
+    IL_000d:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0012:  ldloca.s   V_0
+    IL_0014:  ldc.i4.2
+    IL_0015:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001a:  nop
+    IL_001b:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0020:  ldloc.0
+    IL_0021:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0026:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002b:  nop
+    IL_002c:  ret
+  } // end of method InitializerTests::NotAStructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       45 (0x2d)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  ldloca.s   V_0
+    IL_0008:  ldc.i4.0
+    IL_0009:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_000e:  nop
+    IL_000f:  ldloca.s   V_0
+    IL_0011:  ldc.i4.1
+    IL_0012:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0017:  ldloca.s   V_0
+    IL_0019:  ldc.i4.2
+    IL_001a:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001f:  nop
+    IL_0020:  ldloc.0
+    IL_0021:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0026:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002b:  nop
+    IL_002c:  ret
+  } // end of method InitializerTests::StructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       79 (0x4f)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  ldloca.s   V_0
+    IL_0008:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000e:  ldloca.s   V_0
+    IL_0010:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0015:  ldc.i4.0
+    IL_0016:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001b:  nop
+    IL_001c:  ldloca.s   V_0
+    IL_001e:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0023:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0028:  ldc.i4.0
+    IL_0029:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002e:  nop
+    IL_002f:  ldloca.s   V_0
+    IL_0031:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0036:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_003b:  ldc.i4.1
+    IL_003c:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0041:  nop
+    IL_0042:  ldloc.0
+    IL_0043:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0048:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_004d:  nop
+    IL_004e:  ret
+  } // end of method InitializerTests::StructInitializerWithInitializationOfNestedObjects
+
+  .method public hidebysig static void  StructInitializerWithinObjectInitializer() cil managed
+  {
+    // Code size       54 (0x36)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_1)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  stloc.0
+    IL_000c:  ldloc.0
+    IL_000d:  ldloca.s   V_1
+    IL_000f:  ldc.i4.2
+    IL_0010:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0015:  nop
+    IL_0016:  ldloca.s   V_1
+    IL_0018:  ldc.i4.1
+    IL_0019:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_001e:  ldloca.s   V_1
+    IL_0020:  ldc.i4.2
+    IL_0021:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0026:  nop
+    IL_0027:  ldloc.1
+    IL_0028:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    IL_002d:  nop
+    IL_002e:  ldloc.0
+    IL_002f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0034:  nop
+    IL_0035:  ret
+  } // end of method InitializerTests::StructInitializerWithinObjectInitializer
+
+  .method public hidebysig static void  Bug270_NestedInitialisers() cil managed
+  {
+    // Code size       128 (0x80)
+    .maxstack  6
+    .locals init (class [mscorlib]System.Globalization.NumberFormatInfo[] V_0,
+             class [mscorlib]System.Threading.Thread V_1,
+             class [mscorlib]System.Globalization.CultureInfo V_2,
+             class [mscorlib]System.Globalization.DateTimeFormatInfo V_3)
+    IL_0000:  nop
+    IL_0001:  ldnull
+    IL_0002:  stloc.0
+    IL_0003:  ldc.i4.0
+    IL_0004:  ldnull
+    IL_0005:  ldftn      void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Bug270_NestedInitialisers()
+    IL_000b:  newobj     instance void [mscorlib]System.Threading.ThreadStart::.ctor(object,
+                                                                                     native int)
+    IL_0010:  newobj     instance void [mscorlib]System.Threading.Thread::.ctor(class [mscorlib]System.Threading.ThreadStart)
+    IL_0015:  stloc.1
+    IL_0016:  ldloc.1
+    IL_0017:  ldc.i4.1
+    IL_0018:  callvirt   instance void [mscorlib]System.Threading.Thread::set_Priority(valuetype [mscorlib]System.Threading.ThreadPriority)
+    IL_001d:  nop
+    IL_001e:  ldloc.1
+    IL_001f:  ldc.i4.0
+    IL_0020:  newobj     instance void [mscorlib]System.Globalization.CultureInfo::.ctor(int32)
+    IL_0025:  stloc.2
+    IL_0026:  ldloc.2
+    IL_0027:  newobj     instance void [mscorlib]System.Globalization.DateTimeFormatInfo::.ctor()
+    IL_002c:  stloc.3
+    IL_002d:  ldloc.3
+    IL_002e:  ldstr      "ddmmyy"
+    IL_0033:  callvirt   instance void [mscorlib]System.Globalization.DateTimeFormatInfo::set_ShortDatePattern(string)
+    IL_0038:  nop
+    IL_0039:  ldloc.3
+    IL_003a:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_DateTimeFormat(class [mscorlib]System.Globalization.DateTimeFormatInfo)
+    IL_003f:  nop
+    IL_0040:  ldloc.2
+    IL_0041:  ldloc.0
+    IL_0042:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0047:  brtrue.s   IL_005c
+
+    IL_0049:  ldnull
+    IL_004a:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_0050:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
+                                                                                                                                        native int)
+    IL_0055:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_005a:  br.s       IL_005c
+
+    IL_005c:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0061:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0066:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_006b:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_NumberFormat(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_0070:  nop
+    IL_0071:  ldloc.2
+    IL_0072:  callvirt   instance void [mscorlib]System.Threading.Thread::set_CurrentCulture(class [mscorlib]System.Globalization.CultureInfo)
+    IL_0077:  nop
+    IL_0078:  ldloc.1
+    IL_0079:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                       class [mscorlib]System.Threading.Thread)
+    IL_007e:  nop
+    IL_007f:  ret
+  } // end of method InitializerTests::Bug270_NestedInitialisers
+
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
@@ -267,6 +1364,24 @@
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
   } // end of method InitializerTests::.ctor
+
+  .method private hidebysig static bool  '<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       21 (0x15)
+    .maxstack  2
+    .locals init (bool V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  callvirt   instance string [mscorlib]System.Globalization.NumberFormatInfo::get_CurrencySymbol()
+    IL_0006:  ldstr      "$"
+    IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
+                                                                   string)
+    IL_0010:  stloc.0
+    IL_0011:  br.s       IL_0013
+
+    IL_0013:  ldloc.0
+    IL_0014:  ret
+  } // end of method InitializerTests::'<Bug270_NestedInitialisers>b__19'
 
 } // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.il
@@ -10,7 +10,7 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly '0zopdghu'
+.assembly '0meyjl4r'
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
@@ -20,15 +20,15 @@
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module '0zopdghu.dll'
-// MVID: {56C873AC-FD1E-4808-A65A-845BA0A3C2B7}
+.module '0meyjl4r.dll'
+// MVID: {DBAD72F7-978F-407F-9C77-44D3E99CD8AD}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x032A0000
+// Image base: 0x02FE0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -93,7 +93,7 @@
   } // end of method InitializerTests::TestCall
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
-          Test() cil managed
+          Test1() cil managed
   {
     // Code size       42 (0x2a)
     .maxstack  2
@@ -117,7 +117,39 @@
 
     IL_0028:  ldloc.1
     IL_0029:  ret
-  } // end of method InitializerTests::Test
+  } // end of method InitializerTests::Test1
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test1Alternative() cil managed
+  {
+    // Code size       45 (0x2d)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> V_1,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_2)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.1
+    IL_0002:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0007:  stloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000e:  stloc.1
+    IL_000f:  ldloc.1
+    IL_0010:  ldc.i4.1
+    IL_0011:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_0016:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_001b:  nop
+    IL_001c:  ldloc.1
+    IL_001d:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0022:  ldloc.0
+    IL_0023:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_0028:  stloc.2
+    IL_0029:  br.s       IL_002b
+
+    IL_002b:  ldloc.2
+    IL_002c:  ret
+  } // end of method InitializerTests::Test1Alternative
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           Test2() cil managed
@@ -212,12 +244,12 @@
     IL_000d:  ldc.i4.1
     IL_000e:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
     IL_0013:  ldloc.0
-    IL_0014:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
-    IL_0019:  ldc.i4.3
-    IL_001a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
-    IL_001f:  ldloc.0
-    IL_0020:  ldc.i4.2
-    IL_0021:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0014:  ldc.i4.2
+    IL_0015:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_001a:  ldloc.0
+    IL_001b:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0020:  ldc.i4.3
+    IL_0021:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
     IL_0026:  ldloc.0
     IL_0027:  stloc.1
     IL_0028:  br.s       IL_002a

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
@@ -1,0 +1,207 @@
+
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Copyright (c) Microsoft Corporation. Alle Rechte vorbehalten.
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly xvcsxiw0
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+  .permissionset reqmin
+             = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module xvcsxiw0.dll
+// MVID: {ADB73224-52C3-4DFE-AB87-E9CEDD4FB2C3}
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x00D20000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested public beforefieldinit C
+         extends [mscorlib]System.Object
+  {
+    .field public int32 Z
+    .field public valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S Y
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> L
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method C::.ctor
+
+  } // end of class C
+
+  .class sequential ansi sealed nested public beforefieldinit S
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 A
+    .field public int32 B
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 a) cil managed
+    {
+      // Code size       15 (0xf)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+      IL_0007:  ldarg.0
+      IL_0008:  ldc.i4.0
+      IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+      IL_000e:  ret
+    } // end of method S::.ctor
+
+  } // end of class S
+
+  .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          TestCall(int32 a,
+                   class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C c) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldarg.1
+    IL_0001:  ret
+  } // end of method InitializerTests::TestCall
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test() cil managed
+  {
+    // Code size       36 (0x24)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000c:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0011:  ldloc.0
+    IL_0012:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0017:  ldc.i4.1
+    IL_0018:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_001d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_0022:  ldloc.0
+    IL_0023:  ret
+  } // end of method InitializerTests::Test
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test2() cil managed
+  {
+    // Code size       22 (0x16)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.2
+    IL_000f:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0014:  ldloc.0
+    IL_0015:  ret
+  } // end of method InitializerTests::Test2
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3() cil managed
+  {
+    // Code size       32 (0x20)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_000d:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0012:  ldloc.0
+    IL_0013:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0018:  ldc.i4.2
+    IL_0019:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001e:  ldloc.0
+    IL_001f:  ret
+  } // end of method InitializerTests::Test3
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3b() cil managed
+  {
+    // Code size       33 (0x21)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  ldc.i4.0
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000e:  ldloc.0
+    IL_000f:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0014:  ldc.i4.2
+    IL_0015:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001a:  ldloc.0
+    IL_001b:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_0020:  ret
+  } // end of method InitializerTests::Test3b
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test4() cil managed
+  {
+    // Code size       39 (0x27)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_000c:  ldc.i4.1
+    IL_000d:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_0012:  ldloc.0
+    IL_0013:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0018:  ldc.i4.3
+    IL_0019:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+    IL_001e:  ldloc.0
+    IL_001f:  ldc.i4.2
+    IL_0020:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0025:  ldloc.0
+    IL_0026:  ret
+  } // end of method InitializerTests::Test4
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method InitializerTests::.ctor
+
+} // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************
+// Warnung: Win32-Ressourcendatei "../../../TestCases/Pretty\InitializerTests.opt.res" wurde erstellt.

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
@@ -15,25 +15,25 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly '3csuofts'
+.assembly mo2wq1js
 {
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                              63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .permissionset reqmin
              = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module '3csuofts.dll'
-// MVID: {F78A061E-BAE5-4B9C-AFCF-4B60D826C849}
+.module mo2wq1js.dll
+// MVID: {99F5978B-D68E-4578-9D8F-7D47C1F63A30}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00D80000
+// Image base: 0x027A0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -101,6 +101,7 @@
   {
     .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
     .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> FieldList
+    .field private class [mscorlib]System.EventHandler TestEvent
     .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<a>k__BackingField'
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<b>k__BackingField'
@@ -271,6 +272,74 @@
       IL_0000:  ret
     } // end of method Data::set_Item
 
+    .method public hidebysig specialname 
+            instance void  add_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      // Code size       41 (0x29)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Combine(class [mscorlib]System.Delegate,
+                                                                                              class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  bne.un.s   IL_0007
+
+      IL_0028:  ret
+    } // end of method Data::add_TestEvent
+
+    .method public hidebysig specialname 
+            instance void  remove_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      // Code size       41 (0x29)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Remove(class [mscorlib]System.Delegate,
+                                                                                             class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  bne.un.s   IL_0007
+
+      IL_0028:  ret
+    } // end of method Data::remove_TestEvent
+
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
     {
@@ -284,6 +353,11 @@
       IL_0011:  ret
     } // end of method Data::.ctor
 
+    .event [mscorlib]System.EventHandler TestEvent
+    {
+      .removeon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::remove_TestEvent(class [mscorlib]System.EventHandler)
+      .addon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+    } // end of event Data::TestEvent
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
             a()
     {
@@ -293,33 +367,33 @@
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
             b()
     {
-      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
       .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_b()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
     } // end of property Data::b
     .property instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>
             PropertyList()
     {
-      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
       .get instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
     } // end of property Data::PropertyList
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             MoreData()
     {
-      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
       .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
     } // end of property Data::MoreData
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
             NestedStruct()
     {
-      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
       .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
     } // end of property Data::NestedStruct
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             Item(int32)
     {
-      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
       .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
                                                                                                        class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
     } // end of property Data::Item
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             Item(int32,
@@ -406,8 +480,8 @@
 
     .property instance int32 Property()
     {
-      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
       .get instance int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_Property()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
     } // end of property StructData::Property
     .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
             MoreData()
@@ -417,7 +491,9 @@
     } // end of property StructData::MoreData
   } // end of class StructData
 
-  .field private static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> 'CS$<>9__CachedAnonymousMethodDelegate1a'
+  .field private static class [mscorlib]System.EventHandler 'CS$<>9__CachedAnonymousMethodDelegate8'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> 'CS$<>9__CachedAnonymousMethodDelegate1c'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method private hidebysig static void  X(object a,
                                            object b) cil managed
@@ -729,6 +805,32 @@
                                                                                                 object)
     IL_0018:  ret
   } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializerWithEvent() cil managed
+  {
+    // Code size       53 (0x35)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate8'
+    IL_000c:  brtrue.s   IL_001f
+
+    IL_000e:  ldnull
+    IL_000f:  ldftn      void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<NotAnObjectInitializerWithEvent>b__7'(object,
+                                                                                                                                      class [mscorlib]System.EventArgs)
+    IL_0015:  newobj     instance void [mscorlib]System.EventHandler::.ctor(object,
+                                                                            native int)
+    IL_001a:  stsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate8'
+    IL_001f:  ldsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate8'
+    IL_0024:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+    IL_0029:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_002e:  ldloc.0
+    IL_002f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0034:  ret
+  } // end of method InitializerTests::NotAnObjectInitializerWithEvent
 
   .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
   {
@@ -1116,15 +1218,15 @@
     IL_0037:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_DateTimeFormat(class [mscorlib]System.Globalization.DateTimeFormatInfo)
     IL_003c:  ldloc.2
     IL_003d:  ldloc.0
-    IL_003e:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_003e:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1c'
     IL_0043:  brtrue.s   IL_0056
 
     IL_0045:  ldnull
-    IL_0046:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_0046:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<Bug270_NestedInitialisers>b__1b'(class [mscorlib]System.Globalization.NumberFormatInfo)
     IL_004c:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
                                                                                                                                         native int)
-    IL_0051:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
-    IL_0056:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0051:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1c'
+    IL_0056:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1c'
     IL_005b:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                          class [mscorlib]System.Func`2<!!0,bool>)
     IL_0060:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
@@ -1147,7 +1249,17 @@
     IL_0006:  ret
   } // end of method InitializerTests::.ctor
 
-  .method private hidebysig static bool  '<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+  .method private hidebysig static void  '<NotAnObjectInitializerWithEvent>b__7'(object sender,
+                                                                                 class [mscorlib]System.EventArgs e) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  call       void [mscorlib]System.Console::WriteLine()
+    IL_0005:  ret
+  } // end of method InitializerTests::'<NotAnObjectInitializerWithEvent>b__7'
+
+  .method private hidebysig static bool  '<Bug270_NestedInitialisers>b__1b'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       17 (0x11)
@@ -1158,7 +1270,7 @@
     IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
                                                                    string)
     IL_0010:  ret
-  } // end of method InitializerTests::'<Bug270_NestedInitialisers>b__19'
+  } // end of method InitializerTests::'<Bug270_NestedInitialisers>b__1b'
 
 } // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
@@ -10,7 +10,7 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly u2solxiw
+.assembly ecxzpbak
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
@@ -20,15 +20,15 @@
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module u2solxiw.dll
-// MVID: {D1507E89-2CB3-46B1-AEC7-B176088BA3F9}
+.module ecxzpbak.dll
+// MVID: {F67EEE6A-7EFF-4261-9FC7-3F2C4A0972E9}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x028E0000
+// Image base: 0x02430000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
@@ -10,25 +10,30 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly ecxzpbak
+.assembly extern System.Core
 {
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly '3csuofts'
+{
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                              63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .permissionset reqmin
              = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module ecxzpbak.dll
-// MVID: {F67EEE6A-7EFF-4261-9FC7-3F2C4A0972E9}
+.module '3csuofts.dll'
+// MVID: {F78A061E-BAE5-4B9C-AFCF-4B60D826C849}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x02430000
+// Image base: 0x00D80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -74,6 +79,370 @@
     } // end of method S::.ctor
 
   } // end of class S
+
+  .class auto ansi sealed nested private MyEnum
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum a = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum b = int32(0x00000001)
+  } // end of class MyEnum
+
+  .class auto ansi sealed nested private MyEnum2
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 c = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 d = int32(0x00000001)
+  } // end of class MyEnum2
+
+  .class auto ansi nested private beforefieldinit Data
+         extends [mscorlib]System.Object
+  {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> FieldList
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<a>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<b>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> '<PropertyList>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData '<NestedStruct>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_a() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_a
+
+    .method public hidebysig specialname 
+            instance void  set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_a
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_b() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_b
+
+    .method public hidebysig specialname 
+            instance void  set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_b
+
+    .method public hidebysig specialname 
+            instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 
+            get_PropertyList() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_PropertyList
+
+    .method public hidebysig specialname 
+            instance void  set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_PropertyList
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_MoreData
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 
+            get_NestedStruct() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_NestedStruct
+
+    .method public hidebysig specialname 
+            instance void  set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_NestedStruct
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i) cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i,
+                     string j) cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    string j,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       18 (0x12)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+      IL_0006:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+      IL_000b:  ldarg.0
+      IL_000c:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0011:  ret
+    } // end of method Data::.ctor
+
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            a()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_a()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    } // end of property Data::a
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            b()
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_b()
+    } // end of property Data::b
+    .property instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>
+            PropertyList()
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+      .get instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    } // end of property Data::PropertyList
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::MoreData
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+            NestedStruct()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    } // end of property Data::NestedStruct
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32)
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::Item
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32,
+                 string)
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       string,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32,
+                                                                                                                                                                            string)
+    } // end of property Data::Item
+  } // end of class Data
+
+  .class sequential ansi sealed nested private beforefieldinit StructData
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 Field
+    .field private int32 '<Property>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance int32  get_Property() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0006:  ret
+    } // end of method StructData::get_Property
+
+    .method public hidebysig specialname 
+            instance void  set_Property(int32 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_Property
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0006:  ret
+    } // end of method StructData::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_MoreData
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 initialValue) cil managed
+    {
+      // Code size       22 (0x16)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+      IL_0007:  ldarg.0
+      IL_0008:  ldarg.1
+      IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+      IL_000e:  ldarg.0
+      IL_000f:  ldarg.1
+      IL_0010:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+      IL_0015:  ret
+    } // end of method StructData::.ctor
+
+    .property instance int32 Property()
+    {
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+      .get instance int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_Property()
+    } // end of property StructData::Property
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property StructData::MoreData
+  } // end of class StructData
+
+  .field private static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> 'CS$<>9__CachedAnonymousMethodDelegate1a'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .method private hidebysig static void  X(object a,
+                                           object b) cil managed
+  {
+    // Code size       1 (0x1)
+    .maxstack  8
+    IL_0000:  ret
+  } // end of method InitializerTests::X
+
+  .method private hidebysig static object 
+          Y() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldnull
+    IL_0001:  ret
+  } // end of method InitializerTests::Y
+
+  .method public hidebysig static void  TestCall(int32 a,
+                                                 class [mscorlib]System.Threading.Thread thread) cil managed
+  {
+    // Code size       1 (0x1)
+    .maxstack  8
+    IL_0000:  ret
+  } // end of method InitializerTests::TestCall
 
   .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           TestCall(int32 a,
@@ -213,6 +582,561 @@
     IL_0026:  ret
   } // end of method InitializerTests::Test4
 
+  .method public hidebysig static void  CollectionInitializerList() cil managed
+  {
+    // Code size       39 (0x27)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.1
+    IL_000d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0012:  ldloc.0
+    IL_0013:  ldc.i4.2
+    IL_0014:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0019:  ldloc.0
+    IL_001a:  ldc.i4.3
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0020:  ldloc.0
+    IL_0021:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0026:  ret
+  } // end of method InitializerTests::CollectionInitializerList
+
+  .method public hidebysig static object 
+          RecursiveCollectionInitializer() cil managed
+  {
+    // Code size       15 (0xf)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<object> V_0)
+    IL_0000:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<object>::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<object>::Add(!0)
+    IL_000d:  ldloc.0
+    IL_000e:  ret
+  } // end of method InitializerTests::RecursiveCollectionInitializer
+
+  .method public hidebysig static void  CollectionInitializerDictionary() cil managed
+  {
+    // Code size       54 (0x36)
+    .maxstack  4
+    .locals init (class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32> V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldstr      "First"
+    IL_0011:  ldc.i4.1
+    IL_0012:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0017:  ldloc.0
+    IL_0018:  ldstr      "Second"
+    IL_001d:  ldc.i4.2
+    IL_001e:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0023:  ldloc.0
+    IL_0024:  ldstr      "Third"
+    IL_0029:  ldc.i4.3
+    IL_002a:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_002f:  ldloc.0
+    IL_0030:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0035:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionary
+
+  .method public hidebysig static void  CollectionInitializerDictionaryWithEnumTypes() cil managed
+  {
+    // Code size       34 (0x22)
+    .maxstack  4
+    .locals init (class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_0013:  ldloc.0
+    IL_0014:  ldc.i4.1
+    IL_0015:  ldc.i4.1
+    IL_0016:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_001b:  ldloc.0
+    IL_001c:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0021:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionaryWithEnumTypes
+
+  .method public hidebysig static void  NotACollectionInitializer() cil managed
+  {
+    // Code size       39 (0x27)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.2
+    IL_000f:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0014:  ldloc.0
+    IL_0015:  ldc.i4.3
+    IL_0016:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001b:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0020:  ldloc.0
+    IL_0021:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0026:  ret
+  } // end of method InitializerTests::NotACollectionInitializer
+
+  .method public hidebysig static void  ObjectInitializer() cil managed
+  {
+    // Code size       25 (0x19)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  ldloc.0
+    IL_0013:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0018:  ret
+  } // end of method InitializerTests::ObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializer() cil managed
+  {
+    // Code size       25 (0x19)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.0
+    IL_0008:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_000d:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0012:  ldloc.0
+    IL_0013:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0018:  ret
+  } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
+  {
+    // Code size       52 (0x34)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_1)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  ldloc.0
+    IL_0013:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_0018:  stloc.1
+    IL_0019:  ldloc.1
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0020:  ldloc.1
+    IL_0021:  ldc.i4.1
+    IL_0022:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0027:  ldloc.1
+    IL_0028:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_002d:  ldloc.0
+    IL_002e:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0033:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToField
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInField() cil managed
+  {
+    // Code size       49 (0x31)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  ldloc.0
+    IL_0013:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0018:  ldc.i4.0
+    IL_0019:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001e:  ldloc.0
+    IL_001f:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0024:  ldc.i4.1
+    IL_0025:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002a:  ldloc.0
+    IL_002b:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0030:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInField
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToProperty() cil managed
+  {
+    // Code size       52 (0x34)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> V_1)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  ldloc.0
+    IL_0013:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_0018:  stloc.1
+    IL_0019:  ldloc.1
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0020:  ldloc.1
+    IL_0021:  ldc.i4.1
+    IL_0022:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0027:  ldloc.1
+    IL_0028:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+    IL_002d:  ldloc.0
+    IL_002e:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0033:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToProperty
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInProperty() cil managed
+  {
+    // Code size       49 (0x31)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  ldloc.0
+    IL_0013:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0018:  ldc.i4.0
+    IL_0019:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001e:  ldloc.0
+    IL_001f:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0024:  ldc.i4.1
+    IL_0025:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002a:  ldloc.0
+    IL_002b:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0030:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInProperty
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       47 (0x2f)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0011:  ldc.i4.0
+    IL_0012:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0017:  ldloc.0
+    IL_0018:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001d:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0022:  ldc.i4.1
+    IL_0023:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0028:  ldloc.0
+    IL_0029:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002e:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfNestedObjects
+
+  .method private hidebysig static int32 
+          GetInt() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.1
+    IL_0001:  ret
+  } // end of method InitializerTests::GetInt
+
+  .method private hidebysig static string 
+          GetString() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldstr      "Test"
+    IL_0005:  ret
+  } // end of method InitializerTests::GetString
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfDeeplyNestedObjects() cil managed
+  {
+    // Code size       79 (0x4f)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldc.i4.1
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  ldloc.0
+    IL_0013:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0018:  ldc.i4.0
+    IL_0019:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001e:  ldloc.0
+    IL_001f:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0024:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0029:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_002e:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0033:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0038:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_003d:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0042:  ldc.i4.1
+    IL_0043:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0048:  ldloc.0
+    IL_0049:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_004e:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfDeeplyNestedObjects
+
+  .method public hidebysig static void  CollectionInitializerInsideObjectInitializers() cil managed
+  {
+    // Code size       57 (0x39)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_1)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0011:  stloc.1
+    IL_0012:  ldloc.1
+    IL_0013:  ldc.i4.0
+    IL_0014:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0019:  ldloc.1
+    IL_001a:  ldc.i4.1
+    IL_001b:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0020:  ldloc.1
+    IL_0021:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0026:  ldc.i4.0
+    IL_0027:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002c:  ldloc.1
+    IL_002d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0032:  ldloc.0
+    IL_0033:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0038:  ret
+  } // end of method InitializerTests::CollectionInitializerInsideObjectInitializers
+
+  .method public hidebysig static void  NotAStructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldc.i4.1
+    IL_000b:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0010:  ldloca.s   V_0
+    IL_0012:  ldc.i4.2
+    IL_0013:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0018:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::NotAStructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  StructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  ldloca.s   V_0
+    IL_0007:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  ldc.i4.1
+    IL_0010:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0015:  ldloca.s   V_0
+    IL_0017:  ldc.i4.2
+    IL_0018:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::StructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  NotAStructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  ldc.i4.0
+    IL_0003:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldc.i4.1
+    IL_000b:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0010:  ldloca.s   V_0
+    IL_0012:  ldc.i4.2
+    IL_0013:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0018:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::NotAStructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  ldloca.s   V_0
+    IL_0007:  ldc.i4.0
+    IL_0008:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  ldc.i4.1
+    IL_0010:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0015:  ldloca.s   V_0
+    IL_0017:  ldc.i4.2
+    IL_0018:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::StructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       74 (0x4a)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  ldloca.s   V_0
+    IL_0007:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0014:  ldc.i4.0
+    IL_0015:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001a:  ldloca.s   V_0
+    IL_001c:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0021:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0026:  ldc.i4.0
+    IL_0027:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002c:  ldloca.s   V_0
+    IL_002e:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0033:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0038:  ldc.i4.1
+    IL_0039:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_003e:  ldloc.0
+    IL_003f:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0044:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0049:  ret
+  } // end of method InitializerTests::StructInitializerWithInitializationOfNestedObjects
+
+  .method public hidebysig static void  StructInitializerWithinObjectInitializer() cil managed
+  {
+    // Code size       49 (0x31)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0,
+             valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_1)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  stloc.0
+    IL_000b:  ldloc.0
+    IL_000c:  ldloca.s   V_1
+    IL_000e:  ldc.i4.2
+    IL_000f:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0014:  ldloca.s   V_1
+    IL_0016:  ldc.i4.1
+    IL_0017:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_001c:  ldloca.s   V_1
+    IL_001e:  ldc.i4.2
+    IL_001f:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0024:  ldloc.1
+    IL_0025:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    IL_002a:  ldloc.0
+    IL_002b:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0030:  ret
+  } // end of method InitializerTests::StructInitializerWithinObjectInitializer
+
+  .method public hidebysig static void  Bug270_NestedInitialisers() cil managed
+  {
+    // Code size       119 (0x77)
+    .maxstack  6
+    .locals init (class [mscorlib]System.Globalization.NumberFormatInfo[] V_0,
+             class [mscorlib]System.Threading.Thread V_1,
+             class [mscorlib]System.Globalization.CultureInfo V_2,
+             class [mscorlib]System.Globalization.DateTimeFormatInfo V_3)
+    IL_0000:  ldnull
+    IL_0001:  stloc.0
+    IL_0002:  ldc.i4.0
+    IL_0003:  ldnull
+    IL_0004:  ldftn      void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Bug270_NestedInitialisers()
+    IL_000a:  newobj     instance void [mscorlib]System.Threading.ThreadStart::.ctor(object,
+                                                                                     native int)
+    IL_000f:  newobj     instance void [mscorlib]System.Threading.Thread::.ctor(class [mscorlib]System.Threading.ThreadStart)
+    IL_0014:  stloc.1
+    IL_0015:  ldloc.1
+    IL_0016:  ldc.i4.1
+    IL_0017:  callvirt   instance void [mscorlib]System.Threading.Thread::set_Priority(valuetype [mscorlib]System.Threading.ThreadPriority)
+    IL_001c:  ldloc.1
+    IL_001d:  ldc.i4.0
+    IL_001e:  newobj     instance void [mscorlib]System.Globalization.CultureInfo::.ctor(int32)
+    IL_0023:  stloc.2
+    IL_0024:  ldloc.2
+    IL_0025:  newobj     instance void [mscorlib]System.Globalization.DateTimeFormatInfo::.ctor()
+    IL_002a:  stloc.3
+    IL_002b:  ldloc.3
+    IL_002c:  ldstr      "ddmmyy"
+    IL_0031:  callvirt   instance void [mscorlib]System.Globalization.DateTimeFormatInfo::set_ShortDatePattern(string)
+    IL_0036:  ldloc.3
+    IL_0037:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_DateTimeFormat(class [mscorlib]System.Globalization.DateTimeFormatInfo)
+    IL_003c:  ldloc.2
+    IL_003d:  ldloc.0
+    IL_003e:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0043:  brtrue.s   IL_0056
+
+    IL_0045:  ldnull
+    IL_0046:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_004c:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
+                                                                                                                                        native int)
+    IL_0051:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_0056:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::'CS$<>9__CachedAnonymousMethodDelegate1a'
+    IL_005b:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0060:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0065:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_NumberFormat(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_006a:  ldloc.2
+    IL_006b:  callvirt   instance void [mscorlib]System.Threading.Thread::set_CurrentCulture(class [mscorlib]System.Globalization.CultureInfo)
+    IL_0070:  ldloc.1
+    IL_0071:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                       class [mscorlib]System.Threading.Thread)
+    IL_0076:  ret
+  } // end of method InitializerTests::Bug270_NestedInitialisers
+
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed
   {
@@ -222,6 +1146,19 @@
     IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
     IL_0006:  ret
   } // end of method InitializerTests::.ctor
+
+  .method private hidebysig static bool  '<Bug270_NestedInitialisers>b__19'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       17 (0x11)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  callvirt   instance string [mscorlib]System.Globalization.NumberFormatInfo::get_CurrencySymbol()
+    IL_0006:  ldstr      "$"
+    IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
+                                                                   string)
+    IL_0010:  ret
+  } // end of method InitializerTests::'<Bug270_NestedInitialisers>b__19'
 
 } // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.il
@@ -10,7 +10,7 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
-.assembly xvcsxiw0
+.assembly u2solxiw
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
@@ -20,15 +20,15 @@
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }
-.module xvcsxiw0.dll
-// MVID: {ADB73224-52C3-4DFE-AB87-E9CEDD4FB2C3}
+.module u2solxiw.dll
+// MVID: {D1507E89-2CB3-46B1-AEC7-B176088BA3F9}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00D20000
+// Image base: 0x028E0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -86,7 +86,7 @@
   } // end of method InitializerTests::TestCall
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
-          Test() cil managed
+          Test1() cil managed
   {
     // Code size       36 (0x24)
     .maxstack  2
@@ -103,7 +103,32 @@
     IL_001d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
     IL_0022:  ldloc.0
     IL_0023:  ret
-  } // end of method InitializerTests::Test
+  } // end of method InitializerTests::Test1
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test1Alternative() cil managed
+  {
+    // Code size       39 (0x27)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> V_1)
+    IL_0000:  ldc.i4.1
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000d:  stloc.1
+    IL_000e:  ldloc.1
+    IL_000f:  ldc.i4.1
+    IL_0010:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_0015:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_001a:  ldloc.1
+    IL_001b:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0020:  ldloc.0
+    IL_0021:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_0026:  ret
+  } // end of method InitializerTests::Test1Alternative
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           Test2() cil managed
@@ -178,12 +203,12 @@
     IL_000c:  ldc.i4.1
     IL_000d:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
     IL_0012:  ldloc.0
-    IL_0013:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
-    IL_0018:  ldc.i4.3
-    IL_0019:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
-    IL_001e:  ldloc.0
-    IL_001f:  ldc.i4.2
-    IL_0020:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0013:  ldc.i4.2
+    IL_0014:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0019:  ldloc.0
+    IL_001a:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_001f:  ldc.i4.3
+    IL_0020:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
     IL_0025:  ldloc.0
     IL_0026:  ret
   } // end of method InitializerTests::Test4

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
@@ -25,14 +25,14 @@
   .ver 0:0:0:0
 }
 .module InitializerTests.dll
-// MVID: {73C118AC-648F-43DB-A2FB-1B159DF870BA}
+// MVID: {F2C6C41E-98CC-4261-BF7B-1991B54DA121}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x03230000
+// Image base: 0x029A0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -90,7 +90,7 @@
   } // end of method InitializerTests::TestCall
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
-          Test() cil managed
+          Test1() cil managed
   {
     // Code size       34 (0x22)
     .maxstack  8
@@ -104,7 +104,26 @@
     IL_0017:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
     IL_001c:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
     IL_0021:  ret
-  } // end of method InitializerTests::Test
+  } // end of method InitializerTests::Test1
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test1Alternative() cil managed
+  {
+    // Code size       35 (0x23)
+    .maxstack  8
+    IL_0000:  ldc.i4.1
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  dup
+    IL_0007:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000c:  dup
+    IL_000d:  ldc.i4.1
+    IL_000e:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_0013:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_0018:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_001d:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_0022:  ret
+  } // end of method InitializerTests::Test1Alternative
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           Test2() cil managed
@@ -168,12 +187,12 @@
     IL_000b:  ldc.i4.1
     IL_000c:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
     IL_0011:  dup
-    IL_0012:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
-    IL_0017:  ldc.i4.3
-    IL_0018:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
-    IL_001d:  dup
-    IL_001e:  ldc.i4.2
-    IL_001f:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0012:  ldc.i4.2
+    IL_0013:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0018:  dup
+    IL_0019:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_001e:  ldc.i4.3
+    IL_001f:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
     IL_0024:  ret
   } // end of method InitializerTests::Test4
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
@@ -30,14 +30,14 @@
   .ver 0:0:0:0
 }
 .module InitializerTests.dll
-// MVID: {4B0BA9B1-521C-4C45-A2B8-8774D5BE797E}
+// MVID: {1A200C9E-AB38-4402-A1D6-E7C3307A45E2}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x01500000
+// Image base: 0x02C80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -114,6 +114,8 @@
     .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData '<NestedStruct>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class [mscorlib]System.EventHandler TestEvent
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .method public hidebysig specialname 
             instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
@@ -275,6 +277,76 @@
       IL_0000:  ret
     } // end of method Data::set_Item
 
+    .method public hidebysig specialname 
+            instance void  add_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       41 (0x29)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Combine(class [mscorlib]System.Delegate,
+                                                                                              class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  bne.un.s   IL_0007
+
+      IL_0028:  ret
+    } // end of method Data::add_TestEvent
+
+    .method public hidebysig specialname 
+            instance void  remove_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       41 (0x29)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Remove(class [mscorlib]System.Delegate,
+                                                                                             class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  bne.un.s   IL_0007
+
+      IL_0028:  ret
+    } // end of method Data::remove_TestEvent
+
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
     {
@@ -288,6 +360,11 @@
       IL_0011:  ret
     } // end of method Data::.ctor
 
+    .event [mscorlib]System.EventHandler TestEvent
+    {
+      .addon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+      .removeon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::remove_TestEvent(class [mscorlib]System.EventHandler)
+    } // end of event Data::TestEvent
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
             a()
     {
@@ -426,7 +503,8 @@
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' '<>9'
-    .field public static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> '<>9__40_0'
+    .field public static class [mscorlib]System.EventHandler '<>9__23_0'
+    .field public static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> '<>9__41_0'
     .method private hidebysig specialname rtspecialname static 
             void  .cctor() cil managed
     {
@@ -447,8 +525,18 @@
       IL_0006:  ret
     } // end of method '<>c'::.ctor
 
+    .method assembly hidebysig instance void 
+            '<NotAnObjectInitializerWithEvent>b__23_0'(object sender,
+                                                       class [mscorlib]System.EventArgs e) cil managed
+    {
+      // Code size       6 (0x6)
+      .maxstack  8
+      IL_0000:  call       void [mscorlib]System.Console::WriteLine()
+      IL_0005:  ret
+    } // end of method '<>c'::'<NotAnObjectInitializerWithEvent>b__23_0'
+
     .method assembly hidebysig instance bool 
-            '<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+            '<Bug270_NestedInitialisers>b__41_0'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
     {
       // Code size       17 (0x11)
       .maxstack  8
@@ -458,7 +546,7 @@
       IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
                                                                      string)
       IL_0010:  ret
-    } // end of method '<>c'::'<Bug270_NestedInitialisers>b__40_0'
+    } // end of method '<>c'::'<Bug270_NestedInitialisers>b__41_0'
 
   } // end of class '<>c'
 
@@ -736,6 +824,34 @@
                                                                                                 object)
     IL_0018:  ret
   } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializerWithEvent() cil managed
+  {
+    // Code size       55 (0x37)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__23_0'
+    IL_000c:  dup
+    IL_000d:  brtrue.s   IL_0026
+
+    IL_000f:  pop
+    IL_0010:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
+    IL_0015:  ldftn      instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<NotAnObjectInitializerWithEvent>b__23_0'(object,
+                                                                                                                                                        class [mscorlib]System.EventArgs)
+    IL_001b:  newobj     instance void [mscorlib]System.EventHandler::.ctor(object,
+                                                                            native int)
+    IL_0020:  dup
+    IL_0021:  stsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__23_0'
+    IL_0026:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+    IL_002b:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0030:  ldloc.0
+    IL_0031:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0036:  ret
+  } // end of method InitializerTests::NotAnObjectInitializerWithEvent
 
   .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
   {
@@ -1159,17 +1275,17 @@
     IL_0033:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_DateTimeFormat(class [mscorlib]System.Globalization.DateTimeFormatInfo)
     IL_0038:  dup
     IL_0039:  ldloc.0
-    IL_003a:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_003a:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__41_0'
     IL_003f:  dup
     IL_0040:  brtrue.s   IL_0059
 
     IL_0042:  pop
     IL_0043:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
-    IL_0048:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_0048:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<Bug270_NestedInitialisers>b__41_0'(class [mscorlib]System.Globalization.NumberFormatInfo)
     IL_004e:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
                                                                                                                                         native int)
     IL_0053:  dup
-    IL_0054:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_0054:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__41_0'
     IL_0059:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                          class [mscorlib]System.Func`2<!!0,bool>)
     IL_005e:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
@@ -1,0 +1,195 @@
+
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Copyright (c) Microsoft Corporation. Alle Rechte vorbehalten.
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly InitializerTests
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 02 00 00 00 00 00 ) 
+
+  .permissionset reqmin
+             = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module InitializerTests.dll
+// MVID: {73C118AC-648F-43DB-A2FB-1B159DF870BA}
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x03230000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested public beforefieldinit C
+         extends [mscorlib]System.Object
+  {
+    .field public int32 Z
+    .field public valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S Y
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> L
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method C::.ctor
+
+  } // end of class C
+
+  .class sequential ansi sealed nested public beforefieldinit S
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 A
+    .field public int32 B
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 a) cil managed
+    {
+      // Code size       15 (0xf)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+      IL_0007:  ldarg.0
+      IL_0008:  ldc.i4.0
+      IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+      IL_000e:  ret
+    } // end of method S::.ctor
+
+  } // end of class S
+
+  .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          TestCall(int32 a,
+                   class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C c) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldarg.1
+    IL_0001:  ret
+  } // end of method InitializerTests::TestCall
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test() cil managed
+  {
+    // Code size       34 (0x22)
+    .maxstack  8
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  dup
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000b:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0010:  dup
+    IL_0011:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0016:  ldc.i4.1
+    IL_0017:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_001c:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_0021:  ret
+  } // end of method InitializerTests::Test
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test2() cil managed
+  {
+    // Code size       20 (0x14)
+    .maxstack  8
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  dup
+    IL_0006:  ldc.i4.1
+    IL_0007:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000c:  dup
+    IL_000d:  ldc.i4.2
+    IL_000e:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0013:  ret
+  } // end of method InitializerTests::Test2
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3() cil managed
+  {
+    // Code size       30 (0x1e)
+    .maxstack  8
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  dup
+    IL_0006:  ldc.i4.1
+    IL_0007:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_000c:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0011:  dup
+    IL_0012:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0017:  ldc.i4.2
+    IL_0018:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001d:  ret
+  } // end of method InitializerTests::Test3
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3b() cil managed
+  {
+    // Code size       31 (0x1f)
+    .maxstack  8
+    IL_0000:  ldc.i4.0
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  dup
+    IL_0007:  ldc.i4.1
+    IL_0008:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000d:  dup
+    IL_000e:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0013:  ldc.i4.2
+    IL_0014:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_0019:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_001e:  ret
+  } // end of method InitializerTests::Test3b
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test4() cil managed
+  {
+    // Code size       37 (0x25)
+    .maxstack  8
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0005:  dup
+    IL_0006:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_000b:  ldc.i4.1
+    IL_000c:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_0011:  dup
+    IL_0012:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0017:  ldc.i4.3
+    IL_0018:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+    IL_001d:  dup
+    IL_001e:  ldc.i4.2
+    IL_001f:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0024:  ret
+  } // end of method InitializerTests::Test4
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method InitializerTests::.ctor
+
+} // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
@@ -10,6 +10,11 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
+.assembly extern System.Core
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
 .assembly InitializerTests
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
@@ -25,14 +30,14 @@
   .ver 0:0:0:0
 }
 .module InitializerTests.dll
-// MVID: {F2C6C41E-98CC-4261-BF7B-1991B54DA121}
+// MVID: {4B0BA9B1-521C-4C45-A2B8-8774D5BE797E}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00700000
+// Image base: 0x01500000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -78,6 +83,409 @@
     } // end of method S::.ctor
 
   } // end of class S
+
+  .class auto ansi sealed nested private MyEnum
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum a = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum b = int32(0x00000001)
+  } // end of class MyEnum
+
+  .class auto ansi sealed nested private MyEnum2
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 c = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 d = int32(0x00000001)
+  } // end of class MyEnum2
+
+  .class auto ansi nested private beforefieldinit Data
+         extends [mscorlib]System.Object
+  {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> FieldList
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<a>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<b>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> '<PropertyList>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData '<NestedStruct>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_a() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_a
+
+    .method public hidebysig specialname 
+            instance void  set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_a
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_b() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_b
+
+    .method public hidebysig specialname 
+            instance void  set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_b
+
+    .method public hidebysig specialname 
+            instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 
+            get_PropertyList() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_PropertyList
+
+    .method public hidebysig specialname 
+            instance void  set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_PropertyList
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_MoreData
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 
+            get_NestedStruct() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_NestedStruct
+
+    .method public hidebysig specialname 
+            instance void  set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_NestedStruct
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i) cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i,
+                     string j) cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  ldnull
+      IL_0001:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    string j,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       1 (0x1)
+      .maxstack  8
+      IL_0000:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       18 (0x12)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+      IL_0006:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+      IL_000b:  ldarg.0
+      IL_000c:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0011:  ret
+    } // end of method Data::.ctor
+
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            a()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_a()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    } // end of property Data::a
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            b()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_b()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    } // end of property Data::b
+    .property instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>
+            PropertyList()
+    {
+      .get instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+    } // end of property Data::PropertyList
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::MoreData
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+            NestedStruct()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    } // end of property Data::NestedStruct
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32)
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::Item
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32,
+                 string)
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32,
+                                                                                                                                                                            string)
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       string,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::Item
+  } // end of class Data
+
+  .class sequential ansi sealed nested private beforefieldinit StructData
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 Field
+    .field private int32 '<Property>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance int32  get_Property() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0006:  ret
+    } // end of method StructData::get_Property
+
+    .method public hidebysig specialname 
+            instance void  set_Property(int32 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_Property
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0006:  ret
+    } // end of method StructData::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_MoreData
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 initialValue) cil managed
+    {
+      // Code size       22 (0x16)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+      IL_0007:  ldarg.0
+      IL_0008:  ldarg.1
+      IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+      IL_000e:  ldarg.0
+      IL_000f:  ldarg.1
+      IL_0010:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+      IL_0015:  ret
+    } // end of method StructData::.ctor
+
+    .property instance int32 Property()
+    {
+      .get instance int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_Property()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    } // end of property StructData::Property
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property StructData::MoreData
+  } // end of class StructData
+
+  .class auto ansi serializable sealed nested private beforefieldinit '<>c'
+         extends [mscorlib]System.Object
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' '<>9'
+    .field public static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> '<>9__40_0'
+    .method private hidebysig specialname rtspecialname static 
+            void  .cctor() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  8
+      IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::.ctor()
+      IL_0005:  stsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
+      IL_000a:  ret
+    } // end of method '<>c'::.cctor
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method '<>c'::.ctor
+
+    .method assembly hidebysig instance bool 
+            '<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+    {
+      // Code size       17 (0x11)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  callvirt   instance string [mscorlib]System.Globalization.NumberFormatInfo::get_CurrencySymbol()
+      IL_0006:  ldstr      "$"
+      IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
+                                                                     string)
+      IL_0010:  ret
+    } // end of method '<>c'::'<Bug270_NestedInitialisers>b__40_0'
+
+  } // end of class '<>c'
+
+  .method private hidebysig static void  X(object a,
+                                           object b) cil managed
+  {
+    // Code size       1 (0x1)
+    .maxstack  8
+    IL_0000:  ret
+  } // end of method InitializerTests::X
+
+  .method private hidebysig static object 
+          Y() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldnull
+    IL_0001:  ret
+  } // end of method InitializerTests::Y
+
+  .method public hidebysig static void  TestCall(int32 a,
+                                                 class [mscorlib]System.Threading.Thread thread) cil managed
+  {
+    // Code size       1 (0x1)
+    .maxstack  8
+    IL_0000:  ret
+  } // end of method InitializerTests::TestCall
 
   .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           TestCall(int32 a,
@@ -195,6 +603,582 @@
     IL_001f:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
     IL_0024:  ret
   } // end of method InitializerTests::Test4
+
+  .method public hidebysig static void  CollectionInitializerList() cil managed
+  {
+    // Code size       37 (0x25)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.1
+    IL_000c:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0011:  dup
+    IL_0012:  ldc.i4.2
+    IL_0013:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0018:  dup
+    IL_0019:  ldc.i4.3
+    IL_001a:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0024:  ret
+  } // end of method InitializerTests::CollectionInitializerList
+
+  .method public hidebysig static object 
+          RecursiveCollectionInitializer() cil managed
+  {
+    // Code size       13 (0xd)
+    .maxstack  8
+    IL_0000:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<object>::.ctor()
+    IL_0005:  dup
+    IL_0006:  dup
+    IL_0007:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<object>::Add(!0)
+    IL_000c:  ret
+  } // end of method InitializerTests::RecursiveCollectionInitializer
+
+  .method public hidebysig static void  CollectionInitializerDictionary() cil managed
+  {
+    // Code size       52 (0x34)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldstr      "First"
+    IL_0010:  ldc.i4.1
+    IL_0011:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0016:  dup
+    IL_0017:  ldstr      "Second"
+    IL_001c:  ldc.i4.2
+    IL_001d:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0022:  dup
+    IL_0023:  ldstr      "Third"
+    IL_0028:  ldc.i4.3
+    IL_0029:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_002e:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0033:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionary
+
+  .method public hidebysig static void  CollectionInitializerDictionaryWithEnumTypes() cil managed
+  {
+    // Code size       32 (0x20)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.0
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_0012:  dup
+    IL_0013:  ldc.i4.1
+    IL_0014:  ldc.i4.1
+    IL_0015:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_001a:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_001f:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionaryWithEnumTypes
+
+  .method public hidebysig static void  NotACollectionInitializer() cil managed
+  {
+    // Code size       39 (0x27)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.1
+    IL_0008:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_000d:  ldloc.0
+    IL_000e:  ldc.i4.2
+    IL_000f:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0014:  ldloc.0
+    IL_0015:  ldc.i4.3
+    IL_0016:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001b:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0020:  ldloc.0
+    IL_0021:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0026:  ret
+  } // end of method InitializerTests::NotACollectionInitializer
+
+  .method public hidebysig static void  ObjectInitializer() cil managed
+  {
+    // Code size       23 (0x17)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.0
+    IL_000c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0011:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0016:  ret
+  } // end of method InitializerTests::ObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializer() cil managed
+  {
+    // Code size       25 (0x19)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0005:  stloc.0
+    IL_0006:  ldloc.0
+    IL_0007:  ldc.i4.0
+    IL_0008:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_000d:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0012:  ldloc.0
+    IL_0013:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0018:  ret
+  } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
+  {
+    // Code size       48 (0x30)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.0
+    IL_000c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0011:  dup
+    IL_0012:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_0017:  dup
+    IL_0018:  ldc.i4.0
+    IL_0019:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001e:  dup
+    IL_001f:  ldc.i4.1
+    IL_0020:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0025:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_002a:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002f:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToField
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInField() cil managed
+  {
+    // Code size       47 (0x2f)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.0
+    IL_000c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0011:  dup
+    IL_0012:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0017:  ldc.i4.0
+    IL_0018:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001d:  dup
+    IL_001e:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0023:  ldc.i4.1
+    IL_0024:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0029:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002e:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInField
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToProperty() cil managed
+  {
+    // Code size       48 (0x30)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.0
+    IL_000c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0011:  dup
+    IL_0012:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_0017:  dup
+    IL_0018:  ldc.i4.0
+    IL_0019:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001e:  dup
+    IL_001f:  ldc.i4.1
+    IL_0020:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0025:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+    IL_002a:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002f:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToProperty
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInProperty() cil managed
+  {
+    // Code size       47 (0x2f)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.0
+    IL_000c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0011:  dup
+    IL_0012:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0017:  ldc.i4.0
+    IL_0018:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001d:  dup
+    IL_001e:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0023:  ldc.i4.1
+    IL_0024:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0029:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002e:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInProperty
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       45 (0x2d)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0010:  ldc.i4.0
+    IL_0011:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0016:  dup
+    IL_0017:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0021:  ldc.i4.1
+    IL_0022:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0027:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002c:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfNestedObjects
+
+  .method private hidebysig static int32 
+          GetInt() cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  ldc.i4.1
+    IL_0001:  ret
+  } // end of method InitializerTests::GetInt
+
+  .method private hidebysig static string 
+          GetString() cil managed
+  {
+    // Code size       6 (0x6)
+    .maxstack  8
+    IL_0000:  ldstr      "Test"
+    IL_0005:  ret
+  } // end of method InitializerTests::GetString
+
+  .method public hidebysig static void  SimpleDictInitializer() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0010:  ldc.i4.0
+    IL_0011:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0016:  dup
+    IL_0017:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001c:  ldc.i4.2
+    IL_001d:  ldnull
+    IL_001e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                                     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::SimpleDictInitializer
+
+  .method public hidebysig static void  MixedObjectAndDictInitializer() cil managed
+  {
+    // Code size       130 (0x82)
+    .maxstack  6
+    .locals init (int32 V_0,
+             int32 V_1,
+             string V_2)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0010:  ldc.i4.0
+    IL_0011:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0016:  call       int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::GetInt()
+    IL_001b:  stloc.0
+    IL_001c:  dup
+    IL_001d:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0022:  ldloc.0
+    IL_0023:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_0028:  ldc.i4.1
+    IL_0029:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_002e:  dup
+    IL_002f:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0034:  ldloc.0
+    IL_0035:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_003a:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_003f:  ldc.i4.0
+    IL_0040:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0045:  call       int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::GetInt()
+    IL_004a:  stloc.1
+    IL_004b:  call       string ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::GetString()
+    IL_0050:  stloc.2
+    IL_0051:  dup
+    IL_0052:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0057:  ldloc.0
+    IL_0058:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_005d:  ldloc.1
+    IL_005e:  ldloc.2
+    IL_005f:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0064:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                                     string,
+                                                                                                                     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0069:  dup
+    IL_006a:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_006f:  ldloc.0
+    IL_0070:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_0075:  ldc.i4.2
+    IL_0076:  ldnull
+    IL_0077:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                                     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_007c:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0081:  ret
+  } // end of method InitializerTests::MixedObjectAndDictInitializer
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfDeeplyNestedObjects() cil managed
+  {
+    // Code size       77 (0x4d)
+    .maxstack  4
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldc.i4.1
+    IL_000c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0011:  dup
+    IL_0012:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0017:  ldc.i4.0
+    IL_0018:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001d:  dup
+    IL_001e:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0023:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0028:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_002d:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0032:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0037:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_003c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0041:  ldc.i4.1
+    IL_0042:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0047:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_004c:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfDeeplyNestedObjects
+
+  .method public hidebysig static void  CollectionInitializerInsideObjectInitializers() cil managed
+  {
+    // Code size       53 (0x35)
+    .maxstack  8
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0010:  dup
+    IL_0011:  ldc.i4.0
+    IL_0012:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0017:  dup
+    IL_0018:  ldc.i4.1
+    IL_0019:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001e:  dup
+    IL_001f:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0024:  ldc.i4.0
+    IL_0025:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002a:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_002f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0034:  ret
+  } // end of method InitializerTests::CollectionInitializerInsideObjectInitializers
+
+  .method public hidebysig static void  NotAStructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldc.i4.1
+    IL_000b:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0010:  ldloca.s   V_0
+    IL_0012:  ldc.i4.2
+    IL_0013:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0018:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::NotAStructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  StructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  ldloca.s   V_0
+    IL_0007:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  ldc.i4.1
+    IL_0010:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0015:  ldloca.s   V_0
+    IL_0017:  ldc.i4.2
+    IL_0018:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::StructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  NotAStructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  ldc.i4.0
+    IL_0003:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldc.i4.1
+    IL_000b:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0010:  ldloca.s   V_0
+    IL_0012:  ldc.i4.2
+    IL_0013:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0018:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::NotAStructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  ldloca.s   V_0
+    IL_0007:  ldc.i4.0
+    IL_0008:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  ldc.i4.1
+    IL_0010:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0015:  ldloca.s   V_0
+    IL_0017:  ldc.i4.2
+    IL_0018:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001d:  ldloc.0
+    IL_001e:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  ret
+  } // end of method InitializerTests::StructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       74 (0x4a)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  ldloca.s   V_0
+    IL_0007:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0014:  ldc.i4.0
+    IL_0015:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001a:  ldloca.s   V_0
+    IL_001c:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0021:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0026:  ldc.i4.0
+    IL_0027:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002c:  ldloca.s   V_0
+    IL_002e:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0033:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0038:  ldc.i4.1
+    IL_0039:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_003e:  ldloc.0
+    IL_003f:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0044:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0049:  ret
+  } // end of method InitializerTests::StructInitializerWithInitializationOfNestedObjects
+
+  .method public hidebysig static void  StructInitializerWithinObjectInitializer() cil managed
+  {
+    // Code size       47 (0x2f)
+    .maxstack  5
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0005:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000a:  dup
+    IL_000b:  ldloca.s   V_0
+    IL_000d:  ldc.i4.2
+    IL_000e:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0013:  ldloca.s   V_0
+    IL_0015:  ldc.i4.1
+    IL_0016:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_001b:  ldloca.s   V_0
+    IL_001d:  ldc.i4.2
+    IL_001e:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0023:  ldloc.0
+    IL_0024:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    IL_0029:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002e:  ret
+  } // end of method InitializerTests::StructInitializerWithinObjectInitializer
+
+  .method public hidebysig static void  Bug270_NestedInitialisers() cil managed
+  {
+    // Code size       115 (0x73)
+    .maxstack  8
+    .locals init (class [mscorlib]System.Globalization.NumberFormatInfo[] V_0)
+    IL_0000:  ldnull
+    IL_0001:  stloc.0
+    IL_0002:  ldc.i4.0
+    IL_0003:  ldnull
+    IL_0004:  ldftn      void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Bug270_NestedInitialisers()
+    IL_000a:  newobj     instance void [mscorlib]System.Threading.ThreadStart::.ctor(object,
+                                                                                     native int)
+    IL_000f:  newobj     instance void [mscorlib]System.Threading.Thread::.ctor(class [mscorlib]System.Threading.ThreadStart)
+    IL_0014:  dup
+    IL_0015:  ldc.i4.1
+    IL_0016:  callvirt   instance void [mscorlib]System.Threading.Thread::set_Priority(valuetype [mscorlib]System.Threading.ThreadPriority)
+    IL_001b:  dup
+    IL_001c:  ldc.i4.0
+    IL_001d:  newobj     instance void [mscorlib]System.Globalization.CultureInfo::.ctor(int32)
+    IL_0022:  dup
+    IL_0023:  newobj     instance void [mscorlib]System.Globalization.DateTimeFormatInfo::.ctor()
+    IL_0028:  dup
+    IL_0029:  ldstr      "ddmmyy"
+    IL_002e:  callvirt   instance void [mscorlib]System.Globalization.DateTimeFormatInfo::set_ShortDatePattern(string)
+    IL_0033:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_DateTimeFormat(class [mscorlib]System.Globalization.DateTimeFormatInfo)
+    IL_0038:  dup
+    IL_0039:  ldloc.0
+    IL_003a:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_003f:  dup
+    IL_0040:  brtrue.s   IL_0059
+
+    IL_0042:  pop
+    IL_0043:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
+    IL_0048:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_004e:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
+                                                                                                                                        native int)
+    IL_0053:  dup
+    IL_0054:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_0059:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_005e:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0063:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_NumberFormat(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_0068:  callvirt   instance void [mscorlib]System.Threading.Thread::set_CurrentCulture(class [mscorlib]System.Globalization.CultureInfo)
+    IL_006d:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                       class [mscorlib]System.Threading.Thread)
+    IL_0072:  ret
+  } // end of method InitializerTests::Bug270_NestedInitialisers
 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.opt.roslyn.il
@@ -32,7 +32,7 @@
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x029A0000
+// Image base: 0x00700000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
@@ -25,14 +25,14 @@
   .ver 0:0:0:0
 }
 .module InitializerTests.dll
-// MVID: {53F415C2-DC80-4EFA-8787-82F129B1AC28}
+// MVID: {7000C1D7-C4EC-4376-B053-4BE74428CE7A}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x002F0000
+// Image base: 0x00C90000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -98,7 +98,7 @@
   } // end of method InitializerTests::TestCall
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
-          Test() cil managed
+          Test1() cil managed
   {
     // Code size       42 (0x2a)
     .maxstack  2
@@ -122,7 +122,33 @@
 
     IL_0028:  ldloc.1
     IL_0029:  ret
-  } // end of method InitializerTests::Test
+  } // end of method InitializerTests::Test1
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test1Alternative() cil managed
+  {
+    // Code size       41 (0x29)
+    .maxstack  6
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.1
+    IL_0002:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0007:  dup
+    IL_0008:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000d:  dup
+    IL_000e:  ldc.i4.1
+    IL_000f:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_0014:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_0019:  nop
+    IL_001a:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_001f:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_0024:  stloc.0
+    IL_0025:  br.s       IL_0027
+
+    IL_0027:  ldloc.0
+    IL_0028:  ret
+  } // end of method InitializerTests::Test1Alternative
 
   .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           Test2() cil managed
@@ -214,12 +240,12 @@
     IL_000d:  ldc.i4.1
     IL_000e:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
     IL_0013:  ldloc.0
-    IL_0014:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
-    IL_0019:  ldc.i4.3
-    IL_001a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
-    IL_001f:  ldloc.0
-    IL_0020:  ldc.i4.2
-    IL_0021:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0014:  ldc.i4.2
+    IL_0015:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_001a:  ldloc.0
+    IL_001b:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0020:  ldc.i4.3
+    IL_0021:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
     IL_0026:  ldloc.0
     IL_0027:  stloc.1
     IL_0028:  br.s       IL_002a

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
@@ -30,14 +30,14 @@
   .ver 0:0:0:0
 }
 .module InitializerTests.dll
-// MVID: {EA222E3F-8F60-413B-AF03-0814FF05742B}
+// MVID: {764AEFFE-E491-413B-876B-B40EBE774D84}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00C80000
+// Image base: 0x00FC0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -120,6 +120,9 @@
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData '<NestedStruct>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .field private class [mscorlib]System.EventHandler TestEvent
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
     .method public hidebysig specialname 
@@ -296,6 +299,76 @@
       IL_0001:  ret
     } // end of method Data::set_Item
 
+    .method public hidebysig specialname 
+            instance void  add_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       41 (0x29)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Combine(class [mscorlib]System.Delegate,
+                                                                                              class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  bne.un.s   IL_0007
+
+      IL_0028:  ret
+    } // end of method Data::add_TestEvent
+
+    .method public hidebysig specialname 
+            instance void  remove_TestEvent(class [mscorlib]System.EventHandler 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       41 (0x29)
+      .maxstack  3
+      .locals init (class [mscorlib]System.EventHandler V_0,
+               class [mscorlib]System.EventHandler V_1,
+               class [mscorlib]System.EventHandler V_2)
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  stloc.1
+      IL_0009:  ldloc.1
+      IL_000a:  ldarg.1
+      IL_000b:  call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::Remove(class [mscorlib]System.Delegate,
+                                                                                             class [mscorlib]System.Delegate)
+      IL_0010:  castclass  [mscorlib]System.EventHandler
+      IL_0015:  stloc.2
+      IL_0016:  ldarg.0
+      IL_0017:  ldflda     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::TestEvent
+      IL_001c:  ldloc.2
+      IL_001d:  ldloc.1
+      IL_001e:  call       !!0 [mscorlib]System.Threading.Interlocked::CompareExchange<class [mscorlib]System.EventHandler>(!!0&,
+                                                                                                                            !!0,
+                                                                                                                            !!0)
+      IL_0023:  stloc.0
+      IL_0024:  ldloc.0
+      IL_0025:  ldloc.1
+      IL_0026:  bne.un.s   IL_0007
+
+      IL_0028:  ret
+    } // end of method Data::remove_TestEvent
+
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
     {
@@ -310,6 +383,11 @@
       IL_0012:  ret
     } // end of method Data::.ctor
 
+    .event [mscorlib]System.EventHandler TestEvent
+    {
+      .addon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+      .removeon instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::remove_TestEvent(class [mscorlib]System.EventHandler)
+    } // end of event Data::TestEvent
     .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
             a()
     {
@@ -452,7 +530,8 @@
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' '<>9'
-    .field public static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> '<>9__40_0'
+    .field public static class [mscorlib]System.EventHandler '<>9__23_0'
+    .field public static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> '<>9__41_0'
     .method private hidebysig specialname rtspecialname static 
             void  .cctor() cil managed
     {
@@ -474,8 +553,19 @@
       IL_0007:  ret
     } // end of method '<>c'::.ctor
 
+    .method assembly hidebysig instance void 
+            '<NotAnObjectInitializerWithEvent>b__23_0'(object sender,
+                                                       class [mscorlib]System.EventArgs e) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  call       void [mscorlib]System.Console::WriteLine()
+      IL_0005:  nop
+      IL_0006:  ret
+    } // end of method '<>c'::'<NotAnObjectInitializerWithEvent>b__23_0'
+
     .method assembly hidebysig instance bool 
-            '<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+            '<Bug270_NestedInitialisers>b__41_0'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
     {
       // Code size       17 (0x11)
       .maxstack  8
@@ -485,7 +575,7 @@
       IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
                                                                      string)
       IL_0010:  ret
-    } // end of method '<>c'::'<Bug270_NestedInitialisers>b__40_0'
+    } // end of method '<>c'::'<Bug270_NestedInitialisers>b__41_0'
 
   } // end of class '<>c'
 
@@ -862,6 +952,37 @@
     IL_001a:  nop
     IL_001b:  ret
   } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializerWithEvent() cil managed
+  {
+    // Code size       58 (0x3a)
+    .maxstack  3
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__23_0'
+    IL_000d:  dup
+    IL_000e:  brtrue.s   IL_0027
+
+    IL_0010:  pop
+    IL_0011:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
+    IL_0016:  ldftn      instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<NotAnObjectInitializerWithEvent>b__23_0'(object,
+                                                                                                                                                        class [mscorlib]System.EventArgs)
+    IL_001c:  newobj     instance void [mscorlib]System.EventHandler::.ctor(object,
+                                                                            native int)
+    IL_0021:  dup
+    IL_0022:  stsfld     class [mscorlib]System.EventHandler ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__23_0'
+    IL_0027:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::add_TestEvent(class [mscorlib]System.EventHandler)
+    IL_002c:  nop
+    IL_002d:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0032:  ldloc.0
+    IL_0033:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0038:  nop
+    IL_0039:  ret
+  } // end of method InitializerTests::NotAnObjectInitializerWithEvent
 
   .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
   {
@@ -1369,17 +1490,17 @@
     IL_003b:  nop
     IL_003c:  dup
     IL_003d:  ldloc.0
-    IL_003e:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_003e:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__41_0'
     IL_0043:  dup
     IL_0044:  brtrue.s   IL_005d
 
     IL_0046:  pop
     IL_0047:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
-    IL_004c:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_004c:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<Bug270_NestedInitialisers>b__41_0'(class [mscorlib]System.Globalization.NumberFormatInfo)
     IL_0052:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
                                                                                                                                         native int)
     IL_0057:  dup
-    IL_0058:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_0058:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__41_0'
     IL_005d:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
                                                                                                                                                                                          class [mscorlib]System.Func`2<!!0,bool>)
     IL_0062:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
@@ -32,7 +32,7 @@
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x00C90000
+// Image base: 0x005E0000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
@@ -10,6 +10,11 @@
   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
   .ver 4:0:0:0
 }
+.assembly extern System.Core
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
 .assembly InitializerTests
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
@@ -25,14 +30,14 @@
   .ver 0:0:0:0
 }
 .module InitializerTests.dll
-// MVID: {7000C1D7-C4EC-4376-B053-4BE74428CE7A}
+// MVID: {EA222E3F-8F60-413B-AF03-0814FF05742B}
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .imagebase 0x10000000
 .file alignment 0x00000200
 .stackreserve 0x00100000
 .subsystem 0x0003       // WINDOWS_CUI
 .corflags 0x00000001    //  ILONLY
-// Image base: 0x005E0000
+// Image base: 0x00C80000
 
 
 // =============== CLASS MEMBERS DECLARATION ===================
@@ -80,6 +85,442 @@
     } // end of method S::.ctor
 
   } // end of class S
+
+  .class auto ansi sealed nested private MyEnum
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum a = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum b = int32(0x00000001)
+  } // end of class MyEnum
+
+  .class auto ansi sealed nested private MyEnum2
+         extends [mscorlib]System.Enum
+  {
+    .field public specialname rtspecialname int32 value__
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 c = int32(0x00000000)
+    .field public static literal valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2 d = int32(0x00000001)
+  } // end of class MyEnum2
+
+  .class auto ansi nested private beforefieldinit Data
+         extends [mscorlib]System.Object
+  {
+    .custom instance void [mscorlib]System.Reflection.DefaultMemberAttribute::.ctor(string) = ( 01 00 04 49 74 65 6D 00 00 )                      // ...Item..
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> FieldList
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<a>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum '<b>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .field private class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> '<PropertyList>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .field private valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData '<NestedStruct>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_a() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_a
+
+    .method public hidebysig specialname 
+            instance void  set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<a>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_a
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 
+            get_b() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_b
+
+    .method public hidebysig specialname 
+            instance void  set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<b>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_b
+
+    .method public hidebysig specialname 
+            instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 
+            get_PropertyList() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_PropertyList
+
+    .method public hidebysig specialname 
+            instance void  set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<PropertyList>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_PropertyList
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_MoreData
+
+    .method public hidebysig specialname 
+            instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 
+            get_NestedStruct() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0006:  ret
+    } // end of method Data::get_NestedStruct
+
+    .method public hidebysig specialname 
+            instance void  set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::'<NestedStruct>k__BackingField'
+      IL_0007:  ret
+    } // end of method Data::set_NestedStruct
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+      IL_0000:  nop
+      IL_0001:  ldnull
+      IL_0002:  stloc.0
+      IL_0003:  br.s       IL_0005
+
+      IL_0005:  ldloc.0
+      IL_0006:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_Item(int32 i,
+                     string j) cil managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  1
+      .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+      IL_0000:  nop
+      IL_0001:  ldnull
+      IL_0002:  stloc.0
+      IL_0003:  br.s       IL_0005
+
+      IL_0005:  ldloc.0
+      IL_0006:  ret
+    } // end of method Data::get_Item
+
+    .method public hidebysig specialname 
+            instance void  set_Item(int32 i,
+                                    string j,
+                                    class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method Data::set_Item
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       19 (0x13)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+      IL_0006:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+      IL_000b:  ldarg.0
+      IL_000c:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0011:  nop
+      IL_0012:  ret
+    } // end of method Data::.ctor
+
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            a()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_a()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    } // end of property Data::a
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum
+            b()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_b()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    } // end of property Data::b
+    .property instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>
+            PropertyList()
+    {
+      .get instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+    } // end of property Data::PropertyList
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::MoreData
+    .property instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+            NestedStruct()
+    {
+      .get instance valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_NestedStruct()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    } // end of property Data::NestedStruct
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32)
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::Item
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            Item(int32,
+                 string)
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32,
+                                                                                                                                                                            string)
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                       string,
+                                                                                                       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property Data::Item
+  } // end of class Data
+
+  .class sequential ansi sealed nested private beforefieldinit StructData
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 Field
+    .field private int32 '<Property>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .field private class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data '<MoreData>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 ) 
+    .method public hidebysig specialname 
+            instance int32  get_Property() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0006:  ret
+    } // end of method StructData::get_Property
+
+    .method public hidebysig specialname 
+            instance void  set_Property(int32 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<Property>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_Property
+
+    .method public hidebysig specialname 
+            instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 
+            get_MoreData() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0006:  ret
+    } // end of method StructData::get_MoreData
+
+    .method public hidebysig specialname 
+            instance void  set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data 'value') cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  ldarg.1
+      IL_0002:  stfld      class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::'<MoreData>k__BackingField'
+      IL_0007:  ret
+    } // end of method StructData::set_MoreData
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 initialValue) cil managed
+    {
+      // Code size       24 (0x18)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ldarg.0
+      IL_0002:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+      IL_0008:  ldarg.0
+      IL_0009:  ldarg.1
+      IL_000a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+      IL_000f:  ldarg.0
+      IL_0010:  ldarg.1
+      IL_0011:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+      IL_0016:  nop
+      IL_0017:  ret
+    } // end of method StructData::.ctor
+
+    .property instance int32 Property()
+    {
+      .get instance int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_Property()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    } // end of property StructData::Property
+    .property instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data
+            MoreData()
+    {
+      .get instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+      .set instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    } // end of property StructData::MoreData
+  } // end of class StructData
+
+  .class auto ansi serializable sealed nested private beforefieldinit '<>c'
+         extends [mscorlib]System.Object
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' '<>9'
+    .field public static class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> '<>9__40_0'
+    .method private hidebysig specialname rtspecialname static 
+            void  .cctor() cil managed
+    {
+      // Code size       11 (0xb)
+      .maxstack  8
+      IL_0000:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::.ctor()
+      IL_0005:  stsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
+      IL_000a:  ret
+    } // end of method '<>c'::.cctor
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  nop
+      IL_0007:  ret
+    } // end of method '<>c'::.ctor
+
+    .method assembly hidebysig instance bool 
+            '<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo format) cil managed
+    {
+      // Code size       17 (0x11)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  callvirt   instance string [mscorlib]System.Globalization.NumberFormatInfo::get_CurrencySymbol()
+      IL_0006:  ldstr      "$"
+      IL_000b:  call       bool [mscorlib]System.String::op_Equality(string,
+                                                                     string)
+      IL_0010:  ret
+    } // end of method '<>c'::'<Bug270_NestedInitialisers>b__40_0'
+
+  } // end of class '<>c'
+
+  .method private hidebysig static void  X(object a,
+                                           object b) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method InitializerTests::X
+
+  .method private hidebysig static object 
+          Y() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (object V_0)
+    IL_0000:  nop
+    IL_0001:  ldnull
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method InitializerTests::Y
+
+  .method public hidebysig static void  TestCall(int32 a,
+                                                 class [mscorlib]System.Threading.Thread thread) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method InitializerTests::TestCall
 
   .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
           TestCall(int32 a,
@@ -253,6 +694,704 @@
     IL_002a:  ldloc.1
     IL_002b:  ret
   } // end of method InitializerTests::Test4
+
+  .method public hidebysig static void  CollectionInitializerList() cil managed
+  {
+    // Code size       42 (0x2a)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.1
+    IL_000d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0012:  nop
+    IL_0013:  dup
+    IL_0014:  ldc.i4.2
+    IL_0015:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001a:  nop
+    IL_001b:  dup
+    IL_001c:  ldc.i4.3
+    IL_001d:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0022:  nop
+    IL_0023:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0028:  nop
+    IL_0029:  ret
+  } // end of method InitializerTests::CollectionInitializerList
+
+  .method public hidebysig static object 
+          RecursiveCollectionInitializer() cil managed
+  {
+    // Code size       21 (0x15)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<object> V_0,
+             object V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<object>::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldloc.0
+    IL_0009:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<object>::Add(!0)
+    IL_000e:  nop
+    IL_000f:  ldloc.0
+    IL_0010:  stloc.1
+    IL_0011:  br.s       IL_0013
+
+    IL_0013:  ldloc.1
+    IL_0014:  ret
+  } // end of method InitializerTests::RecursiveCollectionInitializer
+
+  .method public hidebysig static void  CollectionInitializerDictionary() cil managed
+  {
+    // Code size       57 (0x39)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldstr      "First"
+    IL_0011:  ldc.i4.1
+    IL_0012:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0017:  nop
+    IL_0018:  dup
+    IL_0019:  ldstr      "Second"
+    IL_001e:  ldc.i4.2
+    IL_001f:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0024:  nop
+    IL_0025:  dup
+    IL_0026:  ldstr      "Third"
+    IL_002b:  ldc.i4.3
+    IL_002c:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<string,int32>::Add(!0,
+                                                                                                                  !1)
+    IL_0031:  nop
+    IL_0032:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0037:  nop
+    IL_0038:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionary
+
+  .method public hidebysig static void  CollectionInitializerDictionaryWithEnumTypes() cil managed
+  {
+    // Code size       36 (0x24)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.0
+    IL_000d:  ldc.i4.0
+    IL_000e:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_0013:  nop
+    IL_0014:  dup
+    IL_0015:  ldc.i4.1
+    IL_0016:  ldc.i4.1
+    IL_0017:  callvirt   instance void class [mscorlib]System.Collections.Generic.Dictionary`2<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum,valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0,
+                                                                                                                                                                                                                                                                      !1)
+    IL_001c:  nop
+    IL_001d:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0022:  nop
+    IL_0023:  ret
+  } // end of method InitializerTests::CollectionInitializerDictionaryWithEnumTypes
+
+  .method public hidebysig static void  NotACollectionInitializer() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (class [mscorlib]System.Collections.Generic.List`1<int32> V_0)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<int32>::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_000e:  nop
+    IL_000f:  ldloc.0
+    IL_0010:  ldc.i4.2
+    IL_0011:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_0016:  nop
+    IL_0017:  ldloc.0
+    IL_0018:  ldc.i4.3
+    IL_0019:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<int32>::Add(!0)
+    IL_001e:  nop
+    IL_001f:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0024:  ldloc.0
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::NotACollectionInitializer
+
+  .method public hidebysig static void  ObjectInitializer() cil managed
+  {
+    // Code size       26 (0x1a)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  nop
+    IL_0013:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0018:  nop
+    IL_0019:  ret
+  } // end of method InitializerTests::ObjectInitializer
+
+  .method public hidebysig static void  NotAnObjectInitializer() cil managed
+  {
+    // Code size       28 (0x1c)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data V_0)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.0
+    IL_0009:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_000e:  nop
+    IL_000f:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0014:  ldloc.0
+    IL_0015:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_001a:  nop
+    IL_001b:  ret
+  } // end of method InitializerTests::NotAnObjectInitializer
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToField() cil managed
+  {
+    // Code size       53 (0x35)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  nop
+    IL_0013:  dup
+    IL_0014:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_0019:  dup
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0020:  nop
+    IL_0021:  dup
+    IL_0022:  ldc.i4.1
+    IL_0023:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0028:  nop
+    IL_0029:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_002e:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0033:  nop
+    IL_0034:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToField
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInField() cil managed
+  {
+    // Code size       52 (0x34)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  nop
+    IL_0013:  dup
+    IL_0014:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0019:  ldc.i4.0
+    IL_001a:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001f:  nop
+    IL_0020:  dup
+    IL_0021:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0026:  ldc.i4.1
+    IL_0027:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002c:  nop
+    IL_002d:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0032:  nop
+    IL_0033:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInField
+
+  .method public hidebysig static void  ObjectInitializerAssignCollectionToProperty() cil managed
+  {
+    // Code size       54 (0x36)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  nop
+    IL_0013:  dup
+    IL_0014:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::.ctor()
+    IL_0019:  dup
+    IL_001a:  ldc.i4.0
+    IL_001b:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0020:  nop
+    IL_0021:  dup
+    IL_0022:  ldc.i4.1
+    IL_0023:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0028:  nop
+    IL_0029:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_PropertyList(class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>)
+    IL_002e:  nop
+    IL_002f:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0034:  nop
+    IL_0035:  ret
+  } // end of method InitializerTests::ObjectInitializerAssignCollectionToProperty
+
+  .method public hidebysig static void  ObjectInitializerAddToCollectionInProperty() cil managed
+  {
+    // Code size       52 (0x34)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.0
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  nop
+    IL_0013:  dup
+    IL_0014:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0019:  ldc.i4.0
+    IL_001a:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_001f:  nop
+    IL_0020:  dup
+    IL_0021:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0026:  ldc.i4.1
+    IL_0027:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002c:  nop
+    IL_002d:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0032:  nop
+    IL_0033:  ret
+  } // end of method InitializerTests::ObjectInitializerAddToCollectionInProperty
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       49 (0x31)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0011:  ldc.i4.0
+    IL_0012:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0017:  nop
+    IL_0018:  dup
+    IL_0019:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001e:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0023:  ldc.i4.1
+    IL_0024:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0029:  nop
+    IL_002a:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002f:  nop
+    IL_0030:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfNestedObjects
+
+  .method private hidebysig static int32 
+          GetInt() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (int32 V_0)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.1
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method InitializerTests::GetInt
+
+  .method private hidebysig static string 
+          GetString() cil managed
+  {
+    // Code size       11 (0xb)
+    .maxstack  1
+    .locals init (string V_0)
+    IL_0000:  nop
+    IL_0001:  ldstr      "Test"
+    IL_0006:  stloc.0
+    IL_0007:  br.s       IL_0009
+
+    IL_0009:  ldloc.0
+    IL_000a:  ret
+  } // end of method InitializerTests::GetString
+
+  .method public hidebysig static void  SimpleDictInitializer() cil managed
+  {
+    // Code size       45 (0x2d)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0011:  ldc.i4.0
+    IL_0012:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0017:  nop
+    IL_0018:  dup
+    IL_0019:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_001e:  ldc.i4.2
+    IL_001f:  ldnull
+    IL_0020:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                                     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0025:  nop
+    IL_0026:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002b:  nop
+    IL_002c:  ret
+  } // end of method InitializerTests::SimpleDictInitializer
+
+  .method public hidebysig static void  MixedObjectAndDictInitializer() cil managed
+  {
+    // Code size       137 (0x89)
+    .maxstack  6
+    .locals init (int32 V_0,
+             int32 V_1,
+             string V_2)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0011:  ldc.i4.0
+    IL_0012:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0017:  nop
+    IL_0018:  call       int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::GetInt()
+    IL_001d:  stloc.0
+    IL_001e:  dup
+    IL_001f:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0024:  ldloc.0
+    IL_0025:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_002a:  ldc.i4.1
+    IL_002b:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0030:  nop
+    IL_0031:  dup
+    IL_0032:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0037:  ldloc.0
+    IL_0038:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_003d:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0042:  ldc.i4.0
+    IL_0043:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0048:  nop
+    IL_0049:  call       int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::GetInt()
+    IL_004e:  stloc.1
+    IL_004f:  call       string ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::GetString()
+    IL_0054:  stloc.2
+    IL_0055:  dup
+    IL_0056:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_005b:  ldloc.0
+    IL_005c:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_0061:  ldloc.1
+    IL_0062:  ldloc.2
+    IL_0063:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0068:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                                     string,
+                                                                                                                     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_006d:  nop
+    IL_006e:  dup
+    IL_006f:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0074:  ldloc.0
+    IL_0075:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_Item(int32)
+    IL_007a:  ldc.i4.2
+    IL_007b:  ldnull
+    IL_007c:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_Item(int32,
+                                                                                                                     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0081:  nop
+    IL_0082:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0087:  nop
+    IL_0088:  ret
+  } // end of method InitializerTests::MixedObjectAndDictInitializer
+
+  .method public hidebysig static void  ObjectInitializerWithInitializationOfDeeplyNestedObjects() cil managed
+  {
+    // Code size       82 (0x52)
+    .maxstack  4
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldc.i4.1
+    IL_000d:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0012:  nop
+    IL_0013:  dup
+    IL_0014:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0019:  ldc.i4.0
+    IL_001a:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001f:  nop
+    IL_0020:  dup
+    IL_0021:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0026:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_002b:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0030:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0035:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_003a:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_003f:  callvirt   instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_MoreData()
+    IL_0044:  ldc.i4.1
+    IL_0045:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_004a:  nop
+    IL_004b:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0050:  nop
+    IL_0051:  ret
+  } // end of method InitializerTests::ObjectInitializerWithInitializationOfDeeplyNestedObjects
+
+  .method public hidebysig static void  CollectionInitializerInsideObjectInitializers() cil managed
+  {
+    // Code size       59 (0x3b)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_0011:  dup
+    IL_0012:  ldc.i4.0
+    IL_0013:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0018:  nop
+    IL_0019:  dup
+    IL_001a:  ldc.i4.1
+    IL_001b:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_b(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_0020:  nop
+    IL_0021:  dup
+    IL_0022:  callvirt   instance class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::get_PropertyList()
+    IL_0027:  ldc.i4.0
+    IL_0028:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002d:  nop
+    IL_002e:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_MoreData(class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data)
+    IL_0033:  nop
+    IL_0034:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0039:  nop
+    IL_003a:  ret
+  } // end of method InitializerTests::CollectionInitializerInsideObjectInitializers
+
+  .method public hidebysig static void  NotAStructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  ldloca.s   V_0
+    IL_0003:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0009:  ldloca.s   V_0
+    IL_000b:  ldc.i4.1
+    IL_000c:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0011:  ldloca.s   V_0
+    IL_0013:  ldc.i4.2
+    IL_0014:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0019:  nop
+    IL_001a:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001f:  ldloc.0
+    IL_0020:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::NotAStructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  StructInitializer_DefaultConstructor() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  ldloca.s   V_0
+    IL_0008:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000e:  ldloca.s   V_0
+    IL_0010:  ldc.i4.1
+    IL_0011:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0016:  ldloca.s   V_0
+    IL_0018:  ldc.i4.2
+    IL_0019:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001e:  nop
+    IL_001f:  ldloc.0
+    IL_0020:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::StructInitializer_DefaultConstructor
+
+  .method public hidebysig static void  NotAStructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  ldloca.s   V_0
+    IL_0003:  ldc.i4.0
+    IL_0004:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0009:  ldloca.s   V_0
+    IL_000b:  ldc.i4.1
+    IL_000c:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0011:  ldloca.s   V_0
+    IL_0013:  ldc.i4.2
+    IL_0014:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0019:  nop
+    IL_001a:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_001f:  ldloc.0
+    IL_0020:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::NotAStructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializer_ExplicitConstructor() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  ldloca.s   V_0
+    IL_0008:  ldc.i4.0
+    IL_0009:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_000e:  ldloca.s   V_0
+    IL_0010:  ldc.i4.1
+    IL_0011:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_0016:  ldloca.s   V_0
+    IL_0018:  ldc.i4.2
+    IL_0019:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_001e:  nop
+    IL_001f:  ldloc.0
+    IL_0020:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0025:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_002a:  nop
+    IL_002b:  ret
+  } // end of method InitializerTests::StructInitializer_ExplicitConstructor
+
+  .method public hidebysig static void  StructInitializerWithInitializationOfNestedObjects() cil managed
+  {
+    // Code size       79 (0x4f)
+    .maxstack  3
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  ldloca.s   V_0
+    IL_0008:  initobj    ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_000e:  ldloca.s   V_0
+    IL_0010:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0015:  ldc.i4.0
+    IL_0016:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_a(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum)
+    IL_001b:  nop
+    IL_001c:  ldloca.s   V_0
+    IL_001e:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0023:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_0028:  ldc.i4.0
+    IL_0029:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_002e:  nop
+    IL_002f:  ldloca.s   V_0
+    IL_0031:  call       instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::get_MoreData()
+    IL_0036:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::FieldList
+    IL_003b:  ldc.i4.1
+    IL_003c:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/MyEnum2>::Add(!0)
+    IL_0041:  nop
+    IL_0042:  ldloc.0
+    IL_0043:  box        ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData
+    IL_0048:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_004d:  nop
+    IL_004e:  ret
+  } // end of method InitializerTests::StructInitializerWithInitializationOfNestedObjects
+
+  .method public hidebysig static void  StructInitializerWithinObjectInitializer() cil managed
+  {
+    // Code size       51 (0x33)
+    .maxstack  5
+    .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData V_0)
+    IL_0000:  nop
+    IL_0001:  call       object ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Y()
+    IL_0006:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::.ctor()
+    IL_000b:  dup
+    IL_000c:  ldloca.s   V_0
+    IL_000e:  ldc.i4.2
+    IL_000f:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::.ctor(int32)
+    IL_0014:  ldloca.s   V_0
+    IL_0016:  ldc.i4.1
+    IL_0017:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::Field
+    IL_001c:  ldloca.s   V_0
+    IL_001e:  ldc.i4.2
+    IL_001f:  call       instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData::set_Property(int32)
+    IL_0024:  nop
+    IL_0025:  ldloc.0
+    IL_0026:  callvirt   instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/Data::set_NestedStruct(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/StructData)
+    IL_002b:  nop
+    IL_002c:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::X(object,
+                                                                                                object)
+    IL_0031:  nop
+    IL_0032:  ret
+  } // end of method InitializerTests::StructInitializerWithinObjectInitializer
+
+  .method public hidebysig static void  Bug270_NestedInitialisers() cil managed
+  {
+    // Code size       122 (0x7a)
+    .maxstack  8
+    .locals init (class [mscorlib]System.Globalization.NumberFormatInfo[] V_0)
+    IL_0000:  nop
+    IL_0001:  ldnull
+    IL_0002:  stloc.0
+    IL_0003:  ldc.i4.0
+    IL_0004:  ldnull
+    IL_0005:  ldftn      void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::Bug270_NestedInitialisers()
+    IL_000b:  newobj     instance void [mscorlib]System.Threading.ThreadStart::.ctor(object,
+                                                                                     native int)
+    IL_0010:  newobj     instance void [mscorlib]System.Threading.Thread::.ctor(class [mscorlib]System.Threading.ThreadStart)
+    IL_0015:  dup
+    IL_0016:  ldc.i4.1
+    IL_0017:  callvirt   instance void [mscorlib]System.Threading.Thread::set_Priority(valuetype [mscorlib]System.Threading.ThreadPriority)
+    IL_001c:  nop
+    IL_001d:  dup
+    IL_001e:  ldc.i4.0
+    IL_001f:  newobj     instance void [mscorlib]System.Globalization.CultureInfo::.ctor(int32)
+    IL_0024:  dup
+    IL_0025:  newobj     instance void [mscorlib]System.Globalization.DateTimeFormatInfo::.ctor()
+    IL_002a:  dup
+    IL_002b:  ldstr      "ddmmyy"
+    IL_0030:  callvirt   instance void [mscorlib]System.Globalization.DateTimeFormatInfo::set_ShortDatePattern(string)
+    IL_0035:  nop
+    IL_0036:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_DateTimeFormat(class [mscorlib]System.Globalization.DateTimeFormatInfo)
+    IL_003b:  nop
+    IL_003c:  dup
+    IL_003d:  ldloc.0
+    IL_003e:  ldsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_0043:  dup
+    IL_0044:  brtrue.s   IL_005d
+
+    IL_0046:  pop
+    IL_0047:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9'
+    IL_004c:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<Bug270_NestedInitialisers>b__40_0'(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_0052:  newobj     instance void class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool>::.ctor(object,
+                                                                                                                                        native int)
+    IL_0057:  dup
+    IL_0058:  stsfld     class [mscorlib]System.Func`2<class [mscorlib]System.Globalization.NumberFormatInfo,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/'<>c'::'<>9__40_0'
+    IL_005d:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0062:  call       !!0 [System.Core]System.Linq.Enumerable::First<class [mscorlib]System.Globalization.NumberFormatInfo>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_0067:  callvirt   instance void [mscorlib]System.Globalization.CultureInfo::set_NumberFormat(class [mscorlib]System.Globalization.NumberFormatInfo)
+    IL_006c:  nop
+    IL_006d:  callvirt   instance void [mscorlib]System.Threading.Thread::set_CurrentCulture(class [mscorlib]System.Globalization.CultureInfo)
+    IL_0072:  nop
+    IL_0073:  call       void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                       class [mscorlib]System.Threading.Thread)
+    IL_0078:  nop
+    IL_0079:  ret
+  } // end of method InitializerTests::Bug270_NestedInitialisers
 
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor() cil managed

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.roslyn.il
@@ -1,0 +1,247 @@
+
+//  Microsoft (R) .NET Framework IL Disassembler.  Version 4.6.1055.0
+//  Copyright (c) Microsoft Corporation. Alle Rechte vorbehalten.
+
+
+
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly InitializerTests
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
+                                                                                                             63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
+
+  // --- The following custom attribute is added automatically, do not uncomment -------
+  //  .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = ( 01 00 07 01 00 00 00 00 ) 
+
+  .permissionset reqmin
+             = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
+  .hash algorithm 0x00008004
+  .ver 0:0:0:0
+}
+.module InitializerTests.dll
+// MVID: {53F415C2-DC80-4EFA-8787-82F129B1AC28}
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+// Image base: 0x002F0000
+
+
+// =============== CLASS MEMBERS DECLARATION ===================
+
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested public beforefieldinit C
+         extends [mscorlib]System.Object
+  {
+    .field public int32 Z
+    .field public valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S Y
+    .field public class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> L
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  nop
+      IL_0007:  ret
+    } // end of method C::.ctor
+
+  } // end of class C
+
+  .class sequential ansi sealed nested public beforefieldinit S
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 A
+    .field public int32 B
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 a) cil managed
+    {
+      // Code size       16 (0x10)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ldarg.0
+      IL_0002:  ldarg.1
+      IL_0003:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+      IL_0008:  ldarg.0
+      IL_0009:  ldc.i4.0
+      IL_000a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+      IL_000f:  ret
+    } // end of method S::.ctor
+
+  } // end of class S
+
+  .method public hidebysig static class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          TestCall(int32 a,
+                   class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C c) cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method InitializerTests::TestCall
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test() cil managed
+  {
+    // Code size       42 (0x2a)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::.ctor()
+    IL_000d:  stfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0012:  ldloc.0
+    IL_0013:  ldfld      class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S> ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::L
+    IL_0018:  ldc.i4.1
+    IL_0019:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_001e:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S>::Add(!0)
+    IL_0023:  nop
+    IL_0024:  ldloc.0
+    IL_0025:  stloc.1
+    IL_0026:  br.s       IL_0028
+
+    IL_0028:  ldloc.1
+    IL_0029:  ret
+  } // end of method InitializerTests::Test
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test2() cil managed
+  {
+    // Code size       27 (0x1b)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000e:  ldloc.0
+    IL_000f:  ldc.i4.2
+    IL_0010:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0015:  ldloc.0
+    IL_0016:  stloc.1
+    IL_0017:  br.s       IL_0019
+
+    IL_0019:  ldloc.1
+    IL_001a:  ret
+  } // end of method InitializerTests::Test2
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3() cil managed
+  {
+    // Code size       37 (0x25)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldc.i4.1
+    IL_0009:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::.ctor(int32)
+    IL_000e:  stfld      valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0013:  ldloc.0
+    IL_0014:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0019:  ldc.i4.2
+    IL_001a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001f:  ldloc.0
+    IL_0020:  stloc.1
+    IL_0021:  br.s       IL_0023
+
+    IL_0023:  ldloc.1
+    IL_0024:  ret
+  } // end of method InitializerTests::Test3
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test3b() cil managed
+  {
+    // Code size       36 (0x24)
+    .maxstack  4
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0)
+    IL_0000:  nop
+    IL_0001:  ldc.i4.0
+    IL_0002:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0007:  dup
+    IL_0008:  ldc.i4.1
+    IL_0009:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_000e:  dup
+    IL_000f:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0014:  ldc.i4.2
+    IL_0015:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_001a:  call       class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests::TestCall(int32,
+                                                                                                                                                                         class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C)
+    IL_001f:  stloc.0
+    IL_0020:  br.s       IL_0022
+
+    IL_0022:  ldloc.0
+    IL_0023:  ret
+  } // end of method InitializerTests::Test3b
+
+  .method public hidebysig instance class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C 
+          Test4() cil managed
+  {
+    // Code size       44 (0x2c)
+    .maxstack  2
+    .locals init (class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_0,
+             class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C V_1)
+    IL_0000:  nop
+    IL_0001:  newobj     instance void ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::.ctor()
+    IL_0006:  stloc.0
+    IL_0007:  ldloc.0
+    IL_0008:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_000d:  ldc.i4.1
+    IL_000e:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::A
+    IL_0013:  ldloc.0
+    IL_0014:  ldflda     valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Y
+    IL_0019:  ldc.i4.3
+    IL_001a:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/S::B
+    IL_001f:  ldloc.0
+    IL_0020:  ldc.i4.2
+    IL_0021:  stfld      int32 ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests/C::Z
+    IL_0026:  ldloc.0
+    IL_0027:  stloc.1
+    IL_0028:  br.s       IL_002a
+
+    IL_002a:  ldloc.1
+    IL_002b:  ret
+  } // end of method InitializerTests::Test4
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method InitializerTests::.ctor
+
+} // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
+
+
+// =============================================================
+
+// *********** DISASSEMBLY COMPLETE ***********************

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -1427,11 +1427,10 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (currentPath == null) {
 					currentPath = info.Path;
 				} else {
-					int firstDifferenceIndex = Math.Min(currentPath.Count, info.Path.Count);
-					int index = 0;
-					while (index < firstDifferenceIndex && info.Path[index] == currentPath[index])
-						index++;
-					firstDifferenceIndex = index;
+					int minLen = Math.Min(currentPath.Count, info.Path.Count);
+					int firstDifferenceIndex = 0;
+					while (firstDifferenceIndex < minLen && info.Path[firstDifferenceIndex] == currentPath[firstDifferenceIndex])
+						firstDifferenceIndex++;
 					while (elementsStack.Count - 1 > firstDifferenceIndex) {
 						var methodElement = currentPath[elementsStack.Count - 1];
 						var pathElement = currentPath[elementsStack.Count - 2];

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -90,6 +90,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			Space(policy.SpaceBeforeBracketComma);
 			// TODO: Comma policy has changed.
 			writer.WriteToken(Roles.Comma, ",");
+			isAfterSpace = false;
 			Space(!noSpaceAfterComma && policy.SpaceAfterBracketComma);
 			// TODO: Comma policy has changed.
 		}
@@ -194,6 +195,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		
 		#region Write tokens
 		protected bool isAtStartOfLine = true;
+		protected bool isAfterSpace;
 		
 		/// <summary>
 		/// Writes a keyword, and all specials up to
@@ -207,18 +209,21 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			writer.WriteKeyword(tokenRole, token);
 			isAtStartOfLine = false;
+			isAfterSpace = false;
 		}
 		
 		protected virtual void WriteIdentifier(Identifier identifier)
 		{
 			writer.WriteIdentifier(identifier);
 			isAtStartOfLine = false;
+			isAfterSpace = false;
 		}
 		
 		protected virtual void WriteIdentifier(string identifier)
 		{
 			AstType.Create(identifier).AcceptVisitor(this);
 			isAtStartOfLine = false;
+			isAfterSpace = false;
 		}
 		
 		protected virtual void WriteToken(TokenRole tokenRole)
@@ -230,6 +235,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			writer.WriteToken(tokenRole, token);
 			isAtStartOfLine = false;
+			isAfterSpace = false;
 		}
 		
 		protected virtual void LPar()
@@ -260,8 +266,9 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		/// </summary>
 		protected virtual void Space(bool addSpace = true)
 		{
-			if (addSpace) {
+			if (addSpace && !isAfterSpace) {
 				writer.Space();
+				isAfterSpace = true;
 			}
 		}
 		
@@ -269,6 +276,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			writer.NewLine();
 			isAtStartOfLine = true;
+			isAfterSpace = false;
 		}
 		
 		protected virtual void OpenBrace(BraceStyle style)
@@ -278,7 +286,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				case BraceStyle.EndOfLine:
 				case BraceStyle.BannerStyle:
 					if (!isAtStartOfLine)
-						writer.Space();
+						Space();
 					writer.WriteToken(Roles.LBrace, "{");
 					break;
 				case BraceStyle.EndOfLineWithoutSpace:
@@ -937,6 +945,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			StartNode(primitiveExpression);
 			writer.WritePrimitiveValue(primitiveExpression.Value, primitiveExpression.UnsafeLiteralValue);
+			isAfterSpace = false;
 			EndNode(primitiveExpression);
 		}
 		#endregion

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -273,6 +273,7 @@
     <Compile Include="DotNetCore\DotNetCorePathFinderExtensions.cs" />
     <Compile Include="DotNetCore\UnresolvedAssemblyNameReference.cs" />
     <Compile Include="IL\Instructions\CallIndirect.cs" />
+    <Compile Include="IL\Instructions\DefaultValue.cs" />
     <Compile Include="IL\Transforms\EarlyExpressionTransforms.cs" />
     <Compile Include="IL\Transforms\ProxyCallReplacer.cs" />
     <Compile Include="IL\Instructions\StringToInt.cs" />

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -1010,7 +1010,9 @@ namespace ICSharpCode.Decompiler.IL
 
 		ILInstruction InitObj(ILInstruction target, IType type)
 		{
-			return new StObj(target, new DefaultValue(type), type);
+			var value = new DefaultValue(type);
+			value.ILStackWasEmpty = currentStack.IsEmpty;
+			return new StObj(target, value, type);
 		}
 		
 		private ILInstruction DecodeConstrainedCall()

--- a/ICSharpCode.Decompiler/IL/Instructions/DefaultValue.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/DefaultValue.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2017 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ICSharpCode.Decompiler.IL
+{
+	partial class DefaultValue
+	{
+		/// <summary>
+		/// Gets whether the IL stack was empty at the point of this instruction.
+		/// (not counting the argument of the instruction itself)
+		/// </summary>
+		public bool ILStackWasEmpty;
+	}
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -196,7 +196,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					proposedName = proposedNameForLoads[0];
 				}
 			}
-			if (string.IsNullOrEmpty(proposedName)) {
+			if (string.IsNullOrEmpty(proposedName) && variable.Kind == VariableKind.StackSlot) {
 				var proposedNameForStoresFromNewObj = variable.StoreInstructions.OfType<StLoc>()
 					.Select(expr => GetNameByType(GuessType(variable.Type, expr.Value, context)))
 					.Except(currentFieldNames).ToList();

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -198,7 +198,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 			if (string.IsNullOrEmpty(proposedName)) {
 				var proposedNameForStoresFromNewObj = variable.StoreInstructions.OfType<StLoc>()
-					.Select(expr => GetNameByType(GuessType(expr.Value, context)))
+					.Select(expr => GetNameByType(GuessType(variable.Type, expr.Value, context)))
 					.Except(currentFieldNames).ToList();
 				if (proposedNameForStoresFromNewObj.Count == 1) {
 					proposedName = proposedNameForStoresFromNewObj[0];
@@ -357,8 +357,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return char.ToLower(name[0]) + name.Substring(1);
 		}
 
-		internal static IType GuessType(ILInstruction inst, ILTransformContext context)
+		internal static IType GuessType(IType variableType, ILInstruction inst, ILTransformContext context)
 		{
+			if (!variableType.IsKnownType(KnownTypeCode.Object))
+				return variableType;
+
 			switch (inst) {
 				case NewObj newObj:
 					return newObj.Method.DeclaringType;

--- a/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
@@ -104,6 +104,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				var newObj = new NewObj(inst.Method);
 				newObj.ILRange = inst.ILRange;
 				newObj.Arguments.AddRange(inst.Arguments.Skip(1));
+				newObj.ILStackWasEmpty = inst.ILStackWasEmpty;
 				var expr = new StObj(inst.Arguments[0], newObj, inst.Method.DeclaringType);
 				inst.ReplaceWith(expr);
 				return expr;

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
@@ -66,6 +66,13 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						instType = newObjInst.Method.DeclaringType;
 						break;
 					case DefaultValue defaultVal:
+						if (defaultVal.ILStackWasEmpty && v.Kind == VariableKind.Local && !context.Function.Method.IsConstructor) {
+							// on statement level (no other expressions on IL stack),
+							// prefer to keep local variables (but not stack slots),
+							// unless we are in a constructor (where inlining object initializers might be critical
+							// for the base ctor call)
+							return false;
+						}
 						instType = defaultVal.Type;
 						break;
 					case Block existingInitializer:

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
@@ -224,17 +224,18 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 							}
 						}
 						break;
-					case LdObj ldobj:
+					case LdObj ldobj: {
 						if (ldobj.Target is LdFlda ldflda) {
 							path.Insert(0, new AccessPathElement(ldflda.Field));
 							instruction = ldflda.Target;
 							break;
 						}
 						goto default;
-					case StObj stobj:
-						if (stobj.Target is LdFlda ldflda2) {
-							path.Insert(0, new AccessPathElement(ldflda2.Field));
-							instruction = ldflda2.Target;
+					}
+					case StObj stobj: {
+						if (stobj.Target is LdFlda ldflda) {
+							path.Insert(0, new AccessPathElement(ldflda.Field));
+							instruction = ldflda.Target;
 							if (values == null) {
 								values = new List<ILInstruction>(new[] { stobj.Value });
 								kind = AccessPathKind.Setter;
@@ -242,6 +243,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 							break;
 						}
 						goto default;
+					}
 					case LdLoc ldloc:
 						target = ldloc.Variable;
 						instruction = null;
@@ -249,6 +251,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					case LdLoca ldloca:
 						target = ldloca.Variable;
 						instruction = null;
+						break;
+					case LdFlda ldflda:
+						path.Insert(0, new AccessPathElement(ldflda.Field));
+						instruction = ldflda.Target;
 						break;
 					default:
 						kind = AccessPathKind.Invalid;

--- a/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
+++ b/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
@@ -190,5 +190,12 @@ namespace ICSharpCode.Decompiler.Util
 				return maxElement;
 			}
 		}
+
+		public static void RemoveLast<T>(this IList<T> list)
+		{
+			if (list == null)
+				throw new ArgumentNullException(nameof(list));
+			list.RemoveAt(list.Count - 1);
+		}
 	}
 }


### PR DESCRIPTION
* [x] check `AccessPathElement` for invalid duplicate usage.
* [x] abort transform if initializer is followed by plain method calls (on the target) that cannot be transformed.
* [x] add pretty tests for initializers.
* [x] Remove dead code and update documentation.