### PR TITLE
Enable theming for message boxes

### DIFF
--- a/ILSpy/app.manifest
+++ b/ILSpy/app.manifest
@@ -61,7 +61,6 @@
   </application>
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
-  <!--
   <dependency>
     <dependentAssembly>
       <assemblyIdentity
@@ -74,6 +73,5 @@
         />
     </dependentAssembly>
   </dependency>
-  -->
 
 </assembly>


### PR DESCRIPTION
ILSpy uses the [`MessageBox`](https://docs.microsoft.com/en-us/dotnet/api/system.windows.messagebox) class in a couple places. This is a [thin wrapper](https://github.com/dotnet/wpf/blob/d49f8ddb889b5717437d03caa04d7c56819c16aa/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/MessageBox.cs#L399) around the Win32 [`MessageBox`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-messagebox) function. Currently theming support is not enabled for the application, so these Win32 dialogs have the old Windows 2000 styling. By [turning on theming support in the manifest](https://docs.microsoft.com/en-us/windows/win32/sbscs/enabling-updated-common-controls-visual-styles-and-themes), the dialogs look slightly nicer.

# Before
<img width="299" alt="before" src="https://user-images.githubusercontent.com/7751/104821205-1a998100-57ef-11eb-9a5a-529e3bab9637.png">

# After
<img width="299" alt="after" src="https://user-images.githubusercontent.com/7751/104821244-5d5b5900-57ef-11eb-893e-1d3a878311ff.png">
