### PR TITLE
Dev/jacdavis/sequencepoints

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
@@ -18,9 +18,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.DebugInfo;
 using ICSharpCode.Decompiler.IL;
 using ICSharpCode.Decompiler.Util;
 
@@ -108,6 +110,25 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		public override void VisitBlockStatement(BlockStatement blockStatement)
 		{
+			ILInstruction blockContainer = blockStatement.Annotations.OfType<ILInstruction>().FirstOrDefault();
+			if (blockContainer != null) {
+				StartSequencePoint(blockStatement.LBraceToken);
+				int intervalStart = blockContainer.ILRanges.First().Start;
+				// The end will be set to the first sequence point candidate location before the first statement of the function when the seqeunce point is adjusted
+				int intervalEnd = intervalStart + 1; 
+
+				Interval interval = new Interval(intervalStart, intervalEnd);
+				List<Interval> intervals = new List<Interval>();
+				intervals.Add(interval);
+				current.Intervals.AddRange(intervals);
+				current.Function = blockContainer.Ancestors.OfType<ILFunction>().FirstOrDefault();
+				EndSequencePoint(blockStatement.LBraceToken.StartLocation, blockStatement.LBraceToken.EndLocation);
+			}
+			else {
+				// Ideally, we'd be able to address this case. Blocks that are not the top-level function block have no ILInstruction annotations. It isn't clear to me how to determine the il range.
+				// For now, do not add the opening brace sequence in this case.
+			}
+
 			foreach (var stmt in blockStatement.Statements) {
 				VisitAsSequencePoint(stmt);
 			}
@@ -331,11 +352,13 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 				list.Add(sequencePoint);
 			}
+
 			foreach (var (function, list) in dict.ToList()) {
-				// For each function, sort sequence points and fix overlaps+gaps
+				// For each function, sort sequence points and fix overlaps
 				var newList = new List<DebugInfo.SequencePoint>();
 				int pos = 0;
-				foreach (var sequencePoint in list.OrderBy(sp => sp.Offset).ThenBy(sp => sp.EndOffset)) {
+				IOrderedEnumerable<DebugInfo.SequencePoint> currFunctionSequencePoints = list.OrderBy(sp => sp.Offset).ThenBy(sp => sp.EndOffset);
+				foreach (DebugInfo.SequencePoint sequencePoint in currFunctionSequencePoints) {
 					if (sequencePoint.Offset < pos) {
 						// overlapping sequence point?
 						// delete previous sequence points that are after sequencePoint.Offset
@@ -348,17 +371,12 @@ namespace ICSharpCode.Decompiler.CSharp
 								newList[newList.Count - 1] = last;
 							}
 						}
-					} else if (sequencePoint.Offset > pos) {
-						// insert hidden sequence point in the gap.
-						var hidden = new DebugInfo.SequencePoint();
-						hidden.Offset = pos;
-						hidden.EndOffset = sequencePoint.Offset;
-						hidden.SetHidden();
-						newList.Add(hidden);
 					}
+
 					newList.Add(sequencePoint);
 					pos = sequencePoint.EndOffset;
 				}
+				// Add a hidden sequence point to account for the epilog of the function
 				if (pos < function.CodeSize) {
 					var hidden = new DebugInfo.SequencePoint();
 					hidden.Offset = pos;
@@ -366,8 +384,48 @@ namespace ICSharpCode.Decompiler.CSharp
 					hidden.SetHidden();
 					newList.Add(hidden);
 				}
+
+
+				List<int> sequencePointCandidates = function.SequencePointCandidates;
+				int currSPCandidateIndex = 0;
+
+				for (int i = 0; i < newList.Count - 1; i++) {
+					DebugInfo.SequencePoint currSequencePoint = newList[i];
+					DebugInfo.SequencePoint nextSequencePoint = newList[i + 1];
+
+					// Adjust the end offset of the current sequence point to the closest sequence point candidate
+					// but do not create an overlapping sequence point. Moving the start of the current sequence
+					// point is not required as it is 0 for the first sequence point and is moved during the last 
+					// iteration for all others.
+					while (currSPCandidateIndex < sequencePointCandidates.Count &&
+						sequencePointCandidates[currSPCandidateIndex] < currSequencePoint.EndOffset) {
+						currSPCandidateIndex++;
+					}
+					if (currSPCandidateIndex < sequencePointCandidates.Count && sequencePointCandidates[currSPCandidateIndex] <= nextSequencePoint.Offset) {
+						currSequencePoint.EndOffset = sequencePointCandidates[currSPCandidateIndex];
+					}
+
+					// Adjust the start offset of the next sequence point to the closest previous sequence point candidate
+					// but do not create an overlapping sequence point. 
+					while (currSPCandidateIndex < sequencePointCandidates.Count &&
+						sequencePointCandidates[currSPCandidateIndex] < nextSequencePoint.Offset) {
+						currSPCandidateIndex++;
+					}
+					if (currSPCandidateIndex < sequencePointCandidates.Count && sequencePointCandidates[currSPCandidateIndex - 1] >= currSequencePoint.EndOffset) {
+						nextSequencePoint.Offset = sequencePointCandidates[currSPCandidateIndex - 1];
+						currSPCandidateIndex--;
+					}
+
+					// Fill in any gaps with a hidden sequence point
+					if (currSequencePoint.EndOffset != nextSequencePoint.Offset) {
+						SequencePoint newSP = new SequencePoint() { Offset = currSequencePoint.EndOffset, EndOffset = nextSequencePoint.Offset };
+						newSP.SetHidden();
+						newList.Insert(++i, newSP);
+					}
+				}
 				dict[function] = newList;
-			}
+			}			
+
 			return dict;
 		}
 	}

--- a/ICSharpCode.Decompiler/DebugInfo/AsyncDebugInfo.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/AsyncDebugInfo.cs
@@ -5,7 +5,7 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace ICSharpCode.Decompiler.DebugInfo
 {
-	readonly struct AsyncDebugInfo
+	public readonly struct AsyncDebugInfo
 	{
 		public readonly int CatchHandlerOffset;
 		public readonly ImmutableArray<Await> Awaits;
@@ -28,7 +28,7 @@ namespace ICSharpCode.Decompiler.DebugInfo
 			}
 		}
 
-		internal BlobBuilder BuildBlob(MethodDefinitionHandle moveNext)
+		public BlobBuilder BuildBlob(MethodDefinitionHandle moveNext)
 		{
 			BlobBuilder blob = new BlobBuilder();
 			blob.WriteUInt32((uint)CatchHandlerOffset);

--- a/ICSharpCode.Decompiler/DebugInfo/SequencePoint.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/SequencePoint.cs
@@ -25,7 +25,7 @@ namespace ICSharpCode.Decompiler.DebugInfo
 	/// A sequence point read from a PDB file or produced by the decompiler.
 	/// </summary>
 	[DebuggerDisplay("SequencePoint IL_{Offset,h}-IL_{EndOffset,h}, {StartLine}:{StartColumn}-{EndLine}:{EndColumn}, IsHidden={IsHidden}")]
-	public struct SequencePoint
+	public class SequencePoint
 	{
 		/// <summary>
 		/// IL start offset.

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -819,6 +819,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			function.Body = mainTryCatch.TryBlock;
 			function.AsyncReturnType = underlyingReturnType;
 			function.MoveNextMethod = moveNextFunction.Method;
+			function.SequencePointCandidates = moveNextFunction.SequencePointCandidates;
 			function.CodeSize = moveNextFunction.CodeSize;
 			function.IsIterator = IsAsyncEnumerator;
 			moveNextFunction.Variables.Clear();

--- a/ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs
@@ -532,6 +532,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			ILFunction moveNextFunction = CreateILAst(moveNextMethod, context);
 
 			function.MoveNextMethod = moveNextFunction.Method;
+			function.SequencePointCandidates = moveNextFunction.SequencePointCandidates;
 			function.CodeSize = moveNextFunction.CodeSize;
 
 			// Copy-propagate temporaries holding a copy of 'this'.

--- a/ICSharpCode.Decompiler/IL/Instructions/ILFunction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/ILFunction.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Collections.Immutable;
 
 using ICSharpCode.Decompiler.IL.Transforms;
 using ICSharpCode.Decompiler.TypeSystem;
@@ -113,7 +114,7 @@ namespace ICSharpCode.Decompiler.IL
 		/// </summary>
 		internal TypeSystem.Implementation.LocalFunctionMethod ReducedMethod;
 
-		internal DebugInfo.AsyncDebugInfo AsyncDebugInfo;
+		public DebugInfo.AsyncDebugInfo AsyncDebugInfo;
 
 		int ctorCallStart = int.MinValue;
 
@@ -168,6 +169,13 @@ namespace ICSharpCode.Decompiler.IL
 		/// Might be null, if this function was not created from metadata.
 		/// </summary>
 		public readonly IReadOnlyList<IParameter> Parameters;
+
+		/// <summary>
+		/// List of candidate locations for sequence points. Includes any offset
+		/// where the stack is empty, nop instructions, and the instruction following
+		/// a call instruction
+		/// </summary>
+		public List<int> SequencePointCandidates { get; set; }
 
 		/// <summary>
 		/// Constructs a new ILFunction from the given metadata and with the given ILAst body.

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
 		"MSBuild.Sdk.Extras": "2.0.54"
 	},
 	"sdk": {
-		"version": "3.1.100"
+		"version": "3.2.000"
 	}
 }


### PR DESCRIPTION
Expand the range of sequence points out the closest empty ilstack 
or implicit sequence point without creating overlapping sequence points.
If such a location cannot be found do, nothing. Fill in the
gaps with hidden sequence points.

Also emit a sequence point for
the prolog to account for seqeunce point there emitted by the C#
compiler. Without this, the debugger can stop there on a step in
using the original pdb, then decompile resulting in a no-code at this
location failure.
