### PR TITLE
Remove link to non-existing file.

### DIFF
--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -626,12 +626,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\nrefactory\doc\XML Documentation.html">
-      <Link>Documentation\XML Documentation.html</Link>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Include="..\doc\Pattern Matching.html">
       <Link>CSharp\Syntax\PatternMatching\Pattern Matching.html</Link>
     </Content>


### PR DESCRIPTION
This breaks build incrementality (fast up-to-date check) thinks XML Documentation.html is missing so it decides to rebuild the project every time, even if nothing has changed.