### PR TITLE
Fix insertion of result at end position

### DIFF
--- a/ILSpy/Search/SearchPane.cs
+++ b/ILSpy/Search/SearchPane.cs
@@ -269,7 +269,7 @@ namespace ICSharpCode.ILSpy
 						return;
 					}
 				}
-				results.Insert(results.Count - 1, result);
+				results.Add(result);
 			}
 			else
 			{


### PR DESCRIPTION
### Problem
When using "sort result by fitness", some results are not sorted in correct order.

### Solution
* Fix insertion when result has to be inserted at the end (it was inserted at the second last position before)
