### PR TITLE
Fix sealed modifier on interface methods with no body

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1772,7 +1772,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				} else {
 					var declaringType = member.DeclaringType;
 					if (declaringType.Kind == TypeKind.Interface) {
-						if (!member.IsVirtual && !member.IsAbstract && !member.IsOverride && member.Accessibility != Accessibility.Private)
+						if (!member.IsVirtual && !member.IsAbstract && !member.IsOverride && member.Accessibility != Accessibility.Private && member is IMethod method2 && method2.HasBody)
 							m |= Modifiers.Sealed;
 					} else {
 						if (member.IsAbstract)


### PR DESCRIPTION
An interface method with the following IL representation
```
.method public specialname rtspecialname instance void _VtblGap1_2 () runtime managed
```
Decompiles with a a sealed modifier and doesn't recompile because it has no body. I assume only methods in interfaces can be sealed.