### PR TITLE
Display System.Void as struct

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1362,6 +1362,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			ClassType classType;
 			switch (typeDefinition.Kind) {
 				case TypeKind.Struct:
+				case TypeKind.Void:
 					classType = ClassType.Struct;
 					modifiers &= ~Modifiers.Sealed;
 					if (ShowModifiers) {
@@ -1420,7 +1421,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 							decl.BaseTypes.Add(ConvertType(typeDefinition.EnumUnderlyingType));
 						}
 					// if the declared type is a struct, ignore System.ValueType
-					} else if (typeDefinition.Kind == TypeKind.Struct && baseType.IsKnownType(KnownTypeCode.ValueType)) {
+					} else if ((typeDefinition.Kind == TypeKind.Struct || typeDefinition.Kind == TypeKind.Void) && baseType.IsKnownType(KnownTypeCode.ValueType)) {
 						continue;
 					// always ignore System.Object
 					} else if (baseType.IsKnownType(KnownTypeCode.Object)) {

--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -122,6 +122,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				case TypeKind.Interface:
 					return TypeIcon.Interface;
 				case TypeKind.Struct:
+				case TypeKind.Void:
 					return TypeIcon.Struct;
 				case TypeKind.Delegate:
 					return TypeIcon.Delegate;


### PR DESCRIPTION
Change both the icon of `System.Void` in left assemblies tree and decompile result of `System.Void` to struct.