### PR TITLE
Update links to Microsoft Docs.

### DIFF
--- a/ICSharpCode.Decompiler/Disassembler/OpCodeInfo.cs
+++ b/ICSharpCode.Decompiler/Disassembler/OpCodeInfo.cs
@@ -59,7 +59,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			return unchecked(982451629 * Code.GetHashCode() + 982451653 * Name.GetHashCode());
 		}
 
-		public string Link => "http://msdn.microsoft.com/library/system.reflection.emit.opcodes." + EncodedName.ToLowerInvariant() + ".aspx";
+		public string Link => "https://docs.microsoft.com/dotnet/api/system.reflection.emit.opcodes." + EncodedName.ToLowerInvariant();
 		public string EncodedName {
 			get {
 				if (encodedName != null)

--- a/ILSpy/Commands/SearchMsdnContextMenuEntry.cs
+++ b/ILSpy/Commands/SearchMsdnContextMenuEntry.cs
@@ -26,7 +26,7 @@ namespace ICSharpCode.ILSpy
 	[ExportContextMenuEntry(Header = nameof(Resources.SearchMSDN), Icon = "images/SearchMsdn", Order = 9999)]
 	internal sealed class SearchMsdnContextMenuEntry : IContextMenuEntry
 	{
-		private static string msdnAddress = "http://msdn.microsoft.com/{1}/library/{0}";
+		private static string msdnAddress = "https://docs.microsoft.com/dotnet/api/{0}";
 
 		public bool IsVisible(TextViewContext context)
 		{
@@ -100,7 +100,7 @@ namespace ICSharpCode.ILSpy
 
 			var namespaceNode = node as NamespaceTreeNode;
 			if (namespaceNode != null)
-				address = string.Format(msdnAddress, namespaceNode.Name,  Thread.CurrentThread.CurrentUICulture.Name);
+				address = string.Format(msdnAddress, namespaceNode.Name);
 
 			if (node is IMemberTreeNode memberNode) {
 				var member = memberNode.Member;
@@ -111,7 +111,7 @@ namespace ICSharpCode.ILSpy
 				else
 					memberName = string.Format("{0}.{1}", member.DeclaringType.FullName, member.Name);
 
-				address = string.Format(msdnAddress, memberName, Thread.CurrentThread.CurrentUICulture.Name);
+				address = string.Format(msdnAddress, memberName);
 			}
 
 			address = address.ToLower();

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1842,7 +1842,7 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search MSDN....
+        ///   Looks up a localized string similar to Search Microsoft Docs....
         /// </summary>
         public static string SearchMSDN {
             get {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -721,7 +721,7 @@
     <value>Apply Windows Runtime projections on loaded assemblies</value>
   </data>
   <data name="SearchMSDN" xml:space="preserve">
-    <value>Search MSDN...</value>
+    <value>Search Microsoft Docs...</value>
   </data>
   <data name="CannotAnalyzeMissingRef" xml:space="preserve">
     <value>Entity could not be resolved. Cannot analyze entities from missing assembly references. Add the missing reference and try again.</value>

--- a/ILSpy/Properties/Resources.zh-Hans.resx
+++ b/ILSpy/Properties/Resources.zh-Hans.resx
@@ -727,7 +727,7 @@
     <value>在已加载的程序集上应用 Windows 运行时投影</value>
   </data>
   <data name="SearchMSDN" xml:space="preserve">
-    <value>搜索MSDN...</value>
+    <value>搜索Microsoft Docs...</value>
   </data>
   <data name="About" xml:space="preserve">
     <value>关于</value>


### PR DESCRIPTION
Currently the "Search MSDN" button results in a "page not found" message on the MSDN website. This PR:

1. Updates the links to point to the new location of the documentation on docs.microsoft.com.
2. Relies on the browse redirecting to the correct language page. Currently docs.microsoft.com does not elegantly handle language codes it does not recognize.
3. Change menu item text to reflect the new website's name.

I did not change any of the internal class name references to MSDN yet.