### PR TITLE
Fix #1919: Use unmapped IL offsets at the start of a catch-block for the 'exception specifier' sequence point.

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1812,11 +1812,11 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				Space();
 				WriteKeyword(CatchClause.WhenKeywordRole);
 				Space(policy.SpaceBeforeIfParentheses);
-				LPar();
+				WriteToken(CatchClause.CondLPar);
 				Space(policy.SpacesWithinIfParentheses);
 				catchClause.Condition.AcceptVisitor(this);
 				Space(policy.SpacesWithinIfParentheses);
-				RPar();
+				WriteToken(CatchClause.CondRPar);
 			}
 			WriteBlock(catchClause.Body, policy.StatementBraceStyle);
 			EndNode(catchClause);

--- a/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
@@ -118,7 +118,7 @@ namespace ICSharpCode.Decompiler.CSharp
 					// if this block container is part of a TryCatchHandler, do not steal the exception-specifier IL range
 					intervalStart = handler.ExceptionSpecifierILRange.End;
 				} else {
-					intervalStart = blockContainer.ILRanges.First().Start;
+					intervalStart = blockContainer.StartILOffset;
 				}
 				// The end will be set to the first sequence point candidate location before the first statement of the function when the seqeunce point is adjusted
 				int intervalEnd = intervalStart + 1; 

--- a/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
@@ -262,12 +262,15 @@ namespace ICSharpCode.Decompiler.CSharp
 			foreachStatement.InExpression.AcceptVisitor(this);
 			AddToSequencePoint(foreachInfo.GetEnumeratorCall);
 			EndSequencePoint(foreachStatement.InExpression.StartLocation, foreachStatement.InExpression.EndLocation);
+
 			StartSequencePoint(foreachStatement);
 			AddToSequencePoint(foreachInfo.MoveNextCall);
 			EndSequencePoint(foreachStatement.InToken.StartLocation, foreachStatement.InToken.EndLocation);
+			
 			StartSequencePoint(foreachStatement);
 			AddToSequencePoint(foreachInfo.GetCurrentCall);
 			EndSequencePoint(foreachStatement.VariableType.StartLocation, foreachStatement.VariableNameToken.EndLocation);
+			
 			VisitAsSequencePoint(foreachStatement.EmbeddedStatement);
 		}
 
@@ -327,7 +330,6 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		public override void VisitCatchClause(CatchClause catchClause)
 		{
-			StartSequencePoint(catchClause);
 			if (catchClause.Condition.IsNull) {
 				var tryCatchHandler = catchClause.Annotation<TryCatchHandler>();
 				if (!tryCatchHandler.ExceptionSpecifierILRange.IsEmpty) {
@@ -341,8 +343,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				AddToSequencePoint(catchClause.Condition);
 				EndSequencePoint(catchClause.WhenToken.StartLocation, catchClause.CondRParToken.EndLocation);
 			}
-			catchClause.Body.AcceptVisitor(this);
-			EndSequencePoint(catchClause.StartLocation, catchClause.EndLocation);
+			VisitAsSequencePoint(catchClause.Body);
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -363,6 +363,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			tryCatch.TryBlock = ConvertAsBlock(inst.TryBlock);
 			foreach (var handler in inst.Handlers) {
 				var catchClause = new CatchClause();
+				catchClause.AddAnnotation(handler);
 				var v = handler.Variable;
 				if (v != null) {
 					catchClause.AddAnnotation(new ILVariableResolveResult(v, v.Type));

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Statements/TryCatchStatement.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Statements/TryCatchStatement.cs
@@ -32,68 +32,70 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 	/// </summary>
 	public class TryCatchStatement : Statement
 	{
-		public static readonly TokenRole TryKeywordRole = new TokenRole ("try");
+		public static readonly TokenRole TryKeywordRole = new TokenRole("try");
 		public static readonly Role<BlockStatement> TryBlockRole = new Role<BlockStatement>("TryBlock", BlockStatement.Null);
 		public static readonly Role<CatchClause> CatchClauseRole = new Role<CatchClause>("CatchClause", CatchClause.Null);
-		public static readonly TokenRole FinallyKeywordRole = new TokenRole ("finally");
+		public static readonly TokenRole FinallyKeywordRole = new TokenRole("finally");
 		public static readonly Role<BlockStatement> FinallyBlockRole = new Role<BlockStatement>("FinallyBlock", BlockStatement.Null);
-		
+
 		public CSharpTokenNode TryToken {
-			get { return GetChildByRole (TryKeywordRole); }
+			get { return GetChildByRole(TryKeywordRole); }
 		}
-		
+
 		public BlockStatement TryBlock {
-			get { return GetChildByRole (TryBlockRole); }
-			set { SetChildByRole (TryBlockRole, value); }
+			get { return GetChildByRole(TryBlockRole); }
+			set { SetChildByRole(TryBlockRole, value); }
 		}
-		
+
 		public AstNodeCollection<CatchClause> CatchClauses {
-			get { return GetChildrenByRole (CatchClauseRole); }
+			get { return GetChildrenByRole(CatchClauseRole); }
 		}
-		
+
 		public CSharpTokenNode FinallyToken {
-			get { return GetChildByRole (FinallyKeywordRole); }
+			get { return GetChildByRole(FinallyKeywordRole); }
 		}
-		
+
 		public BlockStatement FinallyBlock {
-			get { return GetChildByRole (FinallyBlockRole); }
-			set { SetChildByRole (FinallyBlockRole, value); }
+			get { return GetChildByRole(FinallyBlockRole); }
+			set { SetChildByRole(FinallyBlockRole, value); }
 		}
-		
-		public override void AcceptVisitor (IAstVisitor visitor)
+
+		public override void AcceptVisitor(IAstVisitor visitor)
 		{
-			visitor.VisitTryCatchStatement (this);
+			visitor.VisitTryCatchStatement(this);
 		}
-			
-		public override T AcceptVisitor<T> (IAstVisitor<T> visitor)
+
+		public override T AcceptVisitor<T>(IAstVisitor<T> visitor)
 		{
-			return visitor.VisitTryCatchStatement (this);
+			return visitor.VisitTryCatchStatement(this);
 		}
-		
-		public override S AcceptVisitor<T, S> (IAstVisitor<T, S> visitor, T data)
+
+		public override S AcceptVisitor<T, S>(IAstVisitor<T, S> visitor, T data)
 		{
-			return visitor.VisitTryCatchStatement (this, data);
+			return visitor.VisitTryCatchStatement(this, data);
 		}
-		
+
 		protected internal override bool DoMatch(AstNode other, PatternMatching.Match match)
 		{
 			TryCatchStatement o = other as TryCatchStatement;
 			return o != null && this.TryBlock.DoMatch(o.TryBlock, match) && this.CatchClauses.DoMatch(o.CatchClauses, match) && this.FinallyBlock.DoMatch(o.FinallyBlock, match);
 		}
 	}
-	
+
 	/// <summary>
 	/// catch (Type VariableName) { Body }
 	/// </summary>
 	public class CatchClause : AstNode
 	{
-		public static readonly TokenRole CatchKeywordRole = new TokenRole ("catch");
-		public static readonly TokenRole WhenKeywordRole = new TokenRole ("when");
+		public static readonly TokenRole CatchKeywordRole = new TokenRole("catch");
+		public static readonly TokenRole WhenKeywordRole = new TokenRole("when");
 		public static readonly Role<Expression> ConditionRole = Roles.Condition;
+		public static readonly TokenRole CondLPar = new TokenRole("(");
+		public static readonly TokenRole CondRPar = new TokenRole(")");
 
 		#region Null
-		public new static readonly CatchClause Null = new NullCatchClause ();
-		
+		public new static readonly CatchClause Null = new NullCatchClause();
+
 		sealed class NullCatchClause : CatchClause
 		{
 			public override bool IsNull {
@@ -101,22 +103,22 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 					return true;
 				}
 			}
-			
-			public override void AcceptVisitor (IAstVisitor visitor)
+
+			public override void AcceptVisitor(IAstVisitor visitor)
 			{
 				visitor.VisitNullNode(this);
 			}
-			
-			public override T AcceptVisitor<T> (IAstVisitor<T> visitor)
+
+			public override T AcceptVisitor<T>(IAstVisitor<T> visitor)
 			{
 				return visitor.VisitNullNode(this);
 			}
-			
-			public override S AcceptVisitor<T, S> (IAstVisitor<T, S> visitor, T data)
+
+			public override S AcceptVisitor<T, S>(IAstVisitor<T, S> visitor, T data)
 			{
 				return visitor.VisitNullNode(this, data);
 			}
-			
+
 			protected internal override bool DoMatch(AstNode other, PatternMatching.Match match)
 			{
 				return other == null || other.IsNull;
@@ -129,26 +131,26 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		{
 			return pattern != null ? new PatternPlaceholder(pattern) : null;
 		}
-		
+
 		sealed class PatternPlaceholder : CatchClause, PatternMatching.INode
 		{
 			readonly PatternMatching.Pattern child;
-			
+
 			public PatternPlaceholder(PatternMatching.Pattern child)
 			{
 				this.child = child;
 			}
-			
+
 			public override NodeType NodeType {
 				get { return NodeType.Pattern; }
 			}
-			
-			public override void AcceptVisitor (IAstVisitor visitor)
+
+			public override void AcceptVisitor(IAstVisitor visitor)
 			{
 				visitor.VisitPatternPlaceholder(this, child);
 			}
-				
-			public override T AcceptVisitor<T> (IAstVisitor<T> visitor)
+
+			public override T AcceptVisitor<T>(IAstVisitor<T> visitor)
 			{
 				return visitor.VisitPatternPlaceholder(this, child);
 			}
@@ -157,90 +159,98 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			{
 				return visitor.VisitPatternPlaceholder(this, child, data);
 			}
-			
+
 			protected internal override bool DoMatch(AstNode other, PatternMatching.Match match)
 			{
 				return child.DoMatch(other, match);
 			}
-			
+
 			bool PatternMatching.INode.DoMatchCollection(Role role, PatternMatching.INode pos, PatternMatching.Match match, PatternMatching.BacktrackingInfo backtrackingInfo)
 			{
 				return child.DoMatchCollection(role, pos, match, backtrackingInfo);
 			}
 		}
 		#endregion
-		
+
 		public override NodeType NodeType {
 			get {
 				return NodeType.Unknown;
 			}
 		}
-		
+
 		public CSharpTokenNode CatchToken {
-			get { return GetChildByRole (CatchKeywordRole); }
+			get { return GetChildByRole(CatchKeywordRole); }
 		}
-		
+
 		public CSharpTokenNode LParToken {
-			get { return GetChildByRole (Roles.LPar); }
+			get { return GetChildByRole(Roles.LPar); }
 		}
-		
+
 		public AstType Type {
-			get { return GetChildByRole (Roles.Type); }
-			set { SetChildByRole (Roles.Type, value); }
+			get { return GetChildByRole(Roles.Type); }
+			set { SetChildByRole(Roles.Type, value); }
 		}
-		
+
 		public string VariableName {
-			get { return GetChildByRole (Roles.Identifier).Name; }
+			get { return GetChildByRole(Roles.Identifier).Name; }
 			set {
 				if (string.IsNullOrEmpty(value))
-					SetChildByRole (Roles.Identifier, null);
+					SetChildByRole(Roles.Identifier, null);
 				else
-					SetChildByRole (Roles.Identifier, Identifier.Create (value));
+					SetChildByRole(Roles.Identifier, Identifier.Create(value));
 			}
 		}
-		
+
 		public Identifier VariableNameToken {
 			get {
-				return GetChildByRole (Roles.Identifier);
+				return GetChildByRole(Roles.Identifier);
 			}
 			set {
 				SetChildByRole(Roles.Identifier, value);
 			}
 		}
-		
+
 		public CSharpTokenNode RParToken {
-			get { return GetChildByRole (Roles.RPar); }
+			get { return GetChildByRole(Roles.RPar); }
 		}
-		
+
 		public CSharpTokenNode WhenToken {
-			get { return GetChildByRole (WhenKeywordRole); }
+			get { return GetChildByRole(WhenKeywordRole); }
 		}
-		
+
+		public CSharpTokenNode CondLParToken {
+			get { return GetChildByRole(CondLPar); }
+		}
+
 		public Expression Condition {
-			get { return GetChildByRole(ConditionRole);  }
+			get { return GetChildByRole(ConditionRole); }
 			set { SetChildByRole(ConditionRole, value); }
 		}
-		
+
+		public CSharpTokenNode CondRParToken {
+			get { return GetChildByRole(CondRPar); }
+		}
+
 		public BlockStatement Body {
-			get { return GetChildByRole (Roles.Body); }
-			set { SetChildByRole (Roles.Body, value); }
+			get { return GetChildByRole(Roles.Body); }
+			set { SetChildByRole(Roles.Body, value); }
 		}
-		
-		public override void AcceptVisitor (IAstVisitor visitor)
+
+		public override void AcceptVisitor(IAstVisitor visitor)
 		{
-			visitor.VisitCatchClause (this);
+			visitor.VisitCatchClause(this);
 		}
-			
-		public override T AcceptVisitor<T> (IAstVisitor<T> visitor)
+
+		public override T AcceptVisitor<T>(IAstVisitor<T> visitor)
 		{
-			return visitor.VisitCatchClause (this);
+			return visitor.VisitCatchClause(this);
 		}
-		
-		public override S AcceptVisitor<T, S> (IAstVisitor<T, S> visitor, T data)
+
+		public override S AcceptVisitor<T, S>(IAstVisitor<T, S> visitor, T data)
 		{
-			return visitor.VisitCatchClause (this, data);
+			return visitor.VisitCatchClause(this, data);
 		}
-		
+
 		protected internal override bool DoMatch(AstNode other, PatternMatching.Match match)
 		{
 			CatchClause o = other as CatchClause;

--- a/ICSharpCode.Decompiler/IL/Instructions/ILInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/ILInstruction.cs
@@ -214,24 +214,29 @@ namespace ICSharpCode.Decompiler.IL
 
 		public void AddILRange(Interval newRange)
 		{
-			if (this.ILRange.IsEmpty) {
-				this.ILRange = newRange;
-				return;
+			this.ILRange = CombineILRange(this.ILRange, newRange);
+		}
+
+		protected static Interval CombineILRange(Interval oldRange, Interval newRange)
+		{
+			if (oldRange.IsEmpty) {
+				return newRange;
 			}
 			if (newRange.IsEmpty) {
-				return;
+				return oldRange;
 			}
-			if (newRange.Start <= this.StartILOffset) {
-				if (newRange.End < this.StartILOffset) {
-					this.ILRange = newRange; // use the earlier range
+			if (newRange.Start <= oldRange.Start) {
+				if (newRange.End < oldRange.Start) {
+					return newRange; // use the earlier range
 				} else {
 					// join overlapping ranges
-					this.ILRange = new Interval(newRange.Start, Math.Max(newRange.End, this.ILRange.End));
+					return new Interval(newRange.Start, Math.Max(newRange.End, oldRange.End));
 				}
-			} else if (newRange.Start <= this.ILRange.End) {
+			} else if (newRange.Start <= oldRange.End) {
 				// join overlapping ranges
-				this.ILRange = new Interval(this.StartILOffset, Math.Max(newRange.End, this.ILRange.End));
+				return new Interval(oldRange.Start, Math.Max(newRange.End, oldRange.End));
 			}
+			return oldRange;
 		}
 
 		public void AddILRange(ILInstruction sourceInstruction)

--- a/ICSharpCode.Decompiler/IL/Instructions/TryInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/TryInstruction.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using ICSharpCode.Decompiler.Util;
 
 namespace ICSharpCode.Decompiler.IL
 {
@@ -174,6 +175,17 @@ namespace ICSharpCode.Decompiler.IL
 			output.Write(')');
 			output.Write(' ');
 			body.WriteTo(output, options);
+		}
+
+		/// <summary>
+		/// Gets the ILRange of the instructions at the start of the catch-block,
+		/// that take the exception object and store it in the exception variable slot.
+		/// </summary>
+		public Interval ExceptionSpecifierILRange { get; private set; }
+
+		public void AddExceptionSpecifierILRange(Interval newRange)
+		{
+			ExceptionSpecifierILRange = CombineILRange(ExceptionSpecifierILRange, newRange);
 		}
 	}
 	

--- a/ICSharpCode.Decompiler/IL/Instructions/TryInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/TryInstruction.cs
@@ -180,6 +180,7 @@ namespace ICSharpCode.Decompiler.IL
 		/// <summary>
 		/// Gets the ILRange of the instructions at the start of the catch-block,
 		/// that take the exception object and store it in the exception variable slot.
+		/// Note: This range is empty, if Filter is not empty, i.e., ldloc 1.
 		/// </summary>
 		public Interval ExceptionSpecifierILRange { get; private set; }
 

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -692,7 +692,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				TransformCatchWhen(inst, filterContainer.EntryPoint);
 			}
 			if (inst.Body is BlockContainer catchContainer)
-				TransformCatchVariable(inst, catchContainer.EntryPoint);
+				TransformCatchVariable(inst, catchContainer.EntryPoint, isCatchBlock: true);
 		}
 
 		/// <summary>
@@ -709,7 +709,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		/// 	}
 		/// }
 		/// </summary>
-		void TransformCatchVariable(TryCatchHandler handler, Block entryPoint)
+		void TransformCatchVariable(TryCatchHandler handler, Block entryPoint, bool isCatchBlock)
 		{
 			if (!handler.Variable.IsSingleDefinition || handler.Variable.LoadCount != 1)
 				return; // handle.Variable already has non-trivial uses
@@ -754,7 +754,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		/// </summary>
 		void TransformCatchWhen(TryCatchHandler handler, Block entryPoint)
 		{
-			TransformCatchVariable(handler, entryPoint);
+			TransformCatchVariable(handler, entryPoint, isCatchBlock: false);
 			if (entryPoint.Instructions.Count == 1 && entryPoint.Instructions[0].MatchLeave(out _, out var condition)) {
 				context.Step("TransformCatchWhen", entryPoint.Instructions[0]);
 				handler.Filter = condition;


### PR DESCRIPTION
(complete rewrite based on our discussions and @jacdavis's work)