### PR TITLE
.NET Core 3 Final Updates

### DIFF
--- a/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
+++ b/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.0.0-rc1" />
+    <PackageReference Include="AvalonEdit" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AvalonEdit" Version="6.0.0-rc1" />
+    <PackageReference Include="AvalonEdit" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="15.5.23" />
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
     <PackageReference Include="OSVersionHelper" Version="1.0.11" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ configuration:
 image: Visual Studio 2019
 
 install:
-- cmd: choco install dotnetcore-sdk --pre
 - git submodule update --init --recursive
 - ps: .\BuildTools\appveyor-install.ps1
 
@@ -43,7 +42,6 @@ for:
 - branches:
     only:
       - master
-      - 3.2.x
   artifacts:
     - path: ILSpy_binaries.zip
       name: ILSpy %APPVEYOR_REPO_BRANCH% %ILSPY_VERSION_NUMBER% binaries

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
 		"MSBuild.Sdk.Extras": "2.0.24"
 	},
 	"sdk": {
-		"version": "3.0.100-rc1"
+		"version": "3.0.100"
 	}
 }


### PR DESCRIPTION
Note: won't build atm because AppVeyor still uses a VS 2019 image pre-16.3.