### PR TITLE
Add capability to checksum assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _ReSharper*/
 /ICSharpCode.Decompiler.Tests/TestCases/Correctness/*.exe
 /ICSharpCode.Decompiler.Tests/TestCases/Correctness/*.exe.config
 /ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec
+/ICSharpCode.Decompiler.Console/retarget.props

--- a/Frontends.sln
+++ b/Frontends.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
 MinimumVisualStudioVersion = 15.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{F45DB999-7E72-4000-B5AD-3A7B485A0896}"
 	ProjectSection(SolutionItems) = preProject
@@ -14,7 +14,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.Decompiler.Cons
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.Decompiler.PowerShell", "ICSharpCode.Decompiler.PowerShell\ICSharpCode.Decompiler.PowerShell.csproj", "{FF7D6041-3C52-47D1-A32A-0BFE8EE4EEEB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.Decompiler", "ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj", "{526B267D-1904-4E9E-80DB-BB2259ADCF6C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.Decompiler", "ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj", "{526B267D-1904-4E9E-80DB-BB2259ADCF6C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
+++ b/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
@@ -2,11 +2,32 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <!--
+    Can retarget by adding file like this:
+    
+      retarget.props
+
+      <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+        <PropertyGroup>
+          <TargetFrameworks>net472</TargetFrameworks>
+        </PropertyGroup>
+      </Project>
+
+    Solution re-open is needed after change.
+    
+    (Easier to test with one .exe only)
+-->
+  <Import Project="retarget.props" Condition="Exists('retarget.props')" />
+  <PropertyGroup Condition="!Exists('retarget.props')">
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
-    <PackAsTool>true</PackAsTool>
     <AssemblyName>ilspycmd</AssemblyName>
     <ToolCommandName>ilspycmd</ToolCommandName>
     <Version>7.0.0.6372-preview3</Version>
@@ -23,6 +44,10 @@
     <Authors>ILSpy Team</Authors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net472'">
+    <PackAsTool>true</PackAsTool>
+  </PropertyGroup>  
+    
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors>NU1605</WarningsAsErrors>

--- a/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
+++ b/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
@@ -4,24 +4,15 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <!--
-    Can retarget by adding file like this:
-    
-      retarget.props
-
-      <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-        <PropertyGroup>
-          <TargetFrameworks>net472</TargetFrameworks>
-        </PropertyGroup>
-      </Project>
-
-    Solution re-open is needed after change.
-    
-    (Easier to test with one .exe only)
--->
-  <Import Project="retarget.props" Condition="Exists('retarget.props')" />
-  <PropertyGroup Condition="!Exists('retarget.props')">
+  <PropertyGroup Condition="'$(SolutionName)' != 'ILSpy'">
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <!-- Easier to run as exe file, could use also ReadyToRun, but can be as this for now -->
+  <PropertyGroup Condition="'$(SolutionName)' == 'ILSpy'">
+    <TargetFrameworks>net472</TargetFrameworks>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,7 +21,7 @@
     <IsPackable>true</IsPackable>
     <AssemblyName>ilspycmd</AssemblyName>
     <ToolCommandName>ilspycmd</ToolCommandName>
-    <Version>7.0.0.6372-preview3</Version>
+    <Version>7.0.0.6373</Version>
     <Description>Command-line decompiler using the ILSpy decompilation engine</Description>
     <Copyright>Copyright 2011-2021 AlphaSierraPapa</Copyright>
     <PackageProjectUrl>https://github.com/icsharpcode/ILSpy/</PackageProjectUrl>
@@ -40,7 +31,6 @@
     <Company />
     <AssemblyVersion>7.0.0.0</AssemblyVersion>
     <FileVersion>7.0.0.0</FileVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>ILSpy Team</Authors>
   </PropertyGroup>
 

--- a/ICSharpCode.Decompiler.Console/IlspyCmdProgram.cs
+++ b/ICSharpCode.Decompiler.Console/IlspyCmdProgram.cs
@@ -35,8 +35,8 @@ namespace ICSharpCode.Decompiler.Console
 		public string OutputDirectory { get; }
 
 		[Option("-p|--project", "Decompile assembly as compilable project. If outputdir is omitted - saved to assembly folder", CommandOptionType.NoValue)]
-		public bool WholeProjectDecompile { get; set;  }
-		
+		public bool WholeProjectDecompile { get; set; }
+
 		//[Option("-c|--crc", "Calculate assembly internal checksum", CommandOptionType.NoValue)]
 		public bool CalculateChecksum { get; set; }
 
@@ -85,52 +85,70 @@ namespace ICSharpCode.Decompiler.Console
 				app.HelpTextGenerator.Generate(app, System.Console.Out);
 				return 2;
 			}
-			
+
 			TextWriter output = System.Console.Out;
 			bool outputDirectorySpecified = !string.IsNullOrEmpty(OutputDirectory);
 
-			try {
+			try
+			{
 				if (!(DecompileToFile || ShowILCodeFlag || ShowILSequencePointsFlag || CreateDebugInfoFlag || ShowVersion))
 				{
 					WholeProjectDecompile = true;
 				}
-				
-				if (WholeProjectDecompile || CalculateChecksum) {
+
+				if (WholeProjectDecompile || CalculateChecksum)
+				{
 					return DecompileAsProject(InputAssemblyName, OutputDirectory);
-				} else if (EntityTypes.Any()) {
+				}
+				else if (EntityTypes.Any())
+				{
 					var values = EntityTypes.SelectMany(v => v.Split(',', ';')).ToArray();
 					HashSet<TypeKind> kinds = TypesParser.ParseSelection(values);
-					if (outputDirectorySpecified) {
+					if (outputDirectorySpecified)
+					{
 						string outputName = Path.GetFileNameWithoutExtension(InputAssemblyName);
 						output = File.CreateText(Path.Combine(OutputDirectory, outputName) + ".list.txt");
 					}
 
 					return ListContent(InputAssemblyName, output, kinds);
-				} else if (ShowILCodeFlag || ShowILSequencePointsFlag) {
-					if (outputDirectorySpecified) {
+				}
+				else if (ShowILCodeFlag || ShowILSequencePointsFlag)
+				{
+					if (outputDirectorySpecified)
+					{
 						string outputName = Path.GetFileNameWithoutExtension(InputAssemblyName);
 						output = File.CreateText(Path.Combine(OutputDirectory, outputName) + ".il");
 					}
 
 					return ShowIL(InputAssemblyName, output);
-				} else if (CreateDebugInfoFlag) {
+				}
+				else if (CreateDebugInfoFlag)
+				{
 					string pdbFileName = null;
-					if (outputDirectorySpecified) {
+					if (outputDirectorySpecified)
+					{
 						string outputName = Path.GetFileNameWithoutExtension(InputAssemblyName);
 						pdbFileName = Path.Combine(OutputDirectory, outputName) + ".pdb";
-					} else {
+					}
+					else
+					{
 						pdbFileName = Path.ChangeExtension(InputAssemblyName, ".pdb");
 					}
 
 					return GeneratePdbForAssembly(InputAssemblyName, pdbFileName, app);
-				} else if (ShowVersion) {
+				}
+				else if (ShowVersion)
+				{
 					string vInfo = "ilspycmd: " + typeof(ILSpyCmdProgram).Assembly.GetName().Version.ToString() +
-					               Environment.NewLine
-					               + "ICSharpCode.Decompiler: " +
-					               typeof(FullTypeName).Assembly.GetName().Version.ToString();
+								   Environment.NewLine
+								   + "ICSharpCode.Decompiler: " +
+								   typeof(FullTypeName).Assembly.GetName().Version.ToString();
 					output.WriteLine(vInfo);
-				} else {
-					if (outputDirectorySpecified) {
+				}
+				else
+				{
+					if (outputDirectorySpecified)
+					{
 						string outputName = Path.GetFileNameWithoutExtension(InputAssemblyName);
 						output = File.CreateText(Path.Combine(OutputDirectory,
 							(string.IsNullOrEmpty(TypeName) ? outputName : TypeName) + ".decompiled.cs"));
@@ -138,10 +156,14 @@ namespace ICSharpCode.Decompiler.Console
 
 					return Decompile(InputAssemblyName, output, TypeName);
 				}
-			} catch (Exception ex) {
+			}
+			catch (Exception ex)
+			{
 				app.Error.WriteLine(ex.ToString());
 				return ProgramExitCodes.EX_SOFTWARE;
-			} finally {
+			}
+			finally
+			{
 				output.Close();
 			}
 
@@ -161,7 +183,8 @@ namespace ICSharpCode.Decompiler.Console
 		{
 			var module = new PEFile(assemblyFileName);
 			var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Reader.DetectTargetFrameworkId());
-			foreach (var path in ReferencePaths) {
+			foreach (var path in ReferencePaths)
+			{
 				resolver.AddSearchDirectory(path);
 			}
 			return new CSharpDecompiler(assemblyFileName, resolver, GetSettings()) {
@@ -173,7 +196,8 @@ namespace ICSharpCode.Decompiler.Console
 		{
 			CSharpDecompiler decompiler = GetDecompiler(assemblyFileName);
 
-			foreach (var type in decompiler.TypeSystem.MainModule.TypeDefinitions) {
+			foreach (var type in decompiler.TypeSystem.MainModule.TypeDefinitions)
+			{
 				if (!kinds.Contains(type.Kind))
 					continue;
 				output.WriteLine($"{type.Kind} {type.FullName}");
@@ -185,8 +209,7 @@ namespace ICSharpCode.Decompiler.Console
 		{
 			var module = new PEFile(assemblyFileName);
 			output.WriteLine($"// IL code: {module.Name}");
-			var disassembler = new ReflectionDisassembler(new PlainTextOutput(output), CancellationToken.None)
-			{
+			var disassembler = new ReflectionDisassembler(new PlainTextOutput(output), CancellationToken.None) {
 				DebugInfo = TryLoadPDB(module),
 				ShowSequencePoints = ShowILSequencePointsFlag,
 			};
@@ -219,10 +242,11 @@ namespace ICSharpCode.Decompiler.Console
 			}
 
 			Stopwatch w = Stopwatch.StartNew();
-			
+
 			var module = new PEFile(assemblyFileName);
 			var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Reader.DetectTargetFrameworkId());
-			foreach (var refpath in ReferencePaths) {
+			foreach (var refpath in ReferencePaths)
+			{
 				resolver.AddSearchDirectory(refpath);
 			}
 			var decompiler = new WholeProjectDecompiler(GetSettings(), resolver, resolver, TryLoadPDB(module));
@@ -241,9 +265,12 @@ namespace ICSharpCode.Decompiler.Console
 		{
 			CSharpDecompiler decompiler = GetDecompiler(assemblyFileName);
 
-			if (typeName == null) {
+			if (typeName == null)
+			{
 				output.Write(decompiler.DecompileWholeModuleAsString());
-			} else {
+			}
+			else
+			{
 				var name = new FullTypeName(typeName);
 				output.Write(decompiler.DecompileTypeAsString(name));
 			}
@@ -257,12 +284,14 @@ namespace ICSharpCode.Decompiler.Console
 				PEStreamOptions.PrefetchEntireImage,
 				metadataOptions: MetadataReaderOptions.None);
 
-			if (!PortablePdbWriter.HasCodeViewDebugDirectoryEntry(module)) {
+			if (!PortablePdbWriter.HasCodeViewDebugDirectoryEntry(module))
+			{
 				app.Error.WriteLine($"Cannot create PDB file for {assemblyFileName}, because it does not contain a PE Debug Directory Entry of type 'CodeView'.");
 				return ProgramExitCodes.EX_DATAERR;
 			}
 
-			using (FileStream stream = new FileStream(pdbFileName, FileMode.OpenOrCreate, FileAccess.Write)) {
+			using (FileStream stream = new FileStream(pdbFileName, FileMode.OpenOrCreate, FileAccess.Write))
+			{
 				var decompiler = GetDecompiler(assemblyFileName);
 				PortablePdbWriter.WritePdb(module, decompiler, GetSettings(), stream);
 			}
@@ -272,7 +301,8 @@ namespace ICSharpCode.Decompiler.Console
 
 		IDebugInfoProvider TryLoadPDB(PEFile module)
 		{
-			if (InputPDBFile.IsSet) {
+			if (InputPDBFile.IsSet)
+			{
 				if (InputPDBFile.Value == null)
 					return DebugInfoUtils.LoadSymbols(module);
 				return DebugInfoUtils.FromFile(module, InputPDBFile.Value);

--- a/ICSharpCode.Decompiler.Console/IlspyCmdProgram.cs
+++ b/ICSharpCode.Decompiler.Console/IlspyCmdProgram.cs
@@ -1,21 +1,21 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using McMaster.Extensions.CommandLineUtils;
-using ICSharpCode.Decompiler.CSharp;
-using ICSharpCode.Decompiler.TypeSystem;
-using ICSharpCode.Decompiler.Metadata;
-using ICSharpCode.Decompiler.Disassembler;
-using System.Threading;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using ICSharpCode.Decompiler.DebugInfo;
-using ICSharpCode.Decompiler.PdbProvider;
+using System.Threading;
+
+using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.ProjectDecompiler;
-using System.Diagnostics;
-using McMaster.Extensions.CommandLineUtils.HelpText;
+using ICSharpCode.Decompiler.DebugInfo;
+using ICSharpCode.Decompiler.Disassembler;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.PdbProvider;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using McMaster.Extensions.CommandLineUtils;
 // ReSharper disable All
 
 namespace ICSharpCode.Decompiler.Console

--- a/ICSharpCode.Decompiler.Console/README.md
+++ b/ICSharpCode.Decompiler.Console/README.md
@@ -7,21 +7,23 @@ dotnet tool install ilspycmd -g
 .NET Core 2.1 Tool 
 
 ```
-ilspycmd -h
+ilspycmd
 
 dotnet tool for decompiling .NET assemblies and generating portable PDBs
 
 Usage: ilspycmd [arguments] [options]
 
 Arguments:
-  Assembly file name               The assembly that is being decompiled. This argument is mandatory.
+  Assembly file name               Assembly to decompile
 
 Options:
   -h|--help                        Show help information
   -o|--outputdir <directory>       The output directory, if omitted decompiler output is written to standard out.
-  -p|--project                     Decompile assembly as compilable project. This requires the output directory option.
+  -p|--project                     Decompile assembly as compilable project. If outputdir is omitted - saved to assembly folder
+  -f|--file                        Decompile assembly into single file.
   -t|--type <type-name>            The fully qualified name of the type to decompile.
   -il|--ilcode                     Show IL code.
+  --il-sequence-points             Show IL with sequence points. Implies -il.
   -genpdb                          Generate PDB.
   -usepdb                          Use PDB.
   -l|--list <entity-type(s)>       Lists all entities of the specified type(s). Valid types: c(lass), i(nterface), s(truct), d(elegate), e(num)
@@ -31,6 +33,4 @@ Options:
   --no-dead-code                   Remove dead code.
   --no-dead-stores                 Remove dead stores.
 
-Remarks:
-  -o is valid with every option and required when using -p.
 ```

--- a/ICSharpCode.Decompiler.Console/TypesParser.cs
+++ b/ICSharpCode.Decompiler.Console/TypesParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using ICSharpCode.Decompiler.TypeSystem;
 
 namespace ICSharpCode.Decompiler.Console
@@ -11,9 +12,12 @@ namespace ICSharpCode.Decompiler.Console
 		{
 			var possibleValues = new Dictionary<string, TypeKind>(StringComparer.OrdinalIgnoreCase) { ["class"] = TypeKind.Class, ["struct"] = TypeKind.Struct, ["interface"] = TypeKind.Interface, ["enum"] = TypeKind.Enum, ["delegate"] = TypeKind.Delegate };
 			HashSet<TypeKind> kinds = new HashSet<TypeKind>();
-			if (values.Length == 1 && !possibleValues.Keys.Any(v => values[0].StartsWith(v, StringComparison.OrdinalIgnoreCase))) {
-				foreach (char ch in values[0]) {
-					switch (ch) {
+			if (values.Length == 1 && !possibleValues.Keys.Any(v => values[0].StartsWith(v, StringComparison.OrdinalIgnoreCase)))
+			{
+				foreach (char ch in values[0])
+				{
+					switch (ch)
+					{
 						case 'c':
 							kinds.Add(TypeKind.Class);
 							break;
@@ -31,8 +35,11 @@ namespace ICSharpCode.Decompiler.Console
 							break;
 					}
 				}
-			} else {
-				foreach (var value in values) {
+			}
+			else
+			{
+				foreach (var value in values)
+				{
 					string v = value;
 					while (v.Length > 0 && !possibleValues.ContainsKey(v))
 						v = v.Remove(v.Length - 1);

--- a/ICSharpCode.Decompiler.Console/ValidationAttributes.cs
+++ b/ICSharpCode.Decompiler.Console/ValidationAttributes.cs
@@ -4,24 +4,6 @@ using System.IO;
 
 namespace ICSharpCode.Decompiler.Console
 {
-	[AttributeUsage(AttributeTargets.Class)]
-	public sealed class ProjectOptionRequiresOutputDirectoryValidationAttribute : ValidationAttribute
-	{
-		public ProjectOptionRequiresOutputDirectoryValidationAttribute()
-		{
-		}
-
-		protected override ValidationResult IsValid(object value, ValidationContext context)
-		{
-			if (value is ILSpyCmdProgram obj) {
-				if (obj.CreateCompilableProjectFlag && string.IsNullOrEmpty(obj.OutputDirectory)) {
-					return new ValidationResult("--project cannot be used unless --outputdir is also specified");
-				}
-			}
-			return ValidationResult.Success;
-		}
-	}
-
 	[AttributeUsage(AttributeTargets.Property)]
 	public sealed class FileExistsOrNullAttribute : ValidationAttribute
 	{

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -126,6 +126,58 @@ namespace ICSharpCode.Decompiler.Tests
 			);
 		}
 
+		[Test]
+		public void FunctionNameChanges()
+		{
+			GenerateCheckumProject(CallerName(), false,
+				(w) => {
+					w.WriteLine(
+					@"public class MyTestClass{ 
+						void function1()
+						{
+							Console.WriteLine(""Test1"");
+						}
+					};");
+				},
+
+				(w) => {
+					w.WriteLine(
+						@"public class MyTestClass{ 
+						void function2()
+						{
+							Console.WriteLine(""Test1"");
+						}
+					};");
+				}
+			);
+		}
+
+		[Test]
+		public void ClassNameChanges()
+		{
+			GenerateCheckumProject(CallerName(), false,
+				(w) => {
+					w.WriteLine(
+					@"public class MyTestClass1{ 
+						void function1()
+						{
+							Console.WriteLine(""Test1"");
+						}
+					};");
+				},
+
+				(w) => {
+					w.WriteLine(
+					@"public class MyTestClass2{ 
+						void function1()
+						{
+							Console.WriteLine(""Test1"");
+						}
+					};");
+				}
+			);
+		}
+
 
 		public void GenerateCheckumProject(string title, bool expectEqual,
 			Action<PlainTextOutput> v1gen,

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -83,10 +83,16 @@ namespace ICSharpCode.Decompiler.Tests
 					PlaceIntoTag("PropertyGroup", xml, () => {
 						xml.WriteElementString("OutputType", "Exe");
 						xml.WriteElementString("TargetFramework", targetFramework);
+
+						// This should improve to produce identical dll, but does not work in all cases.
 						xml.WriteElementString("Deterministic", "true");
 						xml.WriteElementString("PathMap",
 							"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./"
 						);
+
+						xml.WriteElementString("SignAssembly", "true");
+						xml.WriteElementString("AssemblyOriginatorKeyFile", "../../../ICSharpCode.Decompiler/ICSharpCode.Decompiler.snk");
+						xml.WriteElementString("DelaySign", "false");
 					});
 				}
 

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+using ICSharpCode.Decompiler.CSharp.ProjectDecompiler;
+using ICSharpCode.Decompiler.Tests.Helpers;
+
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace ICSharpCode.Decompiler.Tests
+{
+	[TestFixture, Parallelizable(ParallelScope.All)]
+	public class ChecksumTest
+	{
+		public static readonly string TestDir = Path.GetFullPath(Path.Combine(Tester.TestCasePath, "../../ILSpy-tests/CheckSumTesting"));
+
+
+		void DeleteDirectory(String sPath, bool root)
+		{
+			foreach (String file in Directory.GetFiles(sPath))
+			{
+				FileInfo fi = new FileInfo(file);
+				fi.Delete();
+			}
+
+			foreach (String subfolder in Directory.GetDirectories(sPath))
+			{
+				DeleteDirectory(subfolder, false);
+			}
+
+			if (!root)
+			{
+				Directory.Delete(sPath);
+			}
+		}
+
+		[SetUp]
+		public void Cleanup()
+		{
+			try
+			{
+				if (Directory.Exists(TestDir))
+				{
+					DeleteDirectory(TestDir, true);
+				}
+			}
+			catch (Exception)
+			{ 
+			}
+		}
+		
+		[Test]
+		public void Test1()
+		{
+			GenerateCheckumProject("basic", "net472");
+			GenerateCheckumProject("basic", "netcoreapp3.1");
+		}
+
+		public void GenerateCheckumProject(string title, string targetFramework)
+		{
+			foreach (bool first in new[] { true, false })
+			{
+				string dirName = $"{title}_{targetFramework}_" + ((first) ? "v1" : "v2");
+				string dir = Path.Combine(TestDir, dirName);
+				if (!Directory.Exists(dir))
+				{
+					Directory.CreateDirectory(dir);
+				}
+
+				string csproj = Path.Combine(dir, "test.csproj");
+				string outdir = Path.Combine(dir, "bin");
+				using (XmlTextWriter xml = new XmlTextWriter(csproj, Encoding.UTF8))
+				{
+					xml.Formatting = Formatting.Indented;
+					xml.WriteStartElement("Project");
+					xml.WriteAttributeString("Sdk", "Microsoft.NET.Sdk");
+
+					PlaceIntoTag("PropertyGroup", xml, () => {
+						xml.WriteElementString("OutputType", "Exe");
+						xml.WriteElementString("TargetFramework", targetFramework);
+						xml.WriteElementString("Deterministic", "true");
+						xml.WriteElementString("PathMap", "\"$(EnlistmentRoot)\"=C:\\ILSpy\\");
+					});
+				}
+
+				using (var writer = new StreamWriter(Path.Combine(dir, "testmain.cs")))
+				{
+					var cscode = new PlainTextOutput(writer);
+					cscode.WriteLine(@"
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(""Hello World!"");
+    }
+}
+");
+				}
+
+				RoundtripAssembly.Compile(csproj, outdir);
+			}
+		}
+
+		static void PlaceIntoTag(string tagName, XmlTextWriter xml, Action content)
+		{
+			xml.WriteStartElement(tagName);
+			try
+			{
+				content();
+			}
+			finally
+			{
+				xml.WriteEndElement();
+			}
+		}
+
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -84,7 +84,9 @@ namespace ICSharpCode.Decompiler.Tests
 						xml.WriteElementString("OutputType", "Exe");
 						xml.WriteElementString("TargetFramework", targetFramework);
 						xml.WriteElementString("Deterministic", "true");
-						xml.WriteElementString("PathMap", "\"$(EnlistmentRoot)\"=C:\\ILSpy\\");
+						xml.WriteElementString("PathMap",
+							"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./"
+						);
 					});
 				}
 

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -85,10 +85,11 @@ namespace ICSharpCode.Decompiler.Tests
 						xml.WriteElementString("TargetFramework", targetFramework);
 
 						// This should improve to produce identical dll, but does not work in all cases.
-						xml.WriteElementString("Deterministic", "true");
-						xml.WriteElementString("PathMap",
-							"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./"
-						);
+						// Use without this code, just so we would compare binary different assemblies
+						//xml.WriteElementString("Deterministic", "true");
+						//xml.WriteElementString("PathMap",
+						//	"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./"
+						//);
 
 						xml.WriteElementString("SignAssembly", "true");
 						xml.WriteElementString("AssemblyOriginatorKeyFile", "../../../ICSharpCode.Decompiler/ICSharpCode.Decompiler.snk");

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -105,10 +105,10 @@ using System;
 
 class Program
 {
-    static void Main(string[] args)
-    {
-        Console.WriteLine(""Hello World!"");
-    }
+	static void Main(string[] args)
+	{
+		Console.WriteLine(""Hello World!"");
+	}
 }
 ");
 				}

--- a/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
+++ b/ICSharpCode.Decompiler.Tests/ChecksumTest.cs
@@ -50,10 +50,10 @@ namespace ICSharpCode.Decompiler.Tests
 				}
 			}
 			catch (Exception)
-			{ 
+			{
 			}
 		}
-		
+
 		[Test]
 		public void Test1()
 		{

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="..\ICSharpCode.Decompiler.PdbProvider.Cecil\MonoCecilDebugInfoProvider.cs" Link="MonoCecilDebugInfoProvider.cs" />
     <Compile Include="..\ILSpy\DebugInfo\DebugInfoUtils.cs" Link="DebugInfoUtils.cs" />
     <Compile Include="..\ILSpy\DebugInfo\PortableDebugInfoProvider.cs" Link="PortableDebugInfoProvider.cs" />
+    <Compile Include="ChecksumTest.cs" />
     <Compile Include="DisassemblerPrettyTestRunner.cs" />
     <Compile Include="Helpers\RoslynToolset.cs" />
     <Compile Include="Output\InsertParenthesesVisitorTests.cs" />

--- a/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
+++ b/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
@@ -257,7 +257,7 @@ namespace ICSharpCode.Decompiler.Tests
 			return Path.Combine(vsPath, "msbuild.exe");
 		}
 
-		static void Compile(string projectFile, string outputDir)
+		public static void Compile(string projectFile, string outputDir)
 		{
 			var info = new ProcessStartInfo(FindMSBuild());
 			info.Arguments = $"/nologo /v:minimal /restore /p:OutputPath=\"{outputDir}\" \"{projectFile}\"";

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1468,7 +1468,13 @@ namespace ICSharpCode.Decompiler.CSharp
 					entityDecl.AddChild(body, Roles.Body);
 					return;
 				}
-				var function = ilReader.ReadIL((MethodDefinitionHandle)method.MetadataToken, methodBody, cancellationToken: CancellationToken);
+
+				var function = ilReader.ReadIL((MethodDefinitionHandle)method.MetadataToken, methodBody, cancellationToken: CancellationToken,
+					checksumcalc: settings.checksumCalc);
+
+				if (!settings.ProduceSourceCode)
+					return;
+
 				function.CheckInvariant(ILPhase.Normal);
 
 				if (entityDecl != null)

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -42,10 +42,6 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 
 		public CSharpOutputVisitor(TextWriter textWriter, CSharpFormattingOptions formattingPolicy)
 		{
-			if (textWriter == null)
-			{
-				throw new ArgumentNullException(nameof(textWriter));
-			}
 			if (formattingPolicy == null)
 			{
 				throw new ArgumentNullException(nameof(formattingPolicy));

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/ITokenWriter.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/ITokenWriter.cs
@@ -65,7 +65,17 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 
 		public static TokenWriter Create(TextWriter writer, string indentation = "\t")
 		{
-			return new InsertSpecialsDecorator(new InsertRequiredSpacesDecorator(new TextWriterTokenWriter(writer) { IndentationString = indentation }));
+			TokenWriter textwriter;
+			if (writer != null)
+			{
+				textwriter = new TextWriterTokenWriter(writer) { IndentationString = indentation };
+			}
+			else
+			{
+				textwriter = new NullWriterTokenWriter();
+			}
+
+			return new InsertSpecialsDecorator(new InsertRequiredSpacesDecorator(textwriter));
 		}
 
 		public static TokenWriter CreateWriterThatSetsLocationsInAST(TextWriter writer, string indentation = "\t")

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/NullWriterTokenWriter.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/NullWriterTokenWriter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using ICSharpCode.Decompiler.CSharp.Syntax;
+
+namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
+{
+	/// <summary>
+	/// Just a quick stub class when checksum is being calculated.
+	/// </summary>
+	public class NullWriterTokenWriter : TokenWriter, ILocatable
+	{
+		public TextLocation Location => throw new NotImplementedException();
+
+		public int Length => throw new NotImplementedException();
+
+		public override void EndNode(AstNode node)
+		{
+		}
+
+		public override void Indent()
+		{
+		}
+
+		public override void NewLine()
+		{
+		}
+
+		public override void Space()
+		{
+		}
+
+		public override void StartNode(AstNode node)
+		{
+		}
+
+		public override void Unindent()
+		{
+		}
+
+		public override void WriteComment(CommentType commentType, string content)
+		{
+		}
+
+		public override void WriteIdentifier(Identifier identifier)
+		{
+		}
+
+		public override void WriteInterpolatedText(string text)
+		{
+		}
+
+		public override void WriteKeyword(Role role, string keyword)
+		{
+		}
+
+		public override void WritePreProcessorDirective(PreProcessorDirectiveType type, string argument)
+		{
+		}
+
+		public override void WritePrimitiveType(string type)
+		{
+		}
+
+		public override void WritePrimitiveValue(object value, LiteralFormat format = LiteralFormat.None)
+		{
+		}
+
+		public override void WriteToken(Role role, string token)
+		{
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/AssemblyCheckumCalculator.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/AssemblyCheckumCalculator.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
+{
+	public class AssemblyCheckumCalculator
+	{
+		/// <summary>
+		/// Calculates checksum over assembly.
+		/// </summary>
+		/// <param name="path">Assembly path</param>
+		/// <returns>Unique string</returns>
+		public static string Calculate(string path)
+		{
+			var module = new PEFile(path);
+			string dir = Path.GetDirectoryName(path);
+			var resolver = new LocalAssemblyResolver(path, dir, module.Reader.DetectTargetFrameworkId());
+			resolver.AddSearchDirectory(dir);
+			resolver.RemoveSearchDirectory(".");
+
+			var settings = new DecompilerSettings();
+			settings.checksumCalc.EnableChecksumCalculation(HashAlgorithmName.SHA256);
+			settings.ProduceSourceCode = false;
+
+			var decompiler = new WholeProjectDecompiler(settings, Guid.Empty, resolver, resolver, debugInfoProvider: null);
+
+			// not needed, but just in case someone will write it
+			string decompiledDir = Path.Combine(Path.GetDirectoryName(path), Path.GetFileNameWithoutExtension(path));
+			decompiler.DecompileProject(module, decompiledDir);
+
+			return settings.checksumCalc.GetHashString();
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -109,7 +109,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 		{
 		}
 
-		protected WholeProjectDecompiler(
+		public WholeProjectDecompiler(
 			DecompilerSettings settings,
 			Guid projectGuid,
 			IAssemblyResolver assemblyResolver,

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -340,10 +340,15 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 							{
 								string fileName = Path.Combine(name.Split('/').Select(p => CleanUpFileName(p)).ToArray());
 								string dirName = Path.GetDirectoryName(fileName);
-								if (!string.IsNullOrEmpty(dirName) && directories.Add(dirName))
+
+								if (Settings.ProduceSourceCode)
 								{
-									Directory.CreateDirectory(Path.Combine(TargetDirectory, dirName));
+									if (!string.IsNullOrEmpty(dirName) && directories.Add(dirName))
+									{
+										Directory.CreateDirectory(Path.Combine(TargetDirectory, dirName));
+									}
 								}
+
 								Stream entryStream = (Stream)value;
 								entryStream.Position = 0;
 								individualResources.AddRange(

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1765,6 +1765,22 @@ namespace ICSharpCode.Decompiler
 				}
 			}
 		}
+		bool produceSourceCode = true;
+
+		/// <summary>
+		/// Produce readable source/IL code out of compiled assembly
+		/// </summary>
+		public bool ProduceSourceCode {
+			get { return produceSourceCode; }
+			set {
+				if (produceSourceCode != value)
+				{
+					produceSourceCode = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 
 		CSharpFormattingOptions csharpFormattingOptions;
 

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1781,6 +1781,11 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		/// <summary>
+		/// Checksum calculator, always will have valid instance even if checksum is not calculated
+		/// </summary>
+		public IncrementalChecksum checksumCalc = new IncrementalChecksum();
+
 
 		CSharpFormattingOptions csharpFormattingOptions;
 

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -61,6 +61,7 @@
     <Compile Include="CSharp\Annotations.cs" />
     <Compile Include="CSharp\CallBuilder.cs" />
     <Compile Include="CSharp\CSharpLanguageVersion.cs" />
+    <Compile Include="CSharp\OutputVisitor\NullWriterTokenWriter.cs" />
     <Compile Include="CSharp\ProjectDecompiler\IProjectFileWriter.cs" />
     <Compile Include="CSharp\OutputVisitor\GenericGrammarAmbiguityVisitor.cs" />
     <Compile Include="CSharp\ProjectDecompiler\IProjectInfoProvider.cs" />
@@ -91,6 +92,7 @@
     <Compile Include="Documentation\XmlDocumentationElement.cs" />
     <Compile Include="IL\ControlFlow\AwaitInFinallyTransform.cs" />
     <Compile Include="IL\Transforms\IntroduceNativeIntTypeOnLocals.cs" />
+    <Compile Include="IncrementalChecksum.cs" />
     <Compile Include="Semantics\OutVarResolveResult.cs" />
     <Compile Include="SingleFileBundle.cs" />
     <Compile Include="Solution\ProjectId.cs" />

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -62,6 +62,7 @@
     <Compile Include="CSharp\CallBuilder.cs" />
     <Compile Include="CSharp\CSharpLanguageVersion.cs" />
     <Compile Include="CSharp\OutputVisitor\NullWriterTokenWriter.cs" />
+    <Compile Include="CSharp\ProjectDecompiler\AssemblyCheckumCalculator.cs" />
     <Compile Include="CSharp\ProjectDecompiler\IProjectFileWriter.cs" />
     <Compile Include="CSharp\OutputVisitor\GenericGrammarAmbiguityVisitor.cs" />
     <Compile Include="CSharp\ProjectDecompiler\IProjectInfoProvider.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="IL\ControlFlow\AwaitInFinallyTransform.cs" />
     <Compile Include="IL\Transforms\IntroduceNativeIntTypeOnLocals.cs" />
     <Compile Include="IncrementalChecksum.cs" />
+    <Compile Include="Metadata\LocalAssemblyResolver.cs" />
     <Compile Include="Semantics\OutVarResolveResult.cs" />
     <Compile Include="SingleFileBundle.cs" />
     <Compile Include="Solution\ProjectId.cs" />

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -575,10 +575,26 @@ namespace ICSharpCode.Decompiler.IL
 		/// <summary>
 		/// Decodes the specified method body and returns an ILFunction.
 		/// </summary>
-		public ILFunction ReadIL(MethodDefinitionHandle method, MethodBodyBlock body, GenericContext genericContext = default, ILFunctionKind kind = ILFunctionKind.TopLevelFunction, CancellationToken cancellationToken = default)
+		public ILFunction ReadIL(MethodDefinitionHandle method, MethodBodyBlock body, GenericContext genericContext = default, 
+			ILFunctionKind kind = ILFunctionKind.TopLevelFunction, CancellationToken cancellationToken = default,
+			IncrementalChecksum checksumcalc = null)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			Init(method, body, genericContext);
+
+			if (checksumcalc != null && checksumcalc.Enabled)
+			{
+				var bytes = body.GetILBytes();
+
+				if (bytes != null)
+				{
+					checksumcalc.AppendString(this.method.FullName);
+					checksumcalc.AppendAndLogBinaryData(bytes);
+				}
+
+				return null;
+			}
+
 			ReadInstructions(cancellationToken);
 			var blockBuilder = new BlockBuilder(body, variableByExceptionHandler);
 			blockBuilder.CreateBlocks(mainContainer, instructionBuilder, isBranchTarget, cancellationToken);

--- a/ICSharpCode.Decompiler/IncrementalChecksum.cs
+++ b/ICSharpCode.Decompiler/IncrementalChecksum.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ICSharpCode.Decompiler
+{
+	public class IncrementalChecksum: IDisposable
+    {
+        IncrementalHash _hash;
+        IncrementalHash calchash;
+        TextWriter logger = new StringWriter();
+
+        /// <summary>
+        /// Can temporarily enable or disable hash calculation
+        /// </summary>
+        public bool Enabled {
+            get {
+                return calchash != null;
+            }
+
+            set {
+                if (value)
+                {
+                    calchash = _hash;
+                }
+                else
+                {
+                    calchash = null;
+                }
+            }
+        }
+
+        public void EnableChecksumCalculation(HashAlgorithmName hashName)
+        {
+            _hash = calchash = IncrementalHash.CreateHash(hashName);
+        }
+
+        public void EnableChecksumLog(string assemblyFileName)
+        {
+            string log = assemblyFileName + ".log.txt";
+            logger = new StreamWriter(log, false, Encoding.UTF8);
+            logger.WriteLine($"Checksumming file '{assemblyFileName}'...");
+        }
+
+        /// <summary>
+        /// Adds string data to hash
+        /// </summary>
+        public void AppendString(string s)
+        {
+            if (calchash == null)
+            {
+                return;
+            }
+
+            logger.WriteLine($"- AppendString: '{s}'");
+            calchash.AppendData(Encoding.UTF8.GetBytes(s));
+        }
+
+        const int binaryBytesToShow = 6;
+
+        /// <summary>
+        /// Adds stream data to hash
+        /// </summary>
+        public void AppendStreamData(string fileName, Stream s)
+        {
+            if (calchash == null)
+            {
+                return;
+            }
+
+            const int bufferSize = 4096;
+            byte[] buf = new byte[bufferSize];
+            var pos = s.Position;
+            bool firstChunk = true;
+            string bufTag = "<empty>";
+            int toDump;
+
+            while (true)
+            {
+                int readed = s.Read(buf, 0, bufferSize);
+                if (readed <= 0)
+                {
+                    if (!firstChunk)
+                    {
+                        bufTag += " ... " + ByteArrayToString(buf, buf.Length - binaryBytesToShow, binaryBytesToShow);
+                    }
+                    break;
+                }
+
+                if (firstChunk)
+                {
+                    firstChunk = false;
+                    toDump = binaryBytesToShow;
+                    if (toDump > readed)
+                    {
+                        toDump = readed;
+                    }
+                    
+                    bufTag = ByteArrayToString(buf, 0, toDump);
+                }
+                
+                calchash.AppendData(buf, 0, readed);
+            }
+
+            AppendString(fileName);
+            logger.WriteLine($"- AppendStreamData: '{bufTag}' (length: {s.Position})");
+            s.Seek(pos, SeekOrigin.Begin);
+        }
+
+        /// <summary>
+        /// Gets hash value as a string
+        /// </summary>
+        /// <returns></returns>
+        public string GetHashString()
+        {
+            var hashv = calchash.GetHashAndReset();
+            string s = ByteArrayToString(hashv);
+            logger.WriteLine($"Resulting checksum: {s}");
+            return s;
+        }
+
+        public static string ByteArrayToString(byte[] ba, int offset = 0, int sizeToProcess = -1)
+        {
+            if (sizeToProcess == -1)
+            {
+                sizeToProcess = ba.Length - offset;
+            }
+
+            StringBuilder hex = new StringBuilder(sizeToProcess * 3);
+            for (int i = 0; i < sizeToProcess; i++)
+            {
+                int off = i + offset;
+                if (off >= ba.Length)	// Flip over buffer
+                {
+                    off -= ba.Length;
+                }
+                hex.AppendFormat("{0:X2} ", ba[off]);
+            }
+
+            var s = hex.ToString();
+            if (s.Length == 0)
+            {
+                return s;
+            }
+
+            return s.Substring(0, s.Length - 1);
+        }
+
+        public void AppendBinaryData(byte[] bytes)
+        {
+            calchash.AppendData(bytes);
+        }
+
+        public void AppendAndLogBinaryData(byte[] bytes)
+        {
+            string bufTag;
+            if (bytes.Length > binaryBytesToShow * 2)
+            {
+                bufTag = ByteArrayToString(bytes, 0, binaryBytesToShow) + " ... " +
+                    ByteArrayToString(bytes, bytes.Length - binaryBytesToShow, binaryBytesToShow);
+            }
+            else
+            {
+                bufTag = ByteArrayToString(bytes, 0, bytes.Length);
+            }
+
+            logger.WriteLine($"- AppendAndLogBinaryData: '{bufTag}' (length: {bytes.Length})");
+
+            calchash.AppendData(bytes);
+        }
+
+        public void Dispose()
+        {
+            logger.Close();
+        }
+    }
+}

--- a/ICSharpCode.Decompiler/Metadata/LocalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/LocalAssemblyResolver.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ICSharpCode.Decompiler.Metadata
+{
+	public class LocalAssemblyResolver : UniversalAssemblyResolver
+	{
+		readonly HashSet<string> localAssemblies = new HashSet<string>();
+
+		public LocalAssemblyResolver(string mainAssemblyFileName, string baseDir, string targetFramework)
+			: base(mainAssemblyFileName, false, targetFramework, PEStreamOptions.PrefetchMetadata, MetadataReaderOptions.ApplyWindowsRuntimeProjections)
+		{
+			var assemblyNames = new DirectoryInfo(baseDir).EnumerateFiles("*.dll").Select(f => Path.GetFileNameWithoutExtension(f.Name));
+			foreach (var name in assemblyNames)
+			{
+				localAssemblies.Add(name);
+			}
+		}
+
+		public override bool IsGacAssembly(IAssemblyReference reference)
+		{
+			return reference != null && !localAssemblies.Contains(reference.Name);
+		}
+	}
+}

--- a/ILSpy.sln
+++ b/ILSpy.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILSpy.Tests", "ILSpy.Tests\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILSpy.ReadyToRun", "ILSpy.ReadyToRun\ILSpy.ReadyToRun.csproj", "{0313F581-C63B-43BB-AA9B-07615DABD8A3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.Decompiler.Console", "ICSharpCode.Decompiler.Console\ICSharpCode.Decompiler.Console.csproj", "{35FBA61E-A13D-4BDA-B210-C1E2B3B7F2FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,10 @@ Global
 		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0313F581-C63B-43BB-AA9B-07615DABD8A3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35FBA61E-A13D-4BDA-B210-C1E2B3B7F2FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35FBA61E-A13D-4BDA-B210-C1E2B3B7F2FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35FBA61E-A13D-4BDA-B210-C1E2B3B7F2FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35FBA61E-A13D-4BDA-B210-C1E2B3B7F2FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Allow to retarget to net472 platform
Make '-p' option default, autoprobe output directory if not specified
Make class public (can be later on used as API)

### Problem
Slightly simplify usage of ilspycmd

### Solution
Easier to check ilspycmd usage (run without arguments), no output directory is required to be provided.
Project recompile is default option now (-p is not needed anymore).
Main class made public (preparing for checksum API usage)
