### PR TITLE
Add support for generic and static local function

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Async.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Async.cs
@@ -190,7 +190,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return await Nested(1) + await Nested(2);
 
+#if CS80
+			static async Task<int> Nested(int i)
+#else
 			async Task<int> Nested(int i)
+#endif
 			{
 				await Task.Delay(i);
 				return i;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CustomTaskType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CustomTaskType.cs
@@ -118,7 +118,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return await Nested(1) + await Nested(2);
 
+#if CS80
+			static async ValueTask<int> Nested(int i)
+#else
 			async ValueTask<int> Nested(int i)
+#endif
 			{
 				await Task.Delay(i);
 				return i;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -187,7 +187,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				Noop("M3", this.M3);
 				Noop("M3", M3);
 
+#if CS80
+				static void M3()
+#else
 				void M3()
+#endif
 				{
 
 				}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -23,6 +23,113 @@ namespace LocalFunctions
 {
 	internal class LocalFunctions
 	{
+		public class Generic<T1> where T1 : struct, ICloneable, IConvertible
+		{
+			public int MixedLocalFunction<T2>() where T2 : ICloneable, IConvertible
+			{
+				object z = this;
+				for (int j = 0; j < 10; j++) {
+					int i = 0;
+					i += NonStaticMethod6<object>();
+					int NonStaticMethod6<T3>()
+					{
+						int l = 0;
+						return NonStaticMethod6_1<T1>() + NonStaticMethod6_1<T2>() + z.GetHashCode();
+						int NonStaticMethod6_1<T4>()
+						{
+							return i + l + NonStaticMethod6<T4>() + StaticMethod1<decimal>();
+						}
+					}
+				}
+				return MixedLocalFunction<T1>() + MixedLocalFunction<T2>() + StaticMethod1<decimal>() + StaticMethod1<int>() + NonStaticMethod3() + StaticMethod4<object>(null) + StaticMethod5<T1>();
+				int NonStaticMethod3()
+				{
+					return GetHashCode();
+				}
+				int StaticMethod1<T3>() where T3 : struct
+				{
+					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>() + StaticMethod2<T2, T3, DayOfWeek>();
+				}
+				int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
+				{
+					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + typeof(T4).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>();
+				}
+				int StaticMethod2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+				{
+					return typeof(T2).Name.Length;
+				}
+				int StaticMethod4<T>(T dd)
+				{
+					return 0;
+				}
+				int StaticMethod5<T3>()
+				{
+					int k = 0;
+					return k + NonStaticMethod5_1<T1>();
+					int NonStaticMethod5_1<T4>()
+					{
+						return k;
+					}
+				}
+			}
+
+			public int MixedLocalFunction2Delegate<T2>() where T2 : ICloneable, IConvertible
+			{
+				object z = this;
+				for (int j = 0; j < 10; j++) {
+					int i = 0;
+					i += StaticInvokeAsFunc(NonStaticMethod6<object>);
+					int NonStaticMethod6<T3>()
+					{
+						int l = 0;
+						return StaticInvokeAsFunc(NonStaticMethod6_1<T1>) + StaticInvokeAsFunc(NonStaticMethod6_1<T2>) + z.GetHashCode();
+						int NonStaticMethod6_1<T4>()
+						{
+							return i + l + StaticInvokeAsFunc(NonStaticMethod6<T4>) + StaticInvokeAsFunc(StaticMethod1<decimal>);
+						}
+					}
+				}
+				return StaticInvokeAsFunc(MixedLocalFunction2Delegate<T1>) + StaticInvokeAsFunc(MixedLocalFunction2Delegate<T2>) + StaticInvokeAsFunc(StaticMethod1<decimal>) + StaticInvokeAsFunc(StaticMethod1<int>) + StaticInvokeAsFunc(NonStaticMethod3) + StaticInvokeAsFunc(StaticMethod5<T1>) + new Func<object, int>(StaticMethod4<object>)(null) + StaticInvokeAsFunc2<object>(StaticMethod4<object>) + new Func<Func<object, int>, int>(StaticInvokeAsFunc2<object>)(StaticMethod4<object>);
+				int NonStaticMethod3()
+				{
+					return GetHashCode();
+				}
+				int StaticInvokeAsFunc(Func<int> func)
+				{
+					return func();
+				}
+				int StaticInvokeAsFunc2<T>(Func<T, int> func)
+				{
+					return func(default(T));
+				}
+				int StaticMethod1<T3>() where T3 : struct
+				{
+					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>) + StaticInvokeAsFunc(StaticMethod2<T2, T3, DayOfWeek>);
+				}
+				int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
+				{
+					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + typeof(T4).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>);
+				}
+				int StaticMethod2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+				{
+					return typeof(T2).Name.Length;
+				}
+				int StaticMethod4<T>(T dd)
+				{
+					return 0;
+				}
+				int StaticMethod5<T3>()
+				{
+					int k = 0;
+					return k + StaticInvokeAsFunc(NonStaticMethod5_1<T1>);
+					int NonStaticMethod5_1<T4>()
+					{
+						return k;
+					}
+				}
+			}
+		}
+
 		private int field;
 
 		private Lazy<object> nonCapturinglocalFunctionInLambda = new Lazy<object>(delegate {

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -246,6 +246,62 @@ namespace LocalFunctions
 					Nop<List<T2>>((List<T2>)(object)t3);
 				}
 			}
+
+#if false
+			public void GenericArgsWithAnonymousType()
+			{
+				Method<int>();
+#if CS80
+				static void Method<T2>()
+#else
+				void Method<T2>()
+#endif
+				{
+					int i = 0;
+					var obj2 = new {
+						A = 1
+					};
+					Method2(obj2);
+					Method3(obj2);
+					void Method2<T3>(T3 obj1)
+					{
+						//keep nested
+						i = 0;
+					}
+#if CS80
+					static void Method3<T3>(T3 obj1)
+#else
+					void Method3<T3>(T3 obj1)
+#endif
+					{
+					}
+				}
+			}
+#if CS80
+			public void NameConflict()
+			{
+				int i = 0;
+				Method<int>();
+				void Method<T2>()
+				{
+					Method();
+					void Method()
+					{
+						Method<T2>();
+						i = 0;
+						void Method<T2>()
+						{
+							i = 0;
+							Method();
+							static void Method()
+							{
+							}
+						}
+					}
+				}
+			}
+#endif
+#endif
 		}
 
 		private int field;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -682,7 +682,6 @@ namespace LocalFunctions
 			}
 		}
 
-#if false
 		public int NestedCapture2()
 		{
 			return Method();
@@ -697,27 +696,28 @@ namespace LocalFunctions
 				int ZZZ_0()
 				{
 					t0 = 0;
-					var t1 = t0;
-					Func<int> zzz2 = () => {
+					int t2 = t0;
+					return new Func<int>(ZZZ_0_0)();
+					int ZZZ_0_0()
+					{
 						t0 = 0;
-						t1 = 0;
+						t2 = 0;
 						return ZZZ_1();
-					};
-					return zzz2();
+					}
 				}
 				int ZZZ_1()
 				{
 					t0 = 0;
-					var t1 = t0;
-					Func<int> zzz = () => {
+					int t = t0;
+					return new Func<int>(ZZZ_1_0)();
+					int ZZZ_1_0()
+					{
 						t0 = 0;
-						t1 = 0;
+						t = 0;
 						return 0;
-					};
-					return zzz();
+					}
 				}
 			}
 		}
-#endif
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -502,11 +502,15 @@ namespace LocalFunctions
 			{
 				return Method1_1;
 
-				void Method1_1(object containerBuilder) =>
+				void Method1_1(object containerBuilder)
+				{
 					Method1_2(containerBuilder);
+				}
 
-				void Method1_2(object containerBuilder) =>
+				void Method1_2(object containerBuilder)
+				{
 					action(containerBuilder);
+				}
 			}
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -514,6 +514,7 @@ namespace LocalFunctions
 			}
 		}
 
+#if false
 		public int NestedCapture2()
 		{
 			return Method();
@@ -545,5 +546,6 @@ namespace LocalFunctions
 				}
 			}
 		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -27,12 +27,14 @@ namespace LocalFunctions
 		{
 			public int MixedLocalFunction<T2>() where T2 : ICloneable, IConvertible
 			{
+				T2 t2 = default(T2);
 				object z = this;
 				for (int j = 0; j < 10; j++) {
 					int i = 0;
 					i += NonStaticMethod6<object>();
 					int NonStaticMethod6<T3>()
 					{
+						t2 = default(T2);
 						int l = 0;
 						return NonStaticMethod6_1<T1>() + NonStaticMethod6_1<T2>() + z.GetHashCode();
 						int NonStaticMethod6_1<T4>()
@@ -48,13 +50,15 @@ namespace LocalFunctions
 				}
 				int StaticMethod1<T3>() where T3 : struct
 				{
-					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>() + StaticMethod2<T2, T3, DayOfWeek>();
+					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>() + StaticMethod2_RepeatT2<T2, T3, DayOfWeek>();
 				}
 				int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
 				{
 					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + typeof(T4).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>();
 				}
-				int StaticMethod2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#pragma warning disable CS8387
+				int StaticMethod2_RepeatT2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#pragma warning restore CS8387
 				{
 					return typeof(T2).Name.Length;
 				}
@@ -75,12 +79,14 @@ namespace LocalFunctions
 
 			public int MixedLocalFunction2Delegate<T2>() where T2 : ICloneable, IConvertible
 			{
+				T2 t2 = default(T2);
 				object z = this;
 				for (int j = 0; j < 10; j++) {
 					int i = 0;
 					i += StaticInvokeAsFunc(NonStaticMethod6<object>);
 					int NonStaticMethod6<T3>()
 					{
+						t2 = default(T2);
 						int l = 0;
 						return StaticInvokeAsFunc(NonStaticMethod6_1<T1>) + StaticInvokeAsFunc(NonStaticMethod6_1<T2>) + z.GetHashCode();
 						int NonStaticMethod6_1<T4>()
@@ -104,13 +110,15 @@ namespace LocalFunctions
 				}
 				int StaticMethod1<T3>() where T3 : struct
 				{
-					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>) + StaticInvokeAsFunc(StaticMethod2<T2, T3, DayOfWeek>);
+					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>) + StaticInvokeAsFunc(StaticMethod2_RepeatT2<T2, T3, DayOfWeek>);
 				}
 				int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
 				{
 					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + typeof(T4).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>);
 				}
-				int StaticMethod2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#pragma warning disable CS8387
+				int StaticMethod2_RepeatT2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#pragma warning restore CS8387
 				{
 					return typeof(T2).Name.Length;
 				}
@@ -126,6 +134,52 @@ namespace LocalFunctions
 					{
 						return k;
 					}
+				}
+			}
+
+			public static void Test_CaptureT<T2>()
+			{
+				T2 t2 = default(T2);
+				Method1<int>();
+				void Method1<T3>()
+				{
+					t2 = default(T2);
+					T2 t2x = t2;
+					T3 t3 = default(T3);
+					Method1_1();
+					void Method1_1()
+					{
+						t2 = default(T2);
+						t2x = t2;
+						t3 = default(T3);
+					}
+				}
+			}
+
+			public void TestGenericArgs<T2>() where T2 : List<T2>
+			{
+				ZZ<T2>(null);
+				ZZ2<object>(null);
+				void Nop<T>(T data)
+				{
+				}
+				void ZZ<T3>(T3 t3) where T3 : T2
+				{
+					Nop<List<T2>>(t3);
+					ZZ1<T3>(t3);
+					ZZ3();
+					void ZZ3()
+					{
+						Nop<List<T2>>(t3);
+					}
+				}
+				void ZZ1<T3>(T3 t3)
+				{
+					Nop<List<T2>>((List<T2>)(object)t3);
+				}
+				void ZZ2<T3>(T3 t3)
+				{
+					Nop<List<T2>>((List<T2>)(object)t3);
 				}
 			}
 		}
@@ -439,5 +493,53 @@ namespace LocalFunctions
 		//		}
 		//	}
 		//}
+
+		public void NestedCapture1()
+		{
+			Method1(null);
+
+			Action<object> Method1(Action<object> action)
+			{
+				return Method1_1;
+
+				void Method1_1(object containerBuilder) =>
+					Method1_2(containerBuilder);
+
+				void Method1_2(object containerBuilder) =>
+					action(containerBuilder);
+			}
+		}
+
+		public int NestedCapture2()
+		{
+			return Method();
+			int Method()
+			{
+				int t0 = 0;
+				return ZZZ_0();
+				int ZZZ_0()
+				{
+					t0 = 0;
+					var t1 = t0;
+					Func<int> zzz2 = () => {
+						t0 = 0;
+						t1 = 0;
+						return ZZZ_1();
+					};
+					return zzz2();
+				}
+				int ZZZ_1()
+				{
+					t0 = 0;
+					var t1 = t0;
+					Func<int> zzz = () => {
+						t0 = 0;
+						t1 = 0;
+						return 0;
+					};
+					return zzz();
+				}
+			}
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -48,25 +48,45 @@ namespace LocalFunctions
 				{
 					return GetHashCode();
 				}
+#if CS80
+				static int StaticMethod1<T3>() where T3 : struct
+#else
 				int StaticMethod1<T3>() where T3 : struct
+#endif
 				{
 					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>() + StaticMethod2_RepeatT2<T2, T3, DayOfWeek>();
 				}
+#if CS80
+				static int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
+#else
 				int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
+#endif
 				{
 					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + typeof(T4).Name.Length + StaticMethod1<float>() + StaticMethod1_1<T3, DayOfWeek>();
 				}
 #pragma warning disable CS8387
+#if CS80
+				static int StaticMethod2_RepeatT2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#else
 				int StaticMethod2_RepeatT2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#endif
 #pragma warning restore CS8387
 				{
 					return typeof(T2).Name.Length;
 				}
+#if CS80
+				static int StaticMethod4<T>(T dd)
+#else
 				int StaticMethod4<T>(T dd)
+#endif
 				{
 					return 0;
 				}
+#if CS80
+				static int StaticMethod5<T3>()
+#else
 				int StaticMethod5<T3>()
+#endif
 				{
 					int k = 0;
 					return k + NonStaticMethod5_1<T1>();
@@ -100,33 +120,61 @@ namespace LocalFunctions
 				{
 					return GetHashCode();
 				}
+#if CS80
+				static int StaticInvokeAsFunc(Func<int> func)
+#else
 				int StaticInvokeAsFunc(Func<int> func)
+#endif
 				{
 					return func();
 				}
+#if CS80
+				static int StaticInvokeAsFunc2<T>(Func<T, int> func)
+#else
 				int StaticInvokeAsFunc2<T>(Func<T, int> func)
+#endif
 				{
 					return func(default(T));
 				}
+#if CS80
+				static int StaticMethod1<T3>() where T3 : struct
+#else
 				int StaticMethod1<T3>() where T3 : struct
+#endif
 				{
 					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>) + StaticInvokeAsFunc(StaticMethod2_RepeatT2<T2, T3, DayOfWeek>);
 				}
+#if CS80
+				static int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
+#else
 				int StaticMethod1_1<T3, T4>() where T3 : struct where T4 : Enum
+#endif
 				{
 					return typeof(T1).Name.Length + typeof(T2).Name.Length + typeof(T3).Name.Length + typeof(T4).Name.Length + StaticInvokeAsFunc(StaticMethod1<float>) + StaticInvokeAsFunc(StaticMethod1_1<T3, DayOfWeek>);
 				}
 #pragma warning disable CS8387
+#if CS80
+				static int StaticMethod2_RepeatT2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#else
 				int StaticMethod2_RepeatT2<T2, T3, T4>() where T2 : IConvertible where T3 : struct where T4 : Enum
+#endif
 #pragma warning restore CS8387
 				{
 					return typeof(T2).Name.Length;
 				}
+#if CS80
+				static int StaticMethod4<T>(T dd)
+#else
 				int StaticMethod4<T>(T dd)
+#endif
 				{
 					return 0;
 				}
+#if CS80
+				static int StaticMethod5<T3>()
+#else
 				int StaticMethod5<T3>()
+#endif
 				{
 					int k = 0;
 					return k + StaticInvokeAsFunc(NonStaticMethod5_1<T1>);
@@ -160,10 +208,18 @@ namespace LocalFunctions
 			{
 				ZZ<T2>(null);
 				ZZ2<object>(null);
+#if CS80
+				static void Nop<T>(T data)
+#else
 				void Nop<T>(T data)
+#endif
 				{
 				}
+#if CS80
+				static void ZZ<T3>(T3 t3) where T3 : T2
+#else
 				void ZZ<T3>(T3 t3) where T3 : T2
+#endif
 				{
 					Nop<List<T2>>(t3);
 					ZZ1<T3>(t3);
@@ -173,11 +229,19 @@ namespace LocalFunctions
 						Nop<List<T2>>(t3);
 					}
 				}
+#if CS80
+				static void ZZ1<T3>(T3 t3)
+#else
 				void ZZ1<T3>(T3 t3)
+#endif
 				{
 					Nop<List<T2>>((List<T2>)(object)t3);
 				}
+#if CS80
+				static void ZZ2<T3>(T3 t3)
+#else
 				void ZZ2<T3>(T3 t3)
+#endif
 				{
 					Nop<List<T2>>((List<T2>)(object)t3);
 				}
@@ -189,7 +253,11 @@ namespace LocalFunctions
 		private Lazy<object> nonCapturinglocalFunctionInLambda = new Lazy<object>(delegate {
 			return CreateValue();
 
+#if CS80
+			static object CreateValue()
+#else
 			object CreateValue()
+#endif
 			{
 				return null;
 			}
@@ -230,7 +298,11 @@ namespace LocalFunctions
 				LocalWrite("Hello " + i);
 			}
 
+#if CS80
+			static void LocalWrite(string s)
+#else
 			void LocalWrite(string s)
+#endif
 			{
 				Console.WriteLine(s);
 			}
@@ -266,7 +338,11 @@ namespace LocalFunctions
 				LocalWrite("Hello " + i);
 			}
 
+#if CS80
+			static void LocalWrite(string s)
+#else
 			void LocalWrite(string s)
+#endif
 			{
 				Console.WriteLine(s);
 			}
@@ -327,7 +403,11 @@ namespace LocalFunctions
 			Test(5);
 			LocalFunctions.Test(2);
 
+#if CS80
+			static void Test(int x)
+#else
 			void Test(int x)
+#endif
 			{
 				Console.WriteLine("x: {0}", x);
 			}
@@ -344,7 +424,11 @@ namespace LocalFunctions
 			Name();
 			action();
 
+#if CS80
+			static void Name()
+#else
 			void Name()
+#endif
 			{
 
 			}
@@ -355,12 +439,20 @@ namespace LocalFunctions
 			Use(Get(1), Get(2), Get(3));
 			Use(Get(1), c: Get(2), b: Get(3));
 
+#if CS80
+			static int Get(int i)
+#else
 			int Get(int i)
+#endif
 			{
 				return i;
 			}
 
+#if CS80
+			static void Use(int a, int b, int c)
+#else
 			void Use(int a, int b, int c)
+#endif
 			{
 				Console.WriteLine(a + b + c);
 			}
@@ -393,7 +485,11 @@ namespace LocalFunctions
 		{
 			return FibHelper(i);
 
+#if CS80
+			static int FibHelper(int n)
+#else
 			int FibHelper(int n)
+#endif
 			{
 				if (n <= 0) {
 					return 0;
@@ -406,7 +502,11 @@ namespace LocalFunctions
 		{
 			return B(4) + C(3);
 
+#if CS80
+			static int A(int i)
+#else
 			int A(int i)
+#endif
 			{
 				if (i > 0) {
 					return A(i - 1) + 2 * B(i - 1) + 3 * C(i - 1);
@@ -414,7 +514,11 @@ namespace LocalFunctions
 				return 1;
 			}
 
+#if CS80
+			static int B(int i)
+#else
 			int B(int i)
+#endif
 			{
 				if (i > 0) {
 					return 3 * A(i - 1) + B(i - 1);
@@ -422,7 +526,11 @@ namespace LocalFunctions
 				return 1;
 			}
 
+#if CS80
+			static int C(int i)
+#else
 			int C(int i)
+#endif
 			{
 				if (i > 0) {
 					return 2 * A(i - 1) + C(i - 1);
@@ -498,7 +606,11 @@ namespace LocalFunctions
 		{
 			Method1(null);
 
+#if CS80
+			static Action<object> Method1(Action<object> action)
+#else
 			Action<object> Method1(Action<object> action)
+#endif
 			{
 				return Method1_1;
 
@@ -518,7 +630,11 @@ namespace LocalFunctions
 		public int NestedCapture2()
 		{
 			return Method();
+#if CS80
+			static int Method()
+#else
 			int Method()
+#endif
 			{
 				int t0 = 0;
 				return ZZZ_0();

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -197,7 +197,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			} else if (localFunction != null) {
 				var ide = new IdentifierExpression(localFunction.Name);
 				if (method.TypeArguments.Count > 0) {
-					int skipCount = localFunction.ReducedMethod.NumberOfCompilerGeneratedGenerics;
+					int skipCount = localFunction.ReducedMethod.NumberOfCompilerGeneratedTypeParameters;
 					ide.TypeArguments.AddRange(method.TypeArguments.Skip(skipCount).Select(expressionBuilder.ConvertType));
 				}
 				target = ide.WithoutILInstruction()
@@ -1401,7 +1401,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				if ((step & 2) != 0) {
 					int skipCount = 0;
 					if (localFunction != null && method.TypeArguments.Count > 0) {
-						skipCount = localFunction.ReducedMethod.NumberOfCompilerGeneratedGenerics;
+						skipCount = localFunction.ReducedMethod.NumberOfCompilerGeneratedTypeParameters;
 					}
 					ide.TypeArguments.AddRange(method.TypeArguments.Skip(skipCount).Select(expressionBuilder.ConvertType));
 				}

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -1462,7 +1462,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						method.DeclaringType,
 						new IParameterizedMember[] { method }
 					)
-				}, method.TypeArguments
+				}, method.TypeArguments.Skip(localFunction.ReducedMethod.NumberOfCompilerGeneratedTypeParameters).ToArray()
 			);
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -217,9 +217,9 @@ namespace ICSharpCode.Decompiler.CSharp
 		internal ILFunction ResolveLocalFunction(IMethod method)
 		{
 			Debug.Assert(method.IsLocalFunction);
-			method = (IMethod)method.ReducedFrom.MemberDefinition;
+			method = (IMethod)((IMethod)method.MemberDefinition).ReducedFrom.MemberDefinition;
 			foreach (var parent in currentFunction.Ancestors.OfType<ILFunction>()) {
-				var definition = parent.LocalFunctions.FirstOrDefault(f => f.Method.Equals(method));
+				var definition = parent.LocalFunctions.FirstOrDefault(f => f.Method.MemberDefinition.Equals(method));
 				if (definition != null) {
 					return definition;
 				}

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -73,7 +73,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		internal readonly ILFunction currentFunction;
 		internal readonly ICompilation compilation;
 		internal readonly CSharpResolver resolver;
-		readonly TypeSystemAstBuilder astBuilder;
+		internal readonly TypeSystemAstBuilder astBuilder;
 		internal readonly TypeInference typeInference;
 		internal readonly DecompilerSettings settings;
 		readonly CancellationToken cancellationToken;
@@ -217,7 +217,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		internal ILFunction ResolveLocalFunction(IMethod method)
 		{
 			Debug.Assert(method.IsLocalFunction);
-			method = method.ReducedFrom;
+			method = (IMethod)method.ReducedFrom.MemberDefinition;
 			foreach (var parent in currentFunction.Ancestors.OfType<ILFunction>()) {
 				var definition = parent.LocalFunctions.FirstOrDefault(f => f.Method.Equals(method));
 				if (definition != null) {

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -987,6 +987,17 @@ namespace ICSharpCode.Decompiler.CSharp
 				stmt.Parameters.AddRange(exprBuilder.MakeParameters(function.Parameters, function));
 				stmt.ReturnType = exprBuilder.ConvertType(function.Method.ReturnType);
 				stmt.Body = nestedBuilder.ConvertAsBlock(function.Body);
+				if (function.Method.TypeParameters.Count > 0) {
+					var parentMethod = ((ILFunction)function.Parent).Method;
+					int skipCount = parentMethod.DeclaringType.TypeParameterCount + parentMethod.TypeParameters.Count - function.Method.DeclaringType.TypeParameterCount;
+					var astBuilder = exprBuilder.astBuilder;
+					if (astBuilder.ShowTypeParameters) {
+						stmt.TypeParameters.AddRange(function.Method.TypeParameters.Skip(skipCount).Select(t => astBuilder.ConvertTypeParameter(t)));
+						if (astBuilder.ShowTypeParameterConstraints) {
+							stmt.Constraints.AddRange(function.Method.TypeParameters.Skip(skipCount).Select(t => astBuilder.ConvertTypeParameterConstraint(t)).Where(c => c != null));
+						}
+					}
+				}
 				if (function.IsAsync) {
 					stmt.Modifiers |= Modifiers.Async;
 				}

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -1001,6 +1001,9 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (function.IsAsync) {
 					stmt.Modifiers |= Modifiers.Async;
 				}
+				if (settings.StaticLocalFunctions && function.Method.IsStatic && function.ReducedMethod.NumberOfCompilerGeneratedParameters == 0) {
+					stmt.Modifiers |= Modifiers.Static;
+				}
 				stmt.AddAnnotation(new MemberResolveResult(null, function.ReducedMethod));
 				return stmt;
 			}

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -988,10 +988,9 @@ namespace ICSharpCode.Decompiler.CSharp
 				stmt.ReturnType = exprBuilder.ConvertType(function.Method.ReturnType);
 				stmt.Body = nestedBuilder.ConvertAsBlock(function.Body);
 				if (function.Method.TypeParameters.Count > 0) {
-					var parentMethod = ((ILFunction)function.Parent).Method;
-					int skipCount = parentMethod.DeclaringType.TypeParameterCount + parentMethod.TypeParameters.Count - function.Method.DeclaringType.TypeParameterCount;
 					var astBuilder = exprBuilder.astBuilder;
 					if (astBuilder.ShowTypeParameters) {
+						int skipCount = function.ReducedMethod.NumberOfCompilerGeneratedGenerics;
 						stmt.TypeParameters.AddRange(function.Method.TypeParameters.Skip(skipCount).Select(t => astBuilder.ConvertTypeParameter(t)));
 						if (astBuilder.ShowTypeParameterConstraints) {
 							stmt.Constraints.AddRange(function.Method.TypeParameters.Skip(skipCount).Select(t => astBuilder.ConvertTypeParameterConstraint(t)).Where(c => c != null));
@@ -1001,7 +1000,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (function.IsAsync) {
 					stmt.Modifiers |= Modifiers.Async;
 				}
-				if (settings.StaticLocalFunctions && function.Method.IsStatic && function.ReducedMethod.NumberOfCompilerGeneratedParameters == 0) {
+				if (settings.StaticLocalFunctions && function.ReducedMethod.IsStaticLocalFunction) {
 					stmt.Modifiers |= Modifiers.Static;
 				}
 				stmt.AddAnnotation(new MemberResolveResult(null, function.ReducedMethod));

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -990,7 +990,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (function.Method.TypeParameters.Count > 0) {
 					var astBuilder = exprBuilder.astBuilder;
 					if (astBuilder.ShowTypeParameters) {
-						int skipCount = function.ReducedMethod.NumberOfCompilerGeneratedGenerics;
+						int skipCount = function.ReducedMethod.NumberOfCompilerGeneratedTypeParameters;
 						stmt.TypeParameters.AddRange(function.Method.TypeParameters.Skip(skipCount).Select(t => astBuilder.ConvertTypeParameter(t)));
 						if (astBuilder.ShowTypeParameterConstraints) {
 							stmt.Constraints.AddRange(function.Method.TypeParameters.Skip(skipCount).Select(t => astBuilder.ConvertTypeParameterConstraint(t)).Where(c => c != null));

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1793,7 +1793,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		#endregion
 		
 		#region Convert Type Parameter
-		TypeParameterDeclaration ConvertTypeParameter(ITypeParameter tp)
+		internal TypeParameterDeclaration ConvertTypeParameter(ITypeParameter tp)
 		{
 			TypeParameterDeclaration decl = new TypeParameterDeclaration();
 			decl.Variance = tp.Variance;
@@ -1803,7 +1803,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			return decl;
 		}
 		
-		Constraint ConvertTypeParameterConstraint(ITypeParameter tp)
+		internal Constraint ConvertTypeParameterConstraint(ITypeParameter tp)
 		{
 			if (!tp.HasDefaultConstructorConstraint && !tp.HasReferenceTypeConstraint && !tp.HasValueTypeConstraint && tp.NullabilityConstraint != Nullability.NotNullable && tp.DirectBaseTypes.All(IsObjectOrValueType)) {
 				return null;

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1065,7 +1065,7 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
-		bool staticLocalFunctions = false;
+		bool staticLocalFunctions = true;
 
 		/// <summary>
 		/// Gets/Sets whether C# 8.0 static local functions should be transformed.

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1065,7 +1065,7 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
-		bool staticLocalFunctions = true;
+		bool staticLocalFunctions = false;
 
 		/// <summary>
 		/// Gets/Sets whether C# 8.0 static local functions should be transformed.

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -110,12 +110,13 @@ namespace ICSharpCode.Decompiler
 				readOnlyMethods = false;
 				asyncUsingAndForEachStatement = false;
 				asyncEnumerator = false;
+				staticLocalFunctions = false;
 			}
 		}
 
 		public CSharp.LanguageVersion GetMinimumRequiredVersion()
 		{
-			if (nullableReferenceTypes || readOnlyMethods || asyncEnumerator || asyncUsingAndForEachStatement)
+			if (nullableReferenceTypes || readOnlyMethods || asyncEnumerator || asyncUsingAndForEachStatement || staticLocalFunctions)
 				return CSharp.LanguageVersion.CSharp8_0;
 			if (introduceUnmanagedConstraint || tupleComparisons || stackAllocInitializers)
 				return CSharp.LanguageVersion.CSharp7_3;
@@ -1059,6 +1060,23 @@ namespace ICSharpCode.Decompiler
 			set {
 				if (localFunctions != value) {
 					localFunctions = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool staticLocalFunctions = true;
+
+		/// <summary>
+		/// Gets/Sets whether C# 8.0 static local functions should be transformed.
+		/// </summary>
+		[Category("C# 8.0 / VS 2019")]
+		[Description("DecompilerSettings.IntroduceStaticLocalFunctions")]
+		public bool StaticLocalFunctions {
+			get { return staticLocalFunctions; }
+			set {
+				if (staticLocalFunctions != value) {
+					staticLocalFunctions = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -100,7 +100,6 @@ namespace ICSharpCode.Decompiler.IL
 				this.method = this.method.Specialize(genericContext.ToSubstitution());
 			}
 			this.genericContext = genericContext;
-			var methodDefinition = metadata.GetMethodDefinition(methodDefinitionHandle);
 			this.body = body;
 			this.reader = body.GetILReader();
 			this.currentStack = ImmutableStack<ILVariable>.Empty;

--- a/ICSharpCode.Decompiler/IL/Transforms/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DelegateConstruction.cs
@@ -95,7 +95,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return false;
 		}
 		
-		internal static GenericContext? GenericContextFromTypeArguments(TypeParameterSubstitution subst)
+		static GenericContext? GenericContextFromTypeArguments(TypeParameterSubstitution subst)
 		{
 			var classTypeParameters = new List<ITypeParameter>();
 			var methodTypeParameters = new List<ITypeParameter>();

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -115,7 +115,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						declaringFunction.LocalFunctions.Add(localFunction);
 					}
 
-					if (TryValidateSkipCount(info, out int skipCount) && skipCount != localFunction.ReducedMethod.NumberOfCompilerGeneratedGenerics) {
+					if (TryValidateSkipCount(info, out int skipCount) && skipCount != localFunction.ReducedMethod.NumberOfCompilerGeneratedTypeParameters) {
 						Debug.Assert(false);
 						function.Warnings.Add($"Could not decode local function '{info.Method}'");
 						if (localFunction.DeclarationScope != function.Body && localFunction.DeclarationScope.Parent is ILFunction declaringFunction) {
@@ -228,8 +228,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			var nestedContext = new ILTransformContext(context, function);
 			function.RunTransforms(CSharpDecompiler.GetILTransforms().TakeWhile(t => !(t is LocalFunctionDecompiler)), nestedContext);
 			function.DeclarationScope = null;
-			function.ReducedMethod = ReduceToLocalFunction(function.Method);
-			function.ReducedMethod.NumberOfCompilerGeneratedGenerics = skipCount;
+			function.ReducedMethod = ReduceToLocalFunction(function.Method, skipCount);
 			return function;
 		}
 
@@ -324,7 +323,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return inst;
 		}
 
-		LocalFunctionMethod ReduceToLocalFunction(IMethod method)
+		LocalFunctionMethod ReduceToLocalFunction(IMethod method, int skipCount)
 		{
 			int parametersToRemove = 0;
 			for (int i = method.Parameters.Count - 1; i >= 0; i--) {
@@ -332,7 +331,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					break;
 				parametersToRemove++;
 			}
-			return new LocalFunctionMethod(method, parametersToRemove);
+			return new LocalFunctionMethod(method, parametersToRemove, skipCount);
 		}
 
 		static void TransformToLocalFunctionReference(ILFunction function, CallInstruction useSite)

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -65,6 +65,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		{
 			if (!context.Settings.LocalFunctions)
 				return;
+			if (IsLocalFunctionMethod(function.Method, context) || IsLocalFunctionDisplayClass(function.Method.ParentModule.PEFile, (TypeDefinitionHandle)function.Method.DeclaringTypeDefinition.MetadataToken, context))
+				return;
 			this.context = context;
 			this.resolveContext = new SimpleTypeResolveContext(function.Method);
 			var localFunctions = new Dictionary<MethodDefinitionHandle, LocalFunctionInfo>();

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -379,8 +379,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					return false;
 				if (closureVar.Kind == VariableKind.NamedArgument)
 					return false;
-				ITypeDefinition potentialDisplayClass = UnwrapByRef(closureVar.Type).GetDefinition();
-				if (!TransformDisplayClassUsage.IsPotentialClosure(context, potentialDisplayClass))
+				if (!TransformDisplayClassUsage.IsClosure(context, closureVar, null, out _, out _))
 					return false;
 				if (i - firstArgumentIndex >= 0) {
 					Debug.Assert(i - firstArgumentIndex < function.Method.Parameters.Count && IsClosureParameter(function.Method.Parameters[i - firstArgumentIndex], resolveContext));

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
@@ -35,8 +35,6 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		{
 			if (baseMethod == null)
 				throw new ArgumentNullException(nameof(baseMethod));
-			if (baseMethod is SpecializedMethod)
-				throw new ArgumentException("Must not be a specialized method!", nameof(baseMethod));
 			this.baseMethod = baseMethod;
 			this.NumberOfCompilerGeneratedParameters = numberOfCompilerGeneratedParameters;
 			this.NumberOfCompilerGeneratedTypeParameters = numberOfCompilerGeneratedTypeParameters;
@@ -88,7 +86,9 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 
 		public IMethod Specialize(TypeParameterSubstitution substitution)
 		{
-			return SpecializedMethod.Create(this, substitution);
+			return new LocalFunctionMethod(
+				baseMethod.Specialize(substitution),
+				NumberOfCompilerGeneratedParameters, NumberOfCompilerGeneratedTypeParameters);
 		}
 		
 		IMember IMember.Specialize(TypeParameterSubstitution substitution)

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using ICSharpCode.Decompiler.Util;
 
@@ -42,7 +43,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			if (!(obj is LocalFunctionMethod other))
 				return false;
 			return baseMethod.Equals(other.baseMethod, typeNormalization)
-				&& NumberOfCompilerGeneratedParameters == other.NumberOfCompilerGeneratedParameters;
+				&& NumberOfCompilerGeneratedParameters == other.NumberOfCompilerGeneratedParameters
+				&& NumberOfCompilerGeneratedGenerics == other.NumberOfCompilerGeneratedGenerics;
 		}
 
 		public override bool Equals(object obj)
@@ -50,7 +52,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			if (!(obj is LocalFunctionMethod other))
 				return false;
 			return baseMethod.Equals(other.baseMethod)
-				&& NumberOfCompilerGeneratedParameters == other.NumberOfCompilerGeneratedParameters;
+				&& NumberOfCompilerGeneratedParameters == other.NumberOfCompilerGeneratedParameters
+				&& NumberOfCompilerGeneratedGenerics == other.NumberOfCompilerGeneratedGenerics;
 		}
 		
 		public override int GetHashCode()
@@ -62,14 +65,14 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 
 		public override string ToString()
 		{
-			return string.Format("[LocalFunctionMethod: ReducedFrom={0}, NumberOfGeneratedParameters={1}]", ReducedFrom, NumberOfCompilerGeneratedParameters);
+			return string.Format("[LocalFunctionMethod: ReducedFrom={0}, NumberOfGeneratedParameters={1}, NumberOfCompilerGeneratedGenerics={2}]", ReducedFrom, NumberOfCompilerGeneratedParameters, NumberOfCompilerGeneratedGenerics);
 		}
 
 		internal int NumberOfCompilerGeneratedParameters { get; }
 
 		internal int NumberOfCompilerGeneratedGenerics { get; set; }
 
-		internal bool IsStaticLocalFunction => NumberOfCompilerGeneratedParameters == 0 && baseMethod.IsStatic;
+		internal bool IsStaticLocalFunction => NumberOfCompilerGeneratedParameters == 0 && (baseMethod.IsStatic || (baseMethod.DeclaringTypeDefinition.IsCompilerGenerated() && !baseMethod.DeclaringType.GetFields(f => !f.IsStatic).Any()));
 
 		public IMember MemberDefinition => this;
 

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
@@ -67,6 +67,10 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 
 		internal int NumberOfCompilerGeneratedParameters { get; }
 
+		internal int NumberOfCompilerGeneratedGenerics { get; set; }
+
+		internal bool IsStaticLocalFunction => NumberOfCompilerGeneratedParameters == 0 && baseMethod.IsStatic;
+
 		public IMember MemberDefinition => this;
 
 		public IType ReturnType => baseMethod.ReturnType;

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
@@ -31,12 +31,16 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 	{
 		readonly IMethod baseMethod;
 
-		public LocalFunctionMethod(IMethod baseMethod, int numberOfCompilerGeneratedParameters)
+		public LocalFunctionMethod(IMethod baseMethod, int numberOfCompilerGeneratedParameters, int numberOfCompilerGeneratedTypeParameters)
 		{
+			if (baseMethod == null)
+				throw new ArgumentNullException(nameof(baseMethod));
+			if (baseMethod is SpecializedMethod)
+				throw new ArgumentException("Must not be a specialized method!", nameof(baseMethod));
 			this.baseMethod = baseMethod;
 			this.NumberOfCompilerGeneratedParameters = numberOfCompilerGeneratedParameters;
+			this.NumberOfCompilerGeneratedTypeParameters = numberOfCompilerGeneratedTypeParameters;
 		}
-
 
 		public bool Equals(IMember obj, TypeVisitor typeNormalization)
 		{
@@ -44,7 +48,7 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				return false;
 			return baseMethod.Equals(other.baseMethod, typeNormalization)
 				&& NumberOfCompilerGeneratedParameters == other.NumberOfCompilerGeneratedParameters
-				&& NumberOfCompilerGeneratedGenerics == other.NumberOfCompilerGeneratedGenerics;
+				&& NumberOfCompilerGeneratedTypeParameters == other.NumberOfCompilerGeneratedTypeParameters;
 		}
 
 		public override bool Equals(object obj)
@@ -53,24 +57,22 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				return false;
 			return baseMethod.Equals(other.baseMethod)
 				&& NumberOfCompilerGeneratedParameters == other.NumberOfCompilerGeneratedParameters
-				&& NumberOfCompilerGeneratedGenerics == other.NumberOfCompilerGeneratedGenerics;
+				&& NumberOfCompilerGeneratedTypeParameters == other.NumberOfCompilerGeneratedTypeParameters;
 		}
 		
 		public override int GetHashCode()
 		{
-			unchecked {
-				return baseMethod.GetHashCode() + NumberOfCompilerGeneratedParameters + 1;
-			}
+			return baseMethod.GetHashCode();
 		}
 
 		public override string ToString()
 		{
-			return string.Format("[LocalFunctionMethod: ReducedFrom={0}, NumberOfGeneratedParameters={1}, NumberOfCompilerGeneratedGenerics={2}]", ReducedFrom, NumberOfCompilerGeneratedParameters, NumberOfCompilerGeneratedGenerics);
+			return string.Format("[LocalFunctionMethod: ReducedFrom={0}, NumberOfGeneratedParameters={1}, NumberOfCompilerGeneratedTypeParameters={2}]", ReducedFrom, NumberOfCompilerGeneratedParameters, NumberOfCompilerGeneratedTypeParameters);
 		}
 
 		internal int NumberOfCompilerGeneratedParameters { get; }
 
-		internal int NumberOfCompilerGeneratedGenerics { get; set; }
+		internal int NumberOfCompilerGeneratedTypeParameters { get; }
 
 		internal bool IsStaticLocalFunction => NumberOfCompilerGeneratedParameters == 0 && (baseMethod.IsStatic || (baseMethod.DeclaringTypeDefinition.IsCompilerGenerated() && !baseMethod.DeclaringType.GetFields(f => !f.IsStatic).Any()));
 

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -773,6 +773,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Introduce static local functions.
+        /// </summary>
+        public static string DecompilerSettings_IntroduceStaticLocalFunctions {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.IntroduceStaticLocalFunctions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to IsByRefLikeAttribute should be replaced with &apos;ref&apos; modifiers on structs.
         /// </summary>
         public static string DecompilerSettings_IsByRefLikeAttributeShouldBeReplacedWithRefModifiersOnStructs {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -775,4 +775,7 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.DetectAsyncUsingAndForeachStatements" xml:space="preserve">
     <value>Detect awaited using and foreach statements</value>
   </data>
+  <data name="DecompilerSettings.IntroduceStaticLocalFunctions" xml:space="preserve">
+    <value>Introduce static local functions</value>
+  </data>
 </root>


### PR DESCRIPTION
Try add basic support for generic local function(fix #1588) and static local function(C#8.0), and fix some other issue found for local function.

Limited and Known Issue(not fixed):
1. Due to some [break changes](https://github.com/dotnet/roslyn/blob/master/docs/compilers/CSharp/Compiler%20Breaking%20Changes%20-%20post%20VS2019.md) and some other issues fixed in roslyn 16.4, `static local function` is incompatible with old versions of roslyn.
```cs
    //It compile on 16.3 as non-static, and fixed in 16.4. The generic version still compile on 16.4 and already reported as roslyn#39706
    public void Roslyn_LE_16_3() {
        int i = 0;
        ZZ1();
        int ZZ() => i;
        static void ZZ1(){
            ZZ();
        }
    }
    //It's able to compile this on 16.4+ but not 16.3
    public void Roslyn_GE_16_4() {
        ZZ1();
        static void ZZ(){}
        static void ZZ1(){
            _ = (Action)ZZ;
        }
    }
    //The method of local function is static in 16.4(See break changes) and non-static in 16.3. The latter one is not supported by the PR.
    public void M() {
        _ = new Action(XX0);
        static void XX0(){
        }
    }
```
2. Nested local function without capture generated the same code as no capture and not nested ones(so all static local function will be moved to the top function), and may cause conflict if the orig code use the same generic name or method name for them.
```cs
public void M()
{
	int i = 0;
	Method1<int>(1);
	void Method1<T1>(int z)
	{
		Method1<T1>();
		void Method1<T1>()
		{
			i = 0;
		}
	}
}
```
->
```cs
public void M()
{
	int i = 0;
	Method1<int>(1);
	void Method1<T1>(int z)
	{
		Method1_1<T1, T1>();
	}
	void Method1<T1, T1>()
	{
		i = 0;
	}
}
```
3. Generic type args of method will not be hidden even if possible.(and may lead to error for Anonymous Types)
```cs
        public void M1()
        {
            Method<int>();
            void Method<T1>()
            {
                int n = 0;
                Method2(new { A = 1 });
                Method3(new { A = 1 });
                void Method2<T2>(T2 obj)
                {
                    //keep nested
                    n = 0;
                }
                void Method3<T2>(T2 obj)
                {
                }
            }
        }
```

4. Assert in LdLoc(#1798)