### PR TITLE
Remove redundant StatementTransform pass.

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -120,18 +120,12 @@ namespace ICSharpCode.Decompiler.CSharp
 				new DetectExitPoints(canIntroduceExitForReturn: true),
 				new BlockILTransform { // per-block transforms
 					PostOrderTransforms = {
-						//new UseExitPoints(),
 						new ConditionDetection(),
 						new LockTransform(),
 						new UsingTransform(),
 						// CachedDelegateInitialization must run after ConditionDetection and before/in LoopingBlockTransform
 						// and must run before NullCoalescingTransform
 						new CachedDelegateInitialization(),
-						// Run the assignment transform both before and after copy propagation.
-						// Before is necessary because inline assignments of constants are otherwise
-						// copy-propated (turned into two separate assignments of the constant).
-						// After is necessary because the assigned value might involve null coalescing/etc.
-						new StatementTransform(new ILInlining(), new TransformAssignment()),
 						new StatementTransform(
 							// per-block transforms that depend on each other, and thus need to
 							// run interleaved (statement by statement).

--- a/ICSharpCode.Decompiler/IL/Instructions/BlockContainer.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/BlockContainer.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using ICSharpCode.Decompiler.IL.Transforms;
 using ICSharpCode.Decompiler.Util;
 
 namespace ICSharpCode.Decompiler.IL
@@ -237,6 +238,19 @@ namespace ICSharpCode.Decompiler.IL
 			get {
 				return InstructionFlags.ControlFlow;
 			}
+		}
+
+		internal override bool CanInlineIntoSlot(int childIndex, ILInstruction expressionBeingMoved)
+		{
+			// Inlining into the entry-point is allowed as long as we're not moving code into a loop.
+			// This is used to inline into the switch expression.
+			return childIndex == 0 && this.EntryPoint.IncomingEdgeCount == 1;
+		}
+
+		internal override bool PrepareExtract(int childIndex, ExtractionContext ctx)
+		{
+			// Un-inlining from the entry-point is allowed as long as we're not moving code out of a loop
+			return childIndex == 0 && this.EntryPoint.IncomingEdgeCount == 1;
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/IL/Instructions/ILFunction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/ILFunction.cs
@@ -358,7 +358,16 @@ namespace ICSharpCode.Decompiler.IL
 				return InstructionFlags.MayThrow | InstructionFlags.ControlFlow;
 			}
 		}
-		
+
+		internal override bool CanInlineIntoSlot(int childIndex, ILInstruction expressionBeingMoved)
+		{
+			// With expression trees, we occasionally need to inline constants into an existing expression tree.
+			// Only allow this for completely pure constants; a MayReadLocals effect would already be problematic
+			// because we're essentially delaying evaluation of the expression until the ILFunction is called.
+			Debug.Assert(childIndex == 0);
+			return kind == ILFunctionKind.ExpressionTree && expressionBeingMoved.Flags == InstructionFlags.None;
+		}
+
 		/// <summary>
 		/// Apply a list of transforms to this function.
 		/// </summary>

--- a/ICSharpCode.Decompiler/IL/Instructions/ILInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/ILInstruction.cs
@@ -802,6 +802,15 @@ namespace ICSharpCode.Decompiler.IL
 			}
 			return true;
 		}
+
+		/// <summary>
+		/// Gets whether the specified instruction may be inlined into the specified slot.
+		/// Note: this does not check whether reordering with the previous slots is valid; only wheter the target slot supports inlining at all!
+		/// </summary>
+		internal virtual bool CanInlineIntoSlot(int childIndex, ILInstruction expressionBeingMoved)
+		{
+			return GetChildSlot(childIndex).CanInlineInto;
+		}
 	}
 	
 	public interface IInstructionWithTypeOperand

--- a/ICSharpCode.Decompiler/IL/Instructions/NullableInstructions.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/NullableInstructions.cs
@@ -63,7 +63,7 @@ namespace ICSharpCode.Decompiler.IL
 		/// </summary>
 		public bool RefOutput { get => ResultType == StackType.Ref; }
 
-		public NullableUnwrap(StackType unwrappedType, ILInstruction argument, bool refInput=false)
+		public NullableUnwrap(StackType unwrappedType, ILInstruction argument, bool refInput = false)
 			: base(OpCode.NullableUnwrap, argument)
 		{
 			this.ResultType = unwrappedType;
@@ -131,6 +131,14 @@ namespace ICSharpCode.Decompiler.IL
 		{
 			return base.PrepareExtract(childIndex, ctx)
 				&& (ctx.FlagsBeingMoved & InstructionFlags.MayUnwrapNull) == 0;
+		}
+
+		internal override bool CanInlineIntoSlot(int childIndex, ILInstruction expressionBeingMoved)
+		{
+			// Inlining into nullable.rewrap is OK unless the expression being inlined
+			// contains a nullable.wrap that isn't being re-wrapped within the expression being inlined.
+			return base.CanInlineIntoSlot(childIndex, expressionBeingMoved)
+				&& !expressionBeingMoved.HasFlag(InstructionFlags.MayUnwrapNull);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/IndexRangeTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/IndexRangeTransform.cs
@@ -271,10 +271,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					return;
 				}
 				if (rangeVar != null) {
-					if (!MatchIndexFromRange(startIndexKind, startIndexLoad, rangeVar, "get_Start"))
-						return;
-					if (!MatchIndexFromRange(endIndexKind, endIndexLoad, rangeVar, "get_End"))
-						return;
+					return; // this should only ever happen in the second step (ExtendSlicing)
 				}
 				if (!(sliceLengthVar.LoadInstructions.Single().Parent is CallInstruction call))
 					return;
@@ -291,8 +288,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				} else {
 					if (!call.Arguments[1].MatchLdLoc(startOffsetVar))
 						return;
+					if (!ILInlining.CanMoveInto(startOffsetVarInit, block.Instructions[pos], call.Arguments[1]))
+						return;
 				}
 				if (!call.Arguments[2].MatchLdLoc(sliceLengthVar))
+					return;
+				if (!ILInlining.CanMoveInto(sliceLengthVarInit, block.Instructions[pos], call.Arguments[2]))
 					return;
 				if (!CSharpWillGenerateIndexer(call.Method.DeclaringType, slicing: true))
 					return;
@@ -385,13 +386,17 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				// holds because we've used containerLengthVar at least once
 				Debug.Assert(startIndexKind != IndexKind.FromStart || endIndexKind != IndexKind.FromStart);
 				if (rangeVar != null) {
+					if (!ILInlining.CanMoveInto(rangeVarInit, block.Instructions[pos], startIndexLoad))
+						return;
 					if (!MatchIndexFromRange(startIndexKind, startIndexLoad, rangeVar, "get_Start"))
 						return;
 					if (!MatchIndexFromRange(endIndexKind, endIndexLoad, rangeVar, "get_End"))
 						return;
 				}
-				context.Step("Merge containerLengthVar into slicing", slicingCall);
 				var specialMethods = new IndexMethods(context.TypeSystem);
+				if (!specialMethods.IsValid)
+					return;
+				context.Step("Merge containerLengthVar into slicing", slicingCall);
 				rangeCtorCall.ReplaceWith(MakeRange(startIndexKind, startIndexLoad, endIndexKind, endIndexLoad, specialMethods));
 				for (int i = startPos; i < pos; i++) {
 					slicingCall.AddILRange(block.Instructions[i]);


### PR DESCRIPTION
This duplicate pass only made sense back when we ran CopyPropagation as part of the BlockILTransform.

* [x] Adjust IndexRangeTransform
* [x] Adjust Expression Tree transform