### PR TITLE
Fix extra minus sign when formatting -0 on .NET Core 3.0

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/TextWriterTokenWriter.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/TextWriterTokenWriter.cs
@@ -298,15 +298,13 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 					}
 					return;
 				}
-				if (f == 0 && 1 / f == float.NegativeInfinity) {
+				var str = f.ToString("R", NumberFormatInfo.InvariantInfo) + "f";
+				if (f == 0 && 1 / f == float.NegativeInfinity && str[0] != '-') {
 					// negative zero is a special case
 					// (again, not a primitive expression, but it's better to handle
 					// the special case here than to do it in all code generators)
-					textWriter.Write("-");
-					column++;
-					Length++;
+					str = '-' + str;
 				}
-				var str = f.ToString("R", NumberFormatInfo.InvariantInfo) + "f";
 				column += str.Length;
 				Length += str.Length;
 				textWriter.Write(str);
@@ -334,14 +332,13 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 					}
 					return;
 				}
-				if (f == 0 && 1 / f == double.NegativeInfinity) {
+				string number = f.ToString("R", NumberFormatInfo.InvariantInfo);
+				if (f == 0 && 1 / f == double.NegativeInfinity && number[0] != '-') {
 					// negative zero is a special case
 					// (again, not a primitive expression, but it's better to handle
 					// the special case here than to do it in all code generators)
-					textWriter.Write("-");
-					Length++;
+					number = '-' + number;
 				}
-				string number = f.ToString("R", NumberFormatInfo.InvariantInfo);
 				if (number.IndexOf('.') < 0 && number.IndexOf('E') < 0) {
 					number += ".0";
 				}


### PR DESCRIPTION
.NET Core fixed some round trip formatting with floats https://devblogs.microsoft.com/dotnet/floating-point-parsing-and-formatting-improvements-in-net-core-3-0/

When decompiling `-0f` on .NET Core, ILSpy currently outputs `--0f` which is a compile error. Simplest reproducible test case:

```cs
using ICSharpCode.Decompiler;
using ICSharpCode.Decompiler.CSharp;
using ICSharpCode.Decompiler.CSharp.OutputVisitor;
using ICSharpCode.Decompiler.TypeSystem;
using System;
using System.Linq;
using System.Reflection;

namespace DecompilerTesting
{
    class Program
    {
        static void Main(string[] args)
        {
            var decompiler = new CSharpDecompiler(Assembly.GetExecutingAssembly().Location, new DecompilerSettings());
            var method = decompiler.TypeSystem.MainModule.GetTypeDefinition(new TopLevelTypeName("DecompilerTesting.Program")).GetMethods(m => m.Name == "MinusZero").Single();
            decompiler.Decompile(method.MetadataToken).AcceptVisitor(new CSharpOutputVisitor(Console.Out, FormattingOptionsFactory.CreateAllman()));
        }

        public static float MinusZero() => -0f;
    }
}
```