### PR TITLE
Added UnwindInfo as an optional printout

### DIFF
--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -103,114 +103,33 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			output.WriteLine("; " + comment);
 		}
 
-		private void WriteDebugInfo(ReadyToRunMethod readyToRunMethod, ITextOutput output)
-		{
-			IReadOnlyList<RuntimeFunction> runTimeList = readyToRunMethod.RuntimeFunctions;
-			foreach (RuntimeFunction runtimeFunction in runTimeList) {
-				DebugInfo debugInfo = runtimeFunction.DebugInfo;
-				if (debugInfo.BoundsList.Count > 0)
-					output.WriteLine("Debug Info");
 
-				output.WriteLine("    Bounds:");
-				for (int i = 0; i < debugInfo.BoundsList.Count; ++i) {
-					output.Write("    ");
-					output.Write($"Native Offset: 0x{debugInfo.BoundsList[i].NativeOffset:X}, ");
-					if (debugInfo.BoundsList[i].ILOffset == (uint)DebugInfoBoundsType.NoMapping) {
-						output.Write("NoMapping");
-					} else if (debugInfo.BoundsList[i].ILOffset == (uint)DebugInfoBoundsType.Prolog) {
-						output.Write("Prolog");
-					} else if (debugInfo.BoundsList[i].ILOffset == (uint)DebugInfoBoundsType.Epilog) {
-						output.Write("Epilog");
-					} else {
-						output.WriteLine($"IL Offset: 0x{debugInfo.BoundsList[i].ILOffset:x4}");
-					}
-					output.Write($", Srouce Types: {debugInfo.BoundsList[i].SourceTypes}");
-					output.WriteLine();
-				}
-				output.WriteLine("");
 
-				if (debugInfo.VariablesList.Count > 0)
-					output.WriteLine("    Variable Locations:");
-
-				for (int i = 0; i < debugInfo.VariablesList.Count; ++i) {
-					var varLoc = debugInfo.VariablesList[i];
-					output.WriteLine($"    Variable Number: {varLoc.VariableNumber}");
-					output.WriteLine($"    Start Offset: 0x{varLoc.StartOffset:X}");
-					output.WriteLine($"    End Offset: 0x{varLoc.EndOffset:X}");
-					output.WriteLine($"    Loc Type: {varLoc.VariableLocation.VarLocType}");
-
-					switch (varLoc.VariableLocation.VarLocType) {
-						case VarLocType.VLT_REG:
-						case VarLocType.VLT_REG_FP:
-						case VarLocType.VLT_REG_BYREF:
-							output.WriteLine($"    Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							break;
-						case VarLocType.VLT_STK:
-						case VarLocType.VLT_STK_BYREF:
-							output.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							output.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data2}");
-							break;
-						case VarLocType.VLT_REG_REG:
-							output.WriteLine($"    Register 1: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							output.WriteLine($"    Register 2: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data2)}");
-							break;
-						case VarLocType.VLT_REG_STK:
-							output.WriteLine($"    Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							output.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data2)}");
-							output.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data3}");
-							break;
-						case VarLocType.VLT_STK_REG:
-							output.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data1}");
-							output.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data2)}");
-							output.WriteLine($"    Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data3)}");
-							break;
-						case VarLocType.VLT_STK2:
-							output.WriteLine($"    Base Register: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							output.WriteLine($"    Stack Offset: {varLoc.VariableLocation.Data2}");
-							break;
-						case VarLocType.VLT_FPSTK:
-							output.WriteLine($"    Offset: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							break;
-						case VarLocType.VLT_FIXED_VA:
-							output.WriteLine($"    Offset: {DebugInfo.GetPlatformSpecificRegister(debugInfo.Machine, varLoc.VariableLocation.Data1)}");
-							break;
-						default:
-							throw new BadImageFormatException("Unexpected var loc type");
-					}
-
-					output.WriteLine("");
-				}
-			}
-		}
-
-		private Dictionary<ulong, UnwindCode> WriteUnwindInfo(ReadyToRunMethod readyToRunMethod, ITextOutput output)
+		private Dictionary<ulong, UnwindCode> WriteUnwindInfo(RuntimeFunction runtimeFunction, ITextOutput output)
 
 		{
-			IReadOnlyList<RuntimeFunction> runTimeList = readyToRunMethod.RuntimeFunctions;
 			Dictionary<ulong, UnwindCode> unwindCodes = new Dictionary<ulong, UnwindCode>();
-			foreach (RuntimeFunction i in runTimeList) {
-				if (i.UnwindInfo is UnwindInfo amd64UnwindInfo) {
-					string parsedFlags = "";
-					if ((amd64UnwindInfo.Flags & (int)UnwindFlags.UNW_FLAG_EHANDLER) != 0) {
-						parsedFlags += " EHANDLER";
-					}
-					if ((amd64UnwindInfo.Flags & (int)UnwindFlags.UNW_FLAG_UHANDLER) != 0) {
-						parsedFlags += " UHANDLER";
-					}
-					if ((amd64UnwindInfo.Flags & (int)UnwindFlags.UNW_FLAG_CHAININFO) != 0) {
-						parsedFlags += " CHAININFO";
-					}
-					if (parsedFlags.Length == 0) {
-						parsedFlags = " NHANDLER";
-					}
-					WriteCommentLine(output, $"UnwindInfo:");
-					WriteCommentLine(output, $"Version:            {amd64UnwindInfo.Version}");
-					WriteCommentLine(output, $"Flags:              0x{amd64UnwindInfo.Flags:X2}{parsedFlags}");
-					WriteCommentLine(output, $"FrameRegister:      {((amd64UnwindInfo.FrameRegister == 0) ? "none" : amd64UnwindInfo.FrameRegister.ToString())}");
-					for (int unwindCodeIndex = 0; unwindCodeIndex < amd64UnwindInfo.CountOfUnwindCodes; unwindCodeIndex++) {
-						unwindCodes.Add(amd64UnwindInfo.UnwindCodeArray[unwindCodeIndex].CodeOffset, amd64UnwindInfo.UnwindCodeArray[unwindCodeIndex]);
+			if (runtimeFunction.UnwindInfo is UnwindInfo amd64UnwindInfo) {
+				string parsedFlags = "";
+				if ((amd64UnwindInfo.Flags & (int)UnwindFlags.UNW_FLAG_EHANDLER) != 0) {
+					parsedFlags += " EHANDLER";
+				}
+				if ((amd64UnwindInfo.Flags & (int)UnwindFlags.UNW_FLAG_UHANDLER) != 0) {
+					parsedFlags += " UHANDLER";
+				}
+				if ((amd64UnwindInfo.Flags & (int)UnwindFlags.UNW_FLAG_CHAININFO) != 0) {
+					parsedFlags += " CHAININFO";
+				}
+				if (parsedFlags.Length == 0) {
+					parsedFlags = " NHANDLER";
+				}
+				WriteCommentLine(output, $"UnwindInfo:");
+				WriteCommentLine(output, $"Version:            {amd64UnwindInfo.Version}");
+				WriteCommentLine(output, $"Flags:              0x{amd64UnwindInfo.Flags:X2}{parsedFlags}");
+				WriteCommentLine(output, $"FrameRegister:      {((amd64UnwindInfo.FrameRegister == 0) ? "none" : amd64UnwindInfo.FrameRegister.ToString())}");
+				for (int unwindCodeIndex = 0; unwindCodeIndex < amd64UnwindInfo.CountOfUnwindCodes; unwindCodeIndex++) {
+					unwindCodes.Add((ulong)(amd64UnwindInfo.UnwindCodeArray[unwindCodeIndex].CodeOffset), amd64UnwindInfo.UnwindCodeArray[unwindCodeIndex]);
 
-					}
 				}
 			}
 			return unwindCodes;
@@ -221,12 +140,10 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			WriteCommentLine(output, readyToRunMethod.SignatureString);
 			Dictionary<ulong, UnwindCode> unwindInfo = null;
 			if (ReadyToRunOptions.GetIsShowUnwindInfo(null) && bitness == 64) {
-				unwindInfo = WriteUnwindInfo(readyToRunMethod, output);
+				unwindInfo = WriteUnwindInfo(runtimeFunction, output);
 			}
 
-			if (ReadyToRunOptions.GetIsShowDebugInfo(null)) {
-				WriteDebugInfo(readyToRunMethod, output);
-			}
+
 			byte[] codeBytes = new byte[runtimeFunction.Size];
 			for (int i = 0; i < runtimeFunction.Size; i++) {
 				codeBytes[i] = reader.Image[reader.GetOffset(runtimeFunction.StartAddress) + i];
@@ -289,7 +206,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 
 		private static void DecorateUnwindInfo(ITextOutput output, Dictionary<ulong, UnwindCode> unwindInfo, ulong baseInstrIP, Instruction instr)
 		{
-			ulong nextInstructionOffset = instr.IP + (ulong)instr.Length - baseInstrIP;
+			ulong nextInstructionOffset = instr.NextIP;
 			if (unwindInfo != null && unwindInfo.ContainsKey(nextInstructionOffset)) {
 				UnwindCode unwindCode = unwindInfo[nextInstructionOffset];
 				output.Write($" ; {unwindCode.UnwindOp}({unwindCode.OpInfoStr})");

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -206,7 +206,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 
 		private static void DecorateUnwindInfo(ITextOutput output, Dictionary<ulong, UnwindCode> unwindInfo, ulong baseInstrIP, Instruction instr)
 		{
-			ulong nextInstructionOffset = instr.NextIP;
+			ulong nextInstructionOffset = instr.NextIP - baseInstrIP;
 			if (unwindInfo != null && unwindInfo.ContainsKey(nextInstructionOffset)) {
 				UnwindCode unwindCode = unwindInfo[nextInstructionOffset];
 				output.Write($" ; {unwindCode.UnwindOp}({unwindCode.OpInfoStr})");

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
@@ -1,23 +1,21 @@
 ﻿<UserControl x:Class="ICSharpCode.ILSpy.ReadyToRun.ReadyToRunOptionPage"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-	<StackPanel>
-		<Grid ShowGridLines="False">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition></ColumnDefinition>
-				<ColumnDefinition></ColumnDefinition>
-			</Grid.ColumnDefinitions>
-			<Grid.RowDefinitions>
-				<RowDefinition></RowDefinition>
-				<RowDefinition></RowDefinition>
-				<RowDefinition></RowDefinition>
-			</Grid.RowDefinitions>
-			<TextBlock Grid.Row="0" Grid.Column="0">Disassembly Format</TextBlock>
-			<ComboBox  Grid.Row="0" Grid.Column="1" ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
-			<TextBlock Grid.Row="1" Grid.Column="0">Show Unwind Info</TextBlock>
-			<CheckBox  Grid.Row="1" Grid.Column="1" IsChecked="{Binding IsShowUnwindInfo}"></CheckBox>
-			<TextBlock Grid.Row="2" Grid.Column="0">Show Debug Info</TextBlock>
-			<CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding DebugIsChecked}"></CheckBox>
-			</Grid>
-	</StackPanel>
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition />
+			<ColumnDefinition />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock Margin="3">Disassembly Format</TextBlock>
+		<ComboBox Grid.Column="1" Margin="3" ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}" />
+		<TextBlock Grid.Row="1" Margin="3">Show Unwind Info</TextBlock>
+		<CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding IsShowUnwindInfo}" />
+		<TextBlock Grid.Row="2" Margin="3">Show Debug Info</TextBlock>
+		<CheckBox Grid.Row="2" Grid.Column="1" Margin="3" IsChecked="{Binding DebugIsChecked}" />
+	</Grid>
 </UserControl>

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
@@ -10,11 +10,14 @@
 			<Grid.RowDefinitions>
 				<RowDefinition></RowDefinition>
 				<RowDefinition></RowDefinition>
+				<RowDefinition></RowDefinition>
 			</Grid.RowDefinitions>
 			<TextBlock Grid.Row="0" Grid.Column="0">Disassembly Format</TextBlock>
 			<ComboBox  Grid.Row="0" Grid.Column="1" ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
 			<TextBlock Grid.Row="1" Grid.Column="0">Show Unwind Info</TextBlock>
 			<CheckBox  Grid.Row="1" Grid.Column="1" IsChecked="{Binding IsShowUnwindInfo}"></CheckBox>
-		</Grid>
+			<TextBlock Grid.Row="2" Grid.Column="0">Show Debug Info</TextBlock>
+			<CheckBox Grid.Row="2" Grid.Column="1" IsChecked="{Binding DebugIsChecked}"></CheckBox>
+			</Grid>
 	</StackPanel>
 </UserControl>

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
@@ -3,8 +3,15 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<StackPanel>
 		<StackPanel Orientation="Horizontal">
-			<TextBlock>Disassembly Format</TextBlock>
-			<ComboBox ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
+			<StackPanel Orientation="Vertical">
+				<TextBlock>Disassembly Format</TextBlock>
+				<TextBlock>Show Unwind Info</TextBlock>
+			</StackPanel>
+			<StackPanel Orientation="Vertical">
+				<ComboBox ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
+				<CheckBox IsChecked="{Binding IsChecked}"></CheckBox>
+
+			</StackPanel>
 		</StackPanel>
 	</StackPanel>
 </UserControl>

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
@@ -35,6 +35,8 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		{
 			Options s = new Options();
 			s.DisassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(settings);
+			s.IsChecked = ReadyToRunOptions.GetIsChecked(settings);
+
 			this.DataContext = s;
 		}
 
@@ -46,7 +48,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		public void Save(XElement root)
 		{
 			Options s = (Options)this.DataContext;
-			ReadyToRunOptions.SetDisassemblyFormat(root, s.DisassemblyFormat);
+			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsChecked);
 		}
 	}
 
@@ -55,6 +57,17 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		public string[] DisassemblyFormats {
 			get {
 				return ReadyToRunOptions.disassemblyFormats;
+			}
+		}
+
+		private bool isChecked;
+		public bool IsChecked {
+			get {
+				return isChecked;
+			}
+			set {
+				isChecked = value;
+				OnPropertyChanged(nameof(IsChecked));
 			}
 		}
 

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
@@ -36,7 +36,6 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			Options s = new Options();
 			s.DisassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(settings);
 			s.IsShowUnwindInfo = ReadyToRunOptions.GetIsShowUnwindInfo(settings);
-			s.IsShowDebugInfo = ReadyToRunOptions.GetIsShowDebugInfo(settings);
 
 			this.DataContext = s;
 		}
@@ -49,7 +48,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		public void Save(XElement root)
 		{
 			Options s = (Options)this.DataContext;
-			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo, s.IsShowDebugInfo);
+			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo);
 		}
 	}
 
@@ -72,17 +71,6 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-
-		private bool isShowDebugInfo;
-		public bool IsShowDebugInfo {
-			get {
-				return isShowDebugInfo;
-			}
-			set {
-				isShowDebugInfo = value;
-				OnPropertyChanged(nameof(isShowDebugInfo));
-			}
-		}
 
 		private string disassemblyFormat;
 

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
@@ -36,6 +36,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			Options s = new Options();
 			s.DisassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(settings);
 			s.IsShowUnwindInfo = ReadyToRunOptions.GetIsShowUnwindInfo(settings);
+			s.IsShowDebugInfo = ReadyToRunOptions.GetIsShowDebugInfo(settings);
 
 			this.DataContext = s;
 		}
@@ -48,7 +49,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		public void Save(XElement root)
 		{
 			Options s = (Options)this.DataContext;
-			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo);
+			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo, s.IsShowDebugInfo);
 		}
 	}
 
@@ -68,6 +69,18 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			set {
 				isShowUnwindInfo = value;
 				OnPropertyChanged(nameof(IsShowUnwindInfo));
+			}
+		}
+
+
+		private bool isShowDebugInfo;
+		public bool IsShowDebugInfo {
+			get {
+				return isShowDebugInfo;
+			}
+			set {
+				isShowDebugInfo = value;
+				OnPropertyChanged(nameof(isShowDebugInfo));
 			}
 		}
 

--- a/ILSpy.ReadyToRun/ReadyToRunOptions.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptions.cs
@@ -42,10 +42,25 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static void SetDisassemblyFormat(XElement root, string disassemblyFormat)
+		public static bool GetIsChecked(ILSpySettings settings)
+		{
+			if (settings == null) {
+				settings = ILSpySettings.Load();
+			}
+			XElement e = settings[ns + "ReadyToRunOptions"];
+			XAttribute a = e.Attribute("IsChecked");
+			if (a == null) {
+				return false;
+			} else {
+				return (bool)a;
+			}
+		}
+
+		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool isChecked)
 		{
 			XElement section = new XElement(ns + "ReadyToRunOptions");
 			section.SetAttributeValue("DisassemblyFormat", disassemblyFormat);
+			section.SetAttributeValue("IsChecked", isChecked);
 
 			XElement existingElement = root.Element(ns + "ReadyToRunOptions");
 			if (existingElement != null) {
@@ -54,5 +69,6 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				root.Add(section);
 			}
 		}
+
 	}
 }

--- a/ILSpy.ReadyToRun/ReadyToRunOptions.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptions.cs
@@ -58,12 +58,11 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool IsShowUnwindInfo, bool IsShowDebugInfo)
+		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool IsShowUnwindInfo)
 		{
 			XElement section = new XElement(ns + "ReadyToRunOptions");
 			section.SetAttributeValue("DisassemblyFormat", disassemblyFormat);
 			section.SetAttributeValue("IsShowUnwindInfo", IsShowUnwindInfo);
-			section.SetAttributeValue("IsShowDebugInfo", IsShowDebugInfo);
 			XElement existingElement = root.Element(ns + "ReadyToRunOptions");
 			if (existingElement != null) {
 				existingElement.ReplaceWith(section);
@@ -72,19 +71,6 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static bool GetIsShowDebugInfo(ILSpySettings settings)
-		{
-			if (settings == null) {
-				settings = ILSpySettings.Load();
-			}
-			XElement e = settings[ns + "ReadyToRunOptions"];
-			XAttribute a = e.Attribute("IsShowDebugInfo");
-			if (a == null) {
-				return false;
-			} else {
-				return (bool)a;
-			}
-		}
 
 	}
 

--- a/ILSpy.ReadyToRun/ReadyToRunOptions.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptions.cs
@@ -43,12 +43,14 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		}
 
 		public static bool GetIsShowUnwindInfo(ILSpySettings settings)
+
 		{
 			if (settings == null) {
 				settings = ILSpySettings.Load();
 			}
 			XElement e = settings[ns + "ReadyToRunOptions"];
 			XAttribute a = e.Attribute("IsShowUnwindInfo");
+
 			if (a == null) {
 				return false;
 			} else {
@@ -56,12 +58,12 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool IsShowUnwindInfo)
+		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool IsShowUnwindInfo, bool IsShowDebugInfo)
 		{
 			XElement section = new XElement(ns + "ReadyToRunOptions");
 			section.SetAttributeValue("DisassemblyFormat", disassemblyFormat);
 			section.SetAttributeValue("IsShowUnwindInfo", IsShowUnwindInfo);
-
+			section.SetAttributeValue("IsShowDebugInfo", IsShowDebugInfo);
 			XElement existingElement = root.Element(ns + "ReadyToRunOptions");
 			if (existingElement != null) {
 				existingElement.ReplaceWith(section);
@@ -70,5 +72,20 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
+		public static bool GetIsShowDebugInfo(ILSpySettings settings)
+		{
+			if (settings == null) {
+				settings = ILSpySettings.Load();
+			}
+			XElement e = settings[ns + "ReadyToRunOptions"];
+			XAttribute a = e.Attribute("IsShowDebugInfo");
+			if (a == null) {
+				return false;
+			} else {
+				return (bool)a;
+			}
+		}
+
 	}
+
 }


### PR DESCRIPTION
Here I tried to add unwindinfo to the print out, as well as adding an option to turn it on or off.
Before the change it would look like:
```
; Void System.IO.BinaryReader.Dispose()
; Prolog
000000000083FC50 55                   push      rbp
000000000083FC51 4883EC20             sub       rsp,20h
000000000083FC55 488D6C2420           lea       rbp,[rsp+20h]
000000000083FC5A 48894D10             mov       [rbp+10h],rcx
; IL_0000
000000000083FC5E 90                   nop
; IL_0001
000000000083FC5F 488B4D10             mov       rcx,[rbp+10h]
000000000083FC63 BA01000000           mov       edx,1
000000000083FC68 488B4510             mov       rax,[rbp+10h]
000000000083FC6C 488B00               mov       rax,[rax]
000000000083FC6F 488B4048             mov       rax,[rax+48h]
; IL_0003
000000000083FC73 FF5028               call      qword [rax+28h]
; IL_0008
000000000083FC76 90                   nop
; IL_0009
000000000083FC77 90                   nop
; Epilog
000000000083FC78 488D6500             lea       rsp,[rbp]
000000000083FC7C 5D                   pop       rbp
000000000083FC7D C3                   ret
```
After turning the option on under View->Options -> ReadyToRun it would look like:
```
; Void System.IO.BinaryReader.Dispose()
; UnwindInfo:
; Version:            1
; Flags:              0x03 EHANDLER UHANDLER
; FrameRegister:      none
; System.Collections.Generic.Dictionary`2[System.UInt64,ILCompiler.Reflection.ReadyToRun.Amd64.UnwindCode]
; Prolog
000000000083FC50 55                   push      rbp
000000000083FC51 4883EC20             sub       rsp,20h ; UnwindCode: OpCode: UWOP_PUSH_NONVOL Op: RBP(5)
000000000083FC55 488D6C2420           lea       rbp,[rsp+20h] ; UnwindCode: OpCode: UWOP_ALLOC_SMALL Op: 32
000000000083FC5A 48894D10             mov       [rbp+10h],rcx
; IL_0000
000000000083FC5E 90                   nop
; IL_0001
000000000083FC5F 488B4D10             mov       rcx,[rbp+10h]
000000000083FC63 BA01000000           mov       edx,1
000000000083FC68 488B4510             mov       rax,[rbp+10h]
000000000083FC6C 488B00               mov       rax,[rax]
000000000083FC6F 488B4048             mov       rax,[rax+48h]
; IL_0003
000000000083FC73 FF5028               call      qword [rax+28h]
; IL_0008
000000000083FC76 90                   nop
; IL_0009
000000000083FC77 90                   nop
; Epilog
000000000083FC78 488D6500             lea       rsp,[rbp]
000000000083FC7C 5D                   pop       rbp
000000000083FC7D C3                   ret
```