### PR TITLE
Show Sequence Points from CLI

### DIFF
--- a/ICSharpCode.Decompiler.Console/IlspyCmdProgram.cs
+++ b/ICSharpCode.Decompiler.Console/IlspyCmdProgram.cs
@@ -47,6 +47,9 @@ Remarks:
 		[Option("-il|--ilcode", "Show IL code.", CommandOptionType.NoValue)]
 		public bool ShowILCodeFlag { get; }
 
+		[Option("--il-sequence-points", "Show IL with sequence points. Implies -il.", CommandOptionType.NoValue)]
+		public bool ShowILSequencePointsFlag { get; }
+
 		[Option("-genpdb", "Generate PDB.", CommandOptionType.NoValue)]
 		public bool CreateDebugInfoFlag { get; }
 
@@ -90,7 +93,7 @@ Remarks:
 					}
 
 					return ListContent(InputAssemblyName, output, kinds);
-				} else if (ShowILCodeFlag) {
+				} else if (ShowILCodeFlag || ShowILSequencePointsFlag) {
 					if (outputDirectorySpecified) {
 						string outputName = Path.GetFileNameWithoutExtension(InputAssemblyName);
 						output = File.CreateText(Path.Combine(OutputDirectory, outputName) + ".il");
@@ -169,7 +172,11 @@ Remarks:
 		{
 			var module = new PEFile(assemblyFileName);
 			output.WriteLine($"// IL code: {module.Name}");
-			var disassembler = new ReflectionDisassembler(new PlainTextOutput(output), CancellationToken.None);
+			var disassembler = new ReflectionDisassembler(new PlainTextOutput(output), CancellationToken.None)
+			{
+				DebugInfo = TryLoadPDB(module),
+				ShowSequencePoints = ShowILSequencePointsFlag,
+			};
 			disassembler.WriteModuleContents(module);
 			return 0;
 		}


### PR DESCRIPTION
When disassembling IL add a flag to enable showing sequence points. We
can already specify PDB loading; take advantage of that to provide
debug information for the decompiler.


### Problem
When disassembling from the command line it isn't currently possible to see sequence
point information.

### Solution

 * When the `--il-sequence-points` flag is used the behavior is the same as
   with `-il`, but sequence point information is aslo emitted. This leaves
   things open to adding an `--il-metadata-tokens` flag too.
 * [ ] At least one test covering the code changed

