### PR TITLE
Upgrade ILSpy.exe to System.Reflection.Metadata 1.8.1

### DIFF
--- a/ILSpy.Tests/ILSpy.Tests.csproj
+++ b/ILSpy.Tests/ILSpy.Tests.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0-3.final" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.6.0-3.final" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="Moq" Version="4.14.1" />
   </ItemGroup>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -56,6 +56,8 @@
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
     <PackageReference Include="OSVersionHelper" Version="1.0.11" />
     <PackageReference Include="DataGridExtensions" Version="2.1.1" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.8.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/Properties/app.config.template
+++ b/ILSpy/Properties/app.config.template
@@ -26,7 +26,11 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
+				<bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.4.5.0" newVersion="1.4.5.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>


### PR DESCRIPTION
Upgrade to newer SRM version on ILSpy *only*. This does not touch ICSharpCode.Decompiler (we have to keep SRM level with Roslyn there).

This is dogeared for vNext - we are too close to releasing v6.