### PR TITLE
Update UniversalAssemblyResolver to include missing .NET 3.x support

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
@@ -84,7 +84,7 @@ namespace ICSharpCode.Decompiler.Metadata
 				$"PublicKeyToken={publicKey}{properties}";
 		}
 
-		static string ToHexString(this IEnumerable<byte> bytes, int estimatedLength)
+		public static string ToHexString(this IEnumerable<byte> bytes, int estimatedLength)
 		{
 			StringBuilder sb = new StringBuilder(estimatedLength * 2);
 			foreach (var b in bytes)

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -374,7 +374,7 @@ namespace ICSharpCode.Decompiler.Metadata
 			if (DetectMono()) {
 				path = GetMonoMscorlibBasePath(version);
 			} else {
-				path = GetMscorlibBasePath(version);
+				path = GetMscorlibBasePath(version, reference.PublicKeyToken.ToHexString(8));
 			}
 
 			if (path == null)
@@ -387,39 +387,8 @@ namespace ICSharpCode.Decompiler.Metadata
 			return null;
 		}
 
-		string GetMscorlibBasePath(Version version)
+		string GetMscorlibBasePath(Version version, string publicKeyToken)
 		{
-			string rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET");
-			string[] frameworkPaths = new[] {
-				Path.Combine(rootPath, "Framework"),
-				Path.Combine(rootPath, "Framework64")
-			};
-
-			string folder = GetSubFolderForVersion();
-
-			if  (folder != null) {
-				foreach (var path in frameworkPaths) {
-					var basePath = Path.Combine(path, folder);
-					if (Directory.Exists(basePath))
-						return basePath;
-				}
-			}
-
-			if (version.Major == 3 && version.Minor == 5) {
-				string cfBasePath = Path.Combine((Environment.Is64BitOperatingSystem ?
-					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) :
-					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)),
-					@"Microsoft.NET\SDK\CompactFramework\v3.5\WindowsCE\");
-
-				if (Directory.Exists(cfBasePath)) {
-					return cfBasePath;
-				}
-			}
-
-			if (throwOnError)
-				throw new NotSupportedException("Version not supported: " + version);
-			return null;
-
 			string GetSubFolderForVersion()
 			{
 				switch (version.Major) {
@@ -437,6 +406,36 @@ namespace ICSharpCode.Decompiler.Metadata
 						return null;
 				}
 			}
+
+			if (publicKeyToken == "969db8053d3322ac") {
+				string programFiles = Environment.Is64BitOperatingSystem ?
+					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) :
+					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+				string cfPath = $@"Microsoft.NET\SDK\CompactFramework\v{version.Major}.{version.Minor}\WindowsCE\";
+				string cfBasePath = Path.Combine(programFiles, cfPath);
+				if (Directory.Exists(cfBasePath))
+					return cfBasePath;
+			} else {
+				string rootPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET");
+				string[] frameworkPaths = new[] {
+					Path.Combine(rootPath, "Framework"),
+					Path.Combine(rootPath, "Framework64")
+				};
+
+				string folder = GetSubFolderForVersion();
+
+				if (folder != null) {
+					foreach (var path in frameworkPaths) {
+						var basePath = Path.Combine(path, folder);
+						if (Directory.Exists(basePath))
+							return basePath;
+					}
+				}
+			}
+
+			if (throwOnError)
+				throw new NotSupportedException("Version not supported: " + version);
+			return null;
 		}
 
 		string GetMonoMscorlibBasePath(Version version)

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -397,10 +397,12 @@ namespace ICSharpCode.Decompiler.Metadata
 
 			string folder = GetSubFolderForVersion();
 
-			foreach (var path in frameworkPaths) {
-				var basePath = Path.Combine(path, folder);
-				if (Directory.Exists(basePath))
-					return basePath;
+			if  (folder != null) {
+				foreach (var path in frameworkPaths) {
+					var basePath = Path.Combine(path, folder);
+					if (Directory.Exists(basePath))
+						return basePath;
+				}
 			}
 
 			if (throwOnError)
@@ -415,7 +417,6 @@ namespace ICSharpCode.Decompiler.Metadata
 							return "v1.0.3705";
 						return "v1.1.4322";
 					case 2:
-					case 3:
 						return "v2.0.50727";
 					case 4:
 						return "v4.0.30319";

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -405,6 +405,17 @@ namespace ICSharpCode.Decompiler.Metadata
 				}
 			}
 
+			if (version.Major == 3 && version.Minor == 5) {
+				string cfBasePath = Path.Combine((Environment.Is64BitOperatingSystem ?
+					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) :
+					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)),
+					@"Microsoft.NET\SDK\CompactFramework\v3.5\WindowsCE\");
+
+				if (Directory.Exists(cfBasePath)) {
+					return cfBasePath;
+				}
+			}
+
 			if (throwOnError)
 				throw new NotSupportedException("Version not supported: " + version);
 			return null;


### PR DESCRIPTION
Fixes issue with opening .NET 3.x assemblies, as they use the 2.0 mscorlib.

Fixes #1346 