### PR TITLE
Support for single-file bundle from .NET 6.

### DIFF
--- a/ILSpy/LoadedPackage.cs
+++ b/ILSpy/LoadedPackage.cs
@@ -197,7 +197,24 @@ namespace ICSharpCode.ILSpy
 			public override Stream TryOpenStream()
 			{
 				Debug.WriteLine("Open bundle member " + Name);
-				return new UnmanagedMemoryStream(view.SafeMemoryMappedViewHandle, entry.Offset, entry.Size);
+
+				if (entry.CompressedSize == 0)
+				{
+					return new UnmanagedMemoryStream(view.SafeMemoryMappedViewHandle, entry.Offset, entry.Size);
+				}
+				else
+				{
+					Stream compressedStream = new UnmanagedMemoryStream(view.SafeMemoryMappedViewHandle, entry.Offset, entry.CompressedSize);
+					using var deflateStream = new DeflateStream(compressedStream, CompressionMode.Decompress);
+					Stream decompressedStream = new MemoryStream((int)entry.Size);
+					deflateStream.CopyTo(decompressedStream);
+					if (decompressedStream.Length != entry.Size)
+					{
+						throw new InvalidDataException($"Corrupted single-file entry '${entry.RelativePath}'. Declared decompressed size '${entry.Size}' is not the same as actual decompressed size '${decompressedStream.Length}'.");
+					}
+
+					return decompressedStream;
+				}
 			}
 		}
 	}

--- a/ILSpy/LoadedPackage.cs
+++ b/ILSpy/LoadedPackage.cs
@@ -213,6 +213,7 @@ namespace ICSharpCode.ILSpy
 						throw new InvalidDataException($"Corrupted single-file entry '${entry.RelativePath}'. Declared decompressed size '${entry.Size}' is not the same as actual decompressed size '${decompressedStream.Length}'.");
 					}
 
+					decompressedStream.Seek(0, SeekOrigin.Begin);
 					return decompressedStream;
 				}
 			}


### PR DESCRIPTION
Adds support for the new version and also the new compressed files.

Reacts to .NET changes:
https://github.com/dotnet/runtime/pull/49855
https://github.com/dotnet/runtime/pull/50817