### PR TITLE
ILSpy should not crash if fullName contains no "/" - no version info

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
+++ b/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
@@ -44,7 +44,14 @@ namespace ICSharpCode.Decompiler.Metadata
 			{
 				var parts = fullName.Split('/');
 				this.Name = parts[0];
-				this.Version = parts[1];
+				if (parts.Length > 1)
+				{
+					this.Version = parts[1];
+				} else
+				{
+					this.Version = "<UNKNOWN>";
+				}
+				
 				this.Type = type;
 				this.Path = path;
 				this.RuntimeComponents = runtimeComponents ?? Empty<string>.Array;


### PR DESCRIPTION
Loading Dlls from RemObjects caused:
```
System.IndexOutOfRangeException: Der Index war außerhalb des Arraybereichs.
   bei ICSharpCode.Decompiler.Metadata.DotNetCorePathFinder.DotNetCorePackageInfo..ctor(String fullName, String type, String path, String[] runtimeComponents)
   bei ICSharpCode.Decompiler.Metadata.DotNetCorePathFinder.<LoadPackageInfos>d__14.MoveNext()
   bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   bei ICSharpCode.Decompiler.Metadata.DotNetCorePathFinder..ctor(String parentAssemblyFileName, String targetFrameworkIdString, TargetFrameworkIdentifier targetFramework, Version targetFrameworkVersion, ReferenceLoadInfo loadInfo)
   bei ICSharpCode.Decompiler.Metadata.UniversalAssemblyResolver.FindAssemblyFile(IAssemblyReference name)
   bei ICSharpCode.ILSpy.LoadedAssembly.LookupReferencedAssemblyInternal(IAssemblyReference fullName, Boolean isWinRT, String tfm)
   bei System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   bei ICSharpCode.ILSpy.LoadedAssembly.LookupReferencedAssembly(IAssemblyReference reference)
   bei ICSharpCode.ILSpy.LoadedAssembly.MyAssemblyResolver.Resolve(IAssemblyReference reference)
   bei ICSharpCode.Decompiler.TypeSystem.DecompilerTypeSystem..ctor(PEFile mainModule, IAssemblyResolver assemblyResolver, TypeSystemOptions typeSystemOptions)
   bei ICSharpCode.ILSpy.CSharpLanguage.DecompileAssembly(LoadedAssembly assembly, ITextOutput output, DecompilationOptions options)
   bei ICSharpCode.ILSpy.TreeNodes.AssemblyTreeNode.Decompile(Language language, ITextOutput output, DecompilationOptions options)
   bei ICSharpCode.ILSpy.TextView.DecompilerTextView.DecompileNodes(DecompilationContext context, ITextOutput textOutput)
   bei ICSharpCode.ILSpy.TextView.DecompilerTextView.<>c__DisplayClass48_0.<DecompileAsync>b__0()
```

### Solution
* We should check if there is a "/" in the string

