### PR TITLE
GH Action build for ILSpy

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -84,7 +84,7 @@ jobs:
       run: dotnet-format --check --verbosity diagnostic ILSpy.sln
     
     - name: Zip ILSpy Release
-      if: matrix.channel == 'zip' && matrix.configuration == 'release'
+      if: matrix.channel == 'zip'
       # run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
       run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*.dll .\ILSpy\bin\${{ matrix.configuration }}\net472\*.exe .\ILSpy\bin\${{ matrix.configuration }}\net472\*.config .\ILSpy\bin\${{ matrix.configuration }}\net472\*\ILSpy.resources.dll .\ILSpy\bin\${{ matrix.configuration }}\net472\*\ILSpy.ReadyToRun.Plugin.resources.dll
       
@@ -100,25 +100,25 @@ jobs:
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: VS Addin
+        name: ILSpy VS Addin ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }} (${{ matrix.configuration }})
         path: ILSpy.Addin\bin\Release\net472\*.vsix
 
     - name: Upload NuGet release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: NuGet Package
+        name: ICSharpCode.Decompiler NuGet Package (${{ matrix.configuration }})
         path: ICSharpCode.Decompiler\bin\Release\ICSharpCode.Decompiler*.nupkg
 
     - name: Upload zip release build artifacts
-      if: matrix.channel == 'zip' && matrix.configuration == 'release'
+      if: matrix.channel == 'zip'
       uses: actions/upload-artifact@v2
       with:
-        name: ILSpy ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }}
+        name: ILSpy ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }} (${{ matrix.configuration }})
         path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip
 
     - name: Push to Github Packages
-      if: github.ref == 'refs/heads/master' && success()
+      if: github.ref == 'refs/heads/master' && success() && matrix.channel == 'zip' && matrix.configuration == 'release'
       run: dotnet nuget push ICSharpCode.Decompiler\bin\Release\ICSharpCode.Decompiler*.nupkg --no-symbols --skip-duplicate
       env:
         NUGET_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -2,7 +2,7 @@ name: Build ILSpy
 
 on:
   push:
-    branches: [ master, release/** ]
+    branches: '**'
   pull_request:
     branches: [ master, release/** ]
 

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -95,13 +95,15 @@ jobs:
       with:
         name: MSIX Store Package
         path: ${{ env.StagingDirectory }}\${{ matrix.channel }}\*.*
+        if-no-files-found: error
 
     - name: Upload VSIX release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
         name: ILSpy VS Addin ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }} (${{ matrix.configuration }})
-        path: ILSpy.Addin\bin\Release\net472\*.vsix
+        path: ILSpy.Addin\bin\${{ matrix.configuration }}\net472\*.vsix
+        if-no-files-found: error
 
     - name: Upload NuGet release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
@@ -109,6 +111,7 @@ jobs:
       with:
         name: ICSharpCode.Decompiler NuGet Package (${{ matrix.configuration }})
         path: ICSharpCode.Decompiler\bin\Release\ICSharpCode.Decompiler*.nupkg
+        if-no-files-found: error
 
     - name: Upload zip release build artifacts
       if: matrix.channel == 'zip'
@@ -116,6 +119,7 @@ jobs:
       with:
         name: ILSpy ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }} (${{ matrix.configuration }})
         path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip
+        if-no-files-found: error
 
     - name: Push to Github Packages
       if: github.ref == 'refs/heads/master' && success() && matrix.channel == 'zip' && matrix.configuration == 'release'

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -2,9 +2,9 @@ name: Build ILSpy
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release/** ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release/** ]
 
 jobs:
   Build:
@@ -56,7 +56,7 @@ jobs:
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
 
     - name: Build
-      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ $env:StagingDirectory }}\${{ matrix.channel }}\" 
+      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ env.StagingDirectory }}\${{ matrix.channel }}\" 
 
     - name: Execute unit tests
       run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe
@@ -68,9 +68,16 @@ jobs:
       run: dotnet-format --check --verbosity diagnostic ILSpy.sln
 
     # https://github.com/actions/upload-artifact
-    - name: Upload build artifacts
+    - name: Upload store build artifacts
       if: matrix.channel == 'store'
       uses: actions/upload-artifact@v2
       with:
-        name: MSIX Package
-        path: ${{ $env:StagingDirectory }}\${{ matrix.channel }}
+        name: MSIX Store Package
+        path: ${{ env.StagingDirectory }}\${{ matrix.channel }}
+
+    - name: Upload zip release build artifacts
+      if: matrix.channel == 'zip' && matrix.configuration == 'release'
+      uses: actions/upload-artifact@v2
+      with:
+        name: VSIX
+        path: ILSpy.Addin\**\*.vsix

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -57,6 +57,8 @@ jobs:
 
     - name: Build
       run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ github.workspace }}\${{ env.StagingDirectory }}\${{ matrix.channel }}\" 
+      env:
+        ReleaseChannel: ${{ env.channel }}
 
     - name: Execute unit tests
       run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -59,7 +59,7 @@ jobs:
       id: version
       run: |
         pwsh .\BuildTools\ghactions-install.ps1
-        echo ::set-output name=ilspy_version::${ILSPY_VERSION_NUMBER}
+        echo "::set-output name=ilspy_version::%ILSPY_VERSION_NUMBER%"
         echo "${{ steps.version.outputs.ilspy_version }}"
 
     - name: Restore the application

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -27,6 +27,7 @@ jobs:
             channel: store
     env:
       BuildPlatform: Any CPU
+      StagingDirectory: buildartefacts 
     steps:
     - name: Force git to use crlf, otherwise dotnet-format --check fails
       run: git config --global core.autocrlf true
@@ -42,10 +43,21 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
       with:
        vs-version: '[16.6,16.9)'
+
     - name: Install dotnet-format
-      run: dotnet tool install dotnet-format --version 4.1.131201
+      run: dotnet tool install dotnet-format --global --version 4.1.131201
     - name: Pipelines PS
       run: pwsh .\BuildTools\pipelines-install.ps1
+
     - name: Restore the application
-      run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }}
+      run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
+
+    - name: Build
+      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="$env:StagingDirectory\${{ matrix.channel }}\\" 
+
+    - name: Tab check
+      run: python BuildTools\tidy.py
+
+    - name: dotnet-format check
+      run: dotnet-format --check --verbosity diagnostic ILSpy.sln
 

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -1,0 +1,51 @@
+name: Build ILSpy
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - configuration: debug
+            solution: ilspy.sln
+            channel: zip
+          - configuration: release
+            solution: ilspy.sln
+            channel: zip
+          - configuration: release
+            solution: ilspy.withpackage.sln
+            channel: ci
+          - configuration: release
+            solution: ilspy.withpackage.sln
+            channel: store
+    env:
+      BuildPlatform: Any CPU
+    steps:
+    - name: Force git to use crlf, otherwise dotnet-format --check fails
+      run: git config --global core.autocrlf true
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+      with:
+       vs-version: '[16.6,16.9)'
+    - name: Install dotnet-format
+      run: dotnet install dotnet-format --version 4.1.131201
+    - name: Pipelines PS
+      run: pwsh .\BuildTools\pipelines-install.ps1
+    - name: Restore the application
+      run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }}
+

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -60,7 +60,6 @@ jobs:
       run: |
         pwsh .\BuildTools\ghactions-install.ps1
         echo "::set-output name=ilspy_version::%ILSPY_VERSION_NUMBER%"
-        echo "${{ steps.version.outputs.ilspy_version }}"
 
     - name: Restore the application
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
@@ -71,21 +70,25 @@ jobs:
         ReleaseChannel: ${{ matrix.channel }}
 
     - name: Execute unit tests
-      run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe
-      
-    - name: Tab check
+      run: dotnet test $env:Tests1 $env:Tests2 $env:Tests3
+      env:
+        Tests1: ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe
+        Tests2: ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe
+        Tests3: ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe
+
+    - name: Style - tab check
       run: python BuildTools\tidy.py
 
-    - name: dotnet-format check
+    - name: Style - dotnet-format check
       run: dotnet-format --check --verbosity diagnostic ILSpy.sln
     
-    - name: Zip ILSpy
+    - name: Zip ILSpy Release
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       # run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
       run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*.dll .\ILSpy\bin\${{ matrix.configuration }}\net472\*.exe .\ILSpy\bin\${{ matrix.configuration }}\net472\*.config .\ILSpy\bin\${{ matrix.configuration }}\net472\*\ILSpy.resources.dll .\ILSpy\bin\${{ matrix.configuration }}\net472\*\ILSpy.ReadyToRun.Plugin.resources.dll
       
     # https://github.com/actions/upload-artifact
-    - name: Upload store build artifacts
+    - name: Upload Store build artifacts
       if: matrix.channel == 'store'
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -69,7 +69,8 @@ jobs:
     
     - name: Zip ILSpy
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
-      run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
+      # run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
+      run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*.dll .\ILSpy\bin\${{ matrix.configuration }}\net472\*.exe .\ILSpy\bin\${{ matrix.configuration }}\net472\*.config .\ILSpy\bin\${{ matrix.configuration }}\net472\*\ILSpy.resources.dll .\ILSpy\bin\${{ matrix.configuration }}\net472\*\ILSpy.ReadyToRun.Plugin.resources.dll
       
     # https://github.com/actions/upload-artifact
     - name: Upload store build artifacts
@@ -97,5 +98,5 @@ jobs:
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: ILSpy
+        name: ILSpy ${{ env.ILSPY_VERSION_NUMBER }}
         path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -77,21 +77,21 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: MSIX Store Package
-        path: ${{ env.StagingDirectory }}\${{ matrix.channel }}
+        path: ${{ env.StagingDirectory }}\${{ matrix.channel }}\*.*
 
     - name: Upload VSIX release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: VSIX
-        path: ILSpy.Addin\**\*.vsix
+        name: VS Addin
+        path: ILSpy.Addin\bin\Release\net472\*.vsix
 
     - name: Upload NuGet release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: nupkg
-        path: ICSharpCode.Decompiler\**\ICSharpCode.Decompiler*.nupkg
+        name: NuGet Package
+        path: ICSharpCode.Decompiler\bin\Release\ICSharpCode.Decompiler*.nupkg
 
     - name: Upload zip release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -69,7 +69,7 @@ jobs:
     
     - name: Zip ILSpy
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
-      run: 7z a -tzip $env:StagingDirectory\ILSpy.zip ILSpy/bin/${{ matrix.configuration }}/net472/*.*
+      run: 7z a -tzip $env:StagingDirectory\ILSpy.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
       
     # https://github.com/actions/upload-artifact
     - name: Upload store build artifacts

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -27,8 +27,11 @@ jobs:
             channel: store
     env:
       BuildPlatform: Any CPU
-      StagingDirectory: buildartefacts 
+      StagingDirectory: buildartifacts 
+
     steps:
+    - run: mkdir -p $env:StagingDirectory
+      
     - name: Force git to use crlf, otherwise dotnet-format --check fails
       run: git config --global core.autocrlf true
     - uses: actions/checkout@v2
@@ -53,7 +56,7 @@ jobs:
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
 
     - name: Build
-      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="$env:StagingDirectory\${{ matrix.channel }}\\" 
+      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ $env:StagingDirectory }}\${{ matrix.channel }}\" 
 
     - name: Execute unit tests
       run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe
@@ -64,9 +67,10 @@ jobs:
     - name: dotnet-format check
       run: dotnet-format --check --verbosity diagnostic ILSpy.sln
 
+    # https://github.com/actions/upload-artifact
     - name: Upload build artifacts
       if: matrix.channel == 'store'
       uses: actions/upload-artifact@v2
       with:
         name: MSIX Package
-        path: $env:StagingDirectory\${{ matrix.channel }}
+        path: ${{ $env:StagingDirectory }}\${{ matrix.channel }}

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -43,7 +43,7 @@ jobs:
       with:
        vs-version: '[16.6,16.9)'
     - name: Install dotnet-format
-      run: dotnet install dotnet-format --version 4.1.131201
+      run: dotnet tool install dotnet-format --version 4.1.131201
     - name: Pipelines PS
       run: pwsh .\BuildTools\pipelines-install.ps1
     - name: Restore the application

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -56,7 +56,7 @@ jobs:
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
 
     - name: Build
-      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ env.StagingDirectory }}\${{ matrix.channel }}\" 
+      run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ github.workspace }}\${{ env.StagingDirectory }}\${{ matrix.channel }}\" 
 
     - name: Execute unit tests
       run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -42,6 +42,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.x'
+        source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
       with:
@@ -102,3 +106,9 @@ jobs:
       with:
         name: ILSpy ${{ env.ILSPY_VERSION_NUMBER }}
         path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip
+
+    - name: Push to Github Packages
+      if: github.ref == 'refs/heads/master' && success()
+      run: dotnet nuget push ICSharpCode.Decompiler\bin\Release\ICSharpCode.Decompiler*.nupkg --no-symbols --skip-duplicate
+      env:
+        NUGET_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -66,7 +66,11 @@ jobs:
 
     - name: dotnet-format check
       run: dotnet-format --check --verbosity diagnostic ILSpy.sln
-
+    
+    - name: Zip ILSpy
+      if: matrix.channel == 'zip' && matrix.configuration == 'release'
+      run: 7z a -tzip $env:StagingDirectory\ILSpy.zip ILSpy/bin/${{ matrix.configuration }}/net472/*.*
+      
     # https://github.com/actions/upload-artifact
     - name: Upload store build artifacts
       if: matrix.channel == 'store'
@@ -75,9 +79,23 @@ jobs:
         name: MSIX Store Package
         path: ${{ env.StagingDirectory }}\${{ matrix.channel }}
 
-    - name: Upload zip release build artifacts
+    - name: Upload VSIX release build artifacts
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
         name: VSIX
         path: ILSpy.Addin\**\*.vsix
+
+    - name: Upload NuGet release build artifacts
+      if: matrix.channel == 'zip' && matrix.configuration == 'release'
+      uses: actions/upload-artifact@v2
+      with:
+        name: nupkg
+        path: ICSharpCode.Decompiler\**\ICSharpCode.Decompiler*.nupkg
+
+    - name: Upload zip release build artifacts
+      if: matrix.channel == 'zip' && matrix.configuration == 'release'
+      uses: actions/upload-artifact@v2
+      with:
+        name: ILSpy
+        path: ${{ env.StagingDirectory }}\ILSpy.zip

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -38,6 +38,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
@@ -53,8 +54,13 @@ jobs:
 
     - name: Install dotnet-format
       run: dotnet tool install dotnet-format --global --version 4.1.131201
+
     - name: Get Version PS
-      run: pwsh .\BuildTools\ghactions-install.ps1
+      id: version
+      run: |
+        pwsh .\BuildTools\ghactions-install.ps1
+        echo ::set-output name=ilspy_version::${ILSPY_VERSION_NUMBER}
+        echo "${{ steps.version.outputs.ilspy_version }}"
 
     - name: Restore the application
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
@@ -104,7 +110,7 @@ jobs:
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: ILSpy ${{ env.ILSPY_VERSION_NUMBER }}
+        name: ILSpy ${{ steps.version.outputs.ilspy_version }}
         path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip
 
     - name: Push to Github Packages

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -69,7 +69,7 @@ jobs:
     
     - name: Zip ILSpy
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
-      run: 7z a -tzip $env:StagingDirectory\ILSpy.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
+      run: 7z a -tzip $env:StagingDirectory\ILSpy_binaries.zip .\ILSpy\bin\${{ matrix.configuration }}\net472\*
       
     # https://github.com/actions/upload-artifact
     - name: Upload store build artifacts
@@ -98,4 +98,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ILSpy
-        path: ${{ env.StagingDirectory }}\ILSpy.zip
+        path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -55,11 +55,12 @@ jobs:
     - name: Install dotnet-format
       run: dotnet tool install dotnet-format --global --version 4.1.131201
 
-    - name: Get Version PS
+    - name: Get Version
       id: version
+      shell: pwsh
       run: |
-        pwsh .\BuildTools\ghactions-install.ps1
-        Write-Output "::set-output name=ilspy_version::$env:ILSPY_VERSION_NUMBER"
+        .\BuildTools\ghactions-install.ps1
+        Get-ChildItem Env: | Where-Object {$_.Name -Match "^ILSPY_"} | %{ echo "::set-output name=$($_.Name)::$($_.Value)" }
 
     - name: Restore the application
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
@@ -113,7 +114,7 @@ jobs:
       if: matrix.channel == 'zip' && matrix.configuration == 'release'
       uses: actions/upload-artifact@v2
       with:
-        name: ILSpy ${{ steps.version.outputs.ilspy_version }}
+        name: ILSpy ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }}
         path: ${{ env.StagingDirectory }}\ILSpy_binaries.zip
 
     - name: Push to Github Packages

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -49,8 +49,8 @@ jobs:
 
     - name: Install dotnet-format
       run: dotnet tool install dotnet-format --global --version 4.1.131201
-    - name: Pipelines PS
-      run: pwsh .\BuildTools\pipelines-install.ps1
+    - name: Get Version PS
+      run: pwsh .\BuildTools\ghactions-install.ps1
 
     - name: Restore the application
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -59,7 +59,7 @@ jobs:
       id: version
       run: |
         pwsh .\BuildTools\ghactions-install.ps1
-        echo "::set-output name=ilspy_version::%ILSPY_VERSION_NUMBER%"
+        Write-Output "::set-output name=ilspy_version::$env:ILSPY_VERSION_NUMBER"
 
     - name: Restore the application
       run: msbuild ${{ matrix.solution }} /t:Restore /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Build
       run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="${{ github.workspace }}\${{ env.StagingDirectory }}\${{ matrix.channel }}\" 
       env:
-        ReleaseChannel: ${{ env.channel }}
+        ReleaseChannel: ${{ matrix.channel }}
 
     - name: Execute unit tests
       run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -55,9 +55,18 @@ jobs:
     - name: Build
       run: msbuild ${{ matrix.solution }} /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /p:AppxPackageDir="$env:StagingDirectory\${{ matrix.channel }}\\" 
 
+    - name: Execute unit tests
+      run: dotnet test ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net472\ICSharpCode.Decompiler.Tests.exe ILSpy.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.Tests.exe ILSpy.BamlDecompiler.Tests\bin\${{ matrix.configuration }}\net472\ILSpy.BamlDecompiler.Tests.exe
+      
     - name: Tab check
       run: python BuildTools\tidy.py
 
     - name: dotnet-format check
       run: dotnet-format --check --verbosity diagnostic ILSpy.sln
 
+    - name: Upload build artifacts
+      if: matrix.channel == 'store'
+      uses: actions/upload-artifact@v2
+      with:
+        name: MSIX Package
+        path: $env:StagingDirectory\${{ matrix.channel }}

--- a/BuildTools/ghactions-install.ps1
+++ b/BuildTools/ghactions-install.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = "Stop"
+
+$baseCommit = "d779383cb85003d6dabeb976f0845631e07bf463";
+$baseCommitRev = 1;
+
+# make sure this matches artifacts-only branches list in appveyor.yml!
+$masterBranches = '^refs/heads/(master|release/.+)$';
+
+$globalAssemblyInfoTemplateFile = "ILSpy/Properties/AssemblyInfo.template.cs";
+
+$versionParts = @{};
+Get-Content $globalAssemblyInfoTemplateFile | where { $_ -match 'string (\w+) = "?(\w+)"?;' } | foreach { $versionParts.Add($Matches[1], $Matches[2]) }
+
+$major = $versionParts.Major;
+$minor = $versionParts.Minor;
+$build = $versionParts.Build;
+$versionName = $versionParts.VersionName;
+
+if ($versionName -ne "null") {
+    $versionName = "-$versionName";
+} else {
+    $versionName = "";
+}
+
+Write-Host "GITHUB_REF: '$env:GITHUB_REF'";
+
+if ($env:GITHUB_REF -match $masterBranches) {
+	$branch = "";
+} else {
+	$branch = "-$env:BUILD_SOURCEBRANCHNAME";
+}
+if ($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) {
+	$suffix = "-pr$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER";
+} else {
+	$suffix = "";
+}
+
+$revision = [Int32]::Parse((git rev-list --count "$baseCommit..HEAD")) + $baseCommitRev;
+
+$newVersion="$major.$minor.$build.$revision";
+$env:ILSPY_VERSION_NUMBER="$newVersion$branch$versionName$suffix";
+Write-Host "new version: $newVersion$branch$versionName$suffix";

--- a/BuildTools/ghactions-install.ps1
+++ b/BuildTools/ghactions-install.ps1
@@ -27,23 +27,20 @@ Write-Host "GITHUB_REF: '$env:GITHUB_REF'";
 if ($env:GITHUB_REF -match $masterBranches) {
 	$branch = "";
 	$suffix = "";
+} elseif ($env:GITHUB_REF -match '^refs/pull/(\d+)/merge$') {
+	$branch = "";
+	$suffix = "-pr" + $Matches[1];
+} elseif ($env:GITHUB_REF -match '^refs/heads/(.+)$') {
+	$branch = "-" + $Matches[1];
+	$suffix = "";
 } else {
-	if ($env:GITHUB_REF -match '^refs/pull/(\d+)/merge$') {
-		$branch = "";
-		$suffix = "-pr" + $Matches[1];
-	} else {
-		if ($env:GITHUB_REF -match '^refs/heads/(.+)$') {
-			$branch = "-" + $Matches[1];
-			$suffix = "";
-		} else {
-			$branch = "";
-			$suffix = "";
-		}
-	}
+	$branch = "";
+	$suffix = "";
 }
 
 $revision = [Int32]::Parse((git rev-list --count "$baseCommit..HEAD")) + $baseCommitRev;
 
 $newVersion="$major.$minor.$build.$revision";
 $env:ILSPY_VERSION_NUMBER="$newVersion$branch$versionName$suffix";
+$env:ILSPY_VERSION_NUMBER | Out-File "ILSPY_VERSION"
 Write-Host "new version: $newVersion$branch$versionName$suffix";

--- a/BuildTools/ghactions-install.ps1
+++ b/BuildTools/ghactions-install.ps1
@@ -26,13 +26,20 @@ Write-Host "GITHUB_REF: '$env:GITHUB_REF'";
 
 if ($env:GITHUB_REF -match $masterBranches) {
 	$branch = "";
-} else {
-	$branch = "-$env:BUILD_SOURCEBRANCHNAME";
-}
-if ($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) {
-	$suffix = "-pr$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER";
-} else {
 	$suffix = "";
+} else {
+	if ($env:GITHUB_REF -match '^refs/pull/(\d+)/merge$') {
+		$branch = "";
+		$suffix = "-pr" + $Matches[1];
+	} else {
+		if ($env:GITHUB_REF -match '^refs/heads/(.+)$') {
+			$branch = "-" + $Matches[1];
+			$suffix = "";
+		} else {
+			$branch = "";
+			$suffix = "";
+		}
+	}
 }
 
 $revision = [Int32]::Parse((git rev-list --count "$baseCommit..HEAD")) + $baseCommitRev;


### PR DESCRIPTION
Supports same build matrix as Azure DevOps (debug, release, store, ci). Current sample output: https://github.com/icsharpcode/ILSpy/actions/runs/352509460 (please verify contents of artifacts, esp. zip).

GH Packages push can only be verified on master because of if.

::set-output finally solved with code from https://github.com/mstum/Simplexcel/blob/master/.github/workflows/cibuild.yml