### PR TITLE
Fix #2013: Add option to extract self-contained executables (PublishSingleFile).

### DIFF
--- a/ILSpy.AddIn/ILSpy.AddIn.csproj
+++ b/ILSpy.AddIn/ILSpy.AddIn.csproj
@@ -117,12 +117,14 @@
     <AdditionalDependencies Include="$(ILSpyBuildPath)Mono.Cecil.Pdb.dll" />
     <AdditionalDependencies Include="$(ILSpyBuildPath)ILSpy.BamlDecompiler.Plugin.dll" />
     <AdditionalDependencies Include="$(ILSpyBuildPath)Microsoft.DiaSymReader*.dll" />
-  	<AdditionalDependencies Include="$(ILSpyBuildPath)OSVersionHelper.dll" />
+    <AdditionalDependencies Include="$(ILSpyBuildPath)OSVersionHelper.dll" />
     <AdditionalDependencies Include="$(ILSpyBuildPath)Xceed.Wpf.AvalonDock.dll" />
-    <AdditionalDependencies Include="$(ILSpyBuildPath)DataGridExtensions.dll" />  
-    <AdditionalDependencies Include="$(ILSpyBuildPath)Iced.dll" />  
-    <AdditionalDependencies Include="$(ILSpyBuildPath)ILCompiler.Reflection.ReadyToRun.dll" />  
-    <AdditionalDependencies Include="$(ILSpyBuildPath)ILSpy.ReadyToRun.Plugin.dll" />  
+    <AdditionalDependencies Include="$(ILSpyBuildPath)DataGridExtensions.dll" />
+    <AdditionalDependencies Include="$(ILSpyBuildPath)Iced.dll" />
+    <AdditionalDependencies Include="$(ILSpyBuildPath)ILCompiler.Reflection.ReadyToRun.dll" />
+    <AdditionalDependencies Include="$(ILSpyBuildPath)ILSpy.ReadyToRun.Plugin.dll" />
+    <AdditionalDependencies Include="$(ILSpyBuildPath)Microsoft.NET.HostModel.dll" />
+    <AdditionalDependencies Include="$(ILSpyBuildPath)Ookii.Dialogs.Wpf.dll" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -56,6 +56,8 @@
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
     <PackageReference Include="OSVersionHelper" Version="1.0.11" />
     <PackageReference Include="DataGridExtensions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.HostModel" Version="3.1.4" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1606,6 +1606,21 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are trying to open a single-file executable (app bundle). In order to work with this type of program, ILSpy will
+        ///
+        ///(i) show you a dialog to select a folder to extract the bundle to
+        ///(ii) extract the assemblies (might take a few seconds)
+        ///(iii) show you a dialog to select one or more of those extracted assemblies to decompile
+        ///
+        ///Do you want to proceed?.
+        /// </summary>
+        public static string OpenSelfContainedExecutableMessage {
+            get {
+                return ResourceManager.GetString("OpenSelfContainedExecutableMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Options.
         /// </summary>
         public static string Options {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -867,4 +867,13 @@ Do you want to continue?</value>
   <data name="CultureLabel" xml:space="preserve">
     <value>Culture</value>
   </data>
+  <data name="OpenSelfContainedExecutableMessage" xml:space="preserve">
+    <value>You are trying to open a single-file executable (app bundle). In order to work with this type of program, ILSpy will
+
+(i) show you a dialog to select a folder to extract the bundle to
+(ii) extract the assemblies (might take a few seconds)
+(iii) show you a dialog to select one or more of those extracted assemblies to decompile
+
+Do you want to proceed?</value>
+  </data>
 </root>


### PR DESCRIPTION
This pull request adds the capability to extract self-contained executables to ILSpy.

Currently the user is asked to pick a directory where the files are extracted to. Then these files can be loaded by ILSpy normally.

Alternative suggestion: We could create a new assembly list out of all extracted modules.