### PR TITLE
Decorate the ready to run disassembly with DebugInfoBounds

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -56,8 +56,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Iced" Version="1.4.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.6-alpha" />
+    <PackageReference Include="Iced" Version="1.6.0" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.7-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -125,13 +125,24 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 			formatter.Options.DigitSeparator = "`";
 			formatter.Options.FirstOperandCharIndex = 10;
-			var tempOutput = new StringBuilderFormatterOutput();
+			var tempOutput = new StringOutput();
 			foreach (var instr in instructions) {
 				int byteBaseIndex = (int)(instr.IP - address);
+				foreach (var bound in runtimeFunction.DebugInfo.BoundsList) {
+					if (bound.NativeOffset == byteBaseIndex) {
+						if (bound.ILOffset == (uint)DebugInfoBoundsType.Prolog) {
+							WriteCommentLine(output, "Prolog");
+						} else if (bound.ILOffset == (uint)DebugInfoBoundsType.Epilog) {
+							WriteCommentLine(output, "Epilog");
+						} else {
+							WriteCommentLine(output, $"IL_{bound.ILOffset:x4}");
+						}
+					}
+				}
 				formatter.Format(instr, tempOutput);
 				output.Write(instr.IP.ToString("X16"));
 				output.Write(" ");
-				int instrLen = instr.ByteLength;
+				int instrLen = instr.Length;
 				for (int i = 0; i < instrLen; i++)
 					output.Write(codeBytes[byteBaseIndex + i].ToString("X2"));
 				int missingBytes = 10 - instrLen;


### PR DESCRIPTION
This is part of #1886

Here is an illustration of how the disassembly of the `Int64.Parse()` method looks before and after the decoration.

**Before**
```
; Int64 System.Int64.Parse(String)
000000000047E8E0 4883EC38             sub       rsp,38h
000000000047E8E4 33C0                 xor       eax,eax
000000000047E8E6 4889442428           mov       [rsp+28h],rax
000000000047E8EB 4885C9               test      rcx,rcx
000000000047E8EE 7431                 je        short 0000`0000`0047`E921h
000000000047E8F0 488D410C             lea       rax,[rcx+0Ch]
000000000047E8F4 8B5108               mov       edx,[rcx+8]
000000000047E8F7 488D4C2428           lea       rcx,[rsp+28h]
000000000047E8FC 488901               mov       [rcx],rax
000000000047E8FF 895108               mov       [rcx+8],edx
000000000047E902 FF15A0F8B8FF         call      qword [rel 0`E1A8h]
000000000047E908 4C8BC0               mov       r8,rax
000000000047E90B 488D4C2428           lea       rcx,[rsp+28h]
000000000047E910 BA07000000           mov       edx,7
000000000047E915 FF15AD51B9FF         call      qword [rel 1`3AC8h]
000000000047E91B 90                   nop
000000000047E91C 4883C438             add       rsp,38h
000000000047E920 C3                   ret
000000000047E921 B911000000           mov       ecx,11h
000000000047E926 FF158CF8B8FF         call      qword [rel 0`E1B8h]
000000000047E92C CC                   int3
```

**After**
```
; Int64 System.Int64.Parse(String)
; Prolog
000000000047E8E0 4883EC38             sub       rsp,38h
000000000047E8E4 33C0                 xor       eax,eax
000000000047E8E6 4889442428           mov       [rsp+28h],rax
; IL_0000
000000000047E8EB 4885C9               test      rcx,rcx
000000000047E8EE 7431                 je        short 0000`0000`0047`E921h
; IL_000a
000000000047E8F0 488D410C             lea       rax,[rcx+0Ch]
000000000047E8F4 8B5108               mov       edx,[rcx+8]
000000000047E8F7 488D4C2428           lea       rcx,[rsp+28h]
000000000047E8FC 488901               mov       [rcx],rax
000000000047E8FF 895108               mov       [rcx+8],edx
000000000047E902 FF15A0F8B8FF         call      qword [rel 0`E1A8h]
000000000047E908 4C8BC0               mov       r8,rax
000000000047E90B 488D4C2428           lea       rcx,[rsp+28h]
000000000047E910 BA07000000           mov       edx,7
000000000047E915 FF15AD51B9FF         call      qword [rel 1`3AC8h]
; Epilog
000000000047E91B 90                   nop
000000000047E91C 4883C438             add       rsp,38h
000000000047E920 C3                   ret
; IL_0003
000000000047E921 B911000000           mov       ecx,11h
000000000047E926 FF158CF8B8FF         call      qword [rel 0`E1B8h]
000000000047E92C CC                   int3
```

Here is the IL for reference:
```
.method public hidebysig static 
	int64 Parse (
		string s
	) cil managed 
{
	.custom instance void System.Runtime.CompilerServices.NullableContextAttribute::.ctor(uint8) = (
		01 00 01 00 00
	)
	// Method begins at RVA 0xd9a8b
	// Code size 28 (0x1c)
	.maxstack 8

	IL_0000: ldarg.0
	IL_0001: brtrue.s IL_000a

	IL_0003: ldc.i4.s 17
	IL_0005: call void System.ThrowHelper::ThrowArgumentNullException(valuetype System.ExceptionArgument)

	IL_000a: ldarg.0
	IL_000b: call valuetype System.ReadOnlySpan`1<char> System.String::op_Implicit(string)
	IL_0010: ldc.i4.7
	IL_0011: call class System.Globalization.NumberFormatInfo System.Globalization.NumberFormatInfo::get_CurrentInfo()
	IL_0016: call int64 System.Number::ParseInt64(valuetype System.ReadOnlySpan`1<char>, valuetype System.Globalization.NumberStyles, class System.Globalization.NumberFormatInfo)
	IL_001b: ret
} // end of method Int64::Parse
```