### PR TITLE
Add sponsoring section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ How to contribute
 
 Current and past [contributors](https://github.com/icsharpcode/ILSpy/graphs/contributors).
 
+How to support contributors
+-----------------
+
+If you are not actively contributing and instead wish to support active [contributors](https://github.com/icsharpcode/ILSpy/graphs/contributors), you can do so by sponsoring them.
+
+The following top contributors currently accept sponsoring:
+- [siegfriedpammer](https://github.com/sponsors/siegfriedpammer)
+- [jbevain](https://github.com/sponsors/jbevain)
+
+
 Privacy Policy for ILSpy
 ------------------------
 


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
Contributors spend a lot of time developing ILSpy and do not receive compensation.

### Solution
Until now, contributors have been working extremely hard on ILSpy without any financial incentive. While this is very nice to see, I don't think it should be that way. Now that top contributors accept GitHub sponsoring, every user should at least consider giving back to those who made all this possible.

I personally went ahead to put my money where my mouth is and am now proudly sponsoring [siegfriedpammer](https://github.com/sponsors/siegfriedpammer) (and I'd encourage you to at least drop that $5/month into his pocket as well).

