### PR TITLE
Lock closed issues after defined time period

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,22 @@
+name: 'Lock threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2.0.1
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '365'
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          issue-lock-reason: 'resolved'
+          process-only: 'issues'
+          # pr-lock-inactive-days: '365'
+          # pr-lock-reason: 'resolved'


### PR DESCRIPTION
Uses https://github.com/marketplace/actions/lock-threads
Settings: issues only, run once a day, lock after 365 days, add comment why it was locked

Should we immediately go for 90 days as per https://github.com/icsharpcode/ILSpy/issues/1933#issuecomment-663998595?
