### PR TITLE
async IAssemblyResolver

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/AssemblyReferences.cs
+++ b/ICSharpCode.Decompiler/Metadata/AssemblyReferences.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.Decompiler.Metadata
 {
@@ -47,6 +48,8 @@ namespace ICSharpCode.Decompiler.Metadata
 #if !VSADDIN
 		PEFile Resolve(IAssemblyReference reference);
 		PEFile ResolveModule(PEFile mainModule, string moduleName);
+		Task<PEFile> ResolveAsync(IAssemblyReference reference);
+		Task<PEFile> ResolveModuleAsync(PEFile mainModule, string moduleName);
 #endif
 	}
 

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -24,6 +24,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.Decompiler.Metadata
 {
@@ -202,6 +203,16 @@ namespace ICSharpCode.Decompiler.Metadata
 				return null;
 			}
 			return new PEFile(moduleFileName, new FileStream(moduleFileName, FileMode.Open, FileAccess.Read), streamOptions, metadataOptions);
+		}
+
+		public Task<PEFile> ResolveAsync(IAssemblyReference name)
+		{
+			return Task.Run(() => Resolve(name));
+		}
+
+		public Task<PEFile> ResolveModuleAsync(PEFile mainModule, string moduleName)
+		{
+			return Task.Run(() => ResolveModule(mainModule, moduleName));
 		}
 #endif
 

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -67,7 +67,6 @@ namespace ICSharpCode.Decompiler.Metadata
 		readonly string baseDirectory;
 		readonly List<string> directories = new List<string>();
 		static readonly List<string> gac_paths = GetGacPaths();
-		HashSet<string> targetFrameworkSearchPaths;
 		static readonly DecompilerRuntime decompilerRuntime;
 
 		public void AddSearchDirectory(string directory)
@@ -87,9 +86,9 @@ namespace ICSharpCode.Decompiler.Metadata
 			return directories.ToArray();
 		}
 
-		string targetFramework;
-		TargetFrameworkIdentifier targetFrameworkIdentifier;
-		Version targetFrameworkVersion;
+		readonly string targetFramework;
+		readonly TargetFrameworkIdentifier targetFrameworkIdentifier;
+		readonly Version targetFrameworkVersion;
 
 		/// <summary>
 		/// Creates a new instance of the <see cref="UniversalAssemblyResolver"/>.
@@ -301,26 +300,20 @@ namespace ICSharpCode.Decompiler.Metadata
 			return null;
 		}
 
-		void AddTargetFrameworkSearchPathIfExists(string path)
-		{
-			if (targetFrameworkSearchPaths == null)
-			{
-				targetFrameworkSearchPaths = new HashSet<string>();
-			}
-			if (Directory.Exists(path))
-				targetFrameworkSearchPaths.Add(path);
-		}
-
 		/// <summary>
 		/// This only works on Windows
 		/// </summary>
 		string ResolveSilverlight(IAssemblyReference name, Version version)
 		{
-			AddTargetFrameworkSearchPathIfExists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft Silverlight"));
-			AddTargetFrameworkSearchPathIfExists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Silverlight"));
+			string[] targetFrameworkSearchPaths = {
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft Silverlight"),
+				Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Silverlight")
+			};
 
 			foreach (var baseDirectory in targetFrameworkSearchPaths)
 			{
+				if (!Directory.Exists(baseDirectory))
+					continue;
 				var versionDirectory = Path.Combine(baseDirectory, FindClosestVersionDirectory(baseDirectory, version));
 				var file = SearchDirectory(name, versionDirectory);
 				if (file != null)

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -212,17 +212,17 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 
 		private class ReadyToRunAssemblyResolver : ILCompiler.Reflection.ReadyToRun.IAssemblyResolver
 		{
-			private LoadedAssembly loadedAssembly;
+			private Decompiler.Metadata.IAssemblyResolver assemblyResolver;
 
 			public ReadyToRunAssemblyResolver(LoadedAssembly loadedAssembly)
 			{
-				this.loadedAssembly = loadedAssembly;
+				assemblyResolver = loadedAssembly.GetAssemblyResolver();
 			}
 
 			public IAssemblyMetadata FindAssembly(MetadataReader metadataReader, AssemblyReferenceHandle assemblyReferenceHandle, string parentFile)
 			{
-				LoadedAssembly loadedAssembly = this.loadedAssembly.LookupReferencedAssembly(new Decompiler.Metadata.AssemblyReference(metadataReader, assemblyReferenceHandle));
-				PEReader reader = loadedAssembly?.GetPEFileOrNull()?.Reader;
+				PEFile module = assemblyResolver.Resolve(new Decompiler.Metadata.AssemblyReference(metadataReader, assemblyReferenceHandle));
+				PEReader reader = module?.Reader;
 				return reader == null ? null : new StandaloneAssemblyMetadata(reader);
 			}
 

--- a/ILSpy/Analyzers/AnalyzerScope.cs
+++ b/ILSpy/Analyzers/AnalyzerScope.cs
@@ -147,16 +147,13 @@ namespace ICSharpCode.ILSpy.Analyzers
 						continue;
 					if (checkedFiles.Contains(module))
 						continue;
-					var resolver = assembly.GetAssemblyResolver();
+					var resolver = assembly.GetAssemblyResolver(loadOnDemand: false);
 					foreach (var reference in module.AssemblyReferences)
 					{
-						using (LoadedAssembly.DisableAssemblyLoad(AssemblyList))
+						if (resolver.Resolve(reference) == curFile)
 						{
-							if (resolver.Resolve(reference) == curFile)
-							{
-								found = true;
-								break;
-							}
+							found = true;
+							break;
 						}
 					}
 					if (found && checkedFiles.Add(module))

--- a/ILSpy/AssemblyList.cs
+++ b/ILSpy/AssemblyList.cs
@@ -329,7 +329,7 @@ namespace ICSharpCode.ILSpy
 				return null;
 			var newAsm = new LoadedAssembly(this, target.FileName, pdbFileName: target.PdbFileName);
 			newAsm.IsAutoLoaded = target.IsAutoLoaded;
-			lock (assemblies)
+			lock (lockObj)
 			{
 				this.assemblies.Remove(target);
 				this.assemblies.Insert(index, newAsm);
@@ -340,7 +340,7 @@ namespace ICSharpCode.ILSpy
 		public void Unload(LoadedAssembly assembly)
 		{
 			App.Current.Dispatcher.VerifyAccess();
-			lock (assemblies)
+			lock (lockObj)
 			{
 				assemblies.Remove(assembly);
 				byFilename.Remove(assembly.FileName);
@@ -350,7 +350,7 @@ namespace ICSharpCode.ILSpy
 
 		static bool gcRequested;
 
-		void RequestGC()
+		static void RequestGC()
 		{
 			if (gcRequested)
 				return;
@@ -370,7 +370,7 @@ namespace ICSharpCode.ILSpy
 		public void Sort(int index, int count, IComparer<LoadedAssembly> comparer)
 		{
 			App.Current.Dispatcher.VerifyAccess();
-			lock (assemblies)
+			lock (lockObj)
 			{
 				List<LoadedAssembly> list = new List<LoadedAssembly>(assemblies);
 				list.Sort(index, Math.Min(count, list.Count - index), comparer);

--- a/ILSpy/AssemblyListManager.cs
+++ b/ILSpy/AssemblyListManager.cs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Xml.Linq;
@@ -165,7 +164,7 @@ namespace ICSharpCode.ILSpy
 			if (!AssemblyLists.Contains(ManageAssemblyListsViewModel.DotNet4List))
 			{
 				AssemblyList dotnet4 = ManageAssemblyListsViewModel.CreateDefaultList(ManageAssemblyListsViewModel.DotNet4List);
-				if (dotnet4.assemblies.Count > 0)
+				if (dotnet4.Count > 0)
 				{
 					CreateList(dotnet4);
 				}
@@ -174,7 +173,7 @@ namespace ICSharpCode.ILSpy
 			if (!AssemblyLists.Contains(ManageAssemblyListsViewModel.DotNet35List))
 			{
 				AssemblyList dotnet35 = ManageAssemblyListsViewModel.CreateDefaultList(ManageAssemblyListsViewModel.DotNet35List);
-				if (dotnet35.assemblies.Count > 0)
+				if (dotnet35.Count > 0)
 				{
 					CreateList(dotnet35);
 				}
@@ -183,7 +182,7 @@ namespace ICSharpCode.ILSpy
 			if (!AssemblyLists.Contains(ManageAssemblyListsViewModel.ASPDotNetMVC3List))
 			{
 				AssemblyList mvc = ManageAssemblyListsViewModel.CreateDefaultList(ManageAssemblyListsViewModel.ASPDotNetMVC3List);
-				if (mvc.assemblies.Count > 0)
+				if (mvc.Count > 0)
 				{
 					CreateList(mvc);
 				}

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -404,86 +404,83 @@ namespace ICSharpCode.ILSpy
 				base.DecompileAssembly(assembly, output, options);
 
 				// don't automatically load additional assemblies when an assembly node is selected in the tree view
-				using (options.FullDecompilation ? null : LoadedAssembly.DisableAssemblyLoad(assembly.AssemblyList))
+				IAssemblyResolver assemblyResolver = assembly.GetAssemblyResolver(loadOnDemand: options.FullDecompilation);
+				var typeSystem = new DecompilerTypeSystem(module, assemblyResolver, options.DecompilerSettings);
+				var globalType = typeSystem.MainModule.TypeDefinitions.FirstOrDefault();
+				if (globalType != null)
 				{
-					IAssemblyResolver assemblyResolver = assembly.GetAssemblyResolver();
-					var typeSystem = new DecompilerTypeSystem(module, assemblyResolver, options.DecompilerSettings);
-					var globalType = typeSystem.MainModule.TypeDefinitions.FirstOrDefault();
-					if (globalType != null)
+					output.Write("// Global type: ");
+					output.WriteReference(globalType, globalType.FullName);
+					output.WriteLine();
+				}
+				var metadata = module.Metadata;
+				var corHeader = module.Reader.PEHeaders.CorHeader;
+				var entrypointHandle = MetadataTokenHelpers.EntityHandleOrNil(corHeader.EntryPointTokenOrRelativeVirtualAddress);
+				if (!entrypointHandle.IsNil && entrypointHandle.Kind == HandleKind.MethodDefinition)
+				{
+					var entrypoint = typeSystem.MainModule.ResolveMethod(entrypointHandle, new Decompiler.TypeSystem.GenericContext());
+					if (entrypoint != null)
 					{
-						output.Write("// Global type: ");
-						output.WriteReference(globalType, globalType.FullName);
+						output.Write("// Entry point: ");
+						output.WriteReference(entrypoint, entrypoint.DeclaringType.FullName + "." + entrypoint.Name);
 						output.WriteLine();
 					}
-					var metadata = module.Metadata;
-					var corHeader = module.Reader.PEHeaders.CorHeader;
-					var entrypointHandle = MetadataTokenHelpers.EntityHandleOrNil(corHeader.EntryPointTokenOrRelativeVirtualAddress);
-					if (!entrypointHandle.IsNil && entrypointHandle.Kind == HandleKind.MethodDefinition)
-					{
-						var entrypoint = typeSystem.MainModule.ResolveMethod(entrypointHandle, new Decompiler.TypeSystem.GenericContext());
-						if (entrypoint != null)
-						{
-							output.Write("// Entry point: ");
-							output.WriteReference(entrypoint, entrypoint.DeclaringType.FullName + "." + entrypoint.Name);
-							output.WriteLine();
-						}
-					}
-					output.WriteLine("// Architecture: " + GetPlatformDisplayName(module));
-					if ((corHeader.Flags & System.Reflection.PortableExecutable.CorFlags.ILOnly) == 0)
-					{
-						output.WriteLine("// This assembly contains unmanaged code.");
-					}
-					string runtimeName = GetRuntimeDisplayName(module);
-					if (runtimeName != null)
-					{
-						output.WriteLine("// Runtime: " + runtimeName);
-					}
-					if ((corHeader.Flags & System.Reflection.PortableExecutable.CorFlags.StrongNameSigned) != 0)
-					{
-						output.WriteLine("// This assembly is signed with a strong name key.");
-					}
-					if (module.Reader.ReadDebugDirectory().Any(d => d.Type == DebugDirectoryEntryType.Reproducible))
-					{
-						output.WriteLine("// This assembly was compiled using the /deterministic option.");
-					}
-					if (metadata.IsAssembly)
-					{
-						var asm = metadata.GetAssemblyDefinition();
-						if (asm.HashAlgorithm != AssemblyHashAlgorithm.None)
-							output.WriteLine("// Hash algorithm: " + asm.HashAlgorithm.ToString().ToUpper());
-						if (!asm.PublicKey.IsNil)
-						{
-							output.Write("// Public key: ");
-							var reader = metadata.GetBlobReader(asm.PublicKey);
-							while (reader.RemainingBytes > 0)
-								output.Write(reader.ReadByte().ToString("x2"));
-							output.WriteLine();
-						}
-					}
-					var debugInfo = assembly.GetDebugInfoOrNull();
-					if (debugInfo != null)
-					{
-						output.WriteLine("// Debug info: " + debugInfo.Description);
-					}
-					output.WriteLine();
-
-					CSharpDecompiler decompiler = new CSharpDecompiler(typeSystem, options.DecompilerSettings);
-					decompiler.CancellationToken = options.CancellationToken;
-					if (options.EscapeInvalidIdentifiers)
-					{
-						decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
-					}
-					SyntaxTree st;
-					if (options.FullDecompilation)
-					{
-						st = decompiler.DecompileWholeModuleAsSingleFile();
-					}
-					else
-					{
-						st = decompiler.DecompileModuleAndAssemblyAttributes();
-					}
-					WriteCode(output, options.DecompilerSettings, st, decompiler.TypeSystem);
 				}
+				output.WriteLine("// Architecture: " + GetPlatformDisplayName(module));
+				if ((corHeader.Flags & System.Reflection.PortableExecutable.CorFlags.ILOnly) == 0)
+				{
+					output.WriteLine("// This assembly contains unmanaged code.");
+				}
+				string runtimeName = GetRuntimeDisplayName(module);
+				if (runtimeName != null)
+				{
+					output.WriteLine("// Runtime: " + runtimeName);
+				}
+				if ((corHeader.Flags & System.Reflection.PortableExecutable.CorFlags.StrongNameSigned) != 0)
+				{
+					output.WriteLine("// This assembly is signed with a strong name key.");
+				}
+				if (module.Reader.ReadDebugDirectory().Any(d => d.Type == DebugDirectoryEntryType.Reproducible))
+				{
+					output.WriteLine("// This assembly was compiled using the /deterministic option.");
+				}
+				if (metadata.IsAssembly)
+				{
+					var asm = metadata.GetAssemblyDefinition();
+					if (asm.HashAlgorithm != AssemblyHashAlgorithm.None)
+						output.WriteLine("// Hash algorithm: " + asm.HashAlgorithm.ToString().ToUpper());
+					if (!asm.PublicKey.IsNil)
+					{
+						output.Write("// Public key: ");
+						var reader = metadata.GetBlobReader(asm.PublicKey);
+						while (reader.RemainingBytes > 0)
+							output.Write(reader.ReadByte().ToString("x2"));
+						output.WriteLine();
+					}
+				}
+				var debugInfo = assembly.GetDebugInfoOrNull();
+				if (debugInfo != null)
+				{
+					output.WriteLine("// Debug info: " + debugInfo.Description);
+				}
+				output.WriteLine();
+
+				CSharpDecompiler decompiler = new CSharpDecompiler(typeSystem, options.DecompilerSettings);
+				decompiler.CancellationToken = options.CancellationToken;
+				if (options.EscapeInvalidIdentifiers)
+				{
+					decompiler.AstTransforms.Add(new EscapeInvalidIdentifiers());
+				}
+				SyntaxTree st;
+				if (options.FullDecompilation)
+				{
+					st = decompiler.DecompileWholeModuleAsSingleFile();
+				}
+				else
+				{
+					st = decompiler.DecompileModuleAndAssemblyAttributes();
+				}
+				WriteCode(output, options.DecompilerSettings, st, decompiler.TypeSystem);
 				return null;
 			}
 		}

--- a/ILSpy/Languages/ILLanguage.cs
+++ b/ILSpy/Languages/ILLanguage.cs
@@ -172,22 +172,19 @@ namespace ICSharpCode.ILSpy
 			}
 
 			// don't automatically load additional assemblies when an assembly node is selected in the tree view
-			using (options.FullDecompilation ? null : LoadedAssembly.DisableAssemblyLoad(assembly.AssemblyList))
+			dis.AssemblyResolver = module.GetAssemblyResolver(loadOnDemand: options.FullDecompilation);
+			dis.DebugInfo = module.GetDebugInfoOrNull();
+			if (options.FullDecompilation)
+				dis.WriteAssemblyReferences(metadata);
+			if (metadata.IsAssembly)
+				dis.WriteAssemblyHeader(module);
+			output.WriteLine();
+			dis.WriteModuleHeader(module);
+			if (options.FullDecompilation)
 			{
-				dis.AssemblyResolver = module.GetAssemblyResolver();
-				dis.DebugInfo = module.GetDebugInfoOrNull();
-				if (options.FullDecompilation)
-					dis.WriteAssemblyReferences(metadata);
-				if (metadata.IsAssembly)
-					dis.WriteAssemblyHeader(module);
 				output.WriteLine();
-				dis.WriteModuleHeader(module);
-				if (options.FullDecompilation)
-				{
-					output.WriteLine();
-					output.WriteLine();
-					dis.WriteModuleContents(module);
-				}
+				output.WriteLine();
+				dis.WriteModuleContents(module);
 			}
 			return null;
 		}

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -26,7 +26,6 @@ using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Threading;
 
 using ICSharpCode.Decompiler.DebugInfo;
 using ICSharpCode.Decompiler.Metadata;
@@ -95,7 +94,6 @@ namespace ICSharpCode.ILSpy
 
 			this.loadingTask = Task.Run(() => LoadAsync(stream)); // requires that this.fileName is set
 			this.shortName = Path.GetFileNameWithoutExtension(fileName);
-			this.resolver = new MyAssemblyResolver(this);
 		}
 
 		public LoadedAssembly(LoadedAssembly bundle, string fileName, Task<Stream> stream, IAssemblyResolver assemblyResolver = null)
@@ -386,106 +384,222 @@ namespace ICSharpCode.ILSpy
 			return debugInfoProvider;
 		}
 
-		[ThreadStatic]
-		static int assemblyLoadDisableCount;
-
-		public static IDisposable DisableAssemblyLoad(AssemblyList assemblyList)
-		{
-			assemblyLoadDisableCount++;
-			return new DecrementAssemblyLoadDisableCount(assemblyList);
-		}
-
-		public static IDisposable DisableAssemblyLoad()
-		{
-			assemblyLoadDisableCount++;
-			return new DecrementAssemblyLoadDisableCount(MainWindow.Instance.CurrentAssemblyList);
-		}
-
-		sealed class DecrementAssemblyLoadDisableCount : IDisposable
-		{
-			bool disposed;
-			AssemblyList assemblyList;
-
-			public DecrementAssemblyLoadDisableCount(AssemblyList assemblyList)
-			{
-				this.assemblyList = assemblyList;
-			}
-
-			public void Dispose()
-			{
-				if (!disposed)
-				{
-					disposed = true;
-					assemblyLoadDisableCount--;
-					// clear the lookup cache since we might have stored the lookups failed due to DisableAssemblyLoad()
-					assemblyList.ClearCache();
-				}
-			}
-		}
-
 		sealed class MyAssemblyResolver : IAssemblyResolver
 		{
 			readonly LoadedAssembly parent;
+			readonly bool loadOnDemand;
 
-			public MyAssemblyResolver(LoadedAssembly parent)
+			readonly IAssemblyResolver providedAssemblyResolver;
+			readonly AssemblyList assemblyList;
+			readonly LoadedAssembly[] alreadyLoadedAssemblies;
+			readonly Task<string> tfmTask;
+			readonly ReferenceLoadInfo referenceLoadInfo;
+
+			public MyAssemblyResolver(LoadedAssembly parent, bool loadOnDemand)
 			{
 				this.parent = parent;
+				this.loadOnDemand = loadOnDemand;
+
+				this.providedAssemblyResolver = parent.providedAssemblyResolver;
+				this.assemblyList = parent.assemblyList;
+				// Note: we cache a copy of the assembly list in the constructor, so that the
+				// resolve calls only search-by-asm-name in the assemblies that were already loaded
+				// at the time of the GetResolver() call.
+				this.alreadyLoadedAssemblies = assemblyList.GetAssemblies();
+				// If we didn't do this, we'd also search in the assemblies that we just started to load
+				// in previous Resolve() calls; but we don't want to wait for those to be loaded.
+				this.tfmTask = parent.GetTargetFrameworkIdAsync();
+				this.referenceLoadInfo = parent.LoadedAssemblyReferencesInfo;
 			}
 
 			public PEFile Resolve(IAssemblyReference reference)
 			{
-				var module = parent.providedAssemblyResolver?.Resolve(reference);
-				if (module != null)
+				return ResolveAsync(reference).GetAwaiter().GetResult();
+			}
+
+			Dictionary<string, PEFile> asmLookupByFullName;
+			Dictionary<string, PEFile> asmLookupByShortName;
+
+			/// <summary>
+			/// 0) if we're inside a package, look for filename.dll in parent directories
+			/// 1) try to find exact match by tfm + full asm name in loaded assemblies
+			/// 2) try to find match in search paths
+			/// 3) if a.deps.json is found: search %USERPROFILE%/.nuget/packages/* as well
+			/// 4) look in /dotnet/shared/{runtime-pack}/{closest-version}
+			/// 5) if the version is retargetable or all zeros or ones, search C:\Windows\Microsoft.NET\Framework64\v4.0.30319
+			/// 6) For "mscorlib.dll" we use the exact same assembly with which ILSpy runs
+			/// 7) Search the GAC
+			/// 8) search C:\Windows\Microsoft.NET\Framework64\v4.0.30319
+			/// 9) try to find match by asm name (no tfm/version) in loaded assemblies
+			/// </summary>
+			public async Task<PEFile> ResolveAsync(IAssemblyReference reference)
+			{
+				PEFile module;
+				// 0) if we're inside a package, look for filename.dll in parent directories
+				if (providedAssemblyResolver != null)
+				{
+					module = await providedAssemblyResolver.ResolveAsync(reference).ConfigureAwait(false);
+					if (module != null)
+						return module;
+				}
+
+				string tfm = await tfmTask.ConfigureAwait(false);
+
+				bool isWinRT = reference.IsWindowsRuntime;
+				string key = tfm + ";" + (isWinRT ? reference.Name : reference.FullName);
+
+				// 1) try to find exact match by tfm + full asm name in loaded assemblies
+				var lookup = LazyInit.VolatileRead(ref isWinRT ? ref asmLookupByShortName : ref asmLookupByFullName);
+				if (lookup == null)
+				{
+					lookup = await CreateLoadedAssemblyLookupAsync(shortNames: isWinRT).ConfigureAwait(false);
+					lookup = LazyInit.GetOrSet(ref isWinRT ? ref asmLookupByShortName : ref asmLookupByFullName, lookup);
+				}
+				if (lookup.TryGetValue(key, out module))
+				{
+					referenceLoadInfo.AddMessageOnce(reference.FullName, MessageKind.Info, "Success - Found in Assembly List");
 					return module;
-				return parent.LookupReferencedAssembly(reference)?.GetPEFileOrNull();
+				}
+
+				string file = parent.GetUniversalResolver().FindAssemblyFile(reference);
+
+				if (file != null)
+				{
+					// Load assembly from disk
+					LoadedAssembly asm;
+					if (loadOnDemand)
+					{
+						asm = assemblyList.OpenAssembly(file, isAutoLoaded: true);
+					}
+					else
+					{
+						asm = assemblyList.FindAssembly(file);
+					}
+					if (asm != null)
+					{
+						referenceLoadInfo.AddMessage(reference.ToString(), MessageKind.Info, "Success - Loading from: " + file);
+						return await asm.GetPEFileOrNullAsync().ConfigureAwait(false);
+					}
+					return null;
+				}
+				else
+				{
+					// Assembly not found; try to find a similar-enough already-loaded assembly
+					var candidates = new List<(LoadedAssembly assembly, Version version)>();
+
+					foreach (LoadedAssembly loaded in alreadyLoadedAssemblies)
+					{
+						module = await loaded.GetPEFileOrNullAsync().ConfigureAwait(false);
+						var reader = module?.Metadata;
+						if (reader == null || !reader.IsAssembly)
+							continue;
+						var asmDef = reader.GetAssemblyDefinition();
+						var asmDefName = reader.GetString(asmDef.Name);
+						if (reference.Name.Equals(asmDefName, StringComparison.OrdinalIgnoreCase))
+						{
+							candidates.Add((loaded, asmDef.Version));
+						}
+					}
+
+					if (candidates.Count == 0)
+					{
+						referenceLoadInfo.AddMessageOnce(reference.ToString(), MessageKind.Error, "Could not find reference: " + reference);
+						return null;
+					}
+
+					candidates.SortBy(c => c.version);
+
+					var bestCandidate = candidates.FirstOrDefault(c => c.version >= reference.Version).assembly ?? candidates.Last().assembly;
+					referenceLoadInfo.AddMessageOnce(reference.ToString(), MessageKind.Info, "Success - Found in Assembly List with different TFM or version: " + bestCandidate.fileName);
+					return await bestCandidate.GetPEFileOrNullAsync().ConfigureAwait(false);
+				}
+			}
+
+			private async Task<Dictionary<string, PEFile>> CreateLoadedAssemblyLookupAsync(bool shortNames)
+			{
+				var result = new Dictionary<string, PEFile>(StringComparer.OrdinalIgnoreCase);
+				foreach (LoadedAssembly loaded in alreadyLoadedAssemblies)
+				{
+					try
+					{
+						var module = await loaded.GetPEFileOrNullAsync().ConfigureAwait(false);
+						var reader = module?.Metadata;
+						if (reader == null || !reader.IsAssembly)
+							continue;
+						var asmDef = reader.GetAssemblyDefinition();
+						string tfm = await loaded.GetTargetFrameworkIdAsync();
+						string key = tfm + ";"
+							+ (shortNames ? reader.GetString(asmDef.Name) : reader.GetFullAssemblyName());
+						if (!result.ContainsKey(key))
+						{
+							result.Add(key, module);
+						}
+					}
+					catch (BadImageFormatException)
+					{
+						continue;
+					}
+				}
+				return result;
 			}
 
 			public PEFile ResolveModule(PEFile mainModule, string moduleName)
 			{
-				var module = parent.providedAssemblyResolver?.ResolveModule(mainModule, moduleName);
-				if (module != null)
-					return module;
-				return parent.LookupReferencedModule(mainModule, moduleName)?.GetPEFileOrNull();
-			}
-
-			public async Task<PEFile> ResolveAsync(IAssemblyReference reference)
-			{
-				if (parent.providedAssemblyResolver != null)
-				{
-					var module = await parent.providedAssemblyResolver.ResolveAsync(reference).ConfigureAwait(false);
-					if (module != null)
-						return module;
-				}
-				var asm = parent.LookupReferencedAssembly(reference);
-				if (asm != null)
-				{
-					return await asm.GetPEFileOrNullAsync().ConfigureAwait(false);
-				}
-				return null;
+				return ResolveModuleAsync(mainModule, moduleName).GetAwaiter().GetResult();
 			}
 
 			public async Task<PEFile> ResolveModuleAsync(PEFile mainModule, string moduleName)
 			{
-				if (parent.providedAssemblyResolver != null)
+				if (providedAssemblyResolver != null)
 				{
-					var module = await parent.providedAssemblyResolver.ResolveModuleAsync(mainModule, moduleName).ConfigureAwait(false);
+					var module = await providedAssemblyResolver.ResolveModuleAsync(mainModule, moduleName).ConfigureAwait(false);
 					if (module != null)
 						return module;
 				}
-				var asm = parent.LookupReferencedModule(mainModule, moduleName);
-				if (asm != null)
+
+
+				string file = Path.Combine(Path.GetDirectoryName(mainModule.FileName), moduleName);
+				if (File.Exists(file))
 				{
-					return await asm.GetPEFileOrNullAsync().ConfigureAwait(false);
+					// Load module from disk
+					LoadedAssembly asm;
+					if (loadOnDemand)
+					{
+						asm = assemblyList.OpenAssembly(file, isAutoLoaded: true);
+					}
+					else
+					{
+						asm = assemblyList.FindAssembly(file);
+					}
+					if (asm != null)
+					{
+						return await asm.GetPEFileOrNullAsync().ConfigureAwait(false);
+					}
+				}
+				else
+				{
+					// Module does not exist on disk, look for one with a matching name in the assemblylist:
+					foreach (LoadedAssembly loaded in alreadyLoadedAssemblies)
+					{
+						var module = await loaded.GetPEFileOrNullAsync().ConfigureAwait(false);
+						var reader = module?.Metadata;
+						if (reader == null || reader.IsAssembly)
+							continue;
+						var moduleDef = reader.GetModuleDefinition();
+						if (moduleName.Equals(reader.GetString(moduleDef.Name), StringComparison.OrdinalIgnoreCase))
+						{
+							referenceLoadInfo.AddMessageOnce(moduleName, MessageKind.Info, "Success - Found in Assembly List");
+							return module;
+						}
+					}
 				}
 				return null;
 			}
 		}
 
-		readonly MyAssemblyResolver resolver;
-
-		public IAssemblyResolver GetAssemblyResolver()
+		public IAssemblyResolver GetAssemblyResolver(bool loadOnDemand = true)
 		{
-			return resolver;
+			return new MyAssemblyResolver(this, loadOnDemand);
 		}
 
 		private MyUniversalResolver GetUniversalResolver()
@@ -508,30 +622,6 @@ namespace ICSharpCode.ILSpy
 			return debugInfoProvider;
 		}
 
-		public LoadedAssembly LookupReferencedAssembly(IAssemblyReference reference)
-		{
-			if (reference == null)
-				throw new ArgumentNullException(nameof(reference));
-			var tfm = GetTargetFrameworkIdAsync().Result;
-			if (reference.IsWindowsRuntime)
-			{
-				return assemblyList.assemblyLookupCache.GetOrAdd((reference.Name, true, tfm), key => LookupReferencedAssemblyInternal(reference, true, tfm));
-			}
-			else
-			{
-				return assemblyList.assemblyLookupCache.GetOrAdd((reference.FullName, false, tfm), key => LookupReferencedAssemblyInternal(reference, false, tfm));
-			}
-		}
-
-		public LoadedAssembly LookupReferencedModule(PEFile mainModule, string moduleName)
-		{
-			if (mainModule == null)
-				throw new ArgumentNullException(nameof(mainModule));
-			if (moduleName == null)
-				throw new ArgumentNullException(nameof(moduleName));
-			return assemblyList.moduleLookupCache.GetOrAdd(mainModule.FileName + ";" + moduleName, _ => LookupReferencedModuleInternal(mainModule, moduleName));
-		}
-
 		class MyUniversalResolver : UniversalAssemblyResolver
 		{
 			public MyUniversalResolver(LoadedAssembly assembly)
@@ -540,186 +630,7 @@ namespace ICSharpCode.ILSpy
 			}
 		}
 
-		static readonly Dictionary<string, LoadedAssembly> loadingAssemblies = new Dictionary<string, LoadedAssembly>();
 		MyUniversalResolver universalResolver;
-
-		/// <summary>
-		/// 0) if we're inside a package, look for filename.dll in parent directories
-		///    (this step already happens in MyAssemblyResolver; not in LookupReferencedAssembly)
-		/// 1) try to find exact match by tfm + full asm name in loaded assemblies
-		/// 2) try to find match in search paths
-		/// 3) if a.deps.json is found: search %USERPROFILE%/.nuget/packages/* as well
-		/// 4) look in /dotnet/shared/{runtime-pack}/{closest-version}
-		/// 5) if the version is retargetable or all zeros or ones, search C:\Windows\Microsoft.NET\Framework64\v4.0.30319
-		/// 6) For "mscorlib.dll" we use the exact same assembly with which ILSpy runs
-		/// 7) Search the GAC
-		/// 8) search C:\Windows\Microsoft.NET\Framework64\v4.0.30319
-		/// 9) try to find match by asm name (no tfm/version) in loaded assemblies
-		/// </summary>
-		LoadedAssembly LookupReferencedAssemblyInternal(IAssemblyReference fullName, bool isWinRT, string tfm)
-		{
-			string key = tfm + ";" + (isWinRT ? fullName.Name : fullName.FullName);
-
-			string file;
-			LoadedAssembly asm;
-			lock (loadingAssemblies)
-			{
-				foreach (LoadedAssembly loaded in assemblyList.GetAssemblies())
-				{
-					try
-					{
-						var module = loaded.GetPEFileOrNull();
-						var reader = module?.Metadata;
-						if (reader == null || !reader.IsAssembly)
-							continue;
-						var asmDef = reader.GetAssemblyDefinition();
-						var asmDefName = loaded.GetTargetFrameworkIdAsync().Result + ";"
-							+ (isWinRT ? reader.GetString(asmDef.Name) : reader.GetFullAssemblyName());
-						if (key.Equals(asmDefName, StringComparison.OrdinalIgnoreCase))
-						{
-							LoadedAssemblyReferencesInfo.AddMessageOnce(fullName.FullName, MessageKind.Info, "Success - Found in Assembly List");
-							return loaded;
-						}
-					}
-					catch (BadImageFormatException)
-					{
-						continue;
-					}
-				}
-
-				file = GetUniversalResolver().FindAssemblyFile(fullName);
-
-				foreach (LoadedAssembly loaded in assemblyList.GetAssemblies())
-				{
-					if (loaded.FileName.Equals(file, StringComparison.OrdinalIgnoreCase))
-					{
-						return loaded;
-					}
-				}
-
-				if (file != null && loadingAssemblies.TryGetValue(file, out asm))
-					return asm;
-
-				if (assemblyLoadDisableCount > 0)
-					return null;
-
-				if (file != null)
-				{
-					LoadedAssemblyReferencesInfo.AddMessage(fullName.ToString(), MessageKind.Info, "Success - Loading from: " + file);
-					asm = new LoadedAssembly(assemblyList, file) { IsAutoLoaded = true };
-				}
-				else
-				{
-					var candidates = new List<(LoadedAssembly assembly, Version version)>();
-
-					foreach (LoadedAssembly loaded in assemblyList.GetAssemblies())
-					{
-						var module = loaded.GetPEFileOrNull();
-						var reader = module?.Metadata;
-						if (reader == null || !reader.IsAssembly)
-							continue;
-						var asmDef = reader.GetAssemblyDefinition();
-						var asmDefName = reader.GetString(asmDef.Name);
-						if (fullName.Name.Equals(asmDefName, StringComparison.OrdinalIgnoreCase))
-						{
-							candidates.Add((loaded, asmDef.Version));
-						}
-					}
-
-					if (candidates.Count == 0)
-					{
-						LoadedAssemblyReferencesInfo.AddMessageOnce(fullName.ToString(), MessageKind.Error, "Could not find reference: " + fullName);
-						return null;
-					}
-
-					candidates.SortBy(c => c.version);
-
-					var bestCandidate = candidates.FirstOrDefault(c => c.version >= fullName.Version).assembly ?? candidates.Last().assembly;
-					LoadedAssemblyReferencesInfo.AddMessageOnce(fullName.ToString(), MessageKind.Info, "Success - Found in Assembly List with different TFM or version: " + bestCandidate.fileName);
-					return bestCandidate;
-				}
-				loadingAssemblies.Add(file, asm);
-			}
-			App.Current.Dispatcher.BeginInvoke((Action)delegate () {
-				lock (assemblyList.assemblies)
-				{
-					assemblyList.assemblies.Add(asm);
-				}
-				lock (loadingAssemblies)
-				{
-					loadingAssemblies.Remove(file);
-				}
-			}, DispatcherPriority.Normal);
-			return asm;
-		}
-
-		LoadedAssembly LookupReferencedModuleInternal(PEFile mainModule, string moduleName)
-		{
-			string file;
-			LoadedAssembly asm;
-			lock (loadingAssemblies)
-			{
-				foreach (LoadedAssembly loaded in assemblyList.GetAssemblies())
-				{
-					var reader = loaded.GetPEFileOrNull()?.Metadata;
-					if (reader == null || reader.IsAssembly)
-						continue;
-					var moduleDef = reader.GetModuleDefinition();
-					if (moduleName.Equals(reader.GetString(moduleDef.Name), StringComparison.OrdinalIgnoreCase))
-					{
-						LoadedAssemblyReferencesInfo.AddMessageOnce(moduleName, MessageKind.Info, "Success - Found in Assembly List");
-						return loaded;
-					}
-				}
-
-				file = Path.Combine(Path.GetDirectoryName(mainModule.FileName), moduleName);
-				if (!File.Exists(file))
-					return null;
-
-				foreach (LoadedAssembly loaded in assemblyList.GetAssemblies())
-				{
-					if (loaded.FileName.Equals(file, StringComparison.OrdinalIgnoreCase))
-					{
-						return loaded;
-					}
-				}
-
-				if (file != null && loadingAssemblies.TryGetValue(file, out asm))
-					return asm;
-
-				if (assemblyLoadDisableCount > 0)
-					return null;
-
-				if (file != null)
-				{
-					LoadedAssemblyReferencesInfo.AddMessage(moduleName, MessageKind.Info, "Success - Loading from: " + file);
-					asm = new LoadedAssembly(assemblyList, file) { IsAutoLoaded = true };
-				}
-				else
-				{
-					LoadedAssemblyReferencesInfo.AddMessageOnce(moduleName, MessageKind.Error, "Could not find reference: " + moduleName);
-					return null;
-				}
-				loadingAssemblies.Add(file, asm);
-			}
-			App.Current.Dispatcher.BeginInvoke((Action)delegate () {
-				lock (assemblyList.assemblies)
-				{
-					assemblyList.assemblies.Add(asm);
-				}
-				lock (loadingAssemblies)
-				{
-					loadingAssemblies.Remove(file);
-				}
-			});
-			return asm;
-		}
-
-		[Obsolete("Use GetPEFileAsync() or GetLoadResultAsync() instead")]
-		public Task ContinueWhenLoaded(Action<Task<PEFile>> onAssemblyLoaded, TaskScheduler taskScheduler)
-		{
-			return this.GetPEFileAsync().ContinueWith(onAssemblyLoaded, default(CancellationToken), TaskContinuationOptions.RunContinuationsAsynchronously, taskScheduler);
-		}
 
 		/// <summary>
 		/// Wait until the assembly is loaded.

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -488,9 +488,14 @@ namespace ICSharpCode.ILSpy
 			return resolver;
 		}
 
+		private MyUniversalResolver GetUniversalResolver()
+		{
+			return LazyInitializer.EnsureInitialized(ref this.universalResolver, () => new MyUniversalResolver(this));
+		}
+
 		public AssemblyReferenceClassifier GetAssemblyReferenceClassifier()
 		{
-			return universalResolver;
+			return GetUniversalResolver();
 		}
 
 		/// <summary>
@@ -582,12 +587,7 @@ namespace ICSharpCode.ILSpy
 					}
 				}
 
-				if (universalResolver == null)
-				{
-					universalResolver = new MyUniversalResolver(this);
-				}
-
-				file = universalResolver.FindAssemblyFile(fullName);
+				file = GetUniversalResolver().FindAssemblyFile(fullName);
 
 				foreach (LoadedAssembly loaded in assemblyList.GetAssemblies())
 				{

--- a/ILSpy/LoadedAssemblyExtensions.cs
+++ b/ILSpy/LoadedAssemblyExtensions.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 using ICSharpCode.Decompiler.DebugInfo;
 using ICSharpCode.Decompiler.Metadata;
@@ -31,9 +26,9 @@ namespace ICSharpCode.ILSpy
 			return Mono.Cecil.ModuleDefinition.ReadModule(new UnmanagedMemoryStream(image.Pointer, image.Length));
 		}
 
-		public static IAssemblyResolver GetAssemblyResolver(this PEFile file)
+		public static IAssemblyResolver GetAssemblyResolver(this PEFile file, bool loadOnDemand = true)
 		{
-			return GetLoadedAssembly(file).GetAssemblyResolver();
+			return GetLoadedAssembly(file).GetAssemblyResolver(loadOnDemand);
 		}
 
 		public static IDebugInfoProvider GetDebugInfoOrNull(this PEFile file)

--- a/ILSpy/LoadedPackage.cs
+++ b/ILSpy/LoadedPackage.cs
@@ -240,6 +240,20 @@ namespace ICSharpCode.ILSpy
 			return parent?.Resolve(reference);
 		}
 
+		public Task<PEFile> ResolveAsync(IAssemblyReference reference)
+		{
+			var asm = ResolveFileName(reference.Name + ".dll");
+			if (asm != null)
+			{
+				return asm.GetPEFileOrNullAsync();
+			}
+			if (parent != null)
+			{
+				return parent.ResolveAsync(reference);
+			}
+			return null;
+		}
+
 		public PEFile ResolveModule(PEFile mainModule, string moduleName)
 		{
 			var asm = ResolveFileName(moduleName + ".dll");
@@ -248,6 +262,20 @@ namespace ICSharpCode.ILSpy
 				return asm.GetPEFileOrNull();
 			}
 			return parent?.ResolveModule(mainModule, moduleName);
+		}
+
+		public Task<PEFile> ResolveModuleAsync(PEFile mainModule, string moduleName)
+		{
+			var asm = ResolveFileName(moduleName + ".dll");
+			if (asm != null)
+			{
+				return asm.GetPEFileOrNullAsync();
+			}
+			if (parent != null)
+			{
+				return parent.ResolveModuleAsync(mainModule, moduleName);
+			}
+			return null;
 		}
 
 		readonly Dictionary<string, LoadedAssembly> assemblies = new Dictionary<string, LoadedAssembly>(StringComparer.OrdinalIgnoreCase);

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -749,7 +749,7 @@ namespace ICSharpCode.ILSpy
 			history.Clear();
 			this.assemblyList = assemblyList;
 
-			assemblyList.assemblies.CollectionChanged += assemblyList_Assemblies_CollectionChanged;
+			assemblyList.CollectionChanged += assemblyList_Assemblies_CollectionChanged;
 
 			assemblyListTreeNode = new AssemblyListTreeNode(assemblyList);
 			assemblyListTreeNode.FilterSettings = sessionSettings.FilterSettings.Clone();

--- a/ILSpy/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyTreeNode.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -460,10 +461,11 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			return true;
 		}
 
-		public void Execute(TextViewContext context)
+		public async void Execute(TextViewContext context)
 		{
 			if (context.SelectedTreeNodes == null)
 				return;
+			var tasks = new List<Task>();
 			foreach (var node in context.SelectedTreeNodes)
 			{
 				var la = ((AssemblyTreeNode)node).LoadedAssembly;
@@ -474,10 +476,11 @@ namespace ICSharpCode.ILSpy.TreeNodes
 					var metadata = module.Metadata;
 					foreach (var assyRef in metadata.AssemblyReferences)
 					{
-						resolver.Resolve(new AssemblyReference(module, assyRef));
+						tasks.Add(resolver.ResolveAsync(new AssemblyReference(module, assyRef)));
 					}
 				}
 			}
+			await Task.WhenAll(tasks);
 			MainWindow.Instance.RefreshDecompiledView();
 		}
 	}

--- a/ILSpy/TreeNodes/ModuleReferenceTreeNode.cs
+++ b/ILSpy/TreeNodes/ModuleReferenceTreeNode.cs
@@ -71,8 +71,13 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			var assemblyListNode = parentAssembly.Parent as AssemblyListTreeNode;
 			if (assemblyListNode != null && containsMetadata)
 			{
-				assemblyListNode.Select(assemblyListNode.FindAssemblyNode(parentAssembly.LoadedAssembly.LookupReferencedModule(parentAssembly.LoadedAssembly.GetPEFileOrNull(), metadata.GetString(reference.Name))));
-				e.Handled = true;
+				var resolver = parentAssembly.LoadedAssembly.GetAssemblyResolver();
+				var mainModule = parentAssembly.LoadedAssembly.GetPEFileOrNull();
+				if (mainModule != null)
+				{
+					assemblyListNode.Select(assemblyListNode.FindAssemblyNode(resolver.ResolveModule(mainModule, metadata.GetString(reference.Name))));
+					e.Handled = true;
+				}
 			}
 		}
 

--- a/ILSpy/ViewModels/ManageAssemblyListsViewModel.cs
+++ b/ILSpy/ViewModels/ManageAssemblyListsViewModel.cs
@@ -358,7 +358,7 @@ namespace ICSharpCode.ILSpy.ViewModels
 			if (dlg.ShowDialog() == true)
 			{
 				var list = CreateDefaultList(config.Name, config.Path, dlg.ListName);
-				if (list.assemblies.Count > 0)
+				if (list.Count > 0)
 				{
 					manager.CreateList(list);
 				}


### PR DESCRIPTION
I encountered a problem where sometimes the ILSpy UI freezes while decompiling a whole solution.
The issue was that the `lock (loadingAssemblies)` was held for too long (due to the blocking `GetPEFileOrNull()` calls inside the lock), and was also used on the UI thread (for the `App.Current.Dispatcher.BeginInvoke((Action)delegate () { ... lock (loadingAssemblies) { loadingAssemblies.Remove(file); }}`).

This PR eliminates the `loadingAssemblies` lock, instead handling multiple load requests for the same file within the `AssemblyList` itself.
It also changes the `DecompilerTypeSystem` to use the new `ResolveAsync` overload in order to parallelize the automatic assembly-loading.

Implementation changes:
* We no longer maintain the weird `loadingAssemblies` global state.
  * `AssemblyList` now internally handles multiple concurrent load requests for the same filename.
  * `AssemblyList.assemblies` and its lock is now private to the AssemblyList.
* `AssemblyList.OpenAssembly` is now usable on background threads; which dramatically simplifies the loading-logic in `LoadedAssembly`.
* Removed a questionable caching layer (cache was per-AssemblyList, but was caching the result of a per-LoadedAssembly lookup function.
* Replaced static `DisableAssemblyLoad()` with bool-parameter on `GetAssemblyResolver()` call.