### PR TITLE
Add option to always qualify member references

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -777,7 +777,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			bool requireTarget;
 			ResolveResult targetResolveResult;
 			if ((allowedTransforms & CallTransformation.RequireTarget) != 0) {
-				if (expressionBuilder.HidesVariableWithName(method.Name)) {
+				if (settings.AlwaysQualifyMemberReferences || expressionBuilder.HidesVariableWithName(method.Name)) {
 					requireTarget = true;
 				} else {
 					if (method.IsLocalFunction)
@@ -1099,7 +1099,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			TranslatedExpression target, List<TranslatedExpression> arguments, string[] argumentNames)
 		{
 			bool requireTarget;
-			if (method.AccessorOwner.SymbolKind == SymbolKind.Indexer || expressionBuilder.HidesVariableWithName(method.AccessorOwner.Name))
+			if (settings.AlwaysQualifyMemberReferences || method.AccessorOwner.SymbolKind == SymbolKind.Indexer || expressionBuilder.HidesVariableWithName(method.AccessorOwner.Name))
 				requireTarget = true;
 			else if (method.IsStatic)
 				requireTarget = !expressionBuilder.IsCurrentOrContainingType(method.DeclaringTypeDefinition);

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -226,7 +226,7 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		bool RequiresQualifier(IMember member, TranslatedExpression target)
 		{
-			if (HidesVariableWithName(member.Name))
+			if (settings.AlwaysQualifyMemberReferences || HidesVariableWithName(member.Name))
 				return true;
 			if (member.IsStatic)
 				return !IsCurrentOrContainingType(member.DeclaringTypeDefinition);

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -619,6 +619,26 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		bool alwaysQualifyMemberReferences = false;
+
+		/// <summary>
+		/// Gets/Sets whether to always qualify member references.
+		/// true: <c>this.DoSomething();</c>
+		/// false: <c>DoSomething();</c>
+		/// default: false
+		/// </summary>
+		[Category("Other")]
+		[Description("DecompilerSettings.AlwaysQualifyMemberReferences")]
+		public bool AlwaysQualifyMemberReferences {
+			get { return alwaysQualifyMemberReferences; }
+			set {
+				if (alwaysQualifyMemberReferences != value) {
+					alwaysQualifyMemberReferences = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		bool alwaysShowEnumMemberValues = false;
 
 		/// <summary>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -649,6 +649,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always qualify member references.
+        /// </summary>
+        public static string DecompilerSettings_AlwaysQualifyMemberReferences {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.AlwaysQualifyMemberReferences", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always show enum member values.
         /// </summary>
         public static string DecompilerSettings_AlwaysShowEnumMemberValues {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -246,6 +246,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.AlwaysCastTargetsOfExplicitInterfaceImplementationCalls" xml:space="preserve">
     <value>Always cast targets of explicit interface implementation calls</value>
   </data>
+  <data name="DecompilerSettings.AlwaysQualifyMemberReferences" xml:space="preserve">
+    <value>Always qualify member references</value>
+  </data>
   <data name="DecompilerSettings.AlwaysShowEnumMemberValues" xml:space="preserve">
     <value>Always show enum member values</value>
   </data>


### PR DESCRIPTION
This commit adds an "always qualify member references" option, which is off by default. Example decompiler output:

```cs
// disabled (default, current behavior)
public BloomSettings(float intensity, bool brightWhiteOnly = false)
{
	bloomIntensity = intensity;
	this.brightWhiteOnly = brightWhiteOnly;
	Init();
	init();
}
```
```cs
// enabled
public BloomSettings(float intensity, bool brightWhiteOnly = false)
{
	this.bloomIntensity = intensity;
	this.brightWhiteOnly = brightWhiteOnly;
	BloomSettings.Init();
	this.init();
}
```

That can make the code much easier to understand when decompiling some projects (like Stardew Valley) which have large methods that heavily mix local/instance/static references.