### PR TITLE
POC for NetCore3App

### DIFF
--- a/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
+++ b/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
@@ -3,7 +3,7 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>ILSpy.BamlDecompiler.Plugin</AssemblyName>
     <LangVersion>7.2</LangVersion>
 

--- a/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
+++ b/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <AssemblyName>ILSpy.BamlDecompiler.Plugin</AssemblyName>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
 
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
 
@@ -32,12 +32,12 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.0.0" />
+    <PackageReference Include="System.Composition" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/AboutPage.cs
+++ b/ILSpy/AboutPage.cs
@@ -18,8 +18,7 @@
 
 using System;
 using System.ComponentModel;
-using System.ComponentModel.Composition;
-using System.Diagnostics;
+using System.Composition;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -42,13 +41,13 @@ namespace ICSharpCode.ILSpy
 	[ExportMainMenuCommand(Menu = nameof(Resources._Help), Header = nameof(Resources._About), MenuOrder = 99999)]
 	sealed class AboutPage : SimpleCommand
 	{
-		[Import]
-		DecompilerTextView decompilerTextView = null;
+		[Import] 
+		private DecompilerTextView DecompilerTextView { get; set; }
 		
 		public override void Execute(object parameter)
 		{
 			MainWindow.Instance.UnselectAll();
-			Display(decompilerTextView);
+			Display(DecompilerTextView);
 		}
 		
 		static readonly Uri UpdateUrl = new Uri("https://ilspy.net/updates.xml");

--- a/ILSpy/Analyzers/Builtin/TypeExposedByAnalyzer.cs
+++ b/ILSpy/Analyzers/Builtin/TypeExposedByAnalyzer.cs
@@ -24,6 +24,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using ICSharpCode.Decompiler.TypeSystem;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.Analyzers.Builtin
 {
@@ -80,7 +81,7 @@ namespace ICSharpCode.ILSpy.Analyzers.Builtin
 
 		bool TypeIsExposedBy(TypeDefinitionUsedVisitor visitor, IField field)
 		{
-			if (field.Accessibility == Accessibility.Private)
+			if (field.Accessibility == TSAccessibility.Private)
 				return false;
 
 			visitor.Found = false;
@@ -91,7 +92,7 @@ namespace ICSharpCode.ILSpy.Analyzers.Builtin
 
 		bool TypeIsExposedBy(TypeDefinitionUsedVisitor visitor, IProperty property)
 		{
-			if (property.Accessibility == Accessibility.Private) {
+			if (property.Accessibility == TSAccessibility.Private) {
 				if (!property.IsExplicitInterfaceImplementation)
 					return false;
 			}
@@ -108,7 +109,7 @@ namespace ICSharpCode.ILSpy.Analyzers.Builtin
 
 		bool TypeIsExposedBy(TypeDefinitionUsedVisitor visitor, IEvent @event)
 		{
-			if (@event.Accessibility == Accessibility.Private) {
+			if (@event.Accessibility == TSAccessibility.Private) {
 				if (!@event.IsExplicitInterfaceImplementation)
 					return false;
 			}
@@ -121,7 +122,7 @@ namespace ICSharpCode.ILSpy.Analyzers.Builtin
 
 		bool TypeIsExposedBy(TypeDefinitionUsedVisitor visitor, IMethod method)
 		{
-			if (method.Accessibility == Accessibility.Private) {
+			if (method.Accessibility == TSAccessibility.Private) {
 				if (!method.IsExplicitInterfaceImplementation)
 					return false;
 			}

--- a/ILSpy/Analyzers/TreeNodes/AnalyzedEventTreeNode.cs
+++ b/ILSpy/Analyzers/TreeNodes/AnalyzedEventTreeNode.cs
@@ -20,6 +20,7 @@ using System;
 using System.Linq;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.TreeNodes;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 {
@@ -67,7 +68,7 @@ namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 		{
 			backingField = null;
 			foreach (var field in analyzedEvent.DeclaringTypeDefinition.GetFields(options: GetMemberOptions.IgnoreInheritedMembers)) {
-				if (field.Name == analyzedEvent.Name && field.Accessibility == Accessibility.Private) {
+				if (field.Name == analyzedEvent.Name && field.Accessibility == TSAccessibility.Private) {
 					backingField = field;
 					return true;
 				}

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -94,7 +94,7 @@ namespace ICSharpCode.ILSpy
 						var name = Path.GetFileNameWithoutExtension(plugin);
 						try {
 							var asm = Assembly.Load(name);
-							var parts = discovery.CreatePartsAsync(asm).Result;
+							var parts = discovery.CreatePartsAsync(asm).GetAwaiter().GetResult();
 							catalog = catalog.AddParts(parts);
 						} catch (Exception ex) {
 							StartupExceptions.Add(new ExceptionData { Exception = ex, PluginName = name });
@@ -102,7 +102,7 @@ namespace ICSharpCode.ILSpy
 					}
 				}
 				// Add the built-in parts
-				catalog = catalog.AddParts(discovery.CreatePartsAsync(Assembly.GetExecutingAssembly()).Result);
+				catalog = catalog.AddParts(discovery.CreatePartsAsync(Assembly.GetExecutingAssembly()).GetAwaiter().GetResult());
 				// If/When the project switches to .NET Standard/Core, this will be needed to allow metadata interfaces (as opposed
 				// to metadata classes). When running on .NET Framework, it's automatic.
 				//   catalog.WithDesktopSupport();

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -91,7 +91,8 @@ namespace ICSharpCode.ILSpy
 				var pluginDir = Path.GetDirectoryName(typeof(App).Module.FullyQualifiedName);
 				if (pluginDir != null) {
 					foreach (var plugin in Directory.GetFiles(pluginDir, "*.Plugin.dll")) {
-						var name = Path.GetFileNameWithoutExtension(plugin);
+						var assemblyName = AssemblyName.GetAssemblyName(plugin);
+						var name = assemblyName.FullName;
 						try {
 							var asm = Assembly.Load(name);
 							var parts = discovery.CreatePartsAsync(asm).GetAwaiter().GetResult();

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <OutputType>WinExe</OutputType>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
 
@@ -49,7 +49,8 @@
 
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="15.5.23" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.3.7" />
+    <PackageReference Include="System.Composition" Version="1.3.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
     <PackageReference Include="OSVersionHelper" Version="1.0.11" />
   </ItemGroup>
@@ -625,6 +626,8 @@
   
   <Target Name="ApplyStackExtension" AfterTargets="PostBuildEvent">
     <Exec Condition="'$(VCToolsVersion)'!=''" Command="&quot;$(VCBasePath)Tools\MSVC\$(VCToolsVersion)\bin\Hostx64\x64\editbin.exe&quot; /stack:16777216 &quot;$(TargetPath)&quot;&#xD;&#xA;EXIT 0" />
-    <Exec Command="&quot;$(TargetFrameworkSDKToolsDirectory)sn.exe&quot; -R &quot;$(TargetPath)&quot; &quot;$(SolutionDir)\ICSharpCode.Decompiler\ICSharpCode.Decompiler.snk&quot;" />
+    <Exec 
+      Command="&quot;$(TargetFrameworkSDKToolsDirectory)sn.exe&quot; -R &quot;$(TargetPath)&quot; &quot;$(SolutionDir)\ICSharpCode.Decompiler\ICSharpCode.Decompiler.snk&quot;" 
+      Condition="'$(TargetFramework)' == 'net472'" />
   </Target>
 </Project>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <LangVersion>7.2</LangVersion>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/ILSpy/ILSpyTraceListener.cs
+++ b/ILSpy/ILSpyTraceListener.cs
@@ -30,8 +30,10 @@ namespace ICSharpCode.ILSpy
 		[Conditional("DEBUG")]
 		public static void Install()
 		{
+#if NET472
 			Debug.Listeners.Clear();
 			Debug.Listeners.Add(new ILSpyTraceListener());
+#endif
 		}
 
 		public ILSpyTraceListener()

--- a/ILSpy/Search/AbstractEntitySearchStrategy.cs
+++ b/ILSpy/Search/AbstractEntitySearchStrategy.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.TreeNodes;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.Search
 {
@@ -28,9 +29,9 @@ namespace ICSharpCode.ILSpy.Search
 
 			do {
 				if (apiVisibility == ApiVisibility.PublicOnly) {
-					if (!(entity.Accessibility == Accessibility.Public ||
-						entity.Accessibility == Accessibility.Protected ||
-						entity.Accessibility == Accessibility.ProtectedOrInternal))
+					if (!(entity.Accessibility == TSAccessibility.Public ||
+						entity.Accessibility == TSAccessibility.Protected ||
+						entity.Accessibility == TSAccessibility.ProtectedOrInternal))
 						return false;
 				} else if (apiVisibility == ApiVisibility.PublicAndInternal) {
 					if (!language.ShowMember(entity))

--- a/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
+++ b/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Threading;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.TypeSystem;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -63,9 +64,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public override bool IsPublicAPI {
 			get {
 				switch (type.Accessibility) {
-					case Accessibility.Public:
-					case Accessibility.Internal:
-					case Accessibility.ProtectedOrInternal:
+					case TSAccessibility.Public:
+					case TSAccessibility.Internal:
+					case TSAccessibility.ProtectedOrInternal:
 						return true;
 					default:
 						return false;

--- a/ILSpy/TreeNodes/EventTreeNode.cs
+++ b/ILSpy/TreeNodes/EventTreeNode.cs
@@ -20,6 +20,7 @@ using System;
 using System.Windows.Media;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.TypeSystem;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -75,9 +76,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public override bool IsPublicAPI {
 			get {
 				switch (EventDefinition.Accessibility) {
-					case Accessibility.Public:
-					case Accessibility.ProtectedOrInternal:
-					case Accessibility.Protected:
+					case TSAccessibility.Public:
+					case TSAccessibility.ProtectedOrInternal:
+					case TSAccessibility.Protected:
 						return true;
 					default:
 						return false;

--- a/ILSpy/TreeNodes/FieldTreeNode.cs
+++ b/ILSpy/TreeNodes/FieldTreeNode.cs
@@ -20,6 +20,7 @@ using System;
 using System.Windows.Media;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.TypeSystem;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -76,9 +77,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public override bool IsPublicAPI {
 			get {
 				switch (FieldDefinition.Accessibility) {
-					case Accessibility.Public:
-					case Accessibility.Protected:
-					case Accessibility.ProtectedOrInternal:
+					case TSAccessibility.Public:
+					case TSAccessibility.Protected:
+					case TSAccessibility.ProtectedOrInternal:
 						return true;
 					default:
 						return false;

--- a/ILSpy/TreeNodes/MethodTreeNode.cs
+++ b/ILSpy/TreeNodes/MethodTreeNode.cs
@@ -21,6 +21,7 @@ using System.Windows.Media;
 
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.TypeSystem;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -63,20 +64,20 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				GetOverlayIcon(method.Accessibility), method.IsStatic);
 		}
 
-		internal static AccessOverlayIcon GetOverlayIcon(Accessibility accessibility)
+		internal static AccessOverlayIcon GetOverlayIcon(TSAccessibility accessibility)
 		{
 			switch (accessibility) {
-				case Accessibility.Public:
+				case TSAccessibility.Public:
 					return AccessOverlayIcon.Public;
-				case Accessibility.Internal:
+				case TSAccessibility.Internal:
 					return AccessOverlayIcon.Internal;
-				case Accessibility.ProtectedAndInternal:
+				case TSAccessibility.ProtectedAndInternal:
 					return AccessOverlayIcon.PrivateProtected;
-				case Accessibility.Protected:
+				case TSAccessibility.Protected:
 					return AccessOverlayIcon.Protected;
-				case Accessibility.ProtectedOrInternal:
+				case TSAccessibility.ProtectedOrInternal:
 					return AccessOverlayIcon.ProtectedInternal;
-				case Accessibility.Private:
+				case TSAccessibility.Private:
 					return AccessOverlayIcon.Private;
 				default:
 					return AccessOverlayIcon.CompilerControlled;
@@ -101,9 +102,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public override bool IsPublicAPI {
 			get {
 				switch (MethodDefinition.Accessibility) {
-					case Accessibility.Public:
-					case Accessibility.Protected:
-					case Accessibility.ProtectedOrInternal:
+					case TSAccessibility.Public:
+					case TSAccessibility.Protected:
+					case TSAccessibility.ProtectedOrInternal:
 						return true;
 					default:
 						return false;

--- a/ILSpy/TreeNodes/PropertyTreeNode.cs
+++ b/ILSpy/TreeNodes/PropertyTreeNode.cs
@@ -24,6 +24,7 @@ using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.TypeSystem;
 using SRM = System.Reflection.Metadata;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -82,9 +83,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public override bool IsPublicAPI {
 			get {
 				switch (PropertyDefinition.Accessibility) {
-					case Accessibility.Public:
-					case Accessibility.ProtectedOrInternal:
-					case Accessibility.Protected:
+					case TSAccessibility.Public:
+					case TSAccessibility.ProtectedOrInternal:
+					case TSAccessibility.Protected:
 						return true;
 					default:
 						return false;

--- a/ILSpy/TreeNodes/SearchMsdnContextMenuEntry.cs
+++ b/ILSpy/TreeNodes/SearchMsdnContextMenuEntry.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.Properties;
 using System.Threading;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -76,9 +77,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			if (entity.DeclaringTypeDefinition == null)
 				return false;
 			switch (entity.DeclaringTypeDefinition.Accessibility) {
-				case Accessibility.Public:
-				case Accessibility.Protected:
-				case Accessibility.ProtectedOrInternal:
+				case TSAccessibility.Public:
+				case TSAccessibility.Protected:
+				case TSAccessibility.ProtectedOrInternal:
 					return true;
 				default:
 					return false;

--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -24,6 +24,7 @@ using System.Windows.Media;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.TypeSystem;
 using SRM = System.Reflection.Metadata;
+using TSAccessibility = ICSharpCode.Decompiler.TypeSystem.Accessibility;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -46,9 +47,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public override bool IsPublicAPI {
 			get {
 				switch (TypeDefinition.Accessibility) {
-					case Accessibility.Public:
-					case Accessibility.Protected:
-					case Accessibility.ProtectedOrInternal:
+					case TSAccessibility.Public:
+					case TSAccessibility.Protected:
+					case TSAccessibility.ProtectedOrInternal:
 						return true;
 					default:
 						return false;
@@ -136,16 +137,16 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		static AccessOverlayIcon GetOverlayIcon(ITypeDefinition type)
 		{
 			switch (type.Accessibility) {
-				case Accessibility.Public:
+				case TSAccessibility.Public:
 					return AccessOverlayIcon.Public;
-				case Accessibility.Internal:
+				case TSAccessibility.Internal:
 					return AccessOverlayIcon.Internal;
-				case Accessibility.ProtectedAndInternal:
+				case TSAccessibility.ProtectedAndInternal:
 					return AccessOverlayIcon.PrivateProtected;
-				case Accessibility.Protected:
-				case Accessibility.ProtectedOrInternal:
+				case TSAccessibility.Protected:
+				case TSAccessibility.ProtectedOrInternal:
 					return AccessOverlayIcon.Protected;
-				case Accessibility.Private:
+				case TSAccessibility.Private:
 					return AccessOverlayIcon.Private;
 				default:
 					return AccessOverlayIcon.CompilerControlled;

--- a/SharpTreeView/ICSharpCode.TreeView.csproj
+++ b/SharpTreeView/ICSharpCode.TreeView.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.0</TargetFrameworks>
 
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
 


### PR DESCRIPTION
We could take pieces from this PR to future-proof ILSpy without going netcoreapp3.0 parallel-building (and a couple lessons learned). This PR is intended for discussion.

Important:
* Crashes on Assembly.Load in app.xaml when plugins are available, otherwise works (to investigate, maybe our loading code is outdated)
* Signing disabled for ILSpy in netcoreapp3 (shim exe signing maybe not a good idea)

Notes:
* Added NuGet System.Composition to ILSpy + BamlDecompiler.Plugin, upgraded vs-mef in ILSpy (that is something we could easily do today)
* Had to upgrade C# compiler to 7.3 in ILSpy because it complained about fixed in app.xaml.cs
* Accessibility enum: needed to qualify that I want the one from TypeSystem (this is specific to netcoreapp3.0)
* [Import] doesn't work on fields any more, only properties (DecompilerTextView)