### PR TITLE
Fix #2138: Add flag values to both "Characteristics" lists in Metadata Explorer

### DIFF
--- a/ILSpy/Metadata/CoffHeaderTreeNode.cs
+++ b/ILSpy/Metadata/CoffHeaderTreeNode.cs
@@ -93,22 +93,22 @@ namespace ICSharpCode.ILSpy.Metadata
 			{
 				FrameworkElementFactory dataGridFactory = new FrameworkElementFactory(typeof(DataGrid));
 				dataGridFactory.SetValue(DataGrid.ItemsSourceProperty, new[] {
-					new { Value = (flags & 0x0001) != 0, Meaning = "Relocation info stripped from file" },
-					new { Value = (flags & 0x0002) != 0, Meaning = "File is executable" },
-					new { Value = (flags & 0x0004) != 0, Meaning = "Line numbers stripped from file" },
-					new { Value = (flags & 0x0008) != 0, Meaning = "Local symbols stripped from file" },
-					new { Value = (flags & 0x0010) != 0, Meaning = "Aggressively trim working set" },
-					new { Value = (flags & 0x0020) != 0, Meaning = "Large address aware" },
-					new { Value = (flags & 0x0040) != 0, Meaning = "Reserved" },
-					new { Value = (flags & 0x0080) != 0, Meaning = "Bytes of machine words are reversed (Low)" },
-					new { Value = (flags & 0x0100) != 0, Meaning = "32-bit word machine" },
-					new { Value = (flags & 0x0200) != 0, Meaning = "Debugging info stripped from file in .DBG file" },
-					new { Value = (flags & 0x0400) != 0, Meaning = "If image is on removable media, copy and run from the swap file" },
-					new { Value = (flags & 0x0800) != 0, Meaning = "If image is on Net, copy and run from the swap file" },
-					new { Value = (flags & 0x1000) != 0, Meaning = "System" },
-					new { Value = (flags & 0x2000) != 0, Meaning = "DLL" },
-					new { Value = (flags & 0x4000) != 0, Meaning = "File should only be run on a UP machine" },
-					new { Value = (flags & 0x8000) != 0, Meaning = "Bytes of machine words are reversed (High)" },
+					new { Value = (flags & 0x0001) != 0, Meaning = "<0001> Relocation info stripped from file" },
+					new { Value = (flags & 0x0002) != 0, Meaning = "<0002> File is executable" },
+					new { Value = (flags & 0x0004) != 0, Meaning = "<0004> Line numbers stripped from file" },
+					new { Value = (flags & 0x0008) != 0, Meaning = "<0008> Local symbols stripped from file" },
+					new { Value = (flags & 0x0010) != 0, Meaning = "<0010> Aggressively trim working set" },
+					new { Value = (flags & 0x0020) != 0, Meaning = "<0020> Large address aware" },
+					new { Value = (flags & 0x0040) != 0, Meaning = "<0040> Reserved" },
+					new { Value = (flags & 0x0080) != 0, Meaning = "<0080> Bytes of machine words are reversed (Low)" },
+					new { Value = (flags & 0x0100) != 0, Meaning = "<0100> 32-bit word machine" },
+					new { Value = (flags & 0x0200) != 0, Meaning = "<0200> Debugging info stripped from file in .DBG file" },
+					new { Value = (flags & 0x0400) != 0, Meaning = "<0400> If image is on removable media, copy and run from the swap file" },
+					new { Value = (flags & 0x0800) != 0, Meaning = "<0800> If image is on Net, copy and run from the swap file" },
+					new { Value = (flags & 0x1000) != 0, Meaning = "<1000> System" },
+					new { Value = (flags & 0x2000) != 0, Meaning = "<2000> DLL" },
+					new { Value = (flags & 0x4000) != 0, Meaning = "<4000> File should only be run on a UP machine" },
+					new { Value = (flags & 0x8000) != 0, Meaning = "<8000> Bytes of machine words are reversed (High)" },
 				});
 				DataTemplate template = new DataTemplate();
 				template.VisualTree = dataGridFactory;

--- a/ILSpy/Metadata/OptionalHeaderTreeNode.cs
+++ b/ILSpy/Metadata/OptionalHeaderTreeNode.cs
@@ -112,22 +112,22 @@ namespace ICSharpCode.ILSpy.Metadata
 			{
 				FrameworkElementFactory dataGridFactory = new FrameworkElementFactory(typeof(DataGrid));
 				dataGridFactory.SetValue(DataGrid.ItemsSourceProperty, new[] {
-					new { Value = (flags & 0x0001) != 0, Meaning = "Unused" },
-					new { Value = (flags & 0x0002) != 0, Meaning = "Unused" },
-					new { Value = (flags & 0x0004) != 0, Meaning = "Unused" },
-					new { Value = (flags & 0x0008) != 0, Meaning = "Unused" },
-					new { Value = (flags & 0x0010) != 0, Meaning = "Unused" },
-					new { Value = (flags & 0x0020) != 0, Meaning = "ASLR with 64-bit address space" },
-					new { Value = (flags & 0x0040) != 0, Meaning = "DLL can be relocated at load time" },
-					new { Value = (flags & 0x0080) != 0, Meaning = "Code integrity checks are enforced" },
-					new { Value = (flags & 0x0100) != 0, Meaning = "Image is NX compatible" },
-					new { Value = (flags & 0x0200) != 0, Meaning = "Isolation aware, but do not isolate the image" },
-					new { Value = (flags & 0x0400) != 0, Meaning = "Does not use structured exception handling (SEH)" },
-					new { Value = (flags & 0x0800) != 0, Meaning = "Do not bind the image" },
-					new { Value = (flags & 0x1000) != 0, Meaning = "Image should execute in an AppContainer" },
-					new { Value = (flags & 0x2000) != 0, Meaning = "Driver is a WDM Driver" },
-					new { Value = (flags & 0x4000) != 0, Meaning = "Image supports Control Flow Guard" },
-					new { Value = (flags & 0x8000) != 0, Meaning = "Image is Terminal Server aware" },
+					new { Value = (flags & 0x0001) != 0, Meaning = "<0001> Unused" },
+					new { Value = (flags & 0x0002) != 0, Meaning = "<0002> Unused" },
+					new { Value = (flags & 0x0004) != 0, Meaning = "<0004> Unused" },
+					new { Value = (flags & 0x0008) != 0, Meaning = "<0008> Unused" },
+					new { Value = (flags & 0x0010) != 0, Meaning = "<0010> Unused" },
+					new { Value = (flags & 0x0020) != 0, Meaning = "<0020> ASLR with 64-bit address space" },
+					new { Value = (flags & 0x0040) != 0, Meaning = "<0040> DLL can be relocated at load time" },
+					new { Value = (flags & 0x0080) != 0, Meaning = "<0080> Code integrity checks are enforced" },
+					new { Value = (flags & 0x0100) != 0, Meaning = "<0100> Image is NX compatible" },
+					new { Value = (flags & 0x0200) != 0, Meaning = "<0200> Isolation aware, but do not isolate the image" },
+					new { Value = (flags & 0x0400) != 0, Meaning = "<0400> Does not use structured exception handling (SEH)" },
+					new { Value = (flags & 0x0800) != 0, Meaning = "<0800> Do not bind the image" },
+					new { Value = (flags & 0x1000) != 0, Meaning = "<1000> Image should execute in an AppContainer" },
+					new { Value = (flags & 0x2000) != 0, Meaning = "<2000> Driver is a WDM Driver" },
+					new { Value = (flags & 0x4000) != 0, Meaning = "<4000> Image supports Control Flow Guard" },
+					new { Value = (flags & 0x8000) != 0, Meaning = "<8000> Image is Terminal Server aware" },
 				});
 				dataGridFactory.SetValue(DataGrid.GridLinesVisibilityProperty, DataGridGridLinesVisibility.None);
 				DataTemplate template = new DataTemplate();


### PR DESCRIPTION
Fixes #2138 

### Problem
Having the "Characteristics" lists in Metadata Explorer is great, but it would be even more helpful to see the individual values for each item in both lists. Doing so would make the relationship between the bit-masked value and the individual items that make up that value much clearer.


### Solution
I added the flag value, wrapped in `<` and `>`, to the beginning (i.e. far left) of each "meaning".

_NOTE:_ I apologize that I have no ability to test this change. However, it should be extremely low-risk as I'm just adding some text to some strings.


&nbsp;
Take care,
Solomon...
https://SqlQuantumLeap.com/

