### PR TITLE
Add information about `powershell not found` error for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ If this problem occurs, please manually install the .NET Core 3.1 SDK from [here
 Unix / Mac:
 - Make sure .NET Core 2.1 LTS Runtime is installed (you can get it here: https://get.dot.net).
 - Make sure [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) is installed.
+- Make sure [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-macos?view=powershell-7)[]() is installed as single executable.  (Not as dotnet tool)
+  - WORKAROUND: Make it executable by the name of `powershell` .
+  - `$ ln -s /usr/local/bin/pwsh /usr/local/bin/powershell`
 - Check out the repository using git.
 - Execute `git submodule update --init --recursive` to download the ILSpy-Tests submodule (used by some test cases).
 - Use `dotnet build Frontends.sln` to build the non-Windows flavors of ILSpy (.NET Core Global Tool and PowerShell Core).


### PR DESCRIPTION
On macOS, it was not possible to build even following the instructions in the README.

I encountered the following error:

```bash
$ dotnet build Frontends.sln
```

```
Copyright (C) Microsoft Corporation.All rights reserved.
  /Users/ryuji-kubota/ghq/github.com/icsharpcode/ILSpy/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj の復元が 35.68 sec で完了しました。
  /Users/ryuji-kubota/ghq/github.com/icsharpcode/ILSpy/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj の復元が 35.68 sec で完了しました。
  /Users/ryuji-kubota/ghq/github.com/icsharpcode/ILSpy/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj の復元が 35.74 sec で完了しました。
  /var/folders/42/zh1jf_v56wq4mlr2frh2twb00000gp/T/tmpfd1494a2e8a849b28b031db7197192e0.exec.cmd: line 2: powershell: command not found
/Users/ryuji-kubota/ghq/github.com/icsharpcode/ILSpy/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj(630,5): error MSB3073: コマンド "powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 Debug" はコード 127 で終了しました。
ビルドに失敗しました。
/Users/ryuji-kubota/ghq/github.com/icsharpcode/ILSpy/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj(630,5): error MSB3073: コマンド "powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 Debug" はコード 127 で終了しました。
```

This reason is that the powershell installed on macOS is named `pwsh` .
I added a workaround on this to the README.
