### PR TITLE
Add XML comments to the NuGet package

### DIFF
--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -42,6 +42,7 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <EmbedAllSources>true</EmbedAllSources>
+    <DocumentationFile>bin/Release/ICSharpCode.Decompiler.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec.template
@@ -24,11 +24,14 @@
   <files>
     <file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.dll" target="lib\net46" />
     <file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.pdb" target="lib\net46" />
+	<file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.xml" target="lib\net46" />
 
     <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.dll" target="lib\net45" />
     <file src="bin\$Configuration$\net45\ICSharpCode.Decompiler.pdb" target="lib\net45" />
+	<file src="bin\$Configuration$\net46\ICSharpCode.Decompiler.xml" target="lib\net45" />
 
     <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.dll" target="lib\netstandard2.0" />
-    <file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.pdb" target="lib\netstandard2.0" />
+	<file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.pdb" target="lib\netstandard2.0" />
+	<file src="bin\$Configuration$\netstandard2.0\ICSharpCode.Decompiler.xml" target="lib\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
Hey,

I've noticed that I am not getting any IntelliSense documentation on the ILDecompiler members. However, when looking at the code, there is plenty of XML documentation. Sure, some members may be missing and for others the comment might be not quite on point, but generally, the quality seemed to be quite high.

The reason I wasn't getting any documentation was due to the fact that the XML file was simply not generated and packed into the NuGet package. I've changed that, it's a pretty tiny change.

The changes are based on the last 4.0.1 release, so that a hotfix could easily be created for the NuGet package. However, there does not seem to be a 4.0 branch in GitHub that I can select for the pull request, so I've selected the master branch for now. It would obviously be ideal to have this change in both the master branch *and* a 4.0 version.