### PR TITLE
DecompileMemberBodies setting

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpFormattingOptions.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpFormattingOptions.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.ComponentModel;
+
 namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 {
 	public enum BraceStyle
@@ -68,6 +70,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		DoNotIndent
 	}
 
+	[TypeConverter(typeof(ExpandableObjectConverter))]
 	public class CSharpFormattingOptions
 	{
 		public string Name {

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -306,7 +306,7 @@ namespace ICSharpCode.Decompiler
 		bool objectCollectionInitializers = true;
 
 		/// <summary>
-		/// Gets/Sets whether to use C# 3.0 object/collection initializers
+		/// Gets/Sets whether to use C# 3.0 object/collection initializers.
 		/// </summary>
 		public bool ObjectOrCollectionInitializers {
 			get { return objectCollectionInitializers; }
@@ -321,7 +321,7 @@ namespace ICSharpCode.Decompiler
 		bool showXmlDocumentation = true;
 
 		/// <summary>
-		/// Gets/Sets whether to include XML documentation comments in the decompiled code
+		/// Gets/Sets whether to include XML documentation comments in the decompiled code.
 		/// </summary>
 		public bool ShowXmlDocumentation {
 			get { return showXmlDocumentation; }
@@ -340,6 +340,21 @@ namespace ICSharpCode.Decompiler
 			set {
 				if (foldBraces != value) {
 					foldBraces = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool decompileMemberBodies = true;
+
+		/// <summary>
+		/// Gets/Sets whether member bodies should be decompiled.
+		/// </summary>
+		public bool DecompileMemberBodies {
+			get { return decompileMemberBodies; }
+			set {
+				if (decompileMemberBodies != value) {
+					decompileMemberBodies = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ILSpy/Controls/BoolToVisibilityConverter.cs
+++ b/ILSpy/Controls/BoolToVisibilityConverter.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2018 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace ICSharpCode.ILSpy.Controls
+{
+	public class BoolToVisibilityConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (!(parameter is Visibility notVisible))
+				notVisible = Visibility.Collapsed;
+			if (!(value is bool b))
+				return notVisible;
+			return b ? Visibility.Visible : notVisible; 
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (!(value is Visibility visibility))
+				return false;
+			return visibility == Visibility.Visible;
+		}
+	}
+}

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Commands\OpenListCommand.cs" />
     <Compile Include="Commands\ShowDebugSteps.cs" />
     <Compile Include="Commands\SortAssemblyListCommand.cs" />
+    <Compile Include="Controls\BoolToVisibilityConverter.cs" />
     <Compile Include="Controls\CustomDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -1,7 +1,12 @@
 ﻿<UserControl x:Class="ICSharpCode.ILSpy.Options.DecompilerSettingsPanel"
              x:ClassModifier="internal"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:options="clr-namespace:ICSharpCode.ILSpy.Options"
+	xmlns:controls="clr-namespace:ICSharpCode.ILSpy.Controls">
+	<UserControl.Resources>
+		<controls:BoolToVisibilityConverter x:Key="boolConv" />
+	</UserControl.Resources>
 	<StackPanel Margin="10">
 		<CheckBox IsChecked="{Binding AnonymousMethods}">Decompile anonymous methods/lambdas</CheckBox>
 		<CheckBox IsChecked="{Binding AnonymousTypes}">Decompile anonymous types</CheckBox>
@@ -18,5 +23,6 @@
 		<CheckBox IsChecked="{Binding UsingDeclarations}">Insert using declarations</CheckBox>
 		<CheckBox IsChecked="{Binding FullyQualifyAmbiguousTypeNames}">Fully qualify ambiguous type names</CheckBox>
 		<CheckBox IsChecked="{Binding AlwaysUseBraces}">Always use braces</CheckBox>
+		<Button Content="Advanced" Click="AdvancedOptions_Click" Visibility="{Binding Source={x:Static options:DecompilerSettingsPanel.IsDebug}, Converter={StaticResource boolConv}, ConverterParameter={x:Static Visibility.Collapsed}}" />
 	</StackPanel>
 </UserControl>


### PR DESCRIPTION
Fixes #1032 

* [x] Add `DecompilerSettings.DecompileMemberBodies`
* [x] Decide whether field initializers should be displayed, if `DecompilerSettings.DecompileMemberBodies` is set to `false`.