### PR TITLE
Introducing ILSpy.ReadyToRun

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -42,9 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Iced">
-      <HintPath>..\..\iced\Iced\bin\Debug\netstandard2.0\Iced.dll</HintPath>
-    </Reference>
     <Reference Include="ILCompiler.Reflection.ReadyToRun">
       <HintPath>..\..\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug\ILCompiler.Reflection.ReadyToRun.dll</HintPath>
     </Reference>
@@ -52,6 +49,10 @@
 
   <ItemGroup>
     <Compile Include="ReadyToRunLanguage.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Iced" Version="1.4.0" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.1-alpha" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.2-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -37,10 +37,22 @@
     <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj">
       <Private>False</Private>
     </ProjectReference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="ReadyToRunLanguage.cs" />
+    <Compile Include="ReadyToRunOptionPage.xaml.cs">
+      <DependentUpon>ReadyToRunOptionPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ReadyToRunOptions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Include="ReadyToRunOptionPage.xaml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.0-alpha" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.1-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -10,8 +10,6 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
 
     <EnableDefaultItems>false</EnableDefaultItems>
-
-    <BaseAddress>6488064</BaseAddress>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -42,17 +42,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="ILCompiler.Reflection.ReadyToRun">
-      <HintPath>..\..\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug\ILCompiler.Reflection.ReadyToRun.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="ReadyToRunLanguage.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.0-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>ILSpy.ReadyToRun.Plugin</AssemblyName>
+    <LangVersion>7.2</LangVersion>
+
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+
+    <EnableDefaultItems>false</EnableDefaultItems>
+
+    <BaseAddress>6488064</BaseAddress>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>..\ILSpy\bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj">
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\ILSpy\ILSpy.csproj">
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\SharpTreeView\ICSharpCode.TreeView.csproj">
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Iced">
+      <HintPath>..\..\iced\Iced\bin\Debug\netstandard2.0\Iced.dll</HintPath>
+    </Reference>
+    <Reference Include="ILCompiler.Reflection.ReadyToRun">
+      <HintPath>..\..\runtime\artifacts\bin\coreclr\Windows_NT.x64.Debug\ILCompiler.Reflection.ReadyToRun.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="ReadyToRunLanguage.cs" />
+  </ItemGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <Target Name="RemoveTransitiveProjectReferences" AfterTargets="IncludeTransitiveProjectReferences">
+    <ItemGroup>
+      <ProjectReference Remove="@(_TransitiveProjectReferences)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/ILSpy.ReadyToRun/Properties/AssemblyInfo.cs
+++ b/ILSpy.ReadyToRun/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿#region Using directives
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+#endregion
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ILSpy.ReadyToRun.Plugin")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ILSpy.ReadyToRun.Plugin")]
+[assembly: AssemblyCopyright("Copyright 2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// This sets the default COM visibility of types in the assembly to invisible.
+// If you need to expose a type to COM, use [ComVisible(true)] on that type.
+[assembly: ComVisible(false)]
+
+[assembly: InternalsVisibleTo("ILSpy.ReadyToRun.Tests")]
+
+// The assembly version has following format :
+//
+// Major.Minor.Build.Revision
+//
+// You can specify all the values or you can use the default the Revision and 
+// Build Numbers by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -32,7 +32,7 @@ namespace ICSharpCode.ILSpy
 	[Export(typeof(Language))]
 	class ReadyToRunLanguage : Language
 	{
-		private ConditionalWeakTable<PEFile, R2RReader> r2rReaders = new ConditionalWeakTable<PEFile, R2RReader>();
+		private static readonly ConditionalWeakTable<PEFile, R2RReader> r2rReaders = new ConditionalWeakTable<PEFile, R2RReader>();
 		public override string Name => "ReadyToRun";
 
 		public override string FileExtension {

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Reflection.PortableExecutable;
 using Iced.Intel;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.Metadata;
@@ -56,6 +57,16 @@ namespace ICSharpCode.ILSpy
 			PEFile module = method.ParentModule.PEFile;
 			// TODO: avoid eager parsing in R2RReader
 			R2RReader reader = new R2RReader(new R2RAssemblyResolver(), module.Metadata, module.Reader, module.FileName);
+			int bitness = -1;
+			if (reader.Machine == Machine.Amd64) {
+				bitness = 64;
+			} else if (reader.Machine == Machine.I386) {
+				bitness = 32;
+			}
+			else {
+				// TODO: Architecture other than x86/amd64
+				throw new NotImplementedException("");
+			}
 			foreach (var m in reader.R2RMethods) {
 				if (m.MethodHandle == method.MetadataToken) {
 					// TODO: Indexing
@@ -64,8 +75,7 @@ namespace ICSharpCode.ILSpy
 						for (int i = 0; i < runtimeFunction.Size; i++) {
 							code[i] = reader.Image[reader.GetOffset(runtimeFunction.StartAddress) + i];
 						}
-						// TODO: Bitness
-						DecoderFormatterExample(output, code, 64, (ulong)runtimeFunction.StartAddress);
+						DecoderFormatterExample(output, code, bitness, (ulong)runtimeFunction.StartAddress);
 					}
 
 				}

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -29,7 +29,7 @@ using ICSharpCode.Decompiler.Solution;
 using ICSharpCode.Decompiler.TypeSystem;
 using ILCompiler.Reflection.ReadyToRun;
 
-namespace ICSharpCode.ILSpy
+namespace ICSharpCode.ILSpy.ReadyToRun
 {
 	[Export(typeof(Language))]
 	internal class ReadyToRunLanguage : Language
@@ -44,7 +44,7 @@ namespace ICSharpCode.ILSpy
 		public override ProjectId DecompileAssembly(LoadedAssembly assembly, ITextOutput output, DecompilationOptions options)
 		{
 			PEFile module = assembly.GetPEFileOrNull();
-			R2RReaderCacheEntry r2rReaderCacheEntry  = GetReader(assembly, module);
+			R2RReaderCacheEntry r2rReaderCacheEntry = GetReader(assembly, module);
 			if (r2rReaderCacheEntry.r2rReader == null) {
 				WriteCommentLine(output, r2rReaderCacheEntry.failureReason);
 			} else {
@@ -109,8 +109,14 @@ namespace ICSharpCode.ILSpy
 				decoder.Decode(out instructions.AllocUninitializedElement());
 			}
 
-			// TODO: DecompilationOptions?
-			var formatter = new NasmFormatter();
+			string disassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(null);
+			Formatter formatter = null;
+			if (disassemblyFormat.Equals(ReadyToRunOptions.intel)) {
+				formatter = new NasmFormatter();
+			} else {
+				Debug.Assert(disassemblyFormat.Equals(ReadyToRunOptions.gas));
+				formatter = new GasFormatter();
+			}
 			formatter.Options.DigitSeparator = "`";
 			formatter.Options.FirstOperandCharIndex = 10;
 			var tempOutput = new StringBuilderFormatterOutput();

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -84,13 +84,14 @@ namespace ICSharpCode.ILSpy
 				if (m.MethodHandle == method.MetadataToken) {
 					// TODO: Indexing
 					foreach (RuntimeFunction runtimeFunction in m.RuntimeFunctions) {
+						output.WriteLine(m.SignatureString);
 						byte[] code = new byte[runtimeFunction.Size];
 						for (int i = 0; i < runtimeFunction.Size; i++) {
 							code[i] = reader.Image[reader.GetOffset(runtimeFunction.StartAddress) + i];
 						}
 						DecoderFormatterExample(output, code, bitness, (ulong)runtimeFunction.StartAddress);
+						output.WriteLine();
 					}
-
 				}
 			}
 		}

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -57,10 +57,10 @@ namespace ICSharpCode.ILSpy
 			PEFile module = assembly.GetPEFileOrNull();
 			R2RReader reader = GetReader(module);
 
-			output.WriteLine("// TODO - display ready to run information");
+			WriteCommentLine(output, "TODO - display ready to run information");
 			// TODO: display other header information
 			foreach (var method in reader.R2RMethods) {
-				output.WriteLine(method.SignatureString);
+				WriteCommentLine(output, method.SignatureString);
 			}
 
 			return base.DecompileAssembly(assembly, output, options);
@@ -84,7 +84,7 @@ namespace ICSharpCode.ILSpy
 				if (m.MethodHandle == method.MetadataToken) {
 					// TODO: Indexing
 					foreach (RuntimeFunction runtimeFunction in m.RuntimeFunctions) {
-						output.WriteLine(m.SignatureString);
+						WriteCommentLine(output, m.SignatureString);
 						byte[] code = new byte[runtimeFunction.Size];
 						for (int i = 0; i < runtimeFunction.Size; i++) {
 							code[i] = reader.Image[reader.GetOffset(runtimeFunction.StartAddress) + i];
@@ -153,6 +153,11 @@ namespace ICSharpCode.ILSpy
 			{
 				throw new NotImplementedException();
 			}
+		}
+
+		public override void WriteCommentLine(ITextOutput output, string comment)
+		{
+			output.WriteLine("; " + comment);
 		}
 	}
 }

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -70,7 +70,7 @@ namespace ICSharpCode.ILSpy
 		public override void DecompileMethod(IMethod method, ITextOutput output, DecompilationOptions options)
 		{
 			PEFile module = method.ParentModule.PEFile;
-			R2RReader reader = GetReader(null, module);
+			R2RReader reader = GetReader(module.GetLoadedAssembly(), module);
 			int bitness = -1;
 			if (reader.Machine == Machine.Amd64) {
 				bitness = 64;

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -1,0 +1,134 @@
+// Copyright (c) 2018 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.ComponentModel.Composition;
+using Iced.Intel;
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.Solution;
+using ICSharpCode.Decompiler.TypeSystem;
+using ILCompiler.Reflection.ReadyToRun;
+
+namespace ICSharpCode.ILSpy
+{
+	[Export(typeof(Language))]
+	class ReadyToRunLanguage : Language
+	{
+		public override string Name => "ReadyToRun";
+
+		public override string FileExtension {
+			get { return ".asm"; }
+		}
+
+		public override ProjectId DecompileAssembly(LoadedAssembly assembly, ITextOutput output, DecompilationOptions options)
+		{
+			PEFile module = assembly.GetPEFileOrNull();
+			// TODO: avoid eager parsing 
+			R2RReader reader = new R2RReader(new R2RAssemblyResolver(), module.Metadata, module.Reader, module.FileName);
+
+			output.WriteLine("// TODO - display ready to run information");
+			// TODO: display other header information
+			foreach (var method in reader.R2RMethods) {
+				output.WriteLine(method.SignatureString);
+			}
+
+			return base.DecompileAssembly(assembly, output, options);
+		}
+
+		public override void DecompileMethod(IMethod method, ITextOutput output, DecompilationOptions options)
+		{
+			PEFile module = method.ParentModule.PEFile;
+			// TODO: avoid eager parsing in R2RReader
+			R2RReader reader = new R2RReader(new R2RAssemblyResolver(), module.Metadata, module.Reader, module.FileName);
+			foreach (var m in reader.R2RMethods) {
+				if (m.MethodHandle == method.MetadataToken) {
+					// TODO: Indexing
+					foreach (RuntimeFunction runtimeFunction in m.RuntimeFunctions) {
+						byte[] code = new byte[runtimeFunction.Size];
+						for (int i = 0; i < runtimeFunction.Size; i++) {
+							code[i] = reader.Image[reader.GetOffset(runtimeFunction.StartAddress) + i];
+						}
+						// TODO: Bitness
+						// TODO: RIP
+						DecoderFormatterExample(output, code, 64, 0);
+					}
+
+				}
+			}
+		}
+		private void DecoderFormatterExample(ITextOutput output, byte[] exampleCode, int exampleCodeBitness, ulong exampleCodeRIP)
+		{
+			// TODO: Decorate the disassembly with Unwind, GC and debug info
+			// You can also pass in a hex string, eg. "90 91 929394", or you can use your own CodeReader
+			// reading data from a file or memory etc
+			var codeBytes = exampleCode;
+			var codeReader = new ByteArrayCodeReader(codeBytes);
+			var decoder = Decoder.Create(exampleCodeBitness, codeReader);
+			decoder.IP = exampleCodeRIP;
+			ulong endRip = decoder.IP + (uint)codeBytes.Length;
+
+			// This list is faster than List<Instruction> since it uses refs to the Instructions
+			// instead of copying them (each Instruction is 32 bytes in size). It has a ref indexer,
+			// and a ref iterator. Add() uses 'in' (ref readonly).
+			var instructions = new InstructionList();
+			while (decoder.IP < endRip) {
+				// The method allocates an uninitialized element at the end of the list and
+				// returns a reference to it which is initialized by Decode().
+				decoder.Decode(out instructions.AllocUninitializedElement());
+			}
+
+			// Formatters: Masm*, Nasm*, Gas* (AT&T) and Intel* (XED)
+			// TODO: DecompilationOptions?
+			var formatter = new NasmFormatter();
+			formatter.Options.DigitSeparator = "`";
+			formatter.Options.FirstOperandCharIndex = 10;
+			var tempOutput = new StringBuilderFormatterOutput();
+			// Use InstructionList's ref iterator (C# 7.3) to prevent copying 32 bytes every iteration
+			foreach (var instr in instructions) {
+				// Don't use instr.ToString(), it allocates more, uses masm syntax and default options
+				formatter.Format(instr, tempOutput);
+				output.Write(instr.IP.ToString("X16"));
+				output.Write(" ");
+				int instrLen = instr.ByteLength;
+				int byteBaseIndex = (int)(instr.IP - exampleCodeRIP);
+				for (int i = 0; i < instrLen; i++)
+					output.Write(codeBytes[byteBaseIndex + i].ToString("X2"));
+				int missingBytes = 10 - instrLen;
+				for (int i = 0; i < missingBytes; i++)
+					output.Write("  ");
+				output.Write(" ");
+				output.WriteLine(tempOutput.ToStringAndReset());
+			}
+		}
+
+		private class R2RAssemblyResolver : ILCompiler.Reflection.ReadyToRun.IAssemblyResolver
+		{
+			public bool Naked => false;
+
+			public bool SignatureBinary => false;
+
+			public bool InlineSignatureBinary => false;
+
+			public string FindAssembly(string name, string filename)
+			{
+				throw new NotImplementedException();
+			}
+		}
+	}
+}

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -65,8 +65,7 @@ namespace ICSharpCode.ILSpy
 							code[i] = reader.Image[reader.GetOffset(runtimeFunction.StartAddress) + i];
 						}
 						// TODO: Bitness
-						// TODO: RIP
-						DecoderFormatterExample(output, code, 64, 0);
+						DecoderFormatterExample(output, code, 64, (ulong)runtimeFunction.StartAddress);
 					}
 
 				}

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
@@ -1,0 +1,10 @@
+﻿<UserControl x:Class="ICSharpCode.ILSpy.ReadyToRun.ReadyToRunOptionPage"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+	<StackPanel>
+		<StackPanel Orientation="Horizontal">
+			<TextBlock>Disassembly Format</TextBlock>
+			<ComboBox ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
+		</StackPanel>
+	</StackPanel>
+</UserControl>

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) 2018 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.ComponentModel;
+using System.Windows.Controls;
+using System.Xml.Linq;
+using ICSharpCode.ILSpy.Options;
+
+namespace ICSharpCode.ILSpy.ReadyToRun
+{
+	[ExportOptionPage(Title = "ReadyToRun", Order = 0)]
+	partial class ReadyToRunOptionPage : UserControl, IOptionPage
+	{
+		public ReadyToRunOptionPage()
+		{
+			InitializeComponent();
+		}
+
+		public void Load(ILSpySettings settings)
+		{
+			Options s = new Options();
+			s.DisassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(settings);
+			this.DataContext = s;
+		}
+
+		public void LoadDefaults()
+		{
+			this.DataContext = new Options();
+		}
+
+		public void Save(XElement root)
+		{
+			Options s = (Options)this.DataContext;
+			ReadyToRunOptions.SetDisassemblyFormat(root, s.DisassemblyFormat);
+		}
+	}
+
+	internal class Options : INotifyPropertyChanged
+	{
+		public string[] DisassemblyFormats {
+			get {
+				return ReadyToRunOptions.disassemblyFormats;
+			}
+		}
+
+		private string disassemblyFormat;
+
+		public string DisassemblyFormat {
+			get { return disassemblyFormat; }
+			set {
+				if (disassemblyFormat != value) {
+					disassemblyFormat = value;
+					OnPropertyChanged(nameof(DisassemblyFormat));
+				}
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected virtual void OnPropertyChanged(string propertyName)
+		{
+			if (PropertyChanged != null) {
+				PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+	}
+}

--- a/ILSpy.ReadyToRun/ReadyToRunOptions.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) 2018 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Xml.Linq;
+
+namespace ICSharpCode.ILSpy.ReadyToRun
+{
+	internal class ReadyToRunOptions
+	{
+		private static readonly XNamespace ns = "http://www.ilspy.net/ready-to-run";
+
+		internal static string intel = "Intel";
+		internal static string gas = "AT & T";
+		internal static string[] disassemblyFormats = new string[] { intel, gas };
+
+		public static string GetDisassemblyFormat(ILSpySettings settings)
+		{
+			if (settings == null) {
+				settings = ILSpySettings.Load();
+			}
+			XElement e = settings[ns + "ReadyToRunOptions"];
+			XAttribute a = e.Attribute("DisassemblyFormat");
+			if (a == null) {
+				return ReadyToRunOptions.intel;
+			} else {
+				return (string)a;
+			}
+		}
+
+		public static void SetDisassemblyFormat(XElement root, string disassemblyFormat)
+		{
+			XElement section = new XElement(ns + "ReadyToRunOptions");
+			section.SetAttributeValue("DisassemblyFormat", disassemblyFormat);
+
+			XElement existingElement = root.Element(ns + "ReadyToRunOptions");
+			if (existingElement != null) {
+				existingElement.ReplaceWith(section);
+			} else {
+				root.Add(section);
+			}
+		}
+	}
+}

--- a/ILSpy.sln
+++ b/ILSpy.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.Decompiler.PdbP
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILSpy.Tests", "ILSpy.Tests\ILSpy.Tests.csproj", "{B51C6636-B8D1-4200-9869-08F2689DE6C2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILSpy.ReadyToRun", "ILSpy.ReadyToRun\ILSpy.ReadyToRun.csproj", "{0313F581-C63B-43BB-AA9B-07615DABD8A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,10 @@ Global
 		{B51C6636-B8D1-4200-9869-08F2689DE6C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B51C6636-B8D1-4200-9869-08F2689DE6C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B51C6636-B8D1-4200-9869-08F2689DE6C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -56,7 +56,6 @@ namespace ICSharpCode.ILSpy
 			this.assemblyTask = Task.Factory.StartNew(LoadAssembly, stream); // requires that this.fileName is set
 			this.shortName = Path.GetFileNameWithoutExtension(fileName);
 			this.resolver = new MyAssemblyResolver(this);
-			this.universalResolver = new MyUniversalResolver(this);
 		}
 
 		/// <summary>
@@ -271,7 +270,7 @@ namespace ICSharpCode.ILSpy
 		}
 
 		static readonly Dictionary<string, LoadedAssembly> loadingAssemblies = new Dictionary<string, LoadedAssembly>();
-		readonly MyUniversalResolver universalResolver;
+		MyUniversalResolver universalResolver;
 
 		LoadedAssembly LookupReferencedAssemblyInternal(Decompiler.Metadata.IAssemblyReference fullName, bool isWinRT)
 		{
@@ -289,6 +288,10 @@ namespace ICSharpCode.ILSpy
 						LoadedAssemblyReferencesInfo.AddMessageOnce(fullName.FullName, MessageKind.Info, "Success - Found in Assembly List");
 						return loaded;
 					}
+				}
+
+				if (universalResolver == null) {
+					universalResolver = new MyUniversalResolver(this);
 				}
 
 				file = universalResolver.FindAssemblyFile(fullName);

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -55,6 +55,8 @@ namespace ICSharpCode.ILSpy
 
 			this.assemblyTask = Task.Factory.StartNew(LoadAssembly, stream); // requires that this.fileName is set
 			this.shortName = Path.GetFileNameWithoutExtension(fileName);
+			this.resolver = new MyAssemblyResolver(this);
+			this.universalResolver = new MyUniversalResolver(this);
 		}
 
 		/// <summary>
@@ -223,9 +225,11 @@ namespace ICSharpCode.ILSpy
 			}
 		}
 
+		readonly MyAssemblyResolver resolver;
+
 		public IAssemblyResolver GetAssemblyResolver()
 		{
-			return new MyAssemblyResolver(this);
+			return resolver;
 		}
 
 		/// <summary>
@@ -266,7 +270,8 @@ namespace ICSharpCode.ILSpy
 			}
 		}
 
-		static Dictionary<string, LoadedAssembly> loadingAssemblies = new Dictionary<string, LoadedAssembly>();
+		static readonly Dictionary<string, LoadedAssembly> loadingAssemblies = new Dictionary<string, LoadedAssembly>();
+		readonly MyUniversalResolver universalResolver;
 
 		LoadedAssembly LookupReferencedAssemblyInternal(Decompiler.Metadata.IAssemblyReference fullName, bool isWinRT)
 		{
@@ -286,8 +291,7 @@ namespace ICSharpCode.ILSpy
 					}
 				}
 
-				var resolver = new MyUniversalResolver(this);
-				file = resolver.FindAssemblyFile(fullName);
+				file = universalResolver.FindAssemblyFile(fullName);
 
 				foreach (LoadedAssembly loaded in assemblyList.GetAssemblies()) {
 					if (loaded.FileName.Equals(file, StringComparison.OrdinalIgnoreCase)) {

--- a/ILSpy/LoadedAssemblyExtensions.cs
+++ b/ILSpy/LoadedAssemblyExtensions.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.ILSpy
 			return GetLoadedAssembly(file).GetTypeSystemOrNull();
 		}
 
-		static LoadedAssembly GetLoadedAssembly(PEFile file)
+		public static LoadedAssembly GetLoadedAssembly(this PEFile file)
 		{
 			if (file == null)
 				throw new ArgumentNullException(nameof(file));

--- a/ILSpy/README.txt
+++ b/ILSpy/README.txt
@@ -13,5 +13,7 @@ Included open-source libraries:
  SharpTreeView: LGPL
  ILSpy.BamlDecompiler: MIT License
  CommandLineUtils: Apache License 2.0 (part of ICSharpCode.Decompiler.Console)
+ ILCompiler.Reflection.ReadyToRun: MIT License (part of ILSpy.ReadyToRun)
+ Iced: MIT License (part of ILSpy.ReadyToRun)
 
 Current and past contributors: https://github.com/icsharpcode/ILSpy/graphs/contributors

--- a/ILSpy/TextView/Asm-Mode.xshd
+++ b/ILSpy/TextView/Asm-Mode.xshd
@@ -1190,7 +1190,7 @@
 			<Begin>;</Begin>
 		</Span>
 		<Rule color="NumberLiteral">
-			\b0[xX][0-9a-fA-F]+  # hex number
+			\b(0[xXhH])?[0-9a-fA-F_`]+[h]?  # hex number
 			|
 			(	\b\d+(\.[0-9]+)?   #number with optional floating point
 			|	\.[0-9]+           #or just starting with floating point

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <add key="Nuget Official" value="https://api.nuget.org/v3/index.json" />
     <add key="ILSpy" value="https://ci.appveyor.com/nuget/ilspy-masterfeed" />
-	<add key="DotNet MyGet" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="DotNet MyGet" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="cshung_public_development" value="https://pkgs.dev.azure.com/cshung/public/_packaging/development/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Included open-source libraries:
  * SharpTreeView: LGPL
  * ILSpy.BamlDecompiler: MIT license
  * CommandLineUtils: Apache License 2.0 (part of ICSharpCode.Decompiler.Console)
+ * ILCompiler.Reflection.ReadyToRun: MIT License (part of ILSpy.ReadyToRun)
 
 How to build
 ------------

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Included open-source libraries:
  * ILSpy.BamlDecompiler: MIT license
  * CommandLineUtils: Apache License 2.0 (part of ICSharpCode.Decompiler.Console)
  * ILCompiler.Reflection.ReadyToRun: MIT License (part of ILSpy.ReadyToRun)
+ * Iced: MIT License (part of ILSpy.ReadyToRun)
 
 How to build
 ------------

--- a/doc/license.txt
+++ b/doc/license.txt
@@ -1,5 +1,7 @@
 The following MIT license applies to ILSpy, NRefactory and ICSharpCode.Decompiler.
 Mono.Cecil also uses the MIT license (Copyright JB Evain).
+ILCompiler.Reflection.ReadyToRun also uses the MIT license (Copyright Microsoft).
+Iced also uses the MIT license (Copyright 0xd4d).
 AvalonEdit and SharpTreeView use LGPL, which can be found in the LGPL.txt file.
 ILSpy.BamlDecompiler uses the MS-PL, which can be found in the MS-PL.txt file.
 


### PR DESCRIPTION
Fixes #1864

This PR introduces `ILSpy.ReadyToRun`, a plugin for disassembling pre-compiled methods contained in a ready-to-run image.

The code is the same as what I wrote before arranged as a plugin.

@christophwille 