### PR TITLE
Combine exitpoints in lambdas

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -213,6 +213,25 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				   select (x);
 		}
 
+		public static IEnumerable<char> Issue1310a(bool test)
+		{
+#if ROSLYN && OPT
+			IEnumerable<char> obj = test ? (from c in Enumerable.Range(0, 255)
+												   where char.IsLetter((char)c)
+												   select (char)c) : (from c in Enumerable.Range(0, 255)
+																	  where char.IsDigit((char)c)
+																	  select (char)c);
+			return obj.Concat(obj);
+#else
+			IEnumerable<char> enumerable = test ? (from c in Enumerable.Range(0, 255)
+												   where char.IsLetter((char)c)
+												   select (char)c) : (from c in Enumerable.Range(0, 255)
+																	  where char.IsDigit((char)c)
+																	  select (char)c);
+			return enumerable.Concat(enumerable);
+#endif
+		}
+
 		public static Maybe<TB> Cast<TA, TB>(Maybe<TA> a) where TB : class
 		{
 			return from m in a

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.il
@@ -17,8 +17,8 @@
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                              63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = ( 01 00 00 00 ) 
   .permissionset reqmin
              = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
   .hash algorithm 0x00008004
@@ -272,6 +272,14 @@
   .field private static class [mscorlib]System.Func`2<bool,bool> 'CS$<>9__CachedAnonymousMethodDelegate69'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private static class [mscorlib]System.Func`2<bool,bool> 'CS$<>9__CachedAnonymousMethodDelegate6a'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,bool> 'CS$<>9__CachedAnonymousMethodDelegate6f'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,char> 'CS$<>9__CachedAnonymousMethodDelegate70'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,bool> 'CS$<>9__CachedAnonymousMethodDelegate71'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,char> 'CS$<>9__CachedAnonymousMethodDelegate72'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig instance object 
           MultipleWhere() cil managed
@@ -1097,6 +1105,92 @@
     IL_004e:  ret
   } // end of method QueryExpressions::Issue437
 
+  .method public hidebysig static class [mscorlib]System.Collections.Generic.IEnumerable`1<char> 
+          Issue1310a(bool test) cil managed
+  {
+    // Code size       186 (0xba)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Collections.Generic.IEnumerable`1<char> V_0,
+             class [mscorlib]System.Collections.Generic.IEnumerable`1<char> V_1)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  brtrue.s   IL_0059
+
+    IL_0004:  ldc.i4.0
+    IL_0005:  ldc.i4     0xff
+    IL_000a:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_000f:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate71'
+    IL_0014:  brtrue.s   IL_0029
+
+    IL_0016:  ldnull
+    IL_0017:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6d'(int32)
+    IL_001d:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_0022:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate71'
+    IL_0027:  br.s       IL_0029
+
+    IL_0029:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate71'
+    IL_002e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0033:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate72'
+    IL_0038:  brtrue.s   IL_004d
+
+    IL_003a:  ldnull
+    IL_003b:  ldftn      char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6e'(int32)
+    IL_0041:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_0046:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate72'
+    IL_004b:  br.s       IL_004d
+
+    IL_004d:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate72'
+    IL_0052:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_0057:  br.s       IL_00ac
+
+    IL_0059:  ldc.i4.0
+    IL_005a:  ldc.i4     0xff
+    IL_005f:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_0064:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate6f'
+    IL_0069:  brtrue.s   IL_007e
+
+    IL_006b:  ldnull
+    IL_006c:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6b'(int32)
+    IL_0072:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_0077:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate6f'
+    IL_007c:  br.s       IL_007e
+
+    IL_007e:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate6f'
+    IL_0083:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0088:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate70'
+    IL_008d:  brtrue.s   IL_00a2
+
+    IL_008f:  ldnull
+    IL_0090:  ldftn      char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6c'(int32)
+    IL_0096:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_009b:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate70'
+    IL_00a0:  br.s       IL_00a2
+
+    IL_00a2:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate70'
+    IL_00a7:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_00ac:  nop
+    IL_00ad:  stloc.0
+    IL_00ae:  ldloc.0
+    IL_00af:  ldloc.0
+    IL_00b0:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Concat<char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00b5:  stloc.1
+    IL_00b6:  br.s       IL_00b8
+
+    IL_00b8:  ldloc.1
+    IL_00b9:  ret
+  } // end of method QueryExpressions::Issue1310a
+
   .method public hidebysig static valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TB> 
           Cast<TA,class TB>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TA> a) cil managed
   {
@@ -1106,19 +1200,19 @@
     IL_0000:  nop
     IL_0001:  ldarg.0
     IL_0002:  ldnull
-    IL_0003:  ldftn      class '<>f__AnonymousType11`2'<!!0,!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__6c'<!!0,!!1>(!!0)
+    IL_0003:  ldftn      class '<>f__AnonymousType11`2'<!!0,!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__74'<!!0,!!1>(!!0)
     IL_0009:  newobj     instance void class [mscorlib]System.Func`2<!!TA,class '<>f__AnonymousType11`2'<!!TA,!!TB>>::.ctor(object,
                                                                                                                             native int)
     IL_000e:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<!!0,class '<>f__AnonymousType11`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                                  class [mscorlib]System.Func`2<!!0,!!1>)
     IL_0013:  ldnull
-    IL_0014:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__6d'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
+    IL_0014:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__75'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
     IL_001a:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType11`2'<!!TA,!!TB>,bool>::.ctor(object,
                                                                                                                             native int)
     IL_001f:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Where<class '<>f__AnonymousType11`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                             class [mscorlib]System.Func`2<!!0,bool>)
     IL_0024:  ldnull
-    IL_0025:  ldftn      !!1 ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__6e'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
+    IL_0025:  ldftn      !!1 ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__76'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
     IL_002b:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType11`2'<!!TA,!!TB>,!!TB>::.ctor(object,
                                                                                                                             native int)
     IL_0030:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<class '<>f__AnonymousType11`2'<!!0,!!1>,!!1>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
@@ -2055,8 +2149,70 @@
     IL_0005:  ret
   } // end of method QueryExpressions::'<Issue437>b__68'
 
+  .method private hidebysig static bool  '<Issue1310a>b__6b'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       12 (0xc)
+    .maxstack  1
+    .locals init (bool V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  call       bool [mscorlib]System.Char::IsLetter(char)
+    IL_0007:  stloc.0
+    IL_0008:  br.s       IL_000a
+
+    IL_000a:  ldloc.0
+    IL_000b:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6b'
+
+  .method private hidebysig static char  '<Issue1310a>b__6c'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (char V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6c'
+
+  .method private hidebysig static bool  '<Issue1310a>b__6d'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       12 (0xc)
+    .maxstack  1
+    .locals init (bool V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  call       bool [mscorlib]System.Char::IsDigit(char)
+    IL_0007:  stloc.0
+    IL_0008:  br.s       IL_000a
+
+    IL_000a:  ldloc.0
+    IL_000b:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6d'
+
+  .method private hidebysig static char  '<Issue1310a>b__6e'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (char V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6e'
+
   .method private hidebysig static class '<>f__AnonymousType11`2'<!!TA,!!TB> 
-          '<Cast>b__6c'<TA,class TB>(!!TA m) cil managed
+          '<Cast>b__74'<TA,class TB>(!!TA m) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       27 (0x1b)
@@ -2074,9 +2230,9 @@
 
     IL_0019:  ldloc.0
     IL_001a:  ret
-  } // end of method QueryExpressions::'<Cast>b__6c'
+  } // end of method QueryExpressions::'<Cast>b__74'
 
-  .method private hidebysig static bool  '<Cast>b__6d'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier6b') cil managed
+  .method private hidebysig static bool  '<Cast>b__75'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier73') cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       22 (0x16)
@@ -2094,9 +2250,9 @@
 
     IL_0014:  ldloc.0
     IL_0015:  ret
-  } // end of method QueryExpressions::'<Cast>b__6d'
+  } // end of method QueryExpressions::'<Cast>b__75'
 
-  .method private hidebysig static !!TB  '<Cast>b__6e'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier6b') cil managed
+  .method private hidebysig static !!TB  '<Cast>b__76'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier73') cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       11 (0xb)
@@ -2109,7 +2265,7 @@
 
     IL_0009:  ldloc.0
     IL_000a:  ret
-  } // end of method QueryExpressions::'<Cast>b__6e'
+  } // end of method QueryExpressions::'<Cast>b__76'
 
 } // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.opt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.opt.il
@@ -17,8 +17,8 @@
 {
   .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = ( 01 00 01 00 54 02 16 57 72 61 70 4E 6F 6E 45 78   // ....T..WrapNonEx
                                                                                                              63 65 70 74 69 6F 6E 54 68 72 6F 77 73 01 )       // ceptionThrows.
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.ExtensionAttribute::.ctor() = ( 01 00 00 00 ) 
   .permissionset reqmin
              = {[mscorlib]System.Security.Permissions.SecurityPermissionAttribute = {property bool 'SkipVerification' = bool(true)}}
   .hash algorithm 0x00008004
@@ -262,6 +262,14 @@
   .field private static class [mscorlib]System.Func`2<bool,bool> 'CS$<>9__CachedAnonymousMethodDelegate69'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .field private static class [mscorlib]System.Func`2<bool,bool> 'CS$<>9__CachedAnonymousMethodDelegate6a'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,bool> 'CS$<>9__CachedAnonymousMethodDelegate6f'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,char> 'CS$<>9__CachedAnonymousMethodDelegate70'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,bool> 'CS$<>9__CachedAnonymousMethodDelegate71'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+  .field private static class [mscorlib]System.Func`2<int32,char> 'CS$<>9__CachedAnonymousMethodDelegate72'
   .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public hidebysig instance object 
           MultipleWhere() cil managed
@@ -909,6 +917,77 @@
     IL_0045:  ret
   } // end of method QueryExpressions::Issue437
 
+  .method public hidebysig static class [mscorlib]System.Collections.Generic.IEnumerable`1<char> 
+          Issue1310a(bool test) cil managed
+  {
+    // Code size       172 (0xac)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Collections.Generic.IEnumerable`1<char> V_0)
+    IL_0000:  ldarg.0
+    IL_0001:  brtrue.s   IL_0054
+
+    IL_0003:  ldc.i4.0
+    IL_0004:  ldc.i4     0xff
+    IL_0009:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_000e:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate71'
+    IL_0013:  brtrue.s   IL_0026
+
+    IL_0015:  ldnull
+    IL_0016:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6d'(int32)
+    IL_001c:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_0021:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate71'
+    IL_0026:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate71'
+    IL_002b:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0030:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate72'
+    IL_0035:  brtrue.s   IL_0048
+
+    IL_0037:  ldnull
+    IL_0038:  ldftn      char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6e'(int32)
+    IL_003e:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_0043:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate72'
+    IL_0048:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate72'
+    IL_004d:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_0052:  br.s       IL_00a3
+
+    IL_0054:  ldc.i4.0
+    IL_0055:  ldc.i4     0xff
+    IL_005a:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_005f:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate6f'
+    IL_0064:  brtrue.s   IL_0077
+
+    IL_0066:  ldnull
+    IL_0067:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6b'(int32)
+    IL_006d:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_0072:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate6f'
+    IL_0077:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate6f'
+    IL_007c:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0081:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate70'
+    IL_0086:  brtrue.s   IL_0099
+
+    IL_0088:  ldnull
+    IL_0089:  ldftn      char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Issue1310a>b__6c'(int32)
+    IL_008f:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_0094:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate70'
+    IL_0099:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'CS$<>9__CachedAnonymousMethodDelegate70'
+    IL_009e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_00a3:  stloc.0
+    IL_00a4:  ldloc.0
+    IL_00a5:  ldloc.0
+    IL_00a6:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Concat<char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00ab:  ret
+  } // end of method QueryExpressions::Issue1310a
+
   .method public hidebysig static valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TB> 
           Cast<TA,class TB>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TA> a) cil managed
   {
@@ -916,19 +995,19 @@
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  ldnull
-    IL_0002:  ldftn      class '<>f__AnonymousType11`2'<!!0,!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__6c'<!!0,!!1>(!!0)
+    IL_0002:  ldftn      class '<>f__AnonymousType11`2'<!!0,!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__74'<!!0,!!1>(!!0)
     IL_0008:  newobj     instance void class [mscorlib]System.Func`2<!!TA,class '<>f__AnonymousType11`2'<!!TA,!!TB>>::.ctor(object,
                                                                                                                             native int)
     IL_000d:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<!!0,class '<>f__AnonymousType11`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                                  class [mscorlib]System.Func`2<!!0,!!1>)
     IL_0012:  ldnull
-    IL_0013:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__6d'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
+    IL_0013:  ldftn      bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__75'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
     IL_0019:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType11`2'<!!TA,!!TB>,bool>::.ctor(object,
                                                                                                                             native int)
     IL_001e:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Where<class '<>f__AnonymousType11`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                             class [mscorlib]System.Func`2<!!0,bool>)
     IL_0023:  ldnull
-    IL_0024:  ldftn      !!1 ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__6e'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
+    IL_0024:  ldftn      !!1 ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions::'<Cast>b__76'<!!0,!!1>(class '<>f__AnonymousType11`2'<!!0,!!1>)
     IL_002a:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType11`2'<!!TA,!!TB>,!!TB>::.ctor(object,
                                                                                                                             native int)
     IL_002f:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<class '<>f__AnonymousType11`2'<!!0,!!1>,!!1>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
@@ -1626,8 +1705,50 @@
     IL_0001:  ret
   } // end of method QueryExpressions::'<Issue437>b__68'
 
+  .method private hidebysig static bool  '<Issue1310a>b__6b'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  call       bool [mscorlib]System.Char::IsLetter(char)
+    IL_0007:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6b'
+
+  .method private hidebysig static char  '<Issue1310a>b__6c'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       3 (0x3)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6c'
+
+  .method private hidebysig static bool  '<Issue1310a>b__6d'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  call       bool [mscorlib]System.Char::IsDigit(char)
+    IL_0007:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6d'
+
+  .method private hidebysig static char  '<Issue1310a>b__6e'(int32 c) cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
+    // Code size       3 (0x3)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  conv.u2
+    IL_0002:  ret
+  } // end of method QueryExpressions::'<Issue1310a>b__6e'
+
   .method private hidebysig static class '<>f__AnonymousType11`2'<!!TA,!!TB> 
-          '<Cast>b__6c'<TA,class TB>(!!TA m) cil managed
+          '<Cast>b__74'<TA,class TB>(!!TA m) cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       23 (0x17)
@@ -1640,9 +1761,9 @@
     IL_0011:  newobj     instance void class '<>f__AnonymousType11`2'<!!TA,!!TB>::.ctor(!0,
                                                                                         !1)
     IL_0016:  ret
-  } // end of method QueryExpressions::'<Cast>b__6c'
+  } // end of method QueryExpressions::'<Cast>b__74'
 
-  .method private hidebysig static bool  '<Cast>b__6d'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier6b') cil managed
+  .method private hidebysig static bool  '<Cast>b__75'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier73') cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       18 (0x12)
@@ -1655,9 +1776,9 @@
     IL_000e:  ldc.i4.0
     IL_000f:  ceq
     IL_0011:  ret
-  } // end of method QueryExpressions::'<Cast>b__6d'
+  } // end of method QueryExpressions::'<Cast>b__75'
 
-  .method private hidebysig static !!TB  '<Cast>b__6e'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier6b') cil managed
+  .method private hidebysig static !!TB  '<Cast>b__76'<TA,class TB>(class '<>f__AnonymousType11`2'<!!TA,!!TB> '<>h__TransparentIdentifier73') cil managed
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
     // Code size       7 (0x7)
@@ -1665,7 +1786,7 @@
     IL_0000:  ldarg.0
     IL_0001:  callvirt   instance !1 class '<>f__AnonymousType11`2'<!!TA,!!TB>::get_t()
     IL_0006:  ret
-  } // end of method QueryExpressions::'<Cast>b__6e'
+  } // end of method QueryExpressions::'<Cast>b__76'
 
 } // end of class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.opt.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.opt.roslyn.il
@@ -3857,6 +3857,10 @@
     .field public static class [mscorlib]System.Func`2<class [System.Core]System.Linq.IGrouping`2<string,class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/Customer>,class '<>f__AnonymousType16`2'<string,int32>> '<>9__19_1'
     .field public static class [mscorlib]System.Func`2<bool,bool> '<>9__20_0'
     .field public static class [mscorlib]System.Func`2<bool,bool> '<>9__20_1'
+    .field public static class [mscorlib]System.Func`2<int32,bool> '<>9__21_0'
+    .field public static class [mscorlib]System.Func`2<int32,char> '<>9__21_1'
+    .field public static class [mscorlib]System.Func`2<int32,bool> '<>9__21_2'
+    .field public static class [mscorlib]System.Func`2<int32,char> '<>9__21_3'
     .method private hidebysig specialname rtspecialname static 
             void  .cctor() cil managed
     {
@@ -4499,25 +4503,67 @@
       IL_0001:  ret
     } // end of method '<>c'::'<Issue437>b__20_1'
 
+    .method assembly hidebysig instance bool 
+            '<Issue1310a>b__21_0'(int32 c) cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  call       bool [mscorlib]System.Char::IsLetter(char)
+      IL_0007:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_0'
+
+    .method assembly hidebysig instance char 
+            '<Issue1310a>b__21_1'(int32 c) cil managed
+    {
+      // Code size       3 (0x3)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_1'
+
+    .method assembly hidebysig instance bool 
+            '<Issue1310a>b__21_2'(int32 c) cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  call       bool [mscorlib]System.Char::IsDigit(char)
+      IL_0007:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_2'
+
+    .method assembly hidebysig instance char 
+            '<Issue1310a>b__21_3'(int32 c) cil managed
+    {
+      // Code size       3 (0x3)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_3'
+
   } // end of class '<>c'
 
-  .class auto ansi serializable sealed nested private beforefieldinit '<>c__21`2'<TA,class TB>
+  .class auto ansi serializable sealed nested private beforefieldinit '<>c__22`2'<TA,class TB>
          extends [mscorlib]System.Object
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!TA,!TB> '<>9'
-    .field public static class [mscorlib]System.Func`2<!TA,class '<>f__AnonymousType17`2'<!TA,!TB>> '<>9__21_0'
-    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,bool> '<>9__21_1'
-    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,!TB> '<>9__21_2'
+    .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!TA,!TB> '<>9'
+    .field public static class [mscorlib]System.Func`2<!TA,class '<>f__AnonymousType17`2'<!TA,!TB>> '<>9__22_0'
+    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,bool> '<>9__22_1'
+    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,!TB> '<>9__22_2'
     .method private hidebysig specialname rtspecialname static 
             void  .cctor() cil managed
     {
       // Code size       11 (0xb)
       .maxstack  8
-      IL_0000:  newobj     instance void class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!TA,!TB>::.ctor()
-      IL_0005:  stsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!TA,!TB>::'<>9'
+      IL_0000:  newobj     instance void class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!TA,!TB>::.ctor()
+      IL_0005:  stsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!TA,!TB>::'<>9'
       IL_000a:  ret
-    } // end of method '<>c__21`2'::.cctor
+    } // end of method '<>c__22`2'::.cctor
 
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
@@ -4527,10 +4573,10 @@
       IL_0000:  ldarg.0
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  ret
-    } // end of method '<>c__21`2'::.ctor
+    } // end of method '<>c__22`2'::.ctor
 
     .method assembly hidebysig instance class '<>f__AnonymousType17`2'<!TA,!TB> 
-            '<Cast>b__21_0'(!TA m) cil managed
+            '<Cast>b__22_0'(!TA m) cil managed
     {
       // Code size       23 (0x17)
       .maxstack  8
@@ -4542,10 +4588,10 @@
       IL_0011:  newobj     instance void class '<>f__AnonymousType17`2'<!TA,!TB>::.ctor(!0,
                                                                                         !1)
       IL_0016:  ret
-    } // end of method '<>c__21`2'::'<Cast>b__21_0'
+    } // end of method '<>c__22`2'::'<Cast>b__22_0'
 
     .method assembly hidebysig instance bool 
-            '<Cast>b__21_1'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
+            '<Cast>b__22_1'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
     {
       // Code size       15 (0xf)
       .maxstack  8
@@ -4555,19 +4601,19 @@
       IL_000b:  ldnull
       IL_000c:  cgt.un
       IL_000e:  ret
-    } // end of method '<>c__21`2'::'<Cast>b__21_1'
+    } // end of method '<>c__22`2'::'<Cast>b__22_1'
 
     .method assembly hidebysig instance !TB 
-            '<Cast>b__21_2'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
+            '<Cast>b__22_2'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
     {
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.1
       IL_0001:  callvirt   instance !1 class '<>f__AnonymousType17`2'<!TA,!TB>::get_t()
       IL_0006:  ret
-    } // end of method '<>c__21`2'::'<Cast>b__21_2'
+    } // end of method '<>c__22`2'::'<Cast>b__22_2'
 
-  } // end of class '<>c__21`2'
+  } // end of class '<>c__22`2'
 
   .field public class [mscorlib]System.Collections.Generic.IEnumerable`1<class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/Customer> customers
   .field public class [mscorlib]System.Collections.Generic.IEnumerable`1<class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/Order> orders
@@ -5305,49 +5351,125 @@
     IL_0049:  ret
   } // end of method QueryExpressions::Issue437
 
+  .method public hidebysig static class [mscorlib]System.Collections.Generic.IEnumerable`1<char> 
+          Issue1310a(bool test) cil managed
+  {
+    // Code size       178 (0xb2)
+    .maxstack  3
+    IL_0000:  ldarg.0
+    IL_0001:  brtrue.s   IL_0058
+
+    IL_0003:  ldc.i4.0
+    IL_0004:  ldc.i4     0xff
+    IL_0009:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_000e:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_2'
+    IL_0013:  dup
+    IL_0014:  brtrue.s   IL_002d
+
+    IL_0016:  pop
+    IL_0017:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_001c:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_2'(int32)
+    IL_0022:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_0027:  dup
+    IL_0028:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_2'
+    IL_002d:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0032:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_3'
+    IL_0037:  dup
+    IL_0038:  brtrue.s   IL_0051
+
+    IL_003a:  pop
+    IL_003b:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_0040:  ldftn      instance char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_3'(int32)
+    IL_0046:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_004b:  dup
+    IL_004c:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_3'
+    IL_0051:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_0056:  br.s       IL_00ab
+
+    IL_0058:  ldc.i4.0
+    IL_0059:  ldc.i4     0xff
+    IL_005e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_0063:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_0'
+    IL_0068:  dup
+    IL_0069:  brtrue.s   IL_0082
+
+    IL_006b:  pop
+    IL_006c:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_0071:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_0'(int32)
+    IL_0077:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_007c:  dup
+    IL_007d:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_0'
+    IL_0082:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0087:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_1'
+    IL_008c:  dup
+    IL_008d:  brtrue.s   IL_00a6
+
+    IL_008f:  pop
+    IL_0090:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_0095:  ldftn      instance char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_1'(int32)
+    IL_009b:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_00a0:  dup
+    IL_00a1:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_1'
+    IL_00a6:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_00ab:  dup
+    IL_00ac:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Concat<char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00b1:  ret
+  } // end of method QueryExpressions::Issue1310a
+
   .method public hidebysig static valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TB> 
           Cast<TA,class TB>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TA> a) cil managed
   {
     // Code size       110 (0x6e)
     .maxstack  3
     IL_0000:  ldarg.0
-    IL_0001:  ldsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_0'
+    IL_0001:  ldsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_0'
     IL_0006:  dup
     IL_0007:  brtrue.s   IL_0020
 
     IL_0009:  pop
-    IL_000a:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9'
-    IL_000f:  ldftn      instance class '<>f__AnonymousType17`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<Cast>b__21_0'(!0)
+    IL_000a:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9'
+    IL_000f:  ldftn      instance class '<>f__AnonymousType17`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<Cast>b__22_0'(!0)
     IL_0015:  newobj     instance void class [mscorlib]System.Func`2<!!TA,class '<>f__AnonymousType17`2'<!!TA,!!TB>>::.ctor(object,
                                                                                                                             native int)
     IL_001a:  dup
-    IL_001b:  stsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_0'
+    IL_001b:  stsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_0'
     IL_0020:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<!!0,class '<>f__AnonymousType17`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                                  class [mscorlib]System.Func`2<!!0,!!1>)
-    IL_0025:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_1'
+    IL_0025:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_1'
     IL_002a:  dup
     IL_002b:  brtrue.s   IL_0044
 
     IL_002d:  pop
-    IL_002e:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9'
-    IL_0033:  ldftn      instance bool class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<Cast>b__21_1'(class '<>f__AnonymousType17`2'<!0,!1>)
+    IL_002e:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9'
+    IL_0033:  ldftn      instance bool class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<Cast>b__22_1'(class '<>f__AnonymousType17`2'<!0,!1>)
     IL_0039:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!!TA,!!TB>,bool>::.ctor(object,
                                                                                                                             native int)
     IL_003e:  dup
-    IL_003f:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_1'
+    IL_003f:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_1'
     IL_0044:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Where<class '<>f__AnonymousType17`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                             class [mscorlib]System.Func`2<!!0,bool>)
-    IL_0049:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_2'
+    IL_0049:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_2'
     IL_004e:  dup
     IL_004f:  brtrue.s   IL_0068
 
     IL_0051:  pop
-    IL_0052:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9'
-    IL_0057:  ldftn      instance !1 class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<Cast>b__21_2'(class '<>f__AnonymousType17`2'<!0,!1>)
+    IL_0052:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9'
+    IL_0057:  ldftn      instance !1 class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<Cast>b__22_2'(class '<>f__AnonymousType17`2'<!0,!1>)
     IL_005d:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!!TA,!!TB>,!!TB>::.ctor(object,
                                                                                                                             native int)
     IL_0062:  dup
-    IL_0063:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_2'
+    IL_0063:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_2'
     IL_0068:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<class '<>f__AnonymousType17`2'<!!0,!!1>,!!1>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                                  class [mscorlib]System.Func`2<!!0,!!1>)
     IL_006d:  ret

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.roslyn.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.roslyn.il
@@ -3960,6 +3960,10 @@
     .field public static class [mscorlib]System.Func`2<class [System.Core]System.Linq.IGrouping`2<string,class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/Customer>,class '<>f__AnonymousType16`2'<string,int32>> '<>9__19_1'
     .field public static class [mscorlib]System.Func`2<bool,bool> '<>9__20_0'
     .field public static class [mscorlib]System.Func`2<bool,bool> '<>9__20_1'
+    .field public static class [mscorlib]System.Func`2<int32,bool> '<>9__21_0'
+    .field public static class [mscorlib]System.Func`2<int32,char> '<>9__21_1'
+    .field public static class [mscorlib]System.Func`2<int32,bool> '<>9__21_2'
+    .field public static class [mscorlib]System.Func`2<int32,char> '<>9__21_3'
     .method private hidebysig specialname rtspecialname static 
             void  .cctor() cil managed
     {
@@ -4605,25 +4609,67 @@
       IL_0001:  ret
     } // end of method '<>c'::'<Issue437>b__20_1'
 
+    .method assembly hidebysig instance bool 
+            '<Issue1310a>b__21_0'(int32 c) cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  call       bool [mscorlib]System.Char::IsLetter(char)
+      IL_0007:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_0'
+
+    .method assembly hidebysig instance char 
+            '<Issue1310a>b__21_1'(int32 c) cil managed
+    {
+      // Code size       3 (0x3)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_1'
+
+    .method assembly hidebysig instance bool 
+            '<Issue1310a>b__21_2'(int32 c) cil managed
+    {
+      // Code size       8 (0x8)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  call       bool [mscorlib]System.Char::IsDigit(char)
+      IL_0007:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_2'
+
+    .method assembly hidebysig instance char 
+            '<Issue1310a>b__21_3'(int32 c) cil managed
+    {
+      // Code size       3 (0x3)
+      .maxstack  8
+      IL_0000:  ldarg.1
+      IL_0001:  conv.u2
+      IL_0002:  ret
+    } // end of method '<>c'::'<Issue1310a>b__21_3'
+
   } // end of class '<>c'
 
-  .class auto ansi serializable sealed nested private beforefieldinit '<>c__21`2'<TA,class TB>
+  .class auto ansi serializable sealed nested private beforefieldinit '<>c__22`2'<TA,class TB>
          extends [mscorlib]System.Object
   {
     .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 ) 
-    .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!TA,!TB> '<>9'
-    .field public static class [mscorlib]System.Func`2<!TA,class '<>f__AnonymousType17`2'<!TA,!TB>> '<>9__21_0'
-    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,bool> '<>9__21_1'
-    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,!TB> '<>9__21_2'
+    .field public static initonly class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!TA,!TB> '<>9'
+    .field public static class [mscorlib]System.Func`2<!TA,class '<>f__AnonymousType17`2'<!TA,!TB>> '<>9__22_0'
+    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,bool> '<>9__22_1'
+    .field public static class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!TA,!TB>,!TB> '<>9__22_2'
     .method private hidebysig specialname rtspecialname static 
             void  .cctor() cil managed
     {
       // Code size       11 (0xb)
       .maxstack  8
-      IL_0000:  newobj     instance void class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!TA,!TB>::.ctor()
-      IL_0005:  stsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!TA,!TB>::'<>9'
+      IL_0000:  newobj     instance void class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!TA,!TB>::.ctor()
+      IL_0005:  stsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!TA,!TB>::'<>9'
       IL_000a:  ret
-    } // end of method '<>c__21`2'::.cctor
+    } // end of method '<>c__22`2'::.cctor
 
     .method public hidebysig specialname rtspecialname 
             instance void  .ctor() cil managed
@@ -4634,10 +4680,10 @@
       IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
       IL_0006:  nop
       IL_0007:  ret
-    } // end of method '<>c__21`2'::.ctor
+    } // end of method '<>c__22`2'::.ctor
 
     .method assembly hidebysig instance class '<>f__AnonymousType17`2'<!TA,!TB> 
-            '<Cast>b__21_0'(!TA m) cil managed
+            '<Cast>b__22_0'(!TA m) cil managed
     {
       // Code size       23 (0x17)
       .maxstack  8
@@ -4649,10 +4695,10 @@
       IL_0011:  newobj     instance void class '<>f__AnonymousType17`2'<!TA,!TB>::.ctor(!0,
                                                                                         !1)
       IL_0016:  ret
-    } // end of method '<>c__21`2'::'<Cast>b__21_0'
+    } // end of method '<>c__22`2'::'<Cast>b__22_0'
 
     .method assembly hidebysig instance bool 
-            '<Cast>b__21_1'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
+            '<Cast>b__22_1'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
     {
       // Code size       15 (0xf)
       .maxstack  8
@@ -4662,19 +4708,19 @@
       IL_000b:  ldnull
       IL_000c:  cgt.un
       IL_000e:  ret
-    } // end of method '<>c__21`2'::'<Cast>b__21_1'
+    } // end of method '<>c__22`2'::'<Cast>b__22_1'
 
     .method assembly hidebysig instance !TB 
-            '<Cast>b__21_2'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
+            '<Cast>b__22_2'(class '<>f__AnonymousType17`2'<!TA,!TB> '<>h__TransparentIdentifier0') cil managed
     {
       // Code size       7 (0x7)
       .maxstack  8
       IL_0000:  ldarg.1
       IL_0001:  callvirt   instance !1 class '<>f__AnonymousType17`2'<!TA,!TB>::get_t()
       IL_0006:  ret
-    } // end of method '<>c__21`2'::'<Cast>b__21_2'
+    } // end of method '<>c__22`2'::'<Cast>b__22_2'
 
-  } // end of class '<>c__21`2'
+  } // end of class '<>c__22`2'
 
   .field public class [mscorlib]System.Collections.Generic.IEnumerable`1<class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/Customer> customers
   .field public class [mscorlib]System.Collections.Generic.IEnumerable`1<class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/Order> orders
@@ -5502,6 +5548,91 @@
     IL_004e:  ret
   } // end of method QueryExpressions::Issue437
 
+  .method public hidebysig static class [mscorlib]System.Collections.Generic.IEnumerable`1<char> 
+          Issue1310a(bool test) cil managed
+  {
+    // Code size       185 (0xb9)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Collections.Generic.IEnumerable`1<char> V_0,
+             class [mscorlib]System.Collections.Generic.IEnumerable`1<char> V_1)
+    IL_0000:  nop
+    IL_0001:  ldarg.0
+    IL_0002:  brtrue.s   IL_0059
+
+    IL_0004:  ldc.i4.0
+    IL_0005:  ldc.i4     0xff
+    IL_000a:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_000f:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_2'
+    IL_0014:  dup
+    IL_0015:  brtrue.s   IL_002e
+
+    IL_0017:  pop
+    IL_0018:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_001d:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_2'(int32)
+    IL_0023:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_0028:  dup
+    IL_0029:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_2'
+    IL_002e:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0033:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_3'
+    IL_0038:  dup
+    IL_0039:  brtrue.s   IL_0052
+
+    IL_003b:  pop
+    IL_003c:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_0041:  ldftn      instance char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_3'(int32)
+    IL_0047:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_004c:  dup
+    IL_004d:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_3'
+    IL_0052:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_0057:  br.s       IL_00ac
+
+    IL_0059:  ldc.i4.0
+    IL_005a:  ldc.i4     0xff
+    IL_005f:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<int32> [System.Core]System.Linq.Enumerable::Range(int32,
+                                                                                                                                    int32)
+    IL_0064:  ldsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_0'
+    IL_0069:  dup
+    IL_006a:  brtrue.s   IL_0083
+
+    IL_006c:  pop
+    IL_006d:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_0072:  ldftn      instance bool ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_0'(int32)
+    IL_0078:  newobj     instance void class [mscorlib]System.Func`2<int32,bool>::.ctor(object,
+                                                                                        native int)
+    IL_007d:  dup
+    IL_007e:  stsfld     class [mscorlib]System.Func`2<int32,bool> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_0'
+    IL_0083:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Where<int32>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Func`2<!!0,bool>)
+    IL_0088:  ldsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_1'
+    IL_008d:  dup
+    IL_008e:  brtrue.s   IL_00a7
+
+    IL_0090:  pop
+    IL_0091:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c' ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9'
+    IL_0096:  ldftn      instance char ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<Issue1310a>b__21_1'(int32)
+    IL_009c:  newobj     instance void class [mscorlib]System.Func`2<int32,char>::.ctor(object,
+                                                                                        native int)
+    IL_00a1:  dup
+    IL_00a2:  stsfld     class [mscorlib]System.Func`2<int32,char> ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c'::'<>9__21_1'
+    IL_00a7:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!1> [System.Core]System.Linq.Enumerable::Select<int32,char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                               class [mscorlib]System.Func`2<!!0,!!1>)
+    IL_00ac:  stloc.0
+    IL_00ad:  ldloc.0
+    IL_00ae:  ldloc.0
+    IL_00af:  call       class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0> [System.Core]System.Linq.Enumerable::Concat<char>(class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>,
+                                                                                                                                         class [mscorlib]System.Collections.Generic.IEnumerable`1<!!0>)
+    IL_00b4:  stloc.1
+    IL_00b5:  br.s       IL_00b7
+
+    IL_00b7:  ldloc.1
+    IL_00b8:  ret
+  } // end of method QueryExpressions::Issue1310a
+
   .method public hidebysig static valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TB> 
           Cast<TA,class TB>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TA> a) cil managed
   {
@@ -5510,43 +5641,43 @@
     .locals init (valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!TB> V_0)
     IL_0000:  nop
     IL_0001:  ldarg.0
-    IL_0002:  ldsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_0'
+    IL_0002:  ldsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_0'
     IL_0007:  dup
     IL_0008:  brtrue.s   IL_0021
 
     IL_000a:  pop
-    IL_000b:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9'
-    IL_0010:  ldftn      instance class '<>f__AnonymousType17`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<Cast>b__21_0'(!0)
+    IL_000b:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9'
+    IL_0010:  ldftn      instance class '<>f__AnonymousType17`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<Cast>b__22_0'(!0)
     IL_0016:  newobj     instance void class [mscorlib]System.Func`2<!!TA,class '<>f__AnonymousType17`2'<!!TA,!!TB>>::.ctor(object,
                                                                                                                             native int)
     IL_001b:  dup
-    IL_001c:  stsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_0'
+    IL_001c:  stsfld     class [mscorlib]System.Func`2<!0,class '<>f__AnonymousType17`2'<!0,!1>> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_0'
     IL_0021:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<!!0,class '<>f__AnonymousType17`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                                  class [mscorlib]System.Func`2<!!0,!!1>)
-    IL_0026:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_1'
+    IL_0026:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_1'
     IL_002b:  dup
     IL_002c:  brtrue.s   IL_0045
 
     IL_002e:  pop
-    IL_002f:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9'
-    IL_0034:  ldftn      instance bool class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<Cast>b__21_1'(class '<>f__AnonymousType17`2'<!0,!1>)
+    IL_002f:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9'
+    IL_0034:  ldftn      instance bool class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<Cast>b__22_1'(class '<>f__AnonymousType17`2'<!0,!1>)
     IL_003a:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!!TA,!!TB>,bool>::.ctor(object,
                                                                                                                             native int)
     IL_003f:  dup
-    IL_0040:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_1'
+    IL_0040:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,bool> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_1'
     IL_0045:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Where<class '<>f__AnonymousType17`2'<!!0,!!1>>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                             class [mscorlib]System.Func`2<!!0,bool>)
-    IL_004a:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_2'
+    IL_004a:  ldsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_2'
     IL_004f:  dup
     IL_0050:  brtrue.s   IL_0069
 
     IL_0052:  pop
-    IL_0053:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9'
-    IL_0058:  ldftn      instance !1 class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<Cast>b__21_2'(class '<>f__AnonymousType17`2'<!0,!1>)
+    IL_0053:  ldsfld     class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!0,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9'
+    IL_0058:  ldftn      instance !1 class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<Cast>b__22_2'(class '<>f__AnonymousType17`2'<!0,!1>)
     IL_005e:  newobj     instance void class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!!TA,!!TB>,!!TB>::.ctor(object,
                                                                                                                             native int)
     IL_0063:  dup
-    IL_0064:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__21`2'<!!TA,!!TB>::'<>9__21_2'
+    IL_0064:  stsfld     class [mscorlib]System.Func`2<class '<>f__AnonymousType17`2'<!0,!1>,!1> class ICSharpCode.Decompiler.Tests.TestCases.Pretty.QueryExpressions/'<>c__22`2'<!!TA,!!TB>::'<>9__22_2'
     IL_0069:  call       valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!1> ICSharpCode.Decompiler.Tests.TestCases.Pretty.MaybeExtensions::Select<class '<>f__AnonymousType17`2'<!!0,!!1>,!!1>(valuetype ICSharpCode.Decompiler.Tests.TestCases.Pretty.Maybe`1<!!0>,
                                                                                                                                                                                                                  class [mscorlib]System.Func`2<!!0,!!1>)
     IL_006e:  stloc.0

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1141,11 +1141,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		public virtual void VisitQueryExpression(QueryExpression queryExpression)
 		{
 			StartNode(queryExpression);
-			bool indent = queryExpression.Parent is QueryClause && !(queryExpression.Parent is QueryContinuationClause);
-			if (indent) {
-				writer.Indent();
-				NewLine();
-			}
+			writer.Indent();
 			bool first = true;
 			foreach (var clause in queryExpression.Clauses) {
 				if (first) {
@@ -1157,9 +1153,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				}
 				clause.AcceptVisitor(this);
 			}
-			if (indent) {
-				writer.Unindent();
-			}
+			writer.Unindent();
 			EndNode(queryExpression);
 		}
 		

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1141,7 +1141,8 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		public virtual void VisitQueryExpression(QueryExpression queryExpression)
 		{
 			StartNode(queryExpression);
-			writer.Indent();
+			if (queryExpression.Role != QueryContinuationClause.PrecedingQueryRole)
+				writer.Indent();
 			bool first = true;
 			foreach (var clause in queryExpression.Clauses) {
 				if (first) {
@@ -1153,7 +1154,8 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				}
 				clause.AcceptVisitor(this);
 			}
-			writer.Unindent();
+			if (queryExpression.Role != QueryContinuationClause.PrecedingQueryRole)
+				writer.Unindent();
 			EndNode(queryExpression);
 		}
 		

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				QueryFromClause fromClause = (QueryFromClause)query.Clauses.First();
 				if (IsDegenerateQuery(query)) {
 					// introduce select for degenerate query
-					query.Clauses.Add(new QuerySelectClause { Expression = new IdentifierExpression(fromClause.Identifier) });
+					query.Clauses.Add(new QuerySelectClause { Expression = new IdentifierExpression(fromClause.Identifier).CopyAnnotationsFrom(fromClause) });
 				}
 				// See if the data source of this query is a degenerate query,
 				// and combine the queries if possible.
@@ -94,12 +94,12 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						if (invocation.Arguments.Count != 1)
 							return null;
-						string parameterName;
+						ParameterDeclaration parameter;
 						Expression body;
-						if (MatchSimpleLambda(invocation.Arguments.Single(), out parameterName, out body)) {
+						if (MatchSimpleLambda(invocation.Arguments.Single(), out parameter, out body)) {
 							QueryExpression query = new QueryExpression();
-							query.Clauses.Add(new QueryFromClause { Identifier = parameterName, Expression = mre.Target.Detach() });
-							query.Clauses.Add(new QuerySelectClause { Expression = WrapExpressionInParenthesesIfNecessary(body.Detach(), parameterName) });
+							query.Clauses.Add(MakeFromClause(parameter, mre.Target.Detach()));
+							query.Clauses.Add(new QuerySelectClause { Expression = WrapExpressionInParenthesesIfNecessary(body.Detach(), parameter.Name) });
 							return query;
 						}
 						return null;
@@ -107,24 +107,24 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				case "GroupBy":
 					{
 						if (invocation.Arguments.Count == 2) {
-							string parameterName1, parameterName2;
+							ParameterDeclaration parameter1, parameter2;
 							Expression keySelector, elementSelector;
-							if (MatchSimpleLambda(invocation.Arguments.ElementAt(0), out parameterName1, out keySelector)
-							    && MatchSimpleLambda(invocation.Arguments.ElementAt(1), out parameterName2, out elementSelector)
-							    && parameterName1 == parameterName2)
+							if (MatchSimpleLambda(invocation.Arguments.ElementAt(0), out parameter1, out keySelector)
+							    && MatchSimpleLambda(invocation.Arguments.ElementAt(1), out parameter2, out elementSelector)
+							    && parameter1.Name == parameter2.Name)
 							{
 								QueryExpression query = new QueryExpression();
-								query.Clauses.Add(new QueryFromClause { Identifier = parameterName1, Expression = mre.Target.Detach() });
+								query.Clauses.Add(MakeFromClause(parameter1, mre.Target.Detach()));
 								query.Clauses.Add(new QueryGroupClause { Projection = elementSelector.Detach(), Key = keySelector.Detach() });
 								return query;
 							}
 						} else if (invocation.Arguments.Count == 1) {
-							string parameterName;
+							ParameterDeclaration parameter;
 							Expression keySelector;
-							if (MatchSimpleLambda(invocation.Arguments.Single(), out parameterName, out keySelector)) {
+							if (MatchSimpleLambda(invocation.Arguments.Single(), out parameter, out keySelector)) {
 								QueryExpression query = new QueryExpression();
-								query.Clauses.Add(new QueryFromClause { Identifier = parameterName, Expression = mre.Target.Detach() });
-								query.Clauses.Add(new QueryGroupClause { Projection = new IdentifierExpression(parameterName), Key = keySelector.Detach() });
+								query.Clauses.Add(MakeFromClause(parameter, mre.Target.Detach()));
+								query.Clauses.Add(new QueryGroupClause { Projection = new IdentifierExpression(parameter.Name).CopyAnnotationsFrom(parameter), Key = keySelector.Detach() });
 								return query;
 							}
 						}
@@ -134,9 +134,9 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						if (invocation.Arguments.Count != 2)
 							return null;
-						string parameterName;
+						ParameterDeclaration parameter;
 						Expression collectionSelector;
-						if (!MatchSimpleLambda(invocation.Arguments.ElementAt(0), out parameterName, out collectionSelector))
+						if (!MatchSimpleLambda(invocation.Arguments.ElementAt(0), out parameter, out collectionSelector))
 							return null;
 						if (IsNullConditional(collectionSelector))
 							return null;
@@ -144,11 +144,11 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						if (lambda != null && lambda.Parameters.Count == 2 && lambda.Body is Expression) {
 							ParameterDeclaration p1 = lambda.Parameters.ElementAt(0);
 							ParameterDeclaration p2 = lambda.Parameters.ElementAt(1);
-							if (p1.Name == parameterName) {
+							if (p1.Name == parameter.Name) {
 								QueryExpression query = new QueryExpression();
-								query.Clauses.Add(new QueryFromClause { Identifier = p1.Name, Expression = mre.Target.Detach() });
-								query.Clauses.Add(new QueryFromClause { Identifier = p2.Name, Expression = collectionSelector.Detach() });
-								query.Clauses.Add(new QuerySelectClause { Expression = WrapExpressionInParenthesesIfNecessary(((Expression)lambda.Body).Detach(), parameterName) });
+								query.Clauses.Add(MakeFromClause(p1, mre.Target.Detach()));
+								query.Clauses.Add(MakeFromClause(p2, collectionSelector.Detach()));
+								query.Clauses.Add(new QuerySelectClause { Expression = WrapExpressionInParenthesesIfNecessary(((Expression)lambda.Body).Detach(), parameter.Name) });
 								return query;
 							}
 						}
@@ -158,11 +158,11 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						if (invocation.Arguments.Count != 1)
 							return null;
-						string parameterName;
+						ParameterDeclaration parameter;
 						Expression body;
-						if (MatchSimpleLambda(invocation.Arguments.Single(), out parameterName, out body)) {
+						if (MatchSimpleLambda(invocation.Arguments.Single(), out parameter, out body)) {
 							QueryExpression query = new QueryExpression();
-							query.Clauses.Add(new QueryFromClause { Identifier = parameterName, Expression = mre.Target.Detach() });
+							query.Clauses.Add(MakeFromClause(parameter, mre.Target.Detach()));
 							query.Clauses.Add(new QueryWhereClause { Condition = body.Detach() });
 							return query;
 						}
@@ -175,10 +175,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						if (invocation.Arguments.Count != 1)
 							return null;
-						string parameterName;
+						ParameterDeclaration parameter;
 						Expression orderExpression;
-						if (MatchSimpleLambda(invocation.Arguments.Single(), out parameterName, out orderExpression)) {
-							if (ValidateThenByChain(invocation, parameterName)) {
+						if (MatchSimpleLambda(invocation.Arguments.Single(), out parameter, out orderExpression)) {
+							if (ValidateThenByChain(invocation, parameter.Name)) {
 								QueryOrderClause orderClause = new QueryOrderClause();
 								InvocationExpression tmp = invocation;
 								while (mre.MemberName == "ThenBy" || mre.MemberName == "ThenByDescending") {
@@ -191,7 +191,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 									
 									tmp = (InvocationExpression)mre.Target;
 									mre = (MemberReferenceExpression)tmp.Target;
-									MatchSimpleLambda(tmp.Arguments.Single(), out parameterName, out orderExpression);
+									MatchSimpleLambda(tmp.Arguments.Single(), out parameter, out orderExpression);
 								}
 								// insert new ordering at beginning
 								orderClause.Orderings.InsertAfter(
@@ -201,7 +201,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 									});
 								
 								QueryExpression query = new QueryExpression();
-								query.Clauses.Add(new QueryFromClause { Identifier = parameterName, Expression = mre.Target.Detach() });
+								query.Clauses.Add(MakeFromClause(parameter, mre.Target.Detach()));
 								query.Clauses.Add(orderClause);
 								return query;
 							}
@@ -217,21 +217,21 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						Expression source2 = invocation.Arguments.ElementAt(0);
 						if (IsNullConditional(source2))
 							return null;
-						string elementName1, elementName2;
+						ParameterDeclaration element1, element2;
 						Expression key1, key2;
-						if (!MatchSimpleLambda(invocation.Arguments.ElementAt(1), out elementName1, out key1))
+						if (!MatchSimpleLambda(invocation.Arguments.ElementAt(1), out element1, out key1))
 							return null;
-						if (!MatchSimpleLambda(invocation.Arguments.ElementAt(2), out elementName2, out key2))
+						if (!MatchSimpleLambda(invocation.Arguments.ElementAt(2), out element2, out key2))
 							return null;
 						LambdaExpression lambda = invocation.Arguments.ElementAt(3) as LambdaExpression;
 						if (lambda != null && lambda.Parameters.Count == 2 && lambda.Body is Expression) {
 							ParameterDeclaration p1 = lambda.Parameters.ElementAt(0);
 							ParameterDeclaration p2 = lambda.Parameters.ElementAt(1);
-							if (p1.Name == elementName1 && (p2.Name == elementName2 || mre.MemberName == "GroupJoin")) {
+							if (p1.Name == element1.Name && (p2.Name == element2.Name || mre.MemberName == "GroupJoin")) {
 								QueryExpression query = new QueryExpression();
-								query.Clauses.Add(new QueryFromClause { Identifier = elementName1, Expression = source1.Detach() });
+								query.Clauses.Add(MakeFromClause(element1, source1.Detach()));
 								QueryJoinClause joinClause = new QueryJoinClause();
-								joinClause.JoinIdentifier = elementName2;    // join elementName2
+								joinClause.JoinIdentifier = element2.Name;    // join elementName2
 								joinClause.InExpression = source2.Detach();  // in source2
 								joinClause.OnExpression = key1.Detach();     // on key1
 								joinClause.EqualsExpression = key2.Detach(); // equals key2
@@ -247,6 +247,35 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					}
 				default:
 					return null;
+			}
+		}
+
+		QueryFromClause MakeFromClause(ParameterDeclaration parameter, Expression body)
+		{
+			QueryFromClause fromClause = new QueryFromClause {
+				Identifier = parameter.Name,
+				Expression = body
+			};
+			fromClause.CopyAnnotationsFrom(parameter);
+			return fromClause;
+		}
+
+		class ApplyAnnotationVisitor : DepthFirstAstVisitor<AstNode>
+		{
+			private LetIdentifierAnnotation annotation;
+			private string identifier;
+
+			public ApplyAnnotationVisitor(LetIdentifierAnnotation annotation, string identifier)
+			{
+				this.annotation = annotation;
+				this.identifier = identifier;
+			}
+
+			public override AstNode VisitIdentifier(Identifier identifier)
+			{
+				if (identifier.Name == this.identifier)
+					identifier.AddAnnotation(annotation);
+				return identifier;
 			}
 		}
 
@@ -278,11 +307,11 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			MemberReferenceExpression mre = invocation.Target as MemberReferenceExpression;
 			if (mre == null)
 				return false;
-			string parameterName;
+			ParameterDeclaration parameter;
 			Expression body;
-			if (!MatchSimpleLambda(invocation.Arguments.Single(), out parameterName, out body))
+			if (!MatchSimpleLambda(invocation.Arguments.Single(), out parameter, out body))
 				return false;
-			if (parameterName != expectedParameterName)
+			if (parameter.Name != expectedParameterName)
 				return false;
 			
 			if (mre.MemberName == "OrderBy" || mre.MemberName == "OrderByDescending")
@@ -294,7 +323,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 		}
 		
 		/// <summary>Matches simple lambdas of the form "a => b"</summary>
-		bool MatchSimpleLambda(Expression expr, out string parameterName, out Expression body)
+		bool MatchSimpleLambda(Expression expr, out ParameterDeclaration parameter, out Expression body)
 		{
 			// HACK : remove workaround after all unnecessary casts are eliminated.
 			LambdaExpression lambda;
@@ -305,12 +334,12 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			if (lambda != null && lambda.Parameters.Count == 1 && lambda.Body is Expression) {
 				ParameterDeclaration p = lambda.Parameters.Single();
 				if (p.ParameterModifier == ParameterModifier.None) {
-					parameterName = p.Name;
+					parameter = p;
 					body = (Expression)lambda.Body;
 					return true;
 				}
 			}
-			parameterName = null;
+			parameter = null;
 			body = null;
 			return false;
 		}

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
@@ -74,7 +74,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			QueryExpression query = DecompileQuery(node as InvocationExpression);
 			if (query != null)
 				node.ReplaceWith(query);
-			for (AstNode child = (query ?? node).FirstChild; child != null; child = child.NextSibling) {
+			AstNode next;
+			for (AstNode child = (query ?? node).FirstChild; child != null; child = next) {
+				// store referece to next child before transformation
+				next = child.NextSibling;
 				DecompileQueries(child);
 			}
 		}

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -74,7 +74,7 @@
     <Compile Include="CSharp\Syntax\ErrorNode.cs" />
     <Compile Include="CSharp\Syntax\Expressions\AnonymousMethodExpression.cs" />
     <Compile Include="CSharp\Syntax\Expressions\AnonymousTypeCreateExpression.cs" />
-    <Compile Include="CSharp\Syntax\Expressions\ArrayCreateExpression.cs"  />
+    <Compile Include="CSharp\Syntax\Expressions\ArrayCreateExpression.cs" />
     <Compile Include="CSharp\Syntax\Expressions\ArrayInitializerExpression.cs" />
     <Compile Include="CSharp\Syntax\Expressions\AsExpression.cs" />
     <Compile Include="CSharp\Syntax\Expressions\AssignmentExpression.cs" />
@@ -265,6 +265,7 @@
     <Compile Include="CSharp\Transforms\AddXmlDocumentationTransform.cs" />
     <Compile Include="DecompileRun.cs" />
     <Compile Include="Disassembler\ILParser.cs" />
+    <Compile Include="IL\Transforms\CombineExitsTransform.cs" />
     <Compile Include="IL\Transforms\ReduceNestingTransform.cs" />
     <Compile Include="IL\Transforms\LocalFunctionDecompiler.cs" />
     <Compile Include="IL\Transforms\UserDefinedLogicTransform.cs" />

--- a/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ICSharpCode.Decompiler.IL.Transforms
+{
+	class CombineExitsTransform : IILTransform
+	{
+		public void Run(ILFunction function, ILTransformContext context)
+		{
+			if (!(function.Body is BlockContainer container && container.Blocks.Count == 1))
+				return;
+			var block = container.EntryPoint;
+			if (block.Kind != BlockKind.ControlFlow)
+				return;
+			if (!(block.Instructions.SecondToLastOrDefault() is IfInstruction ifInst && block.Instructions.LastOrDefault() is Leave leave))
+				return;
+			if (!ifInst.FalseInst.MatchNop())
+				return;
+			if (!(Block.Unwrap(ifInst.TrueInst) is Leave leave2))
+				return;
+			if (!(leave.IsLeavingFunction && leave2.IsLeavingFunction))
+				return;
+			if (leave.Value.MatchNop() || leave2.Value.MatchNop())
+				return;
+			IfInstruction value = new IfInstruction(ifInst.Condition, leave.Value, leave2.Value);
+			Leave combinedLeave = new Leave(leave.TargetContainer, value);
+			ifInst.ReplaceWith(combinedLeave);
+			block.Instructions.RemoveAt(combinedLeave.ChildIndex + 1);
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
@@ -25,8 +25,6 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (!(function.Body is BlockContainer container && container.Blocks.Count == 1))
 				return;
 			var block = container.EntryPoint;
-			if (block.Kind != BlockKind.ControlFlow)
-				return;
 			if (!(block.Instructions.SecondToLastOrDefault() is IfInstruction ifInst && block.Instructions.LastOrDefault() is Leave leaveElse))
 				return;
 			if (!ifInst.FalseInst.MatchNop())
@@ -45,6 +43,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			// leave (if (cond) value else elseValue)
 			IfInstruction value = new IfInstruction(ifInst.Condition, leave.Value, leaveElse.Value) { ILRange = ifInst.ILRange };
 			Leave combinedLeave = new Leave(leave.TargetContainer, value) { ILRange = leaveElse.ILRange };
+			combinedLeave.AddILRange(leave.ILRange);
 			ifInst.ReplaceWith(combinedLeave);
 			block.Instructions.RemoveAt(combinedLeave.ChildIndex + 1);
 		}

--- a/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
@@ -1,6 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) 2019 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
 
 namespace ICSharpCode.Decompiler.IL.Transforms
 {
@@ -13,18 +27,24 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			var block = container.EntryPoint;
 			if (block.Kind != BlockKind.ControlFlow)
 				return;
-			if (!(block.Instructions.SecondToLastOrDefault() is IfInstruction ifInst && block.Instructions.LastOrDefault() is Leave leave2))
+			if (!(block.Instructions.SecondToLastOrDefault() is IfInstruction ifInst && block.Instructions.LastOrDefault() is Leave leaveElse))
 				return;
 			if (!ifInst.FalseInst.MatchNop())
 				return;
 			if (!(Block.Unwrap(ifInst.TrueInst) is Leave leave))
 				return;
-			if (!(leave.IsLeavingFunction && leave2.IsLeavingFunction))
+			if (!(leave.IsLeavingFunction && leaveElse.IsLeavingFunction))
 				return;
-			if (leave.Value.MatchNop() || leave2.Value.MatchNop())
+			if (leave.Value.MatchNop() || leaveElse.Value.MatchNop())
 				return;
-			IfInstruction value = new IfInstruction(ifInst.Condition, leave.Value, leave2.Value);
-			Leave combinedLeave = new Leave(leave.TargetContainer, value);
+			// if (cond) {
+			//   leave (value)
+			// }
+			// leave (elseValue)
+			// =>
+			// leave (if (cond) value else elseValue)
+			IfInstruction value = new IfInstruction(ifInst.Condition, leave.Value, leaveElse.Value) { ILRange = ifInst.ILRange };
+			Leave combinedLeave = new Leave(leave.TargetContainer, value) { ILRange = leaveElse.ILRange };
 			ifInst.ReplaceWith(combinedLeave);
 			block.Instructions.RemoveAt(combinedLeave.ChildIndex + 1);
 		}

--- a/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CombineExitsTransform.cs
@@ -13,11 +13,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			var block = container.EntryPoint;
 			if (block.Kind != BlockKind.ControlFlow)
 				return;
-			if (!(block.Instructions.SecondToLastOrDefault() is IfInstruction ifInst && block.Instructions.LastOrDefault() is Leave leave))
+			if (!(block.Instructions.SecondToLastOrDefault() is IfInstruction ifInst && block.Instructions.LastOrDefault() is Leave leave2))
 				return;
 			if (!ifInst.FalseInst.MatchNop())
 				return;
-			if (!(Block.Unwrap(ifInst.TrueInst) is Leave leave2))
+			if (!(Block.Unwrap(ifInst.TrueInst) is Leave leave))
 				return;
 			if (!(leave.IsLeavingFunction && leave2.IsLeavingFunction))
 				return;

--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -140,6 +140,10 @@ namespace ICSharpCode.Decompiler
 			if (variable != null)
 				return variable;
 
+			var letClauseVariable = node.Annotation<CSharp.Transforms.LetIdentifierAnnotation>();
+			if (letClauseVariable != null)
+				return letClauseVariable;
+
 			var gotoStatement = node as GotoStatement;
 			if (gotoStatement != null)
 			{
@@ -159,6 +163,12 @@ namespace ICSharpCode.Decompiler
 
 			if (node is ParameterDeclaration || node is VariableInitializer || node is CatchClause || node is ForeachStatement) {
 				var variable = node.Annotation<ILVariableResolveResult>()?.Variable;
+				if (variable != null)
+					return variable;
+			}
+
+			if (node is QueryLetClause) {
+				var variable = node.Annotation<CSharp.Transforms.LetIdentifierAnnotation>();
 				if (variable != null)
 					return variable;
 			}


### PR DESCRIPTION
* Add CombineExitsTransform: Merges `if (cond) return cond2; else return false;` or similar to `return cond && cond2;` in lambdas
* Fixed some bugs in QueryExpressions transforms.
* Fix linking in query expressions.