### PR TITLE
[ILSpy.ReadyToRun] Avoid eager parsing

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.4-alpha" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.5-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -175,6 +175,13 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				LoadedAssembly loadedAssembly = this.loadedAssembly.LookupReferencedAssembly(new Decompiler.Metadata.AssemblyReference(metadataReader, assemblyReferenceHandle));
 				return loadedAssembly?.GetPEFileOrNull()?.Metadata;
 			}
+
+			public MetadataReader FindAssembly(string simpleName, string parentFile)
+			{
+				// This is called only for the composite R2R scenario, 
+				// So it will never be called before the feature is released.
+				throw new NotSupportedException("Composite R2R format is not currently supported");
+			}
 		}
 
 		private class ReadyToRunReaderCacheEntry


### PR DESCRIPTION
Fixes #1888 

This fix should make loading `System.Private.CoreLib.dll` appear instant. This change includes:

- https://github.com/dotnet/runtime/pull/1657
- https://github.com/dotnet/runtime/pull/1899
- https://github.com/dotnet/runtime/pull/31646
- https://github.com/dotnet/runtime/pull/32682

This fix also includes some work from @trylek to support a new initiative in the runtime called [composite R2R](https://github.com/dotnet/runtime/blob/master/docs/design/coreclr/botr/readytorun-format.md). As of now, the technology is not released yet, so it does not harm to not support it in the moment.