### PR TITLE
Add assembly search strategy

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
@@ -49,7 +49,7 @@ namespace ICSharpCode.Decompiler.Metadata
 			return publicKeyTokenBytes.TakeLast(8).Reverse().ToHexString(8);
 		}
 
-		public static string GetFullAssemblyName(this MetadataReader reader)
+		public static string GetPublicKeyToken(this MetadataReader reader)
 		{
 			if (!reader.IsAssembly)
 				return string.Empty;
@@ -59,6 +59,15 @@ namespace ICSharpCode.Decompiler.Metadata
 				// AssemblyFlags.PublicKey does not apply to assembly definitions
 				publicKey = CalculatePublicKeyToken(asm.PublicKey, reader);
 			}
+			return publicKey;
+		}
+
+		public static string GetFullAssemblyName(this MetadataReader reader)
+		{
+			if (!reader.IsAssembly)
+				return string.Empty;
+			var asm = reader.GetAssemblyDefinition();
+			string publicKey = reader.GetPublicKeyToken();
 			return $"{reader.GetString(asm.Name)}, " +
 				$"Version={asm.Version}, " +
 				$"Culture={(asm.Culture.IsNil ? "neutral" : reader.GetString(asm.Culture))}, " +

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -168,6 +168,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Search\AbstractEntitySearchStrategy.cs" />
+    <Compile Include="Search\AssemblySearchStrategy.cs" />
     <Compile Include="Search\LiteralSearchStrategy.cs" />
     <Compile Include="LoadedAssembly.cs" />
     <Compile Include="LoadedAssemblyExtensions.cs" />

--- a/ILSpy/Search/AssemblySearchStrategy.cs
+++ b/ILSpy/Search/AssemblySearchStrategy.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.Decompiler.Util;
+using ICSharpCode.ILSpy.TreeNodes;
+using ICSharpCode.TreeView;
+
+namespace ICSharpCode.ILSpy.Search
+{
+	class AssemblySearchStrategy : AbstractSearchStrategy
+	{
+		public AssemblySearchStrategy(IProducerConsumerCollection<SearchResult> resultQueue, string term)
+			: this(resultQueue, new[] { term })
+		{
+		}
+
+		public AssemblySearchStrategy(IProducerConsumerCollection<SearchResult> resultQueue, string[] terms)
+			: base(resultQueue, terms)
+		{
+		}
+
+		public override void Search(PEFile module, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (IsMatch(module.FullName))
+				OnFoundResult(module);
+		}
+
+		void OnFoundResult(PEFile module)
+		{
+			var result = new AssemblySearchResult {
+				Module = module,
+				Fitness = 1.0f / module.Name.Length,
+				Name = module.Name,
+				Location = module.FileName,
+				Assembly = module.FullName,
+				ToolTip = module.FileName,
+			};
+			OnFoundResult(result);
+		}
+	}
+}

--- a/ILSpy/Search/SearchPane.cs
+++ b/ILSpy/Search/SearchPane.cs
@@ -348,7 +348,28 @@ namespace ICSharpCode.ILSpy
 						return new ResourceSearchStrategy(apiVisibility, resultQueue, searchTerm[0].Substring(2));
 
 					if (searchTerm[0].StartsWith("a:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(resultQueue, searchTerm[0].Substring(2));
+						return new AssemblySearchStrategy(searchTerm[0].Substring(2), resultQueue, AssemblySearchKind.Name);
+
+					if (searchTerm[0].StartsWith("afn:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.FullName);
+
+					if (searchTerm[0].StartsWith("af:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.FileName);
+
+					if (searchTerm[0].StartsWith("ac:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.Culture);
+
+					if (searchTerm[0].StartsWith("av:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.Version);
+
+					if (searchTerm[0].StartsWith("apk:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.PublicKey);
+
+					if (searchTerm[0].StartsWith("aha:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.HashAlgorithm);
+
+					if (searchTerm[0].StartsWith("afl:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.Flags);
 				}
 
 				switch (searchMode)
@@ -374,7 +395,7 @@ namespace ICSharpCode.ILSpy
 					case SearchMode.Resource:
 						return new ResourceSearchStrategy(apiVisibility, resultQueue, searchTerm);
 					case SearchMode.Assembly:
-						return new AssemblySearchStrategy(resultQueue, searchTerm);
+						return new AssemblySearchStrategy(resultQueue, searchTerm, AssemblySearchKind.Name);
 				}
 
 				return null;

--- a/ILSpy/Search/SearchPane.cs
+++ b/ILSpy/Search/SearchPane.cs
@@ -76,6 +76,7 @@ namespace ICSharpCode.ILSpy
 			searchModeComboBox.Items.Add(new { Image = Images.Literal, Name = "Constant" });
 			searchModeComboBox.Items.Add(new { Image = Images.Library, Name = "Metadata Token" });
 			searchModeComboBox.Items.Add(new { Image = Images.Resource, Name = "Resource" });
+			searchModeComboBox.Items.Add(new { Image = Images.Assembly, Name = "Assembly" });
 
 			ContextMenuProvider.Add(listBox);
 			MainWindow.Instance.CurrentAssemblyListChanged += MainWindow_Instance_CurrentAssemblyListChanged;
@@ -345,6 +346,9 @@ namespace ICSharpCode.ILSpy
 
 					if (searchTerm[0].StartsWith("r:", StringComparison.Ordinal))
 						return new ResourceSearchStrategy(apiVisibility, resultQueue, searchTerm[0].Substring(2));
+
+					if (searchTerm[0].StartsWith("a:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(resultQueue, searchTerm[0].Substring(2));
 				}
 
 				switch (searchMode)
@@ -369,6 +373,8 @@ namespace ICSharpCode.ILSpy
 						return new MetadataTokenSearchStrategy(language, apiVisibility, resultQueue, searchTerm);
 					case SearchMode.Resource:
 						return new ResourceSearchStrategy(apiVisibility, resultQueue, searchTerm);
+					case SearchMode.Assembly:
+						return new AssemblySearchStrategy(resultQueue, searchTerm);
 				}
 
 				return null;
@@ -400,6 +406,7 @@ namespace ICSharpCode.ILSpy
 		Event,
 		Literal,
 		Token,
-		Resource
+		Resource,
+		Assembly
 	}
 }

--- a/ILSpy/Search/SearchPane.cs
+++ b/ILSpy/Search/SearchPane.cs
@@ -348,28 +348,13 @@ namespace ICSharpCode.ILSpy
 						return new ResourceSearchStrategy(apiVisibility, resultQueue, searchTerm[0].Substring(2));
 
 					if (searchTerm[0].StartsWith("a:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(2), resultQueue, AssemblySearchKind.Name);
-
-					if (searchTerm[0].StartsWith("afn:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.FullName);
+						return new AssemblySearchStrategy(searchTerm[0].Substring(2), resultQueue, AssemblySearchKind.NameOrFileName);
 
 					if (searchTerm[0].StartsWith("af:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.FileName);
+						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.FilePath);
 
-					if (searchTerm[0].StartsWith("ac:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.Culture);
-
-					if (searchTerm[0].StartsWith("av:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.Version);
-
-					if (searchTerm[0].StartsWith("apk:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.PublicKey);
-
-					if (searchTerm[0].StartsWith("aha:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.HashAlgorithm);
-
-					if (searchTerm[0].StartsWith("afl:", StringComparison.Ordinal))
-						return new AssemblySearchStrategy(searchTerm[0].Substring(4), resultQueue, AssemblySearchKind.Flags);
+					if (searchTerm[0].StartsWith("an:", StringComparison.Ordinal))
+						return new AssemblySearchStrategy(searchTerm[0].Substring(3), resultQueue, AssemblySearchKind.FullName);
 				}
 
 				switch (searchMode)
@@ -395,7 +380,7 @@ namespace ICSharpCode.ILSpy
 					case SearchMode.Resource:
 						return new ResourceSearchStrategy(apiVisibility, resultQueue, searchTerm);
 					case SearchMode.Assembly:
-						return new AssemblySearchStrategy(resultQueue, searchTerm, AssemblySearchKind.Name);
+						return new AssemblySearchStrategy(resultQueue, searchTerm, AssemblySearchKind.NameOrFileName);
 				}
 
 				return null;

--- a/ILSpy/Search/SearchResult.cs
+++ b/ILSpy/Search/SearchResult.cs
@@ -94,4 +94,13 @@ namespace ICSharpCode.ILSpy
 		public Resource Resource { get; set; }
 		public override object Reference => ValueTuple.Create(Resource, Name);
 	}
+
+	public class AssemblySearchResult : SearchResult
+	{
+		public PEFile Module { get; set; }
+		public override object Reference => Module;
+
+		public override ImageSource Image => Images.Assembly;
+		public override ImageSource LocationImage => Images.Library;
+	}
 }


### PR DESCRIPTION
Searching assemblies by full name. Shows file path in Location column.

![image](https://user-images.githubusercontent.com/10546952/65390728-7ec24700-dd59-11e9-9dcf-d9fb44049628.png)
