### PR TITLE
Make it easy to play with .NET 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _ReSharper*/
 /ICSharpCode.Decompiler.Tests/TestCases/Correctness/*.exe
 /ICSharpCode.Decompiler.Tests/TestCases/Correctness/*.exe.config
 /ICSharpCode.Decompiler/ICSharpCode.Decompiler.nuspec
+multitargeting.props

--- a/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
+++ b/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
@@ -1,12 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
     <AssemblyName>ILSpy.BamlDecompiler.Plugin</AssemblyName>
     <LangVersion>8.0</LangVersion>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <BaseAddress>6488064</BaseAddress>
     <UseWpf>true</UseWpf>
+  </PropertyGroup>
+  
+  <Import Project="..\multitargeting.props" Condition="Exists('..\multitargeting.props')" />
+  <PropertyGroup Condition="!Exists('..\multitargeting.props')">
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -2,12 +2,16 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
     <AssemblyName>ILSpy.ReadyToRun.Plugin</AssemblyName>
     <LangVersion>8.0</LangVersion>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <NeutralResourcesLanguage>en-US</NeutralResourcesLanguage>
     <UseWpf>true</UseWpf>
+  </PropertyGroup>
+  
+  <Import Project="..\multitargeting.props" Condition="Exists('..\multitargeting.props')" />
+  <PropertyGroup Condition="!Exists('..\multitargeting.props')">
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -35,7 +36,6 @@ using Microsoft.VisualStudio.Composition;
 
 using TomsToolbox.Wpf.Styles;
 
-using System.Runtime.Loader;
 
 namespace ICSharpCode.ILSpy
 {

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -35,6 +35,8 @@ using Microsoft.VisualStudio.Composition;
 
 using TomsToolbox.Wpf.Styles;
 
+using System.Runtime.Loader;
+
 namespace ICSharpCode.ILSpy
 {
 	/// <summary>
@@ -85,8 +87,27 @@ namespace ICSharpCode.ILSpy
 			ILSpyTraceListener.Install();
 		}
 
+		static Assembly ResolvePluginDependencies(AssemblyLoadContext context, AssemblyName assemblyName)
+		{
+#if !NET472
+			var rootPath = Path.GetDirectoryName(typeof(App).Assembly.Location);
+			var assemblyFileName = Path.Combine(rootPath, assemblyName.Name + ".dll");
+			if (!File.Exists(assemblyFileName))
+				return null;
+			return context.LoadFromAssemblyPath(assemblyFileName);
+#else
+			throw new NotImplementedException();
+#endif
+		}
+
 		private static async Task InitializeMef()
 		{
+#if !NET472
+			// Add custom logic for resolution of dependencies.
+			// This necessary because the AssemblyLoadContext.LoadFromAssemblyPath and related methods,
+			// do not automatically load dependencies.
+			AssemblyLoadContext.Default.Resolving += ResolvePluginDependencies;
+#endif
 			// Cannot show MessageBox here, because WPF would crash with a XamlParseException
 			// Remember and show exceptions in text output, once MainWindow is properly initialized
 			try
@@ -98,7 +119,6 @@ namespace ICSharpCode.ILSpy
 				var discovery = new AttributedPartDiscoveryV1(Resolver.DefaultInstance);
 				var catalog = ComposableCatalog.Create(Resolver.DefaultInstance);
 				var pluginDir = Path.GetDirectoryName(typeof(App).Module.FullyQualifiedName);
-#if NET472
 				if (pluginDir != null)
 				{
 					foreach (var plugin in Directory.GetFiles(pluginDir, "*.Plugin.dll"))
@@ -106,7 +126,11 @@ namespace ICSharpCode.ILSpy
 						var name = Path.GetFileNameWithoutExtension(plugin);
 						try
 						{
+#if NET472
 							var asm = Assembly.Load(name);
+#else
+							var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(plugin);
+#endif
 							var parts = await discovery.CreatePartsAsync(asm);
 							catalog = catalog.AddParts(parts);
 						}
@@ -116,7 +140,6 @@ namespace ICSharpCode.ILSpy
 						}
 					}
 				}
-#endif
 				// Add the built-in parts
 				var createdParts = await discovery.CreatePartsAsync(Assembly.GetExecutingAssembly());
 				catalog = catalog.AddParts(createdParts);

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
     <LangVersion>9.0</LangVersion>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
@@ -17,6 +16,11 @@
 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  
+  <Import Project="..\multitargeting.props" Condition="Exists('..\multitargeting.props')" />
+  <PropertyGroup Condition="!Exists('..\multitargeting.props')">
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -49,6 +53,7 @@
     <PackageReference Include="DataGridExtensions" Version="2.5.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.4.3" />
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/StorePackageHelper.cs
+++ b/ILSpy/StorePackageHelper.cs
@@ -9,16 +9,18 @@ namespace ICSharpCode.ILSpy
 			get {
 #if NET472
 				return WindowsVersionHelper.HasPackageIdentity;
-#endif
+#else
 				return false;
+#endif
 			}
 		}
 		public static string GetPackageFamilyName()
 		{
 #if NET472
 			return WindowsVersionHelper.GetPackageFamilyName();
-#endif
+#else
 			return "";
+#endif
 		}
 	}
 }

--- a/SharpTreeView/ICSharpCode.TreeView.csproj
+++ b/SharpTreeView/ICSharpCode.TreeView.csproj
@@ -2,11 +2,15 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
     <UseWpf>true</UseWpf>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  
+  <Import Project="..\multitargeting.props" Condition="Exists('..\multitargeting.props')" />
+  <PropertyGroup Condition="!Exists('..\multitargeting.props')">
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "3.1.100",
     "rollForward": "major",
     "allowPrerelease": true
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "5.0.100",
     "rollForward": "major",
     "allowPrerelease": true
   }

--- a/multitargeting.props.template
+++ b/multitargeting.props.template
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copy this file to multitargeting.props and in global.json, change to framework 5.0.100
+-->
 <Project>
   <PropertyGroup>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TargetFrameworks>net472;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/multitargeting.props.template
+++ b/multitargeting.props.template
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <TargetFrameworks>net472;net5.0-windows</TargetFrameworks>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
See issue #2324

To try: copy `multitargeting.props.template` to `multitargeting.props` and set `global.json/sdk/version` to `5.0.100`. Open VS, compile, select to run / edit for net5.0-windows.

Notes: the assembly resolution is very bare bones, it doesn't find localized assemblies in subfolders.