### PR TITLE
Fix #1462: Inconsistent enum flag check

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ConstantsTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ConstantsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+﻿using System.Threading.Tasks;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
 	internal class ConstantsTests
 	{
@@ -22,6 +24,12 @@
 			Test((v & 0x123) == 0);
 			Test((v | 0xF) == 0);
 			Test((v | 0x123) == 0);
+		}
+
+		public void Enum_Flag_Check(TaskCreationOptions v)
+		{
+			Test((v & TaskCreationOptions.AttachedToParent) != 0);
+			Test((v & TaskCreationOptions.AttachedToParent) == 0);
 		}
 
 		private void Test(bool expr)

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -773,8 +773,9 @@ namespace ICSharpCode.Decompiler.CSharp
 				NullableType.GetUnderlyingType(right.Type).Kind == TypeKind.Enum &&
 				right.Expression is BinaryOperatorExpression binaryExpr &&
 				binaryExpr.Operator == BinaryOperatorType.BitwiseAnd)
+			{
 				return AdjustConstantExpressionToType(left, compilation.FindType(KnownTypeCode.Int32));
-			else
+			} else
 				return AdjustConstantExpressionToType(left, right.Type);
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -763,19 +763,19 @@ namespace ICSharpCode.Decompiler.CSharp
 				.WithRR(rr);
 		}
 
-		TranslatedExpression TryUniteEqualityOperandType(TranslatedExpression operand, TranslatedExpression otherOperand)
+		TranslatedExpression TryUniteEqualityOperandType(TranslatedExpression left, TranslatedExpression right)
 		{
 			// Special case for enum flag check "(enum & EnumType.SomeValue) == 0"
 			// so that the const 0 value is printed as 0 integer and not as enum type, e.g. EnumType.None
-			if (operand.ResolveResult.IsCompileTimeConstant &&
-				operand.ResolveResult.Type.IsCSharpPrimitiveIntegerType() &&
-				(int)operand.ResolveResult.ConstantValue == 0 &&
-				NullableType.GetUnderlyingType(otherOperand.Type).Kind == TypeKind.Enum &&
-				otherOperand.Expression is BinaryOperatorExpression binaryExpr &&
+			if (left.ResolveResult.IsCompileTimeConstant &&
+				left.ResolveResult.Type.IsCSharpPrimitiveIntegerType() &&
+				(left.ResolveResult.ConstantValue as int?) == 0 &&
+				NullableType.GetUnderlyingType(right.Type).Kind == TypeKind.Enum &&
+				right.Expression is BinaryOperatorExpression binaryExpr &&
 				binaryExpr.Operator == BinaryOperatorType.BitwiseAnd)
-				return AdjustConstantExpressionToType(operand, compilation.FindType(KnownTypeCode.Int32));
+				return AdjustConstantExpressionToType(left, compilation.FindType(KnownTypeCode.Int32));
 			else
-				return AdjustConstantExpressionToType(operand, otherOperand.Type);
+				return AdjustConstantExpressionToType(left, right.Type);
 		}
 
 		bool IsSpecialCasedReferenceComparisonWithNull(TranslatedExpression lhs, TranslatedExpression rhs)


### PR DESCRIPTION
Changes
`(enumValue & SomeEnum.SomeValue) == SomeEnum.None`
to
`(enumValue & SomeEnum.SomeValue) == 0`