### PR TITLE
Add command line argument "/config:" to specify settings file

### DIFF
--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -30,6 +30,7 @@ namespace ICSharpCode.ILSpy
 		public string Search;
 		public string Language;
 		public bool NoActivate;
+		public string ConfigFile;
 		
 		public CommandLineArguments(IEnumerable<string> arguments)
 		{
@@ -49,6 +50,8 @@ namespace ICSharpCode.ILSpy
 						this.Language = arg.Substring("/language:".Length);
 					else if (arg.Equals("/noActivate", StringComparison.OrdinalIgnoreCase))
 						this.NoActivate = true;
+					else if (arg.StartsWith("/config:", StringComparison.OrdinalIgnoreCase))
+						this.ConfigFile = arg.Substring("/config:".Length);
 				} else {
 					this.AssembliesToLoad.Add(arg);
 				}

--- a/ILSpy/ILSpySettings.cs
+++ b/ILSpy/ILSpySettings.cs
@@ -114,6 +114,8 @@ namespace ICSharpCode.ILSpy
 		
 		static string GetConfigFile()
 		{
+			if (App.CommandLineArguments.ConfigFile != null)
+				return App.CommandLineArguments.ConfigFile;
 			string localPath = Path.Combine(Path.GetDirectoryName(typeof(MainWindow).Assembly.Location), "ILSpy.xml");
 			if (File.Exists(localPath))
 				return localPath;


### PR DESCRIPTION
This allows multiple instances to use different settings file. Example: `"/config:c:\foo bar\ilspy.xml"`