### PR TITLE
Missing `x:Static` in decompiled BAML

### DIFF
--- a/ILSpy.BamlDecompiler.Tests/BamlTestRunner.cs
+++ b/ILSpy.BamlDecompiler.Tests/BamlTestRunner.cs
@@ -142,6 +142,12 @@ namespace ILSpy.BamlDecompiler.Tests
 			RunTest("cases/issue2097");
 		}
 
+		[Test]
+		public void Issue2116()
+		{
+			RunTest("cases/issue2116");
+		}
+
 		#region RunTest
 		void RunTest(string name)
 		{

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
@@ -5,5 +5,8 @@
       <Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
     </ResourceDictionary>
   </FrameworkElement.Resources>
-  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+	<Grid>
+	  <Grid Style="{StaticResource TestStyle1}" />
+	  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+	</Grid>
 </UserControl>

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
@@ -1,0 +1,9 @@
+﻿<UserControl x:Class="ILSpy.BamlDecompiler.Tests.Cases.Issue2116" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:local="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <FrameworkElement.Resources>
+    <ResourceDictionary>
+      <Style x:Key="TestStyle1" />
+      <Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+    </ResourceDictionary>
+  </FrameworkElement.Resources>
+  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+</UserControl>

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml.cs
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace ILSpy.BamlDecompiler.Tests.Cases
+{
+	using System.Windows;
+	using System.Windows.Controls;
+
+	public partial class Issue2116 : UserControl
+	{
+		public static ComponentResourceKey StyleKey1 => new ComponentResourceKey(typeof(Issue2116), "TestStyle1");
+		public static ComponentResourceKey StyleKey2 => new ComponentResourceKey(typeof(Issue2116), "TestStyle2");
+
+		public Issue2116()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Cases\CustomControl.cs" />
     <Compile Include="Cases\Issue1547.xaml.cs" />
     <Compile Include="Cases\Issue2097.xaml.cs" />
+    <Compile Include="Cases\Issue2116.xaml.cs" />
     <Compile Include="Cases\MyControl.xaml.cs">
       <DependentUpon>MyControl.xaml</DependentUpon>
     </Compile>
@@ -90,6 +91,9 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Cases\Issue2097.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Cases\Issue2116.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Cases\Issue775.xaml">


### PR DESCRIPTION
This adds a test case that reproduces #2116.

### Problem

`x:Static` style references are currently not decompiled correctly:

Original XAML:

```xml
<TreeView Style="{StaticResource {x:Static controls:CodeSenseResources.TreeViewStyleKey}}" />
```

Decompiled XAML:

```xml
<TreeView Style="{StaticResource controls:CodeSenseResources.TreeViewStyleKey}" />
```

Test output:

```
 1    1     <UserControl x:Class="ILSpy.BamlDecompiler.Tests.Cases.Issue2116" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:local="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
 2    2       <FrameworkElement.Resources>
 3    3         <ResourceDictionary>
 4    4           <Style x:Key="TestStyle1" />
 5    5           <Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
 6    6         </ResourceDictionary>
 7    7       </FrameworkElement.Resources>
 8    8     	<Grid>
 9    9     	  <Grid Style="{StaticResource TestStyle1}" />
10      (-) 	  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
     10 (+)       <Grid Style="{StaticResource local:Issue2116.StyleKey1}" />
11   11     	</Grid>
12   12     </UserControl>
```

Note how the `BasedOn` reference is decompiled correctly, but the `Style` reference is not.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
  * No solution yet, only a repro.
* Which part of this PR is most in need of attention/improvement?
  * Actual fix missing so far. I'm going to look into it later.
* [ ] At least one test covering the code changed

