### PR TITLE
Fix baml decompiler can't find EventSetter

### DIFF
--- a/ILSpy.BamlDecompiler/BamlConnectionId.cs
+++ b/ILSpy.BamlDecompiler/BamlConnectionId.cs
@@ -23,6 +23,14 @@
 namespace ILSpy.BamlDecompiler
 {
 	/// <summary>
+	/// Represents a field assignment of a XAML code-behind class.
+	/// </summary>
+	internal sealed class FieldAssignment
+	{
+		public string FieldName;
+	}
+
+	/// <summary>
 	/// Represents an event registration of a XAML code-behind class.
 	/// </summary>
 	internal sealed class EventRegistration

--- a/ILSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
+++ b/ILSpy.BamlDecompiler/Handlers/Records/OptimizedStaticResourceHandler.cs
@@ -81,7 +81,7 @@ namespace ILSpy.BamlDecompiler.Handlers
 						name = res.Item1 + "." + res.Item2;
 					else
 						name = res.Item1 + "." + res.Item3;
-					var xmlns = ctx.GetXmlNamespace("http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+					var xmlns = ctx.GetXmlNamespace(XamlContext.KnownNamespace_Presentation);
 					attrName = ctx.ToString(parent.Xaml, xmlns.GetName(name));
 				}
 				else

--- a/ILSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/ILSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -85,7 +85,7 @@ namespace ILSpy.BamlDecompiler.Handlers
 						name = res.Item1 + "." + res.Item2;
 					else
 						name = res.Item1 + "." + res.Item3;
-					var xmlns = ctx.GetXmlNamespace("http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+					var xmlns = ctx.GetXmlNamespace(XamlContext.KnownNamespace_Presentation);
 					attrName = ctx.ToString(parent.Xaml, xmlns.GetName(name));
 				}
 				else

--- a/ILSpy.BamlDecompiler/Rewrite/ConnectionIdRewritePass.cs
+++ b/ILSpy.BamlDecompiler/Rewrite/ConnectionIdRewritePass.cs
@@ -72,6 +72,10 @@ namespace ILSpy.BamlDecompiler.Rewrite
 						}
 					}
 				}
+				else
+				{
+					element.Add(new XComment($"Unknown connection ID: {annotation.Id}"));
+				}
 			}
 		}
 

--- a/ILSpy.BamlDecompiler/Rewrite/ConnectionIdRewritePass.cs
+++ b/ILSpy.BamlDecompiler/Rewrite/ConnectionIdRewritePass.cs
@@ -213,7 +213,7 @@ namespace ILSpy.BamlDecompiler.Rewrite
 			@event = null;
 			if (!b.FinalInstruction.MatchNop())
 			{
-				pos = int.MaxValue;
+				pos = b.Instructions.Count;
 				return false;
 			}
 			var instr = b.Instructions;


### PR DESCRIPTION
### Problem
MatchEventSetterCreation can't find EventSetter in followed cases:

```
example1:

<Style>
    <EventSetter Event="MouseRightButtonDown" Handler="DataGridRow_OnMouseRightButtonDown" />
</Style>

ILFunction System.Windows.Markup.IStyleConnector.Connect {
	param this : SmartQuant.WPF.Controls.Controller.StrategiesControl(Index=-1, LoadCount=1, AddressCount=0, StoreCount=1)
	param connectionId : System.Int32(Index=0, LoadCount=1, AddressCount=0, StoreCount=1)
	param target : System.Object(Index=1, LoadCount=1, AddressCount=0, StoreCount=1)
	local eventSetter : System.Windows.EventSetter(Index=0, LoadCount=3, AddressCount=0, StoreCount=1)

	BlockContainer {
		Block IL_0000 (incoming: 1) {
			if (comp.i4(ldloc connectionId == ldc.i4 6)) Block IL_0009 {
				stloc eventSetter(newobj EventSetter..ctor())
				callvirt set_Event(ldloc eventSetter, ldobj System.Windows.RoutedEvent(ldsflda MouseRightButtonDownEvent))
				callvirt set_Handler(ldloc eventSetter, newobj MouseButtonEventHandler..ctor(ldloc this, ldftn DataGridRow_OnMouseRightButtonDown))
				callvirt Add(callvirt get_Setters(castclass System.Windows.Style(ldloc target)), ldloc eventSetter)
			}
			leave IL_0000 (nop)
		}

	}
}


example2:

<Style>
    <EventSetter Event="MouseRightButtonDown" Handler="DataGridRow_OnMouseRightButtonDown" />
    <EventSetter Event="MouseRightButtonDown" Handler="DataGridRow_OnMouseRightButtonDown" />
</Style>

ILFunction System.Windows.Markup.IStyleConnector.Connect {
	param this : SmartQuant.WPF.Controls.Controller.StrategiesControl(Index=-1, LoadCount=2, AddressCount=0, StoreCount=1)
	param connectionId : System.Int32(Index=0, LoadCount=1, AddressCount=0, StoreCount=1)
	param target : System.Object(Index=1, LoadCount=2, AddressCount=0, StoreCount=1)
	local eventSetter : System.Windows.EventSetter(Index=0, LoadCount=3, AddressCount=0, StoreCount=1)
	local eventSetter : System.Windows.EventSetter(Index=0, LoadCount=3, AddressCount=0, StoreCount=1)

	BlockContainer {
		Block IL_0000 (incoming: 1) {
			if (comp.i4(ldloc connectionId == ldc.i4 6)) Block IL_0009 {
				stloc eventSetter(newobj EventSetter..ctor())
				callvirt set_Event(ldloc eventSetter, ldobj System.Windows.RoutedEvent(ldsflda MouseRightButtonDownEvent))
				callvirt set_Handler(ldloc eventSetter, newobj MouseButtonEventHandler..ctor(ldloc this, ldftn DataGridRow_OnMouseRightButtonDown))
				callvirt Add(callvirt get_Setters(castclass System.Windows.Style(ldloc target)), ldloc eventSetter)
				stloc eventSetter(newobj EventSetter..ctor())
				callvirt set_Event(ldloc eventSetter, ldobj System.Windows.RoutedEvent(ldsflda MouseRightButtonDownEvent))
				callvirt set_Handler(ldloc eventSetter, newobj MouseButtonEventHandler..ctor(ldloc this, ldftn DataGridRow_OnMouseRightButtonDown))
				callvirt Add(callvirt get_Setters(castclass System.Windows.Style(ldloc target)), ldloc eventSetter)
			}
			leave IL_0000 (nop)
		}

	}
}
```

### Solution
Now MatchEventSetterCreation will not match "leave IL_0007 (nop)" and it can match multiple EventSettser in one ConnectionId
