### PR TITLE
netstandard2.1 fixes

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1044,9 +1044,14 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				if (isDouble)
 					mathType = compilation.FindType(typeof(Math));
 				else {
-					mathType = compilation.FindType(new TopLevelTypeName("System", "MathF")).GetDefinition();
-					if (mathType == null || !mathType.GetFields(f => f.Name == "PI" && f.IsConst).Any() || !mathType.GetFields(f => f.Name == "E" && f.IsConst).Any())
+					mathType = compilation.FindType(new TopLevelTypeName("System", "MathF"));
+					var typeDef = mathType.GetDefinition();
+					if (typeDef == null
+						|| !typeDef.IsDirectImportOf(compilation.MainModule)
+						|| !typeDef.GetFields(f => f.Name == "PI" && f.IsConst).Any() || !typeDef.GetFields(f => f.Name == "E" && f.IsConst).Any())
+					{
 						mathType = compilation.FindType(typeof(Math));
+					}
 				}
 
 				expr = TryExtractExpression(mathType, type, constantValue, "PI", isDouble)

--- a/ICSharpCode.Decompiler/Metadata/AssemblyReferences.cs
+++ b/ICSharpCode.Decompiler/Metadata/AssemblyReferences.cs
@@ -185,7 +185,7 @@ namespace ICSharpCode.Decompiler.Metadata
 		{
 			var inst = This();
 			if (inst.PublicKeyOrToken.IsNil)
-				return Empty<byte>.Array;
+				return null;
 			var bytes = Module.Metadata.GetBlobBytes(inst.PublicKeyOrToken);
 			if ((inst.Flags & AssemblyFlags.PublicKey) != 0) {
 				return sha1.ComputeHash(bytes).Skip(12).ToArray();

--- a/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
+++ b/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
@@ -70,11 +70,18 @@ namespace ICSharpCode.Decompiler.Metadata
 			this.version = version;
 		}
 
-		public DotNetCorePathFinder(string parentAssemblyFileName, string targetFrameworkId, Version version, ReferenceLoadInfo loadInfo = null)
+		public DotNetCorePathFinder(string parentAssemblyFileName, string targetFrameworkIdString, TargetFrameworkIdentifier targetFramework, Version version, ReferenceLoadInfo loadInfo = null)
 		{
 			string assemblyName = Path.GetFileNameWithoutExtension(parentAssemblyFileName);
 			string basePath = Path.GetDirectoryName(parentAssemblyFileName);
 			this.version = version;
+
+			if (targetFramework == TargetFrameworkIdentifier.NETStandard) {
+				// .NET Standard 2.1 is implemented by .NET Core 3.0 or higher
+				if (version.Major == 2 && version.Minor == 1) {
+					this.version = new Version(3, 0, 0);
+				}
+			}
 
 			var depsJsonFileName = Path.Combine(basePath, $"{assemblyName}.deps.json");
 			if (!File.Exists(depsJsonFileName)) {
@@ -82,7 +89,7 @@ namespace ICSharpCode.Decompiler.Metadata
 				return;
 			}
 
-			packages = LoadPackageInfos(depsJsonFileName, targetFrameworkId).ToArray();
+			packages = LoadPackageInfos(depsJsonFileName, targetFrameworkIdString).ToArray();
 
 			foreach (var path in LookupPaths) {
 				foreach (var p in packages) {

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -26,7 +26,7 @@ using System.Text;
 
 namespace ICSharpCode.Decompiler.Metadata
 {
-	enum TargetFrameworkIdentifier
+	public enum TargetFrameworkIdentifier
 	{
 		NETFramework,
 		NETCoreApp,
@@ -183,7 +183,7 @@ namespace ICSharpCode.Decompiler.Metadata
 					if (IsZeroOrAllOnes(targetFrameworkVersion))
 						goto default;
 					if (dotNetCorePathFinder == null) {
-						dotNetCorePathFinder = new DotNetCorePathFinder(mainAssemblyFileName, targetFramework, targetFrameworkVersion);
+						dotNetCorePathFinder = new DotNetCorePathFinder(mainAssemblyFileName, targetFramework, targetFrameworkIdentifier, targetFrameworkVersion);
 					}
 					file = dotNetCorePathFinder.TryResolveDotNetCore(name);
 					if (file != null)


### PR DESCRIPTION
* Adds some kind of support to `DotNetCorePathFinder` so that we treat .netstandard 2.1 libraries as .net core version 3.0 at least.
* Fixes #1785

@tamlin-mike