### PR TITLE
Update to net45 targetframework

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -117,7 +117,7 @@ namespace ICSharpCode.Decompiler.CSharp
 									expandedArguments.Add(expressionBuilder.GetDefaultValueExpression(elementType).WithoutILInstruction());
 							}
 						}
-						if (IsUnambiguousCall(expectedTargetDetails, method, target, Array.Empty<IType>(), expandedArguments) == OverloadResolutionErrors.None) {
+						if (IsUnambiguousCall(expectedTargetDetails, method, target, new IType[0], expandedArguments) == OverloadResolutionErrors.None) {
 							isExpandedForm = true;
 							expectedParameters = expandedParameters;
 							arguments = expandedArguments.SelectList(a => new TranslatedExpression(a.Expression.Detach()));
@@ -170,7 +170,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						.WithRR(rr);
 				} else {
 
-					if (IsUnambiguousCall(expectedTargetDetails, method, target, Array.Empty<IType>(), arguments) != OverloadResolutionErrors.None) {
+					if (IsUnambiguousCall(expectedTargetDetails, method, target, new IType[0], arguments) != OverloadResolutionErrors.None) {
 						for (int i = 0; i < arguments.Count; i++) {
 							if (settings.AnonymousTypes && expectedParameters[i].Type.ContainsAnonymousType()) {
 								if (arguments[i].Expression is LambdaExpression lambda) {
@@ -199,7 +199,7 @@ namespace ICSharpCode.Decompiler.CSharp
 					bool requireTypeArguments = false;
 					bool targetCasted = false;
 					bool argumentsCasted = false;
-					IType[] typeArguments = Array.Empty<IType>();
+					IType[] typeArguments = new IType[0];
 
 					OverloadResolutionErrors errors;
 					while ((errors = IsUnambiguousCall(expectedTargetDetails, method, target, typeArguments, arguments)) != OverloadResolutionErrors.None) {

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net45;net46</TargetFrameworks>
 
     <Description>IL decompiler engine</Description>
     <Company>ic#code</Company>
@@ -20,7 +20,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>ICSharpCode.Decompiler.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  
+
   <!-- HACK: Disable package generation on Unix due to tooling issues. -->
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;net45</TargetFrameworks>
 
     <Description>IL decompiler engine</Description>
     <Company>ic#code</Company>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
@@ -25,6 +25,9 @@
     <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.dll" target="lib\net45" />
     <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.pdb" target="lib\net45" />
 
+	<file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.dll" target="lib\net46" />
+    <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.pdb" target="lib\net46" />
+
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.dll" target="lib\netstandard2.0" />
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.pdb" target="lib\netstandard2.0" />
   </files>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
@@ -22,8 +22,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.dll" target="lib\net46" />
-    <file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.pdb" target="lib\net46" />
+    <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.dll" target="lib\net45" />
+    <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.pdb" target="lib\net45" />
 
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.dll" target="lib\netstandard2.0" />
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.pdb" target="lib\netstandard2.0" />


### PR DESCRIPTION
I'm planning to include ICSharpCode.Decompiler nuget package to https://github.com/fsharp/FsAutoComplete which is targeting .net 4.5. Can you release a new version of your libs targeting this version ? The only compatibility issue is the use of `Array.emtpy`