### PR TITLE
Feature Request: Search by abbreviated qualified name #1090

### DIFF
--- a/ILSpy/SearchStrategies.cs
+++ b/ILSpy/SearchStrategies.cs
@@ -491,10 +491,10 @@ namespace ICSharpCode.ILSpy
 
 		public override void Search(TypeDefinition type, Language language, Action<SearchResult> addResult)
 		{
-			if (MatchName(type, language)) 
+			if (MatchName(type, language))
 			{
 				string name = language.TypeToString(type, includeNamespace: false);
-				addResult(new SearchResult 
+				addResult(new SearchResult
 				{
 					Member = type,
 					Image = TypeTreeNode.GetIcon(type),

--- a/ILSpy/SearchStrategies.cs
+++ b/ILSpy/SearchStrategies.cs
@@ -17,6 +17,7 @@ namespace ICSharpCode.ILSpy
 		protected string[] searchTerm;
 		protected Regex regex;
 		protected bool fullNameSearch;
+		protected bool allowNonContiguousMatch;
 
 		protected AbstractSearchStrategy(params string[] terms)
 		{
@@ -114,10 +115,35 @@ namespace ICSharpCode.ILSpy
 						}
 						break;
 					default:
-						if (text.IndexOf(term, StringComparison.OrdinalIgnoreCase) < 0)
-							return false;
+						if (!fullNameSearch && allowNonContiguousMatch) {
+							if (!IsNonContiguousMatch(text.ToLower(), term.ToLower()))
+								return false;
+						} else {
+							if (text.IndexOf(term, StringComparison.OrdinalIgnoreCase) < 0)
+								return false;
+						}
 						break;
 				}
+			}
+			return true;
+		}
+
+		private bool IsNonContiguousMatch(string text, string searchTerm)
+		{
+			if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(searchTerm)) {
+				return false;
+			}
+			var index = 0;
+			foreach (char c in searchTerm) {
+				while (index != text.Length) {
+					if (text[index] == c) {
+						index++;
+						break;
+					}
+					index++;
+				}
+				if (index == text.Length)
+					return false;
 			}
 			return true;
 		}
@@ -227,23 +253,23 @@ namespace ICSharpCode.ILSpy
 				if (value != null && value.LiteralValue != null) {
 					TypeCode valueType = Type.GetTypeCode(value.LiteralValue.GetType());
 					switch (valueType) {
-					case TypeCode.Byte:
-					case TypeCode.SByte:
-					case TypeCode.Int16:
-					case TypeCode.UInt16:
-					case TypeCode.Int32:
-					case TypeCode.UInt32:
-					case TypeCode.Int64:
-					case TypeCode.UInt64:
-						searchTermLiteralType = TypeCode.Int64;
-						searchTermLiteralValue = CSharpPrimitiveCast.Cast(TypeCode.Int64, value.LiteralValue, false);
-						break;
-					case TypeCode.Single:
-					case TypeCode.Double:
-					case TypeCode.String:
-						searchTermLiteralType = valueType;
-						searchTermLiteralValue = value.LiteralValue;
-						break;
+						case TypeCode.Byte:
+						case TypeCode.SByte:
+						case TypeCode.Int16:
+						case TypeCode.UInt16:
+						case TypeCode.Int32:
+						case TypeCode.UInt32:
+						case TypeCode.Int64:
+						case TypeCode.UInt64:
+							searchTermLiteralType = TypeCode.Int64;
+							searchTermLiteralValue = CSharpPrimitiveCast.Cast(TypeCode.Int64, value.LiteralValue, false);
+							break;
+						case TypeCode.Single:
+						case TypeCode.Double:
+						case TypeCode.String:
+							searchTermLiteralType = valueType;
+							searchTermLiteralValue = value.LiteralValue;
+							break;
 					}
 				}
 			}
@@ -301,74 +327,74 @@ namespace ICSharpCode.ILSpy
 				long val = (long)searchTermLiteralValue;
 				foreach (var inst in body.Instructions) {
 					switch (inst.OpCode.Code) {
-					case Code.Ldc_I8:
-						if (val == (long)inst.Operand)
-							return true;
-						break;
-					case Code.Ldc_I4:
-						if (val == (int)inst.Operand)
-							return true;
-						break;
-					case Code.Ldc_I4_S:
-						if (val == (sbyte)inst.Operand)
-							return true;
-						break;
-					case Code.Ldc_I4_M1:
-						if (val == -1)
-							return true;
-						break;
-					case Code.Ldc_I4_0:
-						if (val == 0)
-							return true;
-						break;
-					case Code.Ldc_I4_1:
-						if (val == 1)
-							return true;
-						break;
-					case Code.Ldc_I4_2:
-						if (val == 2)
-							return true;
-						break;
-					case Code.Ldc_I4_3:
-						if (val == 3)
-							return true;
-						break;
-					case Code.Ldc_I4_4:
-						if (val == 4)
-							return true;
-						break;
-					case Code.Ldc_I4_5:
-						if (val == 5)
-							return true;
-						break;
-					case Code.Ldc_I4_6:
-						if (val == 6)
-							return true;
-						break;
-					case Code.Ldc_I4_7:
-						if (val == 7)
-							return true;
-						break;
-					case Code.Ldc_I4_8:
-						if (val == 8)
-							return true;
-						break;
+						case Code.Ldc_I8:
+							if (val == (long)inst.Operand)
+								return true;
+							break;
+						case Code.Ldc_I4:
+							if (val == (int)inst.Operand)
+								return true;
+							break;
+						case Code.Ldc_I4_S:
+							if (val == (sbyte)inst.Operand)
+								return true;
+							break;
+						case Code.Ldc_I4_M1:
+							if (val == -1)
+								return true;
+							break;
+						case Code.Ldc_I4_0:
+							if (val == 0)
+								return true;
+							break;
+						case Code.Ldc_I4_1:
+							if (val == 1)
+								return true;
+							break;
+						case Code.Ldc_I4_2:
+							if (val == 2)
+								return true;
+							break;
+						case Code.Ldc_I4_3:
+							if (val == 3)
+								return true;
+							break;
+						case Code.Ldc_I4_4:
+							if (val == 4)
+								return true;
+							break;
+						case Code.Ldc_I4_5:
+							if (val == 5)
+								return true;
+							break;
+						case Code.Ldc_I4_6:
+							if (val == 6)
+								return true;
+							break;
+						case Code.Ldc_I4_7:
+							if (val == 7)
+								return true;
+							break;
+						case Code.Ldc_I4_8:
+							if (val == 8)
+								return true;
+							break;
 					}
 				}
 			} else if (searchTermLiteralType != TypeCode.Empty) {
 				Code expectedCode;
 				switch (searchTermLiteralType) {
-				case TypeCode.Single:
-					expectedCode = Code.Ldc_R4;
-					break;
-				case TypeCode.Double:
-					expectedCode = Code.Ldc_R8;
-					break;
-				case TypeCode.String:
-					expectedCode = Code.Ldstr;
-					break;
-				default:
-					throw new InvalidOperationException();
+					case TypeCode.Single:
+						expectedCode = Code.Ldc_R4;
+						break;
+					case TypeCode.Double:
+						expectedCode = Code.Ldc_R8;
+						break;
+					case TypeCode.String:
+						expectedCode = Code.Ldstr;
+						break;
+					default:
+						throw new InvalidOperationException();
 				}
 				foreach (var inst in body.Instructions) {
 					if (inst.OpCode.Code == expectedCode && searchTermLiteralValue.Equals(inst.Operand))
@@ -465,10 +491,10 @@ namespace ICSharpCode.ILSpy
 
 		public override void Search(TypeDefinition type, Language language, Action<SearchResult> addResult)
 		{
-			if (MatchName(type, language))
+			if (MatchName(type, language)) 
 			{
 				string name = language.TypeToString(type, includeNamespace: false);
-				addResult(new SearchResult
+				addResult(new SearchResult 
 				{
 					Member = type,
 					Image = TypeTreeNode.GetIcon(type),

--- a/ILSpy/SearchStrategies.cs
+++ b/ILSpy/SearchStrategies.cs
@@ -14,10 +14,11 @@ namespace ICSharpCode.ILSpy
 {
 	abstract class AbstractSearchStrategy
 	{
+		private const string NoncontiguousSearchPrefix = "s:";
+
 		protected string[] searchTerm;
 		protected Regex regex;
 		protected bool fullNameSearch;
-		protected bool allowNonContiguousMatch;
 
 		protected AbstractSearchStrategy(params string[] terms)
 		{
@@ -115,8 +116,8 @@ namespace ICSharpCode.ILSpy
 						}
 						break;
 					default:
-						if (!fullNameSearch && allowNonContiguousMatch) {
-							if (!IsNonContiguousMatch(text.ToLower(), term.ToLower()))
+						if (term.Length > 2 && term.StartsWith(NoncontiguousSearchPrefix, StringComparison.OrdinalIgnoreCase)) {
+							if (!IsNoncontiguousMatch(text.ToLower(), term.Substring(2).ToLower()))
 								return false;
 						} else {
 							if (text.IndexOf(term, StringComparison.OrdinalIgnoreCase) < 0)
@@ -128,7 +129,7 @@ namespace ICSharpCode.ILSpy
 			return true;
 		}
 
-		private bool IsNonContiguousMatch(string text, string searchTerm)
+		private bool IsNoncontiguousMatch(string text, string searchTerm)
 		{
 			if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(searchTerm)) {
 				return false;

--- a/ILSpy/SearchStrategies.cs
+++ b/ILSpy/SearchStrategies.cs
@@ -115,14 +115,13 @@ namespace ICSharpCode.ILSpy
 								return false;
 						}
 						break;
+					case '~':
+						if (term.Length > 1 && !IsNoncontiguousMatch(text.ToLower(), term.Substring(1).ToLower()))
+							return false;
+						break;
 					default:
-						if (term.Length > 2 && term.StartsWith(NoncontiguousSearchPrefix, StringComparison.OrdinalIgnoreCase)) {
-							if (!IsNoncontiguousMatch(text.ToLower(), term.Substring(2).ToLower()))
-								return false;
-						} else {
-							if (text.IndexOf(term, StringComparison.OrdinalIgnoreCase) < 0)
-								return false;
-						}
+						if (text.IndexOf(term, StringComparison.OrdinalIgnoreCase) < 0)
+							return false;
 						break;
 				}
 			}
@@ -138,20 +137,22 @@ namespace ICSharpCode.ILSpy
 			if (searchTerm.Length > textLength) {
 				return false;
 			}
-			var index = 0;
-			foreach (char c in searchTerm) {
-				while (index != textLength) {
-					if (text[index] == c) {
-						index++;
+			var i = 0;
+			for (int searchIndex = 0; searchIndex < searchTerm.Length;) {
+				while (i != textLength) {
+					if (text[i] == searchTerm[searchIndex]) {
+						// Check if all characters in searchTerm have been matched
+						if (searchTerm.Length == ++searchIndex)
+							return true;
+						i++;
 						break;
 					}
-					index++;
-				} 
-				// Check if we reached end of text without matching the full search string
-				if (index == textLength)
+					i++;
+				}
+				if (i == textLength)
 					return false;
 			}
-			return true;
+			return false;
 		}
 
 		string GetLanguageSpecificName(Language language, IMemberDefinition member, bool fullName = false)

--- a/ILSpy/SearchStrategies.cs
+++ b/ILSpy/SearchStrategies.cs
@@ -14,8 +14,6 @@ namespace ICSharpCode.ILSpy
 {
 	abstract class AbstractSearchStrategy
 	{
-		private const string NoncontiguousSearchPrefix = "s:";
-
 		protected string[] searchTerm;
 		protected Regex regex;
 		protected bool fullNameSearch;

--- a/ILSpy/SearchStrategies.cs
+++ b/ILSpy/SearchStrategies.cs
@@ -129,21 +129,26 @@ namespace ICSharpCode.ILSpy
 			return true;
 		}
 
-		private bool IsNoncontiguousMatch(string text, string searchTerm)
+		bool IsNoncontiguousMatch(string text, string searchTerm)
 		{
 			if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(searchTerm)) {
 				return false;
 			}
+			var textLength = text.Length;
+			if (searchTerm.Length > textLength) {
+				return false;
+			}
 			var index = 0;
 			foreach (char c in searchTerm) {
-				while (index != text.Length) {
+				while (index != textLength) {
 					if (text[index] == c) {
 						index++;
 						break;
 					}
 					index++;
-				}
-				if (index == text.Length)
+				} 
+				// Check if we reached end of text without matching the full search string
+				if (index == textLength)
 					return false;
 			}
 			return true;


### PR DESCRIPTION
Added the ability to have partial search matches when fullNameSearch is false and allowNonContiguousMatch is true. It is possible to use the in-word matching even with the full name search but since the full names are quite long, a lot of irrelevant matches are picked up. 