### PR TITLE
Make `XmlBamlReader.Value` more defensive against null node values

### DIFF
--- a/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
+++ b/ILSpy.BamlDecompiler/Ricciolo.StylesExplorer.MarkupReflection/XmlBamlReader.cs
@@ -1638,7 +1638,7 @@ namespace Ricciolo.StylesExplorer.MarkupReflection
 				XmlBamlNode node = CurrentNode;
 				if (node is XmlBamlSimpleProperty)
 					return ((XmlBamlSimpleProperty)node).Value;
-				else if (node is XmlBamlProperty)
+				else if (node is XmlBamlProperty && ((XmlBamlProperty)node).Value != null)
 					return ((XmlBamlProperty)node).Value.ToString();
 				else if (node is XmlBamlText)
 					return ((XmlBamlText)node).Text;


### PR DESCRIPTION
This will help to fix an [issue with Obfuscar ](https://github.com/obfuscar/obfuscar/issues/181)

I can't get a repro on ILSpy directly, though, so it's hard for me to prove that this requires an ILSpy fix.

However, there seems to be cases where `XmlBamlNode` is an `XmlBamlProperty` and its value is `null`. 

All this does is add a defense around this so that it returns an empty string, rather than throwing an exception.