### PR TITLE
Removing csproj Hacks

### DIFF
--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -619,7 +619,7 @@
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
-  <Target Name="BeforeBuild">
+  <Target Name="ILSpyUpdateAssemblyInfo" BeforeTargets="BeforeBuild">
     <PropertyGroup>
       <UpdateAssemblyInfo>powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 $(Configuration)</UpdateAssemblyInfo>
     </PropertyGroup>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project>
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -620,12 +619,11 @@
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
-
   <Target Name="BeforeBuild">
     <PropertyGroup>
       <UpdateAssemblyInfo>powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 $(Configuration)</UpdateAssemblyInfo>
     </PropertyGroup>
     <Exec WorkingDirectory=".." Command="$(UpdateAssemblyInfo)" Timeout="60000" />
   </Target>
+  
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"msbuild-sdks": {
-		"MSBuild.Sdk.Extras": "2.0.24"
+		"MSBuild.Sdk.Extras": "2.0.54"
 	},
 	"sdk": {
 		"version": "3.0.100"


### PR DESCRIPTION
This does not yet solve the problem that

* Check out into a new directory
* Open ILSpy.sln in VS
* Build

fails because BamlDecompiler and others start building before ILSpy.csproj actually builds. Funnily, Rebuild All immediately after works fine.