### PR TITLE
Display ReadyToRun header information

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.3-alpha" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.4-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />


### PR DESCRIPTION
Another accumulated fixes for `ILCompiler.Reflection.ReadyToRun`

- Fixed some GCInfo decoding issue
- Make DebugInfo/EHInfo parsing lazy

Along with the fixes, I put in refactoring to get rid of `R2R` from the names and replaced them with `ReadyToRun`. Many of the changes in `ReadyToRunLanguage` is simply that. 