### PR TITLE
Reduced allocations

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/TextWriterTokenWriter.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/TextWriterTokenWriter.cs
@@ -239,13 +239,17 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			}
 			
 			if (value is string) {
-				string tmp = "\"" + ConvertString(value.ToString()) + "\"";
-				column += tmp.Length;
+				string tmp = ConvertString(value.ToString());
+				column += tmp.Length + 2;
+				textWriter.Write('"');
 				textWriter.Write(tmp);
+				textWriter.Write('"');
 			} else if (value is char) {
-				string tmp = "'" + ConvertCharLiteral((char)value) + "'";
-				column += tmp.Length;
+				string tmp = ConvertCharLiteral((char)value);
+				column += tmp.Length + 2;
+				textWriter.Write('\'');
 				textWriter.Write(tmp);
+				textWriter.Write('\'');
 			} else if (value is decimal) {
 				string str = ((decimal)value).ToString(NumberFormatInfo.InvariantInfo) + "m";
 				column += str.Length;
@@ -342,7 +346,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			if (ch == '\'') {
 				return "\\'";
 			}
-			return ConvertChar(ch);
+			return ConvertChar(ch) ?? ch.ToString();
 		}
 		
 		/// <summary>
@@ -376,7 +380,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				case '^':
 					// ASCII characters we allow directly in the output even though we don't use
 					// other Unicode characters of the same category.
-					return ch.ToString();
+					return null;
 				default:
 					switch (char.GetUnicodeCategory(ch)) {
 						case UnicodeCategory.ModifierLetter:
@@ -395,7 +399,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 						case UnicodeCategory.SpaceSeparator:
 							return "\\u" + ((int)ch).ToString("x4");
 						default:
-							return ch.ToString();
+							return null;
 					}
 			}
 		}
@@ -407,11 +411,9 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			StringBuilder sb = new StringBuilder ();
 			foreach (char ch in str) {
-				if (ch == '"') {
-					sb.Append("\\\"");
-				} else {
-					sb.Append(ConvertChar(ch));
-				}
+				string s = ch == '"' ? "\\\"" : ConvertChar(ch);
+				if (s != null) sb.Append(s);
+				else sb.Append(ch);
 			}
 			return sb.ToString();
 		}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/CSharpModifierToken.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/CSharpModifierToken.cs
@@ -25,7 +25,7 @@
 // THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using ICSharpCode.Decompiler.CSharp.OutputVisitor;
 
 namespace ICSharpCode.Decompiler.CSharp.Syntax
@@ -61,7 +61,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		
 		// Not worth using a dictionary for such few elements.
 		// This table is sorted in the order that modifiers should be output when generating code.
-		static readonly Modifiers[] allModifiers = {
+		public static ImmutableArray<Modifiers> AllModifiers { get; } = ImmutableArray.Create(
 			Modifiers.Public, Modifiers.Private, Modifiers.Protected, Modifiers.Internal,
 			Modifiers.New,
 			Modifiers.Unsafe,
@@ -71,11 +71,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			Modifiers.Extern, Modifiers.Partial, Modifiers.Const,
 			Modifiers.Async,
 			Modifiers.Any
-		};
-		
-		public static IEnumerable<Modifiers> AllModifiers {
-			get { return allModifiers; }
-		}
+		);
 		
 		public CSharpModifierToken (TextLocation location, Modifiers modifier) : base (location, null)
 		{

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -996,7 +996,6 @@ namespace ICSharpCode.Decompiler.IL
 			Debug.Assert(inst.ResultType != StackType.Void);
 			IType type = compilation.FindType(inst.ResultType.ToKnownTypeCode());
 			var v = new ILVariable(VariableKind.StackSlot, type, inst.ResultType, inst.ILRange.Start);
-			v.Name = "S_" + inst.ILRange.Start.ToString("x4");
 			v.HasGeneratedName = true;
 			currentStack = currentStack.Push(v);
 			return new StLoc(v, inst);

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformExpressionTrees.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformExpressionTrees.cs
@@ -40,10 +40,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		static bool MightBeExpressionTree(ILInstruction inst, ILInstruction stmt)
 		{
 			if (!(inst is CallInstruction call
-				&& call.Method.FullName == "System.Linq.Expressions.Expression.Lambda"
+				&& call.Method.FullNameIs("System.Linq.Expressions.Expression", "Lambda")
 				&& call.Arguments.Count == 2))
 				return false;
-			if (call.Parent is CallInstruction parentCall && parentCall.Method.FullName == "System.Linq.Expressions.Expression.Quote")
+			if (call.Parent is CallInstruction parentCall && parentCall.Method.FullNameIs("System.Linq.Expressions.Expression", "Quote"))
 				return false;
 			if (!(IsEmptyParameterList(call.Arguments[1]) || (call.Arguments[1] is Block block && block.Kind == BlockKind.ArrayInitializer)))
 				return false;
@@ -54,7 +54,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		static bool IsEmptyParameterList(ILInstruction inst)
 		{
-			if (inst is CallInstruction emptyCall && emptyCall.Method.FullName == "System.Array.Empty" && emptyCall.Arguments.Count == 0)
+			if (inst is CallInstruction emptyCall && emptyCall.Method.FullNameIs("System.Array", "Empty") && emptyCall.Arguments.Count == 0)
 				return true;
 			if (inst.MatchNewArr(out var type) && type.FullName == "System.Linq.Expressions.ParameterExpression")
 				return true;
@@ -78,13 +78,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return false;
 			if (!(init is CallInstruction initCall && initCall.Arguments.Count == 2))
 				return false;
-			IMethod parameterMethod = initCall.Method;
-			if (!(parameterMethod.Name == "Parameter" && parameterMethod.DeclaringType.FullName == "System.Linq.Expressions.Expression"))
+			if (!(initCall.Method.FullNameIs("System.Linq.Expressions.Expression", "Parameter")))
 				return false;
 			CallInstruction typeArg = initCall.Arguments[0] as CallInstruction;
 			if (typeArg == null || typeArg.Arguments.Count != 1)
 				return false;
-			if (typeArg.Method.FullName != "System.Type.GetTypeFromHandle")
+			if (!typeArg.Method.FullNameIs("System.Type", "GetTypeFromHandle"))
 				return false;
 			return typeArg.Arguments[0].MatchLdTypeToken(out type) && initCall.Arguments[1].MatchLdStr(out name);
 		}

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -814,5 +814,10 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			isGeneric = null;
 			return SpecialType.UnknownType;
 		}
+
+		public static bool FullNameIs(this IMethod method, string type, string name)
+		{
+			return method.Name == name && method.DeclaringType?.FullName == type;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
+++ b/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
@@ -252,5 +252,19 @@ namespace ICSharpCode.Decompiler.Util
 				throw new ArgumentNullException(nameof(list));
 			list.RemoveAt(list.Count - 1);
 		}
+
+		#region Aliases/shortcuts for Enumerable extension methods
+		public static bool Any<T>(this ICollection<T> list) => list.Count > 0;
+		public static bool Any<T>(this T[] array, Predicate<T> match) => Array.Exists(array, match);
+		public static bool Any<T>(this List<T> list, Predicate<T> match) => list.Exists(match);
+
+		public static bool All<T>(this T[] array, Predicate<T> match) => Array.TrueForAll(array, match);
+		public static bool All<T>(this List<T> list, Predicate<T> match) => list.TrueForAll(match);
+
+		public static T FirstOrDefault<T>(this T[] array, Predicate<T> predicate) => Array.Find(array, predicate);
+		public static T FirstOrDefault<T>(this List<T> list, Predicate<T> predicate) => list.Find(predicate);
+
+		public static T Last<T>(this IList<T> list) => list[list.Count - 1];
+		#endregion
 	}
 }


### PR DESCRIPTION
This reduces allocations for a full decompilation about 3% (CPU time is also reduced about 3-4%).

_Because I haven't contributed for a long time to ILSpy I'm not sure if these changes have acceptable quality and style. Most of them are independent of each other, so I can remove some of them based on feedback._