### PR TITLE
Replace invalid characters in identifiers

### DIFF
--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -42,7 +42,8 @@ namespace ICSharpCode.Decompiler
 		
 		public bool FoldBraces = false;
 		public bool ExpandMemberDefinitions = false;
-		
+		public string NonPrintingCharacterReplacement = "_";
+
 		public TextTokenWriter(ITextOutput output, DecompilerSettings settings, IDecompilerTypeSystem typeSystem)
 		{
 			if (output == null)
@@ -63,7 +64,7 @@ namespace ICSharpCode.Decompiler
 			}
 			
 			var definition = GetCurrentDefinition();
-			string name = TextWriterTokenWriter.EscapeIdentifier(identifier.Name);
+			string name = TextWriterTokenWriter.ReplaceNonPrintingCharacters(identifier.Name, NonPrintingCharacterReplacement);
 			switch (definition) {
 				case IType t:
 					output.WriteReference(t, name, true);


### PR DESCRIPTION
As far as I understand, characters in identifiers are replaced depending on `IsPrintableIdentifierChar` to make the identifiers valid. However, they do not get valid by escaping the unicode characters.

This patch corrects `IsPrintableIdentifierChar` to adhere to the specification *9.4.2 Identifiers in ECMA-334* and replaces non-printable characters by a customizable replacement string.