### PR TITLE
Upgrade ready to run binary

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.5-alpha" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.6-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />


### PR DESCRIPTION
This change reflects the latest change in the `ILCompiler.Reflection.ReadyToRun` package.

The latest change has public API changes, so I think it is a good idea to make sure things keep in sync.

There are some refactorings done to existing code, this is to make future work easier. In particular, with the  `readyToRunMethod` and `runtimeFunction` available, we can start to weave information into the disassembly.