### PR TITLE
Reference Mono.Cecil using a PackageReference

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -39,7 +39,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
     <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
   </ItemGroup>
 

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -565,7 +565,8 @@
     <Compile Include="Util\ReferenceComparer.cs" />
     <Compile Include="Util\TreeTraversal.cs" />
     <Compile Include="Util\UnionFind.cs" />
-    <None Include="ICSharpCode.Decompiler.nuspec" />
+    <None Include="ICSharpCode.Decompiler.nuspec" DependentUpon="ICSharpCode.Decompiler.nuspec.template" />
+    <None Include="ICSharpCode.Decompiler.nuspec.template" />
     <None Include="ICSharpCode.Decompiler.ruleset" />
     <None Include="ICSharpCode.Decompiler.snk" />
     <None Include="IL\ILOpCodes.tt">

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -50,12 +50,9 @@
 
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.2.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
@@ -16,6 +16,7 @@
     <tags>C# Decompiler ILSpy</tags>
     <dependencies>
       <dependency id="Humanizer.Core" version="2.2.0" />
+      <dependency id="Mono.Cecil" version="0.10.0-beta7" />
       <dependency id="System.Collections.Immutable" version="1.3.1" />
       <dependency id="System.ValueTuple" version="4.3.0" />
     </dependencies>
@@ -23,12 +24,8 @@
   <files>
     <file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.dll" target="lib\net46" />
     <file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.pdb" target="lib\net46" />
-    <file src="bin\$Configuration$\net46\Mono.Cecil.dll" target="lib\net46" />
-    <file src="bin\$Configuration$\net46\Mono.Cecil.pdb" target="lib\net46" />
 
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.dll" target="lib\netstandard2.0" />
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.pdb" target="lib\netstandard2.0" />
-    <file src="bin\$Configuration$\netstandard2.0\Mono.Cecil.dll" target="lib\netstandard2.0" />
-    <file src="bin\$Configuration$\netstandard2.0\Mono.Cecil.pdb" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/ILSpy.AddIn/ILSpy.AddIn.csproj
+++ b/ILSpy.AddIn/ILSpy.AddIn.csproj
@@ -51,8 +51,6 @@
     <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
     <ProjectReference Include="..\ILSpy.BamlDecompiler\ILSpy.BamlDecompiler.csproj" />
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
-    <ProjectReference Include="..\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
     <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj" />
   </ItemGroup>
 

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
     <ProjectReference Include="..\ICSharpCode.Decompiler.Tests\ICSharpCode.Decompiler.Tests.csproj" />
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
     <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj" />

--- a/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
+++ b/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
@@ -46,9 +46,6 @@
     <ProjectReference Include="..\ILSpy\ILSpy.csproj">
       <Private>False</Private>
     </ProjectReference>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false">
-      <Private>False</Private>
-    </ProjectReference>
     <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj">
       <Private>False</Private>
     </ProjectReference>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -54,8 +54,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
-    <ProjectReference Include="..\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
     <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
     <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj" />
   </ItemGroup>

--- a/TestPlugin/TestPlugin.csproj
+++ b/TestPlugin/TestPlugin.csproj
@@ -35,7 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj" AdditionalProperties="NuGetRestoreTargets=;ResolveNuGetPackages=false" />
     <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
     <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj" />

--- a/clean.bat
+++ b/clean.bat
@@ -1,6 +1,3 @@
-@if not exist "cecil\Mono.Cecil.csproj" (
-	git submodule update --init || exit /b 1
-)
 @setlocal enabledelayedexpansion
 @set MSBUILD=
 @for /D %%M in ("%ProgramFiles(x86)%\Microsoft Visual Studio\2017"\*) do (

--- a/debugbuild.bat
+++ b/debugbuild.bat
@@ -1,7 +1,3 @@
-@if not exist "cecil\Mono.Cecil.csproj" (
-	git submodule update --init || exit /b 1
-	git submodule update --remote ILSpy-tests || exit /b 1
-)
 @setlocal enabledelayedexpansion
 @set MSBUILD=
 @for /D %%M in ("%ProgramFiles(x86)%\Microsoft Visual Studio\2017"\*) do (

--- a/releasebuild.bat
+++ b/releasebuild.bat
@@ -1,6 +1,3 @@
-@if not exist "cecil\Mono.Cecil.csproj" (
-	git submodule update --init || exit /b 1
-)
 @setlocal enabledelayedexpansion
 @set MSBUILD=
 @for /D %%M in ("%ProgramFiles(x86)%\Microsoft Visual Studio\2017"\*) do (


### PR DESCRIPTION
The current submodule and bundling approach causes problems for consumers of **ICSharpCode.Decompiler** due to the embedding of a "non-standard" build of **Mono.Cecil.dll**. This pull request modifies the references to use `PackageReference` instead, and declare a NuGet dependency on the Mono.Cecil package on NuGet.

For this pull request, I did not remove the submodule itself. It's possible that developers have local branches in the submodule and would like to continue working with those branches, so I decided to leave that decision for a future pull request.

This pull request is very similar to #998. Specific differences are:

1. This pull request leaves the **cecil** submodule in place, and updates the commit reference to match the commit we're referencing as a NuGet package
2. This pull request leverages transitive `<PackageReference>` in a few places, so there are fewer explicit references to Mono.Cecil
3. This pull request updates the NuGet package specification for ICSharpCode.Decompiler to declare the dependency on Mono.Cecil