### PR TITLE
Remove global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,0 @@
-{
-	"msbuild-sdks": {
-		"MSBuild.Sdk.Extras": "3.0.23"
-	},
-	"sdk": {
-		"version": "3.1.100",
-		"rollForward": "latestFeature"
-	}
-}


### PR DESCRIPTION
We are receiving reports of people that have the .NET 5 SDK only on their machines, but our global.json requires 3.1 - which they then have to install additionally (or fumble with global.json if they know about that feature).

global.json was introduced in the very, very early days of .NET Core to make use of the then new project file format. So we had to pin a minimum version. Today, basically anything >= 3.1 LTS is fine in terms of what we need from the SDK (project file format and netstandard2.0). 

Also, MSBuild.Sdk.Extras has been removed entirely from our projects, so the version lock in global.json for that is also no longer needed.

Only downside: if a user has something &lt; than the required version installed, they aren't told. Mostly they'd be using unsupported versions according to https://dotnet.microsoft.com/platform/support/policy/dotnet-core (we don't support unsupported Windows versions either). So this is a minor issue if at all (only 2.1 is still in support).