### PR TITLE
Refactor searchresult insert

### DIFF
--- a/ILSpy/ExtensionMethods.cs
+++ b/ILSpy/ExtensionMethods.cs
@@ -93,6 +93,25 @@ namespace ICSharpCode.ILSpy
 			}
 			return ~start;
 		}
+
+		public static void InsertSorted<T>(this IList<T> list, T item, IComparer<T> comparer)
+		{
+			if (list == null)
+				throw new ArgumentNullException(nameof(list));
+			if (comparer == null)
+				throw new ArgumentNullException(nameof(comparer));
+
+			if (list.Count == 0)
+			{
+				list.Add(item);
+			}
+			else
+			{
+				int index = list.BinarySearch(item, 0, list.Count, comparer);
+				list.Insert(index < 0 ? ~index : index, item);
+			}
+		}
+
 		/*
 		public static bool IsCustomAttribute(this TypeDefinition type)
 		{

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1587,7 +1587,7 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hightlight current line.
+        ///   Looks up a localized string similar to Highlight current line.
         /// </summary>
         public static string HighlightCurrentLine {
             get {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -556,7 +556,7 @@ Are you sure you want to continue?</value>
     <value>Hide empty metadata tables from tree view</value>
   </data>
   <data name="HighlightCurrentLine" xml:space="preserve">
-    <value>Hightlight current line</value>
+    <value>Highlight current line</value>
   </data>
   <data name="HighlightMatchingBraces" xml:space="preserve">
     <value>Highlight matching braces</value>

--- a/ILSpy/Search/SearchPane.cs
+++ b/ILSpy/Search/SearchPane.cs
@@ -49,6 +49,7 @@ namespace ICSharpCode.ILSpy
 		const int MAX_REFRESH_TIME_MS = 10; // More means quicker forward of data, less means better responsibility
 		RunningSearch currentSearch;
 		bool runSearchOnNextShow;
+		IComparer<SearchResult> resultsComparer;
 
 		public static readonly DependencyProperty ResultsProperty =
 			DependencyProperty.Register("Results", typeof(ObservableCollection<SearchResult>), typeof(SearchPane),
@@ -211,7 +212,7 @@ namespace ICSharpCode.ILSpy
 			int resultsAdded = 0;
 			while (Results.Count < MAX_RESULTS && timer.ElapsedMilliseconds < MAX_REFRESH_TIME_MS && currentSearch.resultQueue.TryTake(out var result))
 			{
-				InsertResult(Results, result);
+				Results.InsertSorted(result, resultsComparer);
 				++resultsAdded;
 			}
 
@@ -230,6 +231,9 @@ namespace ICSharpCode.ILSpy
 				currentSearch = null;
 			}
 
+			resultsComparer = DisplaySettingsPanel.CurrentDisplaySettings.SortResults ?
+				SearchResult.ComparerByFitness :
+				SearchResult.ComparerByName;
 			Results.Clear();
 
 			RunningSearch startedSearch = null;
@@ -250,15 +254,6 @@ namespace ICSharpCode.ILSpy
 			{ //are we still running the same search
 				searchProgressBar.IsIndeterminate = false;
 			}
-		}
-
-		void InsertResult(IList<SearchResult> results, SearchResult result)
-		{
-			var comparer = DisplaySettingsPanel.CurrentDisplaySettings.SortResults ?
-				SearchResult.ComparerByFitness :
-				SearchResult.ComparerByName;
-
-			results.InsertSorted(result, comparer);
 		}
 
 		void JumpToSelectedItem()

--- a/ILSpy/Search/SearchPane.cs
+++ b/ILSpy/Search/SearchPane.cs
@@ -34,6 +34,7 @@ using System.Windows.Threading;
 
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.Docking;
+using ICSharpCode.ILSpy.Options;
 using ICSharpCode.ILSpy.Search;
 using ICSharpCode.ILSpy.ViewModels;
 
@@ -253,30 +254,11 @@ namespace ICSharpCode.ILSpy
 
 		void InsertResult(IList<SearchResult> results, SearchResult result)
 		{
-			if (results.Count == 0)
-			{
-				results.Add(result);
-			}
-			else if (Options.DisplaySettingsPanel.CurrentDisplaySettings.SortResults)
-			{
-				// Keep results collection sorted by "Fitness" by inserting result into correct place
-				// Inserts in the beginning shifts all elements, but there can be no more than 1000 items.
-				for (int i = 0; i < results.Count; i++)
-				{
-					if (results[i].Fitness < result.Fitness)
-					{
-						results.Insert(i, result);
-						return;
-					}
-				}
-				results.Add(result);
-			}
-			else
-			{
-				// Original Code
-				int index = results.BinarySearch(result, 0, results.Count - 1, SearchResult.Comparer);
-				results.Insert(index < 0 ? ~index : index, result);
-			}
+			var comparer = DisplaySettingsPanel.CurrentDisplaySettings.SortResults ?
+				SearchResult.ComparerByFitness :
+				SearchResult.ComparerByName;
+
+			results.InsertSorted(result, comparer);
 		}
 
 		void JumpToSelectedItem()

--- a/ILSpy/Search/SearchResult.cs
+++ b/ILSpy/Search/SearchResult.cs
@@ -29,7 +29,8 @@ namespace ICSharpCode.ILSpy
 {
 	public class SearchResult
 	{
-		public static readonly IComparer<SearchResult> Comparer = new SearchResultComparer();
+		public static readonly IComparer<SearchResult> ComparerByName = new SearchResultNameComparer();
+		public static readonly IComparer<SearchResult> ComparerByFitness = new SearchResultFitnessComparer();
 
 		public virtual object Reference {
 			get {
@@ -57,11 +58,20 @@ namespace ICSharpCode.ILSpy
 			return Name;
 		}
 
-		class SearchResultComparer : IComparer<SearchResult>
+		class SearchResultNameComparer : IComparer<SearchResult>
 		{
 			public int Compare(SearchResult x, SearchResult y)
 			{
 				return StringComparer.Ordinal.Compare(x?.Name ?? "", y?.Name ?? "");
+			}
+		}
+
+		class SearchResultFitnessComparer : IComparer<SearchResult>
+		{
+			public int Compare(SearchResult x, SearchResult y)
+			{
+				//elements with higher Fitness come first
+				return Comparer<float>.Default.Compare(y?.Fitness ?? 0, x?.Fitness ?? 0);
 			}
 		}
 	}


### PR DESCRIPTION
Refactoring of the InsertResult method of the SearchPane to use BinarySearch in all cases for sorted insertion, as discussed in #2333
Also contains a small typo fix.

