### PR TITLE
Using import cell name to describe callees

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.6.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.7-alpha" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun" Version="1.0.8-alpha" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -84,7 +84,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				if (cacheEntry.methodMap.TryGetValue(method.MetadataToken, out var methods)) {
 					foreach (var readyToRunMethod in methods) {
 						foreach (RuntimeFunction runtimeFunction in readyToRunMethod.RuntimeFunctions) {
-							Disassemble(output, reader, readyToRunMethod, runtimeFunction, bitness, (ulong)runtimeFunction.StartAddress);
+							Disassemble(method, output, reader, readyToRunMethod, runtimeFunction, bitness, (ulong)runtimeFunction.StartAddress);
 						}
 					}
 				}
@@ -96,7 +96,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			output.WriteLine("; " + comment);
 		}
 
-		private void Disassemble(ITextOutput output, ReadyToRunReader reader, ReadyToRunMethod readyToRunMethod, RuntimeFunction runtimeFunction, int bitness, ulong address)
+		private void Disassemble(IMethod method, ITextOutput output, ReadyToRunReader reader, ReadyToRunMethod readyToRunMethod, RuntimeFunction runtimeFunction, int bitness, ulong address)
 		{
 			WriteCommentLine(output, readyToRunMethod.SignatureString);
 			byte[] codeBytes = new byte[runtimeFunction.Size];
@@ -151,7 +151,11 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				output.Write(" ");
 				output.Write(tempOutput.ToStringAndReset());
 				if (instr.IsCallNearIndirect && reader.ImportCellNames.ContainsKey((int)instr.IPRelativeMemoryAddress)) {
-					WriteCommentLine(output, reader.ImportCellNames[(int)instr.IPRelativeMemoryAddress]);
+					output.Write(" ;");
+					// TODO: Get the right PEFile
+					// TODO: Get the right method def token
+					output.WriteReference(method.ParentModule.PEFile, System.Reflection.Metadata.Ecma335.MetadataTokens.Handle(0x06001e24), reader.ImportCellNames[(int)instr.IPRelativeMemoryAddress]);
+					output.WriteLine();
 				} else {
 					output.WriteLine();
 				}

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -149,7 +149,12 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				for (int i = 0; i < missingBytes; i++)
 					output.Write("  ");
 				output.Write(" ");
-				output.WriteLine(tempOutput.ToStringAndReset());
+				output.Write(tempOutput.ToStringAndReset());
+				if (instr.IsCallNearIndirect && reader.ImportCellNames.ContainsKey((int)instr.IPRelativeMemoryAddress)) {
+					WriteCommentLine(output, reader.ImportCellNames[(int)instr.IPRelativeMemoryAddress]);
+				} else {
+					output.WriteLine();
+				}
 			}
 			output.WriteLine();
 		}

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -898,9 +898,10 @@ namespace ICSharpCode.ILSpy
 							}
 						}
 					}
-					if (MetadataTokenHelpers.TryAsEntityHandle(MetadataTokens.GetToken(unresolvedEntity.Handle)) != null) {
+					var possibleToken = MetadataTokenHelpers.TryAsEntityHandle(MetadataTokens.GetToken(unresolvedEntity.Handle));
+					if (possibleToken != null) {
 						var typeSystem = new DecompilerTypeSystem(file, file.GetAssemblyResolver(), TypeSystemOptions.Default | TypeSystemOptions.Uncached);
-						reference = typeSystem.MainModule.ResolveEntity((EntityHandle)unresolvedEntity.Handle);
+						reference = typeSystem.MainModule.ResolveEntity(possibleToken.Value);
 						goto default;
 					}
 					break;


### PR DESCRIPTION
Here is my attempt to describe the callees - see the samples to see how it looks like:

Some of the added descriptions can be clicked to navigate to the associated definitions!

**Here is how it looks like before the change:**
```
; Int64 System.Int64.Parse(String)
; Prolog
000000000047E8E0 4883EC38             sub       rsp,38h
000000000047E8E4 33C0                 xor       eax,eax
000000000047E8E6 4889442428           mov       [rsp+28h],rax
; IL_0000
000000000047E8EB 4885C9               test      rcx,rcx
000000000047E8EE 7431                 je        short 0000`0000`0047`E921h
; IL_000a
000000000047E8F0 488D410C             lea       rax,[rcx+0Ch]
000000000047E8F4 8B5108               mov       edx,[rcx+8]
000000000047E8F7 488D4C2428           lea       rcx,[rsp+28h]
000000000047E8FC 488901               mov       [rcx],rax
000000000047E8FF 895108               mov       [rcx+8],edx
000000000047E902 FF15A0F8B8FF         call      qword [rel 0`E1A8h]
000000000047E908 4C8BC0               mov       r8,rax
000000000047E90B 488D4C2428           lea       rcx,[rsp+28h]
000000000047E910 BA07000000           mov       edx,7
000000000047E915 FF15AD51B9FF         call      qword [rel 1`3AC8h]
; Epilog
000000000047E91B 90                   nop
000000000047E91C 4883C438             add       rsp,38h
000000000047E920 C3                   ret
; IL_0003
000000000047E921 B911000000           mov       ecx,11h
000000000047E926 FF158CF8B8FF         call      qword [rel 0`E1B8h]
000000000047E92C CC                   int3
```

**and here is how it looks like after the change:**

```
; Int64 System.Int64.Parse(String)
; Prolog
000000000047E8E0 4883EC38             sub       rsp,38h
000000000047E8E4 33C0                 xor       eax,eax
000000000047E8E6 4889442428           mov       [rsp+28h],rax
; IL_0000
000000000047E8EB 4885C9               test      rcx,rcx
000000000047E8EE 7431                 je        short 0000`0000`0047`E921h
; IL_000a
000000000047E8F0 488D410C             lea       rax,[rcx+0Ch]
000000000047E8F4 8B5108               mov       edx,[rcx+8]
000000000047E8F7 488D4C2428           lea       rcx,[rsp+28h]
000000000047E8FC 488901               mov       [rcx],rax
000000000047E8FF 895108               mov       [rcx+8],edx
000000000047E902 FF15A0F8B8FF         call      qword [rel 0`E1A8h]; System.Globalization.NumberFormatInfo System.Globalization.NumberFormatInfo.get_CurrentInfo() (METHOD_ENTRY_DEF_TOKEN)
000000000047E908 4C8BC0               mov       r8,rax
000000000047E90B 488D4C2428           lea       rcx,[rsp+28h]
000000000047E910 BA07000000           mov       edx,7
000000000047E915 FF15AD51B9FF         call      qword [rel 1`3AC8h]; Int64 System.Number.ParseInt64(System.ReadOnlySpan`1<Char>, System.Globalization.NumberStyles, System.Globalization.NumberFormatInfo) (METHOD_ENTRY_DEF_TOKEN)
; Epilog
000000000047E91B 90                   nop
000000000047E91C 4883C438             add       rsp,38h
000000000047E920 C3                   ret
; IL_0003
000000000047E921 B911000000           mov       ecx,11h
000000000047E926 FF158CF8B8FF         call      qword [rel 0`E1B8h]; Void System.ThrowHelper.ThrowArgumentNullException(System.ExceptionArgument) (METHOD_ENTRY_DEF_TOKEN)
000000000047E92C CC                   int3
```