### PR TITLE
Default app.config that allows VS to build in correct order

### DIFF
--- a/ILSpy/app.config
+++ b/ILSpy/app.config
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+	</startup>
+	<runtime>
+		<AppContextSwitchOverrides value="Switch.System.Windows.DoNotScaleForDpiChanges=false;Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<!-- The redirects allow using AddIns with a different ILSpy version than they were compiled against. -->
+			<!-- No guarantee they'll work correctly, though (there might be breaking API changes in ILSpy). -->
+			<dependentAssembly>
+				<assemblyIdentity name="ICSharpCode.TreeView" publicKeyToken="d4bfe873e7598c49" culture="neutral"/>
+				<bindingRedirect oldVersion="4.1.0.0-99.9.9.9" newVersion="4.2.0.8752"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="ICSharpCode.AvalonEdit" publicKeyToken="9cc39be672370310" culture="neutral"/>
+				<bindingRedirect oldVersion="4.1.0.0-99.9.9.9" newVersion="6.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="ICSharpCode.Decompiler" publicKeyToken="d4bfe873e7598c49" culture="neutral"/>
+				<bindingRedirect oldVersion="1.0.0.0-99.9.9.9" newVersion="6.0.0.1111"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="ILSpy" publicKeyToken="d4bfe873e7598c49" culture="neutral"/>
+				<bindingRedirect oldVersion="1.0.0.0-99.9.9.9" newVersion="6.0.0.1111"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+	</runtime>
+</configuration>


### PR DESCRIPTION
Fixes #1731