### PR TITLE
Set the tab size in .editorconfig so it's reflected on GitHub

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
+tab_size = 4
 
 [*.il]
 indent_style = space


### PR DESCRIPTION
Currently GitHub shows hard tabs as 8 spaces wide in this repository, which makes it hard to view files with the default views. This change sets the tab size in a way GitHub understands, so they show up as 4 spaces wide instead.