### PR TITLE
Abort SwitchAnalysis on duplicate condition (redundant code)

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/Loops.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/Loops.cs
@@ -79,6 +79,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			Console.WriteLine(NoForeachDueToMultipleCurrentAccess(new List<int> { 1, 2, 3, 4, 5 }));
 			Console.WriteLine(NoForeachCallWithSideEffect(new CustomClassEnumeratorWithIDisposable<int>()));
 			LoopWithGotoRepeat();
+			Console.WriteLine("LoopFollowedByIf: {0}", LoopFollowedByIf());
 		}
 
 		public static void ForWithMultipleVariables()
@@ -245,6 +246,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 				Console.WriteLine("finally");
 			}
 			Console.WriteLine("after finally");
+		}
+		
+		private static int LoopFollowedByIf()
+		{
+			int num = 0;
+			while (num == 0) {
+				num++;
+			}
+			if (num == 0) {
+				return -1;
+			}
+			return num;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue959.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue959.cs
@@ -4,7 +4,7 @@
 	{
 		public void Test(bool arg)
 		{
-			switch (arg) {
+			if (!arg && arg) {
 
 			}
 		}

--- a/ICSharpCode.Decompiler/IL/ControlFlow/SwitchAnalysis.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/SwitchAnalysis.cs
@@ -116,6 +116,8 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				if (!(tailOnly || block.Instructions.Count == 2))
 					return false;
 				trueValues = trueValues.IntersectWith(inputValues);
+				if (trueValues.SetEquals(inputValues) || trueValues.IsEmpty)
+					return false;
 				Block trueBlock;
 				if (trueInst.MatchBranch(out trueBlock) && AnalyzeBlock(trueBlock, trueValues)) {
 					// OK, true block was further analyzed.


### PR DESCRIPTION
This fixes a failing assertion in `SwitchDetection` (debug mode) because blocks get added to `InnerBlocks` but not to the switch `Sections`. Previously the redundant/unreachable code got removed.