### PR TITLE
Switch from powershell to pwsh

### DIFF
--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -625,7 +625,7 @@
 
   <Target Name="ILSpyUpdateAssemblyInfo" BeforeTargets="BeforeBuild">
     <PropertyGroup>
-      <UpdateAssemblyInfo>powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 $(Configuration)</UpdateAssemblyInfo>
+      <UpdateAssemblyInfo>pwsh -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 $(Configuration)</UpdateAssemblyInfo>
     </PropertyGroup>
     <Exec WorkingDirectory=".." Command="$(UpdateAssemblyInfo)" Timeout="60000" />
   </Target>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -624,7 +624,10 @@
   </ItemGroup>
 
   <Target Name="ILSpyUpdateAssemblyInfo" BeforeTargets="BeforeBuild">
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+      <UpdateAssemblyInfo>powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 $(Configuration)</UpdateAssemblyInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
       <UpdateAssemblyInfo>pwsh -NoProfile -ExecutionPolicy Bypass -File BuildTools/update-assemblyinfo.ps1 $(Configuration)</UpdateAssemblyInfo>
     </PropertyGroup>
     <Exec WorkingDirectory=".." Command="$(UpdateAssemblyInfo)" Timeout="60000" />

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Windows:
   - Workload "Visual Studio extension development" (ILSpy.sln contains a VS extension project)
   - Individual Component "MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.23)" (or similar)
     - The VC++ toolset is optional; if present it is used for `editbin.exe` to modify the stack size used by ILSpy.exe from 1MB to 16MB, because the decompiler makes heavy use of recursion, where small stack sizes lead to problems in very complex methods.
+- Make sure [PowerShell](https://github.com/PowerShell/PowerShell) is installed (formerly known as PowerShell Core) - recommended way of installation via [choco install powershell-core](https://chocolatey.org/packages/powershell-core)
 - Check out the ILSpy repository using git.
 - Execute `git submodule update --init --recursive` to download the ILSpy-Tests submodule (used by some test cases).
 - Open ILSpy.sln in Visual Studio.
@@ -59,6 +60,7 @@ If this problem occurs, please manually install the .NET Core 3.1 SDK from [here
 Unix / Mac:
 - Make sure .NET Core 2.1 LTS Runtime is installed (you can get it here: https://get.dot.net).
 - Make sure [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) is installed.
+- Make sure [PowerShell](https://github.com/PowerShell/PowerShell) is installed (formerly known as PowerShell Core)
 - Check out the repository using git.
 - Execute `git submodule update --init --recursive` to download the ILSpy-Tests submodule (used by some test cases).
 - Use `dotnet build Frontends.sln` to build the non-Windows flavors of ILSpy (.NET Core Global Tool and PowerShell Core).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Windows:
   - Workload "Visual Studio extension development" (ILSpy.sln contains a VS extension project)
   - Individual Component "MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.23)" (or similar)
     - The VC++ toolset is optional; if present it is used for `editbin.exe` to modify the stack size used by ILSpy.exe from 1MB to 16MB, because the decompiler makes heavy use of recursion, where small stack sizes lead to problems in very complex methods.
-- Make sure [PowerShell](https://github.com/PowerShell/PowerShell) is installed (formerly known as PowerShell Core) - recommended way of installation via [choco install powershell-core](https://chocolatey.org/packages/powershell-core)
 - Check out the ILSpy repository using git.
 - Execute `git submodule update --init --recursive` to download the ILSpy-Tests submodule (used by some test cases).
 - Open ILSpy.sln in Visual Studio.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ image: Visual Studio 2019
 
 install:
 - git submodule update --init --recursive
-- ps: .\BuildTools\appveyor-install.ps1
+- pwsh .\BuildTools\appveyor-install.ps1
 
 nuget:
   account_feed: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,9 +45,9 @@ jobs:
       version: '3.1.100'
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
-  - powershell: .\BuildTools\pipelines-install.ps1
+  - script: pwsh .\BuildTools\pipelines-install.ps1
     displayName: Install
-
+    
   - task: MSBuild@1
     displayName: Restore ILSpy
     inputs:


### PR DESCRIPTION
pwsh is supported by both our build systems:

* https://www.appveyor.com/docs/windows-images-software/#powershell
* https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md

Advantage: *nix and Mac can easily use ics.d.csproj (needed a symlink previously)

Disadvantage: on Windows the new PowerShell needs to be installed (up until now we relied on Windows PowerShell which comes by default)