### PR TITLE
Add support for C# 9 native integers

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Helpers/RemoveCompilerAttribute.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/RemoveCompilerAttribute.cs
@@ -39,6 +39,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			"System.Runtime.CompilerServices.IsUnmanagedAttribute",
 			"System.Runtime.CompilerServices.NullableAttribute",
 			"System.Runtime.CompilerServices.NullableContextAttribute",
+			"System.Runtime.CompilerServices.NativeIntegerAttribute",
 			"Microsoft.CodeAnalysis.EmbeddedAttribute",
 		};
 

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -57,6 +57,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 		ReferenceVisualBasic = 0x40,
 		ReferenceCore = 0x80,
 		GeneratePdb = 0x100,
+		Preview = 0x200
 	}
 
 	[Flags]
@@ -271,7 +272,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			if (flags.HasFlag(CompilerOptions.UseRoslyn)) {
 				var parseOptions = new CSharpParseOptions(
 					preprocessorSymbols: preprocessorSymbols.ToArray(),
-					languageVersion: Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8
+					languageVersion: flags.HasFlag(CompilerOptions.Preview) ? Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview : Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp8
 				);
 				var syntaxTrees = sourceFileNames.Select(f => SyntaxFactory.ParseSyntaxTree(File.ReadAllText(f), parseOptions, path: f, encoding: Encoding.UTF8));
 				if (flags.HasFlag(CompilerOptions.ReferenceCore)) {
@@ -399,7 +400,11 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 		internal static DecompilerSettings GetSettings(CompilerOptions cscOptions)
 		{
 			if (cscOptions.HasFlag(CompilerOptions.UseRoslyn)) {
-				return new DecompilerSettings(CSharp.LanguageVersion.Latest);
+				if (cscOptions.HasFlag(CompilerOptions.Preview)) {
+					return new DecompilerSettings(CSharp.LanguageVersion.Latest);
+				} else {
+					return new DecompilerSettings(CSharp.LanguageVersion.CSharp8_0);
+				}
 			} else {
 				return new DecompilerSettings(CSharp.LanguageVersion.CSharp5);
 			}

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -42,8 +42,8 @@
   <ItemGroup>
     <PackageReference Include="DiffLib" Version="2017.7.26.1241" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0-2.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0-3.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0-3.final" />
     <PackageReference Include="Microsoft.DiaSymReader.Converter.Xml" Version="1.1.0-beta1-63314-01" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="ProjectDecompiler\TargetFrameworkTests.cs" />
     <Compile Include="TestAssemblyResolver.cs" />
     <Compile Include="TestCases\Correctness\StringConcat.cs" />
+    <None Include="TestCases\Pretty\NativeInts.cs" />
     <None Include="TestCases\ILPretty\CallIndirect.cs" />
     <Compile Include="TestCases\ILPretty\Issue1681.cs" />
     <Compile Include="TestCases\Ugly\AggressiveScalarReplacementOfAggregates.cs" />

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -338,6 +338,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public void NativeInts([ValueSource(nameof(roslynOnlyOptions))] CompilerOptions cscOptions)
+		{
+			RunForLibrary(cscOptions: cscOptions | CompilerOptions.Preview);
+		}
+
+		[Test]
 		public void NullPropagation([ValueSource(nameof(roslynOnlyOptions))] CompilerOptions cscOptions)
 		{
 			RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
@@ -32,6 +32,8 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 	// assign short names to the fake reflection types
 	using Null = ICSharpCode.Decompiler.TypeSystem.ReflectionHelper.Null;
 	using dynamic = ICSharpCode.Decompiler.TypeSystem.ReflectionHelper.Dynamic;
+	using nuint = ICSharpCode.Decompiler.TypeSystem.ReflectionHelper.NUInt;
+	using nint = ICSharpCode.Decompiler.TypeSystem.ReflectionHelper.NInt;
 	using C = Conversion;
 
 	[TestFixture, Parallelizable(ParallelScope.All)]
@@ -54,6 +56,13 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			IType from2 = compilation.FindType(from);
 			IType to2 = compilation.FindType(to);
 			return conversions.ImplicitConversion(from2, to2);
+		}
+
+		Conversion ExplicitConversion(Type from, Type to)
+		{
+			IType from2 = compilation.FindType(from);
+			IType to2 = compilation.FindType(to);
+			return conversions.ExplicitConversion(from2, to2);
 		}
 
 		[Test]
@@ -283,6 +292,126 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 		{
 			Assert.AreEqual(C.None, ImplicitConversion(typeof(int*), typeof(object)));
 			Assert.AreEqual(C.None, ImplicitConversion(typeof(int*), typeof(dynamic)));
+		}
+
+		[Test]
+		public void ConversionToNInt()
+		{
+			// Test based on the table in https://github.com/dotnet/csharplang/blob/master/proposals/native-integers.md
+			Assert.AreEqual(C.UnboxingConversion, ExplicitConversion(typeof(object), typeof(nint)));
+			Assert.AreEqual(C.ExplicitPointerConversion, ExplicitConversion(typeof(void*), typeof(nint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(sbyte), typeof(nint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(byte), typeof(nint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(short), typeof(nint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(ushort), typeof(nint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(int), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(uint), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(long), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(ulong), typeof(nint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(char), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(float), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(double), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(decimal), typeof(nint)));
+			Assert.AreEqual(C.IdentityConversion, ExplicitConversion(typeof(IntPtr), typeof(nint)));
+			Assert.AreEqual(C.None, ExplicitConversion(typeof(UIntPtr), typeof(nint)));
+		}
+
+		[Test]
+		public void ConversionToNUInt()
+		{
+			// Test based on the table in https://github.com/dotnet/csharplang/blob/master/proposals/native-integers.md
+			Assert.AreEqual(C.UnboxingConversion, ExplicitConversion(typeof(object), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitPointerConversion, ExplicitConversion(typeof(void*), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(sbyte), typeof(nuint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(byte), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(short), typeof(nuint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(ushort), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(int), typeof(nuint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(uint), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(long), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(ulong), typeof(nuint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(char), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(float), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(double), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(decimal), typeof(nuint)));
+			Assert.AreEqual(C.None, ExplicitConversion(typeof(IntPtr), typeof(nuint)));
+			Assert.AreEqual(C.IdentityConversion, ExplicitConversion(typeof(UIntPtr), typeof(nuint)));
+		}
+
+		[Test]
+		public void ConversionFromNInt()
+		{
+			// Test based on the table in https://github.com/dotnet/csharplang/blob/master/proposals/native-integers.md
+			Assert.AreEqual(C.BoxingConversion, ExplicitConversion(typeof(nint), typeof(object)));
+			Assert.AreEqual(C.ExplicitPointerConversion, ExplicitConversion(typeof(nint), typeof(void*)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(nuint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(sbyte)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(byte)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(short)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(ushort)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(int)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(uint)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(long)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(ulong)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(char)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(float)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(double)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nint), typeof(decimal)));
+			Assert.AreEqual(C.IdentityConversion, ExplicitConversion(typeof(nint), typeof(IntPtr)));
+			Assert.AreEqual(C.None, ExplicitConversion(typeof(nint), typeof(UIntPtr)));
+		}
+
+		[Test]
+		public void ConversionFromNUInt()
+		{
+			// Test based on the table in https://github.com/dotnet/csharplang/blob/master/proposals/native-integers.md
+			Assert.AreEqual(C.BoxingConversion, ExplicitConversion(typeof(nuint), typeof(object)));
+			Assert.AreEqual(C.ExplicitPointerConversion, ExplicitConversion(typeof(nuint), typeof(void*)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(nint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(sbyte)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(byte)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(short)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(ushort)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(int)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(uint)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(long)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(ulong)));
+			Assert.AreEqual(C.ExplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(char)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(float)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(double)));
+			Assert.AreEqual(C.ImplicitNumericConversion, ExplicitConversion(typeof(nuint), typeof(decimal)));
+			Assert.AreEqual(C.None, ExplicitConversion(typeof(nuint), typeof(IntPtr)));
+			Assert.AreEqual(C.IdentityConversion, ExplicitConversion(typeof(nuint), typeof(UIntPtr)));
+		}
+
+
+		[Test]
+		public void NIntEnumConversion()
+		{
+			var explicitEnumConversion = C.EnumerationConversion(isImplicit: false, isLifted: false);
+			Assert.AreEqual(explicitEnumConversion, ExplicitConversion(typeof(nint), typeof(StringComparison)));
+			Assert.AreEqual(explicitEnumConversion, ExplicitConversion(typeof(nuint), typeof(StringComparison)));
+			Assert.AreEqual(explicitEnumConversion, ExplicitConversion(typeof(StringComparison), typeof(nint)));
+			Assert.AreEqual(explicitEnumConversion, ExplicitConversion(typeof(StringComparison), typeof(nuint)));
+		}
+
+		[Test]
+		public void IntegerLiteralToNIntConversions()
+		{
+			Assert.IsTrue(IntegerLiteralConversion(0, typeof(nint)));
+			Assert.IsTrue(IntegerLiteralConversion(-1, typeof(nint)));
+			Assert.IsFalse(IntegerLiteralConversion(uint.MaxValue, typeof(nint)));
+			Assert.IsFalse(IntegerLiteralConversion(long.MaxValue, typeof(nint)));
+		}
+
+
+		[Test]
+		public void IntegerLiteralToNUIntConversions()
+		{
+			Assert.IsTrue(IntegerLiteralConversion(0, typeof(nuint)));
+			Assert.IsFalse(IntegerLiteralConversion(-1, typeof(nuint)));
+			Assert.IsTrue(IntegerLiteralConversion(uint.MaxValue, typeof(nuint)));
+			Assert.IsFalse(IntegerLiteralConversion(long.MaxValue, typeof(nuint)));
 		}
 
 		[Test]

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/CompoundAssignment.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/CompoundAssignment.cs
@@ -32,6 +32,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			UnsignedShiftRightStaticProperty();
 			DivideByBigValue();
 			Overflow();
+			IntPtr_CompoundAssign();
 		}
 
 		static void Test(int a, int b)
@@ -104,6 +105,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			}
 		}
 
+		IntPtr intPtrField = new IntPtr(IntPtr.Size == 8 ? long.MaxValue : int.MaxValue);
+
+		public IntPtr IntPtrProperty {
+			get {
+				Console.WriteLine("In {0}.get_IntPtrProperty", instanceNumber);
+				return intPtrField;
+			}
+			set {
+				Console.WriteLine("In {0}.set_IntPtrProperty, value={1}", instanceNumber, value);
+				intPtrField = value;
+			}
+		}
+
 		public static Dictionary<string, int> GetDict()
 		{
 			Console.WriteLine("In GetDict()");
@@ -112,8 +126,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 
 		static CompoundAssignment GetObject()
 		{
-			Console.WriteLine("In GetObject() (instance #)");
-			return new CompoundAssignment();
+			var obj = new CompoundAssignment();
+			Console.WriteLine("In GetObject() (instance #{0})", obj.instanceNumber);
+			return obj;
 		}
 
 		static string GetString()
@@ -207,6 +222,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		static T Id<T>(T val)
 		{
 			return val;
+		}
+
+		static void IntPtr_CompoundAssign()
+		{
+			Console.WriteLine("IntPtr_CompoundAssign:");
+#if !MCS
+			GetObject().IntPtrProperty -= 2;
+			GetObject().IntPtrProperty += 2;
+#endif
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Unsafe.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Unsafe.cs
@@ -186,7 +186,7 @@ namespace System.Runtime.CompilerServices
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public unsafe static void* Add<T>(void* source, int elementOffset)
 		{
-			return (byte*)source + (long)elementOffset * (long)sizeof(T);
+			return (byte*)source + (nint)elementOffset * (nint)sizeof(T);
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -210,7 +210,7 @@ namespace System.Runtime.CompilerServices
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public unsafe static void* Subtract<T>(void* source, int elementOffset)
 		{
-			return (byte*)source - (long)elementOffset * (long)sizeof(T);
+			return (byte*)source - (nint)elementOffset * (nint)sizeof(T);
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -134,5 +134,32 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				(nint)i64
 			};
 		}
+
+		public NativeInts GetInstance(int i)
+		{
+			return this;
+		}
+
+		public void CompoundAssign()
+		{
+			GetInstance(0).i += i32;
+			checked {
+				GetInstance(1).i += i32;
+			}
+			GetInstance(2).u *= 2u;
+			checked {
+				GetInstance(3).u *= 2u;
+			}
+			GetInstance(4).intptr += (nint)i32;
+			checked {
+				// Note: the cast is necessary here, without it we'd call IntPtr.op_Addition
+				// but that is always unchecked.
+				GetInstance(5).intptr += (nint)i32;
+			}
+			// multiplication results in compiler-error without the cast
+			GetInstance(6).intptr *= (nint)2;
+
+			GetInstance(7).i <<= i32;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -161,5 +161,38 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			GetInstance(7).i <<= i32;
 		}
+
+		public void LocalTypeFromStore()
+		{
+			nint num = 42;
+			IntPtr zero = IntPtr.Zero;
+			nint zero2 = IntPtr.Zero;
+			nuint num2 = 43u;
+			nint num3 = i;
+			IntPtr intPtr = intptr;
+
+			Console.WriteLine();
+			zero2 = 1;
+			Console.WriteLine();
+
+			intptr = num;
+			intptr = zero;
+			intptr = zero2;
+			uintptr = num2;
+			intptr = num3;
+			intptr = intPtr;
+		}
+
+
+		public void LocalTypeFromUse()
+		{
+			IntPtr intPtr = intptr;
+			nint num = intptr;
+
+			Console.WriteLine();
+
+			intptr = intPtr;
+			i = num + 1;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -102,6 +102,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine((nuint)i < u);
 		}
 
+		public void Unary()
+		{
+			Console.WriteLine(~i);
+			Console.WriteLine(~u);
+			Console.WriteLine(-i);
+		}
+
 		public object[] Boxing()
 		{
 			return new object[10] {

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -109,6 +109,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(-i);
 		}
 
+		public unsafe int* PtrArithmetic(int* ptr)
+		{
+			return ptr + i;
+		}
+
+		public unsafe nint* PtrArithmetic(nint* ptr)
+		{
+			return ptr + u;
+		}
+
 		public object[] Boxing()
 		{
 			return new object[10] {

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) 2020 Daniel Grunwald
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class NativeInts
+	{
+		private const nint nint_const = 42;
+		private const nuint nuint_const = 99u;
+
+		private IntPtr intptr;
+		private UIntPtr uintptr;
+		private nint i;
+		private nuint u;
+		private int i32;
+		private uint u32;
+		private long i64;
+		private ulong u64;
+		private (IntPtr, nint, UIntPtr, nuint) tuple_field;
+		private Dictionary<nint, IntPtr> dict1;
+		private Dictionary<IntPtr, nint> dict2;
+
+		public void Convert()
+		{
+			intptr = i;
+			intptr = (nint)u;
+			intptr = (nint)(nuint)uintptr;
+
+			uintptr = (nuint)i;
+			uintptr = u;
+			uintptr = (nuint)(nint)intptr;
+
+			i = intptr;
+			i = (nint)u;
+			i = (nint)(nuint)uintptr;
+
+			u = (nuint)i;
+			u = uintptr;
+			u = (nuint)(nint)intptr;
+		}
+
+		public void Convert2()
+		{
+			i32 = (int)i;
+			i = i32;
+			intptr = (IntPtr)i32;
+
+			i64 = (long)intptr;
+			i64 = i;
+			i = (nint)i64;
+
+			u32 = (uint)i;
+			i = (nint)u32;
+
+			u64 = (uint)i;
+			i = (nint)u64;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -73,5 +73,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			u64 = (uint)i;
 			i = (nint)u64;
 		}
+
+		public void Arithmetic()
+		{
+			Console.WriteLine((nint)intptr * 2);
+			Console.WriteLine(i * 2);
+
+			Console.WriteLine(i + (nint)u);
+			Console.WriteLine((nuint)i + u);
+		}
+
+		public object[] Boxing()
+		{
+			return new object[10] {
+				1,
+				(nint)2,
+				3L,
+				4u,
+				(nuint)5u,
+				6uL,
+				int.MaxValue,
+				(nint)int.MaxValue,
+				i64,
+				(nint)i64
+			};
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NativeInts.cs
@@ -83,6 +83,25 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine((nuint)i + u);
 		}
 
+		public void Shifts()
+		{
+			Console.WriteLine(i << i32);
+			Console.WriteLine(i >> i32);
+			Console.WriteLine(u >> i32);
+			Console.WriteLine(u << i32);
+		}
+
+		public void Comparisons()
+		{
+			Console.WriteLine(i < i32);
+			Console.WriteLine(i <= i32);
+			Console.WriteLine(i > i32);
+			Console.WriteLine(i >= i32);
+			Console.WriteLine(i == (nint)u);
+			Console.WriteLine(i < (nint)u);
+			Console.WriteLine((nuint)i < u);
+		}
+
 		public object[] Boxing()
 		{
 			return new object[10] {

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TupleTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TupleTests.cs
@@ -146,9 +146,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void LocalVariables((int, int) a)
 		{
-			(int, int) valueTuple = (a.Item1 + a.Item2, a.Item1 * a.Item2);
-			Console.WriteLine(valueTuple.ToString());
-			Console.WriteLine(valueTuple.GetType().FullName);
+			(int, int) tuple = (a.Item1 + a.Item2, a.Item1 * a.Item2);
+			Console.WriteLine(tuple.ToString());
+			Console.WriteLine(tuple.GetType().FullName);
 		}
 
 		public void Foreach(IEnumerable<(int, string)> input)

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -165,6 +165,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				new HighLevelLoopTransform(),
 				new ReduceNestingTransform(),
 				new IntroduceDynamicTypeOnLocals(),
+				new IntroduceNativeIntTypeOnLocals(),
 				new AssignVariableNames(),
 			};
 		}

--- a/ICSharpCode.Decompiler/CSharp/CSharpLanguageVersion.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpLanguageVersion.cs
@@ -17,7 +17,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		CSharp7_2 = 702,
 		CSharp7_3 = 703,
 		CSharp8_0 = 800,
-		CSharp9_0 = 900,
+		Preview = 900,
 		Latest = 0x7FFFFFFF
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/CSharpLanguageVersion.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpLanguageVersion.cs
@@ -17,6 +17,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		CSharp7_2 = 702,
 		CSharp7_3 = 703,
 		CSharp8_0 = 800,
+		CSharp9_0 = 900,
 		Latest = 0x7FFFFFFF
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -1143,10 +1143,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		{
 			if (!expr.Type.IsCSharpPrimitiveIntegerType() && !expr.Type.IsCSharpNativeIntegerType()) {
 				// pointer arithmetic accepts all primitive integer types, but no enums etc.
-				StackType targetType = expr.Type.GetStackType() == StackType.I4 ? StackType.I4 : StackType.I8;
-				expr = expr.ConvertTo(
-					compilation.FindType(targetType.ToKnownTypeCode(expr.Type.GetSign())),
-					this);
+				expr = expr.ConvertTo(FindArithmeticType(expr.Type.GetStackType(), expr.Type.GetSign()), this); 
 			}
 			return expr;
 		}

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2301,19 +2301,14 @@ namespace ICSharpCode.Decompiler.CSharp
 				.WithoutILInstruction().WithRR(new ByReferenceResolveResult(expr.Type, ReferenceKind.Ref));
 		}
 		
-		TranslatedExpression TranslateArrayIndex(ILInstruction i, bool expectSystemIndex = false)
+		TranslatedExpression TranslateArrayIndex(ILInstruction i)
 		{
 			var input = Translate(i);
-			KnownTypeCode targetType;
-			if (i.ResultType == StackType.I4) {
-				if (input.Type.IsSmallIntegerType() && input.Type.Kind != TypeKind.Enum) {
-					return input; // we don't need a cast, just let small integers be promoted to int
-				}
-				targetType = input.Type.GetSign() == Sign.Unsigned ? KnownTypeCode.UInt32 : KnownTypeCode.Int32;
-			} else {
-				targetType = input.Type.GetSign() == Sign.Unsigned ? KnownTypeCode.UInt64 : KnownTypeCode.Int64;
+			if (i.ResultType == StackType.I4 && input.Type.IsSmallIntegerType() && input.Type.Kind != TypeKind.Enum) {
+				return input; // we don't need a cast, just let small integers be promoted to int
 			}
-			return input.ConvertTo(compilation.FindType(targetType), this);
+			IType targetType = FindArithmeticType(i.ResultType, input.Type.GetSign());
+			return input.ConvertTo(targetType, this);
 		}
 		
 		internal static bool IsUnboxAnyWithIsInst(UnboxAny unboxAny, IsInst isInst)

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -1650,8 +1650,15 @@ namespace ICSharpCode.Decompiler.CSharp
 			IType GetType(KnownTypeCode typeCode)
 			{
 				IType type = compilation.FindType(typeCode);
-				if (inst.IsLifted)
+				// Prefer n(u)int over (U)IntPtr
+				if (typeCode == KnownTypeCode.IntPtr && settings.NativeIntegers && !type.Equals(context.TypeHint)) {
+					type = SpecialType.NInt;
+				} else if (typeCode == KnownTypeCode.UIntPtr && settings.NativeIntegers && !type.Equals(context.TypeHint)) {
+					type = SpecialType.NUInt;
+				}
+				if (inst.IsLifted) {
 					type = NullableType.Create(compilation, type);
+				}
 				return type;
 			}
 

--- a/ICSharpCode.Decompiler/CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/CSharpResolver.cs
@@ -449,14 +449,20 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 					// C# 4.0 spec: §7.6.9 Postfix increment and decrement operators
 					// C# 4.0 spec: §7.7.5 Prefix increment and decrement operators
 					TypeCode code = ReflectionHelper.GetTypeCode(type);
-					if ((code >= TypeCode.Char && code <= TypeCode.Decimal) || type.Kind == TypeKind.Enum || type.Kind == TypeKind.Pointer)
+					if ((code >= TypeCode.Char && code <= TypeCode.Decimal) || type.Kind == TypeKind.Enum || type.Kind == TypeKind.Pointer || type.IsCSharpNativeIntegerType())
 						return UnaryOperatorResolveResult(expression.Type, op, expression, isNullable);
 					else
 						return new ErrorResolveResult(expression.Type);
 				case UnaryOperatorType.Plus:
+					if (type.IsCSharpNativeIntegerType()) {
+						return UnaryOperatorResolveResult(expression.Type, op, expression, isNullable);
+					}
 					methodGroup = operators.UnaryPlusOperators;
 					break;
 				case UnaryOperatorType.Minus:
+					if (type.IsCSharpNativeIntegerType()) {
+						return UnaryOperatorResolveResult(expression.Type, op, expression, isNullable);
+					}
 					methodGroup = CheckForOverflow ? operators.CheckedUnaryMinusOperators : operators.UncheckedUnaryMinusOperators;
 					break;
 				case UnaryOperatorType.Not:
@@ -472,7 +478,9 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 							rr = WithCheckForOverflow(false).ResolveCast(type, rr);
 							if (rr.IsCompileTimeConstant)
 								return rr;
-						} 
+						}
+						return UnaryOperatorResolveResult(expression.Type, op, expression, isNullable);
+					} else if (type.IsCSharpNativeIntegerType()) {
 						return UnaryOperatorResolveResult(expression.Type, op, expression, isNullable);
 					} else {
 						methodGroup = operators.BitwiseComplementOperators;

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -248,6 +248,12 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		AstType ConvertTypeHelper(IType type)
 		{
+			switch (type.Kind) {
+				case TypeKind.Dynamic:
+				case TypeKind.NInt:
+				case TypeKind.NUInt:
+					return new PrimitiveType(type.Name);
+			}
 			if (type is TypeWithElementType typeWithElementType) {
 				if (typeWithElementType is PointerType) {
 					return ConvertType(typeWithElementType.ElementType).MakePointerType();

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -248,12 +248,6 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		AstType ConvertTypeHelper(IType type)
 		{
-			switch (type.Kind) {
-				case TypeKind.Dynamic:
-				case TypeKind.NInt:
-				case TypeKind.NUInt:
-					return new PrimitiveType(type.Name);
-			}
 			if (type is TypeWithElementType typeWithElementType) {
 				if (typeWithElementType is PointerType) {
 					return ConvertType(typeWithElementType.ElementType).MakePointerType();
@@ -309,7 +303,16 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 						astType = ConvertTypeHelper(pt.GenericType, pt.TypeArguments);
 						break;
 					default:
-						astType = MakeSimpleType(type.Name);
+						switch (type.Kind) {
+							case TypeKind.Dynamic:
+							case TypeKind.NInt:
+							case TypeKind.NUInt:
+								astType = new PrimitiveType(type.Name);
+								break;
+							default:
+								astType = MakeSimpleType(type.Name);
+								break;
+						}
 						break;
 				}
 				if (type.Nullability == Nullability.Nullable) {

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -114,7 +114,7 @@ namespace ICSharpCode.Decompiler
 				staticLocalFunctions = false;
 				ranges = false;
 			}
-			if (languageVersion < CSharp.LanguageVersion.CSharp9_0) {
+			if (languageVersion < CSharp.LanguageVersion.Preview) {
 				nativeIntegers = false;
 			}
 		}
@@ -122,7 +122,7 @@ namespace ICSharpCode.Decompiler
 		public CSharp.LanguageVersion GetMinimumRequiredVersion()
 		{
 			if (nativeIntegers)
-				return CSharp.LanguageVersion.CSharp9_0;
+				return CSharp.LanguageVersion.Preview;
 			if (nullableReferenceTypes || readOnlyMethods || asyncEnumerator || asyncUsingAndForEachStatement || staticLocalFunctions || ranges)
 				return CSharp.LanguageVersion.CSharp8_0;
 			if (introduceUnmanagedConstraint || tupleComparisons || stackAllocInitializers || patternBasedFixedStatement)

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -114,10 +114,15 @@ namespace ICSharpCode.Decompiler
 				staticLocalFunctions = false;
 				ranges = false;
 			}
+			if (languageVersion < CSharp.LanguageVersion.CSharp9_0) {
+				nativeIntegers = false;
+			}
 		}
 
 		public CSharp.LanguageVersion GetMinimumRequiredVersion()
 		{
+			if (nativeIntegers)
+				return CSharp.LanguageVersion.CSharp9_0;
 			if (nullableReferenceTypes || readOnlyMethods || asyncEnumerator || asyncUsingAndForEachStatement || staticLocalFunctions || ranges)
 				return CSharp.LanguageVersion.CSharp8_0;
 			if (introduceUnmanagedConstraint || tupleComparisons || stackAllocInitializers || patternBasedFixedStatement)
@@ -139,6 +144,23 @@ namespace ICSharpCode.Decompiler
 			if (anonymousMethods || liftNullables || yieldReturn || useImplicitMethodGroupConversion)
 				return CSharp.LanguageVersion.CSharp2;
 			return CSharp.LanguageVersion.CSharp1;
+		}
+
+		bool nativeIntegers = true;
+
+		/// <summary>
+		/// Use C# 9 <c>nint</c>/<c>nuint</c> types.
+		/// </summary>
+		[Category("C# 9.0 (experimental)")]
+		[Description("DecompilerSettings.NativeIntegers")]
+		public bool NativeIntegers {
+			get { return nativeIntegers; }
+			set {
+				if (nativeIntegers != value) {
+					nativeIntegers = value;
+					OnPropertyChanged();
+				}
+			}
 		}
 
 		bool anonymousMethods = true;

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Disassembler\DisassemblerSignatureTypeProvider.cs" />
     <Compile Include="Documentation\XmlDocumentationElement.cs" />
     <Compile Include="IL\ControlFlow\AwaitInFinallyTransform.cs" />
+    <Compile Include="IL\Transforms\IntroduceNativeIntTypeOnLocals.cs" />
     <Compile Include="Solution\ProjectId.cs" />
     <Compile Include="Solution\ProjectItem.cs" />
     <Compile Include="Solution\SolutionCreator.cs" />

--- a/ICSharpCode.Decompiler/IL/ILTypeExtensions.cs
+++ b/ICSharpCode.Decompiler/IL/ILTypeExtensions.cs
@@ -202,7 +202,7 @@ namespace ICSharpCode.Decompiler.IL
 						case BinaryNumericOperator.BitXor:
 							var left = bni.Left.InferType(compilation);
 							var right = bni.Right.InferType(compilation);
-							if (left.Equals(right) && (left.IsCSharpPrimitiveIntegerType() || left.IsKnownType(KnownTypeCode.Boolean)))
+							if (left.Equals(right) && (left.IsCSharpPrimitiveIntegerType() || left.IsCSharpNativeIntegerType() || left.IsKnownType(KnownTypeCode.Boolean)))
 								return left;
 							else
 								return SpecialType.UnknownType;

--- a/ICSharpCode.Decompiler/IL/Instructions/CompoundAssignmentInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/CompoundAssignmentInstruction.cs
@@ -128,7 +128,7 @@ namespace ICSharpCode.Decompiler.IL
 		/// Gets whether the instruction checks for overflow.
 		/// </summary>
 		public readonly bool CheckForOverflow;
-		
+
 		/// <summary>
 		/// For integer operations that depend on the sign, specifies whether the operation
 		/// is signed or unsigned.
@@ -151,7 +151,7 @@ namespace ICSharpCode.Decompiler.IL
 			CompoundTargetKind targetKind, ILInstruction value, IType type, CompoundEvalMode evalMode)
 			: base(OpCode.NumericCompoundAssign, evalMode, target, targetKind, value)
 		{
-			Debug.Assert(IsBinaryCompatibleWithType(binary, type));
+			Debug.Assert(IsBinaryCompatibleWithType(binary, type, null));
 			this.CheckForOverflow = binary.CheckForOverflow;
 			this.Sign = binary.Sign;
 			this.LeftInputType = binary.LeftInputType;
@@ -164,11 +164,11 @@ namespace ICSharpCode.Decompiler.IL
 			Debug.Assert(evalMode == CompoundEvalMode.EvaluatesToNewValue || (Operator == BinaryNumericOperator.Add || Operator == BinaryNumericOperator.Sub));
 			Debug.Assert(this.ResultType == (IsLifted ? StackType.O : UnderlyingResultType));
 		}
-		
+
 		/// <summary>
 		/// Gets whether the specific binary instruction is compatible with a compound operation on the specified type.
 		/// </summary>
-		internal static bool IsBinaryCompatibleWithType(BinaryNumericInstruction binary, IType type)
+		internal static bool IsBinaryCompatibleWithType(BinaryNumericInstruction binary, IType type, DecompilerSettings settings)
 		{
 			if (binary.IsLifted) {
 				if (!NullableType.IsNullable(type))
@@ -200,6 +200,19 @@ namespace ICSharpCode.Decompiler.IL
 						) != null;
 					default:
 						return false; // operator not supported on pointer types
+				}
+			} else if (type.IsKnownType(KnownTypeCode.IntPtr) || type.IsKnownType(KnownTypeCode.UIntPtr)) {
+				// "target.intptr *= 2;" is compiler error, but
+				// "target.intptr *= (nint)2;" works
+				if (settings != null && !settings.NativeIntegers) {
+					// But if native integers are not available, we cannot use compound assignment.
+					return false;
+				}
+				// The trick with casting the RHS to n(u)int doesn't work for shifts:
+				switch (binary.Operator) {
+					case BinaryNumericOperator.ShiftLeft:
+					case BinaryNumericOperator.ShiftRight:
+						return false;
 				}
 			}
 			if (binary.Sign != Sign.None) {

--- a/ICSharpCode.Decompiler/IL/PointerArithmeticOffset.cs
+++ b/ICSharpCode.Decompiler/IL/PointerArithmeticOffset.cs
@@ -36,7 +36,7 @@ namespace ICSharpCode.Decompiler.IL
 				if (mul.CheckForOverflow != checkForOverflow)
 					return null;
 				if (elementSize > 0 && mul.Right.MatchLdcI(elementSize.Value)
-					|| mul.Right.UnwrapConv(ConversionKind.SignExtend) is SizeOf sizeOf && sizeOf.Type.Equals(pointerElementType)) {
+					|| mul.Right.UnwrapConv(ConversionKind.SignExtend) is SizeOf sizeOf && NormalizeTypeVisitor.TypeErasure.EquivalentTypes(sizeOf.Type, pointerElementType)) {
 					var countOffsetInst = mul.Left;
 					if (unwrapZeroExtension) {
 						countOffsetInst = countOffsetInst.UnwrapConv(ConversionKind.ZeroExtend);

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -417,19 +417,28 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				type = NullableType.GetUnderlyingType(((TypeWithElementType)type).ElementType);
 			}
 
-			string name;
-			if (type is ArrayType) {
-				name = "array";
-			} else if (type is PointerType) {
-				name = "ptr";
-			} else if (type.Kind == TypeKind.TypeParameter || type.Kind == TypeKind.Unknown || type.Kind == TypeKind.Dynamic) {
-				name = "val";
-			} else if (type.Kind == TypeKind.ByReference) {
-				name = "reference";
-			} else if (type.IsAnonymousType()) {
+			string name = type.Kind switch
+			{
+				TypeKind.Array => "array",
+				TypeKind.Pointer => "ptr",
+				TypeKind.TypeParameter => "val",
+				TypeKind.Unknown => "val",
+				TypeKind.Dynamic => "val",
+				TypeKind.ByReference => "reference",
+				TypeKind.Tuple => "tuple",
+				TypeKind.NInt => "num",
+				TypeKind.NUInt => "num",
+				_ => null
+			};
+			if (name != null) {
+				return name;
+			}
+			if (type.IsAnonymousType()) {
 				name = "anon";
 			} else if (type.Name.EndsWith("Exception", StringComparison.Ordinal)) {
 				name = "ex";
+			} else if (type.IsCSharpNativeIntegerType()) {
+				name = "num";
 			} else if (!typeNameToVariableNameDict.TryGetValue(type.FullName, out name)) {
 				name = type.Name;
 				// remove the 'I' for interfaces

--- a/ICSharpCode.Decompiler/IL/Transforms/IntroduceNativeIntTypeOnLocals.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/IntroduceNativeIntTypeOnLocals.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) 2020 Daniel Grunwald
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ICSharpCode.Decompiler.IL.Transforms;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ICSharpCode.Decompiler.IL
+{
+	class IntroduceNativeIntTypeOnLocals : IILTransform
+	{
+		public void Run(ILFunction function, ILTransformContext context)
+		{
+			if (!context.Settings.NativeIntegers)
+				return;
+			foreach (var variable in function.Variables) {
+				if (variable.Kind != VariableKind.Local &&
+					variable.Kind != VariableKind.StackSlot &&
+					variable.Kind != VariableKind.ForeachLocal &&
+					variable.Kind != VariableKind.UsingLocal) {
+					continue;
+				}
+				if (!(variable.Type.IsKnownType(KnownTypeCode.IntPtr) || variable.Type.IsKnownType(KnownTypeCode.UIntPtr)))
+					continue;
+				bool isUsedAsNativeInt = variable.LoadInstructions.Any(IsUsedAsNativeInt);
+				bool isAssignedNativeInt = variable.StoreInstructions.Any(store => IsNativeIntStore(store, context.TypeSystem));
+				if (isUsedAsNativeInt || isAssignedNativeInt) {
+					variable.Type = variable.Type.GetSign() == Sign.Unsigned ? SpecialType.NUInt : SpecialType.NInt;
+				}
+			}
+		}
+
+		static bool IsUsedAsNativeInt(LdLoc load)
+		{
+			return load.Parent switch
+			{
+				BinaryNumericInstruction { UnderlyingResultType: StackType.I } => true,
+				BitNot { UnderlyingResultType: StackType.I } => true,
+				CallInstruction call => call.GetParameter(load.ChildIndex)?.Type.IsCSharpNativeIntegerType() ?? false,
+				_ => false,
+			};
+		}
+
+		static bool IsNativeIntStore(IStoreInstruction store, ICompilation compilation)
+		{
+			if (store is StLoc stloc) {
+				switch (stloc.Value) {
+					case BinaryNumericInstruction { UnderlyingResultType: StackType.I }:
+						return true;
+					case Conv { ResultType: StackType.I }:
+						return true;
+					default:
+						var inferredType = stloc.Value.InferType(compilation);
+						return inferredType.IsCSharpNativeIntegerType();
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformAssignment.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformAssignment.cs
@@ -198,9 +198,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 		}
 
-		static bool ValidateCompoundAssign(BinaryNumericInstruction binary, Conv conv, IType targetType)
+		static bool ValidateCompoundAssign(BinaryNumericInstruction binary, Conv conv, IType targetType, DecompilerSettings settings)
 		{
-			if (!NumericCompoundAssign.IsBinaryCompatibleWithType(binary, targetType))
+			if (!NumericCompoundAssign.IsBinaryCompatibleWithType(binary, targetType, settings))
 				return false;
 			if (conv != null && !(conv.TargetType == targetType.ToPrimitiveType() && conv.CheckForOverflow == binary.CheckForOverflow))
 				return false; // conv does not match binary operation
@@ -305,7 +305,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				}
 				if (!IsMatchingCompoundLoad(binary.Left, compoundStore, out var target, out var targetKind, out var finalizeMatch, forbiddenVariable: storeInSetter?.Variable))
 					return false;
-				if (!ValidateCompoundAssign(binary, smallIntConv, targetType))
+				if (!ValidateCompoundAssign(binary, smallIntConv, targetType, context.Settings))
 					return false;
 				context.Step($"Compound assignment (binary.numeric)", compoundStore);
 				finalizeMatch?.Invoke(context);
@@ -656,7 +656,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (binary != null && (binary.Right.MatchLdcI(1) || binary.Right.MatchLdcF4(1) || binary.Right.MatchLdcF8(1))) {
 				if (!(binary.Operator == BinaryNumericOperator.Add || binary.Operator == BinaryNumericOperator.Sub))
 					return false;
-				if (!ValidateCompoundAssign(binary, conv, targetType))
+				if (!ValidateCompoundAssign(binary, conv, targetType, context.Settings))
 					return false;
 				stloc = binary.Left as StLoc;
 			} else if (value is Call operatorCall && operatorCall.Method.IsOperator && operatorCall.Arguments.Count == 1) {
@@ -731,7 +731,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					return false;
 				if (!(binary.Operator == BinaryNumericOperator.Add || binary.Operator == BinaryNumericOperator.Sub))
 					return false;
-				if (!ValidateCompoundAssign(binary, conv, targetType))
+				if (!ValidateCompoundAssign(binary, conv, targetType, context.Settings))
 					return false;
 				context.Step("TransformPostIncDecOperator (builtin)", inst);
 				finalizeMatch?.Invoke(context);

--- a/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
@@ -110,10 +110,15 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// </summary>
 		ReadOnlyMethods = 0x800,
 		/// <summary>
+		/// [NativeIntegerAttribute] is used to replace 'IntPtr' types with the 'nint' type.
+		/// </summary>
+		NativeIntegers = 0x1000,
+		/// <summary>
 		/// Default settings: typical options for the decompiler, with all C# languages features enabled.
 		/// </summary>
 		Default = Dynamic | Tuple | ExtensionMethods | DecimalConstants | ReadOnlyStructsAndParameters
 			| RefStructs | UnmanagedConstraints | NullabilityAnnotations | ReadOnlyMethods
+			| NativeIntegers
 	}
 
 	/// <summary>
@@ -145,6 +150,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				typeSystemOptions |= TypeSystemOptions.NullabilityAnnotations;
 			if (settings.ReadOnlyMethods)
 				typeSystemOptions |= TypeSystemOptions.ReadOnlyMethods;
+			if (settings.NativeIntegers)
+				typeSystemOptions |= TypeSystemOptions.NativeIntegers;
 			return typeSystemOptions;
 		}
 

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/AttributeListBuilder.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/AttributeListBuilder.cs
@@ -194,6 +194,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 					switch (attributeType.Name) {
 						case "DynamicAttribute":
 							return (options & TypeSystemOptions.Dynamic) != 0;
+						case "NativeIntegerAttribute":
+							return (options & TypeSystemOptions.NativeIntegers) != 0;
 						case "TupleElementNamesAttribute":
 							return (options & TypeSystemOptions.Tuple) != 0;
 						case "ExtensionAttribute":

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -98,11 +98,14 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		// Security attributes:
 		PermissionSet,
+
+		// C# 9 attributes:
+		NativeInteger,
 	}
 
 	static class KnownAttributes
 	{
-		internal const int Count = (int)KnownAttribute.PermissionSet + 1;
+		internal const int Count = (int)KnownAttribute.NativeInteger + 1;
 
 		static readonly TopLevelTypeName[] typeNames = new TopLevelTypeName[Count]{
 			default,
@@ -160,6 +163,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			new TopLevelTypeName("System.Runtime.InteropServices", nameof(MarshalAsAttribute)),
 			// Security attributes:
 			new TopLevelTypeName("System.Security.Permissions", "PermissionSetAttribute"),
+			// C# 9 attributes:
+			new TopLevelTypeName("System.Runtime.CompilerServices", "NativeIntegerAttribute"),
 		};
 
 		public static ref readonly TopLevelTypeName GetTypeName(this KnownAttribute attr)

--- a/ICSharpCode.Decompiler/TypeSystem/NormalizeTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/NormalizeTypeVisitor.cs
@@ -22,6 +22,17 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			RemoveNullability = true,
 		};
 
+		internal static readonly NormalizeTypeVisitor IgnoreNullabilityAndTuples = new NormalizeTypeVisitor {
+			ReplaceClassTypeParametersWithDummy = false,
+			ReplaceMethodTypeParametersWithDummy = false,
+			DynamicAndObject = false,
+			IntPtrToNInt = false,
+			TupleToUnderlyingType = true,
+			RemoveModOpt = true,
+			RemoveModReq = true,
+			RemoveNullability = true,
+		};
+
 		public bool EquivalentTypes(IType a, IType b)
 		{
 			a = a.AcceptVisitor(this);

--- a/ICSharpCode.Decompiler/TypeSystem/NormalizeTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/NormalizeTypeVisitor.cs
@@ -15,6 +15,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			ReplaceClassTypeParametersWithDummy = false,
 			ReplaceMethodTypeParametersWithDummy = false,
 			DynamicAndObject = true,
+			IntPtrToNInt = true,
 			TupleToUnderlyingType = true,
 			RemoveModOpt = true,
 			RemoveModReq = true,
@@ -33,6 +34,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		public bool ReplaceClassTypeParametersWithDummy = true;
 		public bool ReplaceMethodTypeParametersWithDummy = true;
 		public bool DynamicAndObject = true;
+		public bool IntPtrToNInt = true;
 		public bool TupleToUnderlyingType = true;
 		public bool RemoveNullability = true;
 
@@ -51,13 +53,18 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		public override IType VisitTypeDefinition(ITypeDefinition type)
 		{
-			if (DynamicAndObject && type.KnownTypeCode == KnownTypeCode.Object) {
-				// Instead of normalizing dynamic->object,
-				// we do this the opposite direction, so that we don't need a compilation to find the object type.
-				if (RemoveNullability)
-					return SpecialType.Dynamic;
-				else
-					return SpecialType.Dynamic.ChangeNullability(type.Nullability);
+			switch (type.KnownTypeCode) {
+				case KnownTypeCode.Object when DynamicAndObject:
+					// Instead of normalizing dynamic->object,
+					// we do this the opposite direction, so that we don't need a compilation to find the object type.
+					if (RemoveNullability)
+						return SpecialType.Dynamic;
+					else
+						return SpecialType.Dynamic.ChangeNullability(type.Nullability);
+				case KnownTypeCode.IntPtr when IntPtrToNInt:
+					return SpecialType.NInt;
+				case KnownTypeCode.UIntPtr when IntPtrToNInt:
+					return SpecialType.NUInt;
 			}
 			return base.VisitTypeDefinition(type);
 		}

--- a/ICSharpCode.Decompiler/TypeSystem/ReflectionHelper.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ReflectionHelper.cs
@@ -36,7 +36,17 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// A reflection class used to represent <c>dynamic</c>.
 		/// </summary>
 		public sealed class Dynamic {}
-		
+
+		/// <summary>
+		/// A reflection class used to represent <c>nint</c>.
+		/// </summary>
+		public sealed class NInt { }
+
+		/// <summary>
+		/// A reflection class used to represent <c>nuint</c>.
+		/// </summary>
+		public sealed class NUInt { }
+
 		/// <summary>
 		/// A reflection class used to represent an unbound type argument.
 		/// </summary>
@@ -101,6 +111,10 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			} else if (type.DeclaringType != null) {
 				if (type == typeof(Dynamic))
 					return SpecialType.Dynamic;
+				else if (type == typeof(NInt))
+					return SpecialType.NInt;
+				else if (type == typeof(NUInt))
+					return SpecialType.NUInt;
 				else if (type == typeof(Null))
 					return SpecialType.NullType;
 				else if (type == typeof(UnboundTypeArgument))

--- a/ICSharpCode.Decompiler/TypeSystem/SpecialType.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/SpecialType.cs
@@ -46,7 +46,17 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// Type representing the C# 'dynamic' type.
 		/// </summary>
 		public readonly static SpecialType Dynamic = new SpecialType(TypeKind.Dynamic, "dynamic", isReferenceType: true);
-		
+
+		/// <summary>
+		/// Type representing the C# 9 'nint' type.
+		/// </summary>
+		public readonly static SpecialType NInt = new SpecialType(TypeKind.NInt, "nint", isReferenceType: false);
+
+		/// <summary>
+		/// Type representing the C# 9 'nuint' type.
+		/// </summary>
+		public readonly static SpecialType NUInt = new SpecialType(TypeKind.NUInt, "nuint", isReferenceType: false);
+
 		/// <summary>
 		/// Type representing the result of the C# '__arglist()' expression.
 		/// </summary>

--- a/ICSharpCode.Decompiler/TypeSystem/TypeKind.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeKind.cs
@@ -94,5 +94,14 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// Modified type, with required modifier.
 		/// </summary>
 		ModReq,
+
+		/// <summary>
+		/// C# 9 <c>nint</c>
+		/// </summary>
+		NInt,
+		/// <summary>
+		/// C# 9 <c>nuint</c>
+		/// </summary>
+		NUInt,
 	}
 }

--- a/ICSharpCode.Decompiler/TypeSystem/TypeUtils.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeUtils.cs
@@ -36,6 +36,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				case TypeKind.Pointer:
 				case TypeKind.ByReference:
 				case TypeKind.Class:
+				case TypeKind.NInt:
+				case TypeKind.NUInt:
 					return NativeIntSize;
 				case TypeKind.Enum:
 					type = type.GetEnumUnderlyingType();
@@ -243,6 +245,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				case TypeKind.ByReference:
 					return StackType.Ref;
 				case TypeKind.Pointer:
+				case TypeKind.NInt:
+				case TypeKind.NUInt:
 					return StackType.I;
 				case TypeKind.TypeParameter:
 					// Type parameters are always considered StackType.O, even
@@ -305,8 +309,13 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		public static Sign GetSign(this IType type)
 		{
 			type = type.SkipModifiers();
-			if (type.Kind == TypeKind.Pointer)
-				return Sign.Unsigned;
+			switch (type.Kind) {
+				case TypeKind.Pointer:
+				case TypeKind.NUInt:
+					return Sign.Unsigned;
+				case TypeKind.NInt:
+					return Sign.Signed;
+			}
 			var typeDef = type.GetEnumUnderlyingType().GetDefinition();
 			if (typeDef == null)
 				return Sign.None;
@@ -375,8 +384,12 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		public static PrimitiveType ToPrimitiveType(this IType type)
 		{
 			type = type.SkipModifiers();
-			if (type.Kind == TypeKind.Unknown) return PrimitiveType.Unknown;
-			if (type.Kind == TypeKind.ByReference) return PrimitiveType.Ref;
+			switch (type.Kind) {
+				case TypeKind.Unknown: return PrimitiveType.Unknown;
+				case TypeKind.ByReference: return PrimitiveType.Ref;
+				case TypeKind.NInt: return PrimitiveType.I;
+				case TypeKind.NUInt: return PrimitiveType.U;
+			}
 			var def = type.GetEnumUnderlyingType().GetDefinition();
 			return def != null ? def.KnownTypeCode.ToPrimitiveType() : PrimitiveType.None;
 		}

--- a/ICSharpCode.Decompiler/TypeSystem/TypeUtils.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeUtils.cs
@@ -134,6 +134,22 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		/// <summary>
+		/// Gets whether the type is a C# 9 native integer type: nint or nuint.
+		/// 
+		/// Returns false for (U)IntPtr.
+		/// </summary>
+		public static bool IsCSharpNativeIntegerType(this IType type)
+		{
+			switch (type.Kind) {
+				case TypeKind.NInt:
+				case TypeKind.NUInt:
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		/// <summary>
 		/// Gets whether the type is a C# primitive integer type: byte, sbyte, short, ushort, int, uint, long and ulong.
 		/// 
 		/// Unlike the ILAst, C# does not consider bool, enums, pointers or IntPtr to be integers.

--- a/ILSpy.Tests/ILSpy.Tests.csproj
+++ b/ILSpy.Tests/ILSpy.Tests.csproj
@@ -46,8 +46,8 @@
 
   <ItemGroup>
     <PackageReference Include="DiffLib" Version="2017.7.26.1241" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0-2.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0-3.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0-3.final" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/ILSpy/Languages/CSharpHighlightingTokenWriter.cs
+++ b/ILSpy/Languages/CSharpHighlightingTokenWriter.cs
@@ -298,12 +298,15 @@ namespace ICSharpCode.ILSpy
 				case "ushort":
 				case "ulong":
 				case "unmanaged":
+				case "nint":
+				case "nuint":
 					color = valueTypeKeywordsColor;
 					break;
 				case "class":
 				case "object":
 				case "string":
 				case "void":
+				case "dynamic":
 					color = referenceTypeKeywordsColor;
 					break;
 			}
@@ -327,7 +330,7 @@ namespace ICSharpCode.ILSpy
 			{
 				color = valueKeywordColor;
 			}
-			if ((identifier.Name == "dynamic" || identifier.Name == "var") && identifier.Parent is AstType)
+			if (identifier.Name == "var" && identifier.Parent is AstType)
 				color = queryKeywordsColor;
 			switch (GetCurrentDefinition()) {
 				case ITypeDefinition t:

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -107,7 +107,7 @@ namespace ICSharpCode.ILSpy
 						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp7_2.ToString(), "C# 7.2 / VS 2017.4"),
 						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp7_3.ToString(), "C# 7.3 / VS 2017.7"),
 						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp8_0.ToString(), "C# 8.0 / VS 2019"),
-						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp9_0.ToString(), "C# 9.0 (experimental)"),
+						new LanguageVersion(Decompiler.CSharp.LanguageVersion.Preview.ToString(), "C# 9.0 (experimental)"),
 					};
 				}
 				return versions;

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -107,6 +107,7 @@ namespace ICSharpCode.ILSpy
 						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp7_2.ToString(), "C# 7.2 / VS 2017.4"),
 						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp7_3.ToString(), "C# 7.3 / VS 2017.7"),
 						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp8_0.ToString(), "C# 8.0 / VS 2019"),
+						new LanguageVersion(Decompiler.CSharp.LanguageVersion.CSharp9_0.ToString(), "C# 9.0 (experimental)"),
 					};
 				}
 				return versions;

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -577,15 +577,6 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Aggressively perform Scalar Replacement Of Aggregates (SROA).
-        /// </summary>
-        public static string DecompilerSettings_AggressiveScalarReplacementOfAggregates {
-            get {
-                return ResourceManager.GetString("DecompilerSettings.AggressiveScalarReplacementOfAggregates", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Allow extension &apos;Add&apos; methods in collection initializer expressions.
         /// </summary>
         public static string DecompilerSettings_AllowExtensionAddMethodsInCollectionInitializerExpressions {
@@ -917,6 +908,15 @@ namespace ICSharpCode.ILSpy.Properties {
             get {
                 return ResourceManager.GetString("DecompilerSettings.IsUnmanagedAttributeOnTypeParametersShouldBeReplacedWithUnmana" +
                         "gedConstraints", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use nint/nuint types.
+        /// </summary>
+        public static string DecompilerSettings_NativeIntegers {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.NativeIntegers", resourceCulture);
             }
         }
         

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -873,4 +873,7 @@ Do you want to continue?</value>
   <data name="DecompilerSettings.UseSdkStyleProjectFormat" xml:space="preserve">
     <value>Use new SDK style format for generated project files (*.csproj)</value>
   </data>
+  <data name="DecompilerSettings.NativeIntegers" xml:space="preserve">
+    <value>Use nint/nuint types</value>
+  </data>
 </root>


### PR DESCRIPTION
* [X] Decode [NativeIntegerAttribute]
* [X] Conversions between native integers
* [x] Arithmetic on native integers
* [x] Compound assignments on native integers
* [ ] ~~Indexing with native integers~~
* [x] Figure out something like `IntroduceDynamicTypeOnLocals` to tell `nint` locals from `IntPtr` locals