### PR TITLE
Search predicates

### DIFF
--- a/ILSpy/Commands/CopyFullyQualifiedNameContextMenuEntry.cs
+++ b/ILSpy/Commands/CopyFullyQualifiedNameContextMenuEntry.cs
@@ -1,9 +1,22 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
 using System.Windows;
 
-using ICSharpCode.Decompiler;
-using ICSharpCode.Decompiler.Metadata;
-using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.Properties;
 using ICSharpCode.ILSpy.TreeNodes;
 

--- a/ILSpy/Commands/ScopeSearchToAssembly.cs
+++ b/ILSpy/Commands/ScopeSearchToAssembly.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) 2021 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
+
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.ILSpy.Properties;
+using ICSharpCode.ILSpy.TreeNodes;
+
+namespace ICSharpCode.ILSpy
+{
+	[ExportContextMenuEntry(Header = nameof(Resources.ScopeSearchToThisAssembly), Category = nameof(Resources.Analyze), Order = 9999)]
+	public class ScopeSearchToAssembly : IContextMenuEntry
+	{
+		public void Execute(TextViewContext context)
+		{
+			string asmName = GetAssembly(context);
+			string searchTerm = MainWindow.Instance.SearchPane.SearchTerm;
+			string[] args = NativeMethods.CommandLineToArgumentArray(searchTerm);
+			bool replaced = false;
+			for (int i = 0; i < args.Length; i++)
+			{
+				if (args[i].StartsWith("inassembly:", StringComparison.OrdinalIgnoreCase))
+				{
+					args[i] = "inassembly:" + asmName;
+					replaced = true;
+					break;
+				}
+			}
+			if (!replaced)
+			{
+				searchTerm += " inassembly:" + asmName;
+			}
+			else
+			{
+				searchTerm = NativeMethods.ArgumentArrayToCommandLine(args);
+			}
+			MainWindow.Instance.SearchPane.SearchTerm = searchTerm;
+		}
+
+		public bool IsEnabled(TextViewContext context)
+		{
+			return GetAssembly(context) != null;
+		}
+
+		public bool IsVisible(TextViewContext context)
+		{
+			return GetAssembly(context) != null;
+		}
+
+		string GetAssembly(TextViewContext context)
+		{
+			if (context.Reference?.Reference is IEntity entity)
+				return entity.ParentModule.AssemblyName;
+			if (context.SelectedTreeNodes?.Length != 1)
+				return null;
+			switch (context.SelectedTreeNodes[0])
+			{
+				case AssemblyTreeNode tn:
+					return tn.LoadedAssembly.ShortName;
+				case IMemberTreeNode member:
+					return member.Member.ParentModule.AssemblyName;
+				default:
+					return null;
+			}
+		}
+	}
+}

--- a/ILSpy/Commands/ScopeSearchToNamespace.cs
+++ b/ILSpy/Commands/ScopeSearchToNamespace.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) 2021 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
+
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.ILSpy.Properties;
+using ICSharpCode.ILSpy.TreeNodes;
+
+namespace ICSharpCode.ILSpy
+{
+	[ExportContextMenuEntry(Header = nameof(Resources.ScopeSearchToThisNamespace), Category = nameof(Resources.Analyze), Order = 9999)]
+	public class ScopeSearchToNamespace : IContextMenuEntry
+	{
+		public void Execute(TextViewContext context)
+		{
+			string ns = GetNamespace(context);
+			string searchTerm = MainWindow.Instance.SearchPane.SearchTerm;
+			string[] args = NativeMethods.CommandLineToArgumentArray(searchTerm);
+			bool replaced = false;
+			for (int i = 0; i < args.Length; i++)
+			{
+				if (args[i].StartsWith("innamespace:", StringComparison.OrdinalIgnoreCase))
+				{
+					args[i] = "innamespace:" + ns;
+					replaced = true;
+					break;
+				}
+			}
+			if (!replaced)
+			{
+				searchTerm += " innamespace:" + ns;
+			}
+			else
+			{
+				searchTerm = NativeMethods.ArgumentArrayToCommandLine(args);
+			}
+			MainWindow.Instance.SearchPane.SearchTerm = searchTerm;
+		}
+
+		public bool IsEnabled(TextViewContext context)
+		{
+			return GetNamespace(context) != null;
+		}
+
+		public bool IsVisible(TextViewContext context)
+		{
+			return GetNamespace(context) != null;
+		}
+
+		string GetNamespace(TextViewContext context)
+		{
+			if (context.Reference?.Reference is IEntity entity)
+				return entity.Namespace;
+			if (context.SelectedTreeNodes?.Length != 1)
+				return null;
+			switch (context.SelectedTreeNodes[0])
+			{
+				case NamespaceTreeNode tn:
+					return tn.Name;
+				case IMemberTreeNode member:
+					return member.Member.Namespace;
+				default:
+					return null;
+			}
+		}
+	}
+}

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -2195,6 +2195,24 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Scope search to this assembly.
+        /// </summary>
+        public static string ScopeSearchToThisAssembly {
+            get {
+                return ResourceManager.GetString("ScopeSearchToThisAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Scope search to this namespace.
+        /// </summary>
+        public static string ScopeSearchToThisNamespace {
+            get {
+                return ResourceManager.GetString("ScopeSearchToThisNamespace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search....
         /// </summary>
         public static string Search {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -755,6 +755,12 @@ Do you want to continue?</value>
   <data name="SaveCode" xml:space="preserve">
     <value>Save Code</value>
   </data>
+  <data name="ScopeSearchToThisAssembly" xml:space="preserve">
+    <value>Scope search to this assembly</value>
+  </data>
+  <data name="ScopeSearchToThisNamespace" xml:space="preserve">
+    <value>Scope search to this namespace</value>
+  </data>
   <data name="Search" xml:space="preserve">
     <value>Search...</value>
   </data>

--- a/ILSpy/Search/AbstractEntitySearchStrategy.cs
+++ b/ILSpy/Search/AbstractEntitySearchStrategy.cs
@@ -1,10 +1,25 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
-using System.Threading;
 using System.Windows.Media;
 
-using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.ILSpy.TreeNodes;
 
 namespace ICSharpCode.ILSpy.Search
@@ -16,8 +31,9 @@ namespace ICSharpCode.ILSpy.Search
 		protected readonly Language language;
 		protected readonly ApiVisibility apiVisibility;
 
-		protected AbstractEntitySearchStrategy(Language language, ApiVisibility apiVisibility, IProducerConsumerCollection<SearchResult> resultQueue, params string[] terms)
-			: base(resultQueue, terms)
+		protected AbstractEntitySearchStrategy(Language language, ApiVisibility apiVisibility,
+			SearchRequest searchRequest, IProducerConsumerCollection<SearchResult> resultQueue)
+			: base(searchRequest, resultQueue)
 		{
 			this.language = language;
 			this.apiVisibility = apiVisibility;
@@ -45,6 +61,31 @@ namespace ICSharpCode.ILSpy.Search
 				entity = entity.DeclaringTypeDefinition;
 			}
 			while (entity != null);
+
+			return true;
+		}
+
+		protected bool IsInNamespaceOrAssembly(IEntity entity)
+		{
+			if (searchRequest.InAssembly != null)
+			{
+				if (!entity.ParentModule.FullAssemblyName.Contains(searchRequest.InAssembly))
+				{
+					return false;
+				}
+			}
+
+			if (searchRequest.InNamespace != null)
+			{
+				if (searchRequest.InNamespace.Length == 0)
+				{
+					return entity.Namespace.Length == 0;
+				}
+				else if (!entity.Namespace.Contains(searchRequest.InNamespace))
+				{
+					return false;
+				}
+			}
 
 			return true;
 		}

--- a/ILSpy/Search/AssemblySearchStrategy.cs
+++ b/ILSpy/Search/AssemblySearchStrategy.cs
@@ -1,18 +1,26 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
-using System.Reflection.Metadata;
 using System.Threading;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 using ICSharpCode.Decompiler.Metadata;
-using ICSharpCode.Decompiler.TypeSystem;
-using ICSharpCode.Decompiler.Util;
-using ICSharpCode.ILSpy.TreeNodes;
-using ICSharpCode.TreeView;
 
 namespace ICSharpCode.ILSpy.Search
 {
@@ -20,13 +28,9 @@ namespace ICSharpCode.ILSpy.Search
 	{
 		readonly AssemblySearchKind searchKind;
 
-		public AssemblySearchStrategy(string term, IProducerConsumerCollection<SearchResult> resultQueue, AssemblySearchKind searchKind)
-			: this(resultQueue, new[] { term }, searchKind)
-		{
-		}
-
-		public AssemblySearchStrategy(IProducerConsumerCollection<SearchResult> resultQueue, string[] terms, AssemblySearchKind searchKind)
-			: base(resultQueue, terms)
+		public AssemblySearchStrategy(SearchRequest request,
+			IProducerConsumerCollection<SearchResult> resultQueue, AssemblySearchKind searchKind)
+			: base(request, resultQueue)
 		{
 			this.searchKind = searchKind;
 		}

--- a/ILSpy/Search/MemberSearchStrategy.cs
+++ b/ILSpy/Search/MemberSearchStrategy.cs
@@ -1,4 +1,21 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -11,13 +28,9 @@ namespace ICSharpCode.ILSpy.Search
 	{
 		readonly MemberSearchKind searchKind;
 
-		public MemberSearchStrategy(Language language, ApiVisibility apiVisibility, string term, IProducerConsumerCollection<SearchResult> resultQueue, MemberSearchKind searchKind = MemberSearchKind.All)
-			: this(language, apiVisibility, resultQueue, new[] { term }, searchKind)
-		{
-		}
-
-		public MemberSearchStrategy(Language language, ApiVisibility apiVisibility, IProducerConsumerCollection<SearchResult> resultQueue, string[] terms, MemberSearchKind searchKind = MemberSearchKind.All)
-			: base(language, apiVisibility, resultQueue, terms)
+		public MemberSearchStrategy(Language language, ApiVisibility apiVisibility, SearchRequest searchRequest,
+			IProducerConsumerCollection<SearchResult> resultQueue, MemberSearchKind searchKind = MemberSearchKind.All)
+			: base(language, apiVisibility, searchRequest, resultQueue)
 		{
 			this.searchKind = searchKind;
 		}
@@ -39,7 +52,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (languageSpecificName != null && !IsMatch(languageSpecificName))
 						continue;
 					var type = ((MetadataModule)typeSystem.MainModule).GetDefinition(handle);
-					if (!CheckVisibility(type))
+					if (!CheckVisibility(type) || !IsInNamespaceOrAssembly(type))
 						continue;
 					OnFoundResult(type);
 				}
@@ -54,7 +67,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (languageSpecificName != null && !IsMatch(languageSpecificName))
 						continue;
 					var method = ((MetadataModule)typeSystem.MainModule).GetDefinition(handle);
-					if (!CheckVisibility(method))
+					if (!CheckVisibility(method) || !IsInNamespaceOrAssembly(method))
 						continue;
 					OnFoundResult(method);
 				}
@@ -69,7 +82,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (languageSpecificName != null && !IsMatch(languageSpecificName))
 						continue;
 					var field = ((MetadataModule)typeSystem.MainModule).GetDefinition(handle);
-					if (!CheckVisibility(field))
+					if (!CheckVisibility(field) || !IsInNamespaceOrAssembly(field))
 						continue;
 					OnFoundResult(field);
 				}
@@ -84,7 +97,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (languageSpecificName != null && !IsMatch(languageSpecificName))
 						continue;
 					var property = ((MetadataModule)typeSystem.MainModule).GetDefinition(handle);
-					if (!CheckVisibility(property))
+					if (!CheckVisibility(property) || !IsInNamespaceOrAssembly(property))
 						continue;
 					OnFoundResult(property);
 				}
@@ -99,7 +112,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (!IsMatch(languageSpecificName))
 						continue;
 					var @event = ((MetadataModule)typeSystem.MainModule).GetDefinition(handle);
-					if (!CheckVisibility(@event))
+					if (!CheckVisibility(@event) || !IsInNamespaceOrAssembly(@event))
 						continue;
 					OnFoundResult(@event);
 				}

--- a/ILSpy/Search/MetadataTokenSearchStrategy.cs
+++ b/ILSpy/Search/MetadataTokenSearchStrategy.cs
@@ -1,4 +1,21 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection.Metadata;
@@ -14,9 +31,11 @@ namespace ICSharpCode.ILSpy.Search
 	{
 		readonly EntityHandle searchTermToken;
 
-		public MetadataTokenSearchStrategy(Language language, ApiVisibility apiVisibility, IProducerConsumerCollection<SearchResult> resultQueue, params string[] terms)
-			: base(language, apiVisibility, resultQueue, terms)
+		public MetadataTokenSearchStrategy(Language language, ApiVisibility apiVisibility, SearchRequest request,
+			IProducerConsumerCollection<SearchResult> resultQueue)
+			: base(language, apiVisibility, request, resultQueue)
 		{
+			var terms = request.Keywords;
 			if (terms.Length == 1)
 			{
 				int.TryParse(terms[0], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var token);
@@ -41,7 +60,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (row < 1 || row > module.Metadata.TypeDefinitions.Count)
 						break;
 					var type = metadataModule.GetDefinition((TypeDefinitionHandle)searchTermToken);
-					if (!CheckVisibility(type))
+					if (!CheckVisibility(type) || !IsInNamespaceOrAssembly(type))
 						break;
 					OnFoundResult(type);
 					break;
@@ -49,7 +68,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (row < 1 || row > module.Metadata.MethodDefinitions.Count)
 						break;
 					var method = metadataModule.GetDefinition((MethodDefinitionHandle)searchTermToken);
-					if (!CheckVisibility(method))
+					if (!CheckVisibility(method) || !IsInNamespaceOrAssembly(method))
 						break;
 					OnFoundResult(method);
 					break;
@@ -57,7 +76,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (row < 1 || row > module.Metadata.FieldDefinitions.Count)
 						break;
 					var field = metadataModule.GetDefinition((FieldDefinitionHandle)searchTermToken);
-					if (!CheckVisibility(field))
+					if (!CheckVisibility(field) || !IsInNamespaceOrAssembly(field))
 						break;
 					OnFoundResult(field);
 					break;
@@ -65,7 +84,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (row < 1 || row > module.Metadata.PropertyDefinitions.Count)
 						break;
 					var property = metadataModule.GetDefinition((PropertyDefinitionHandle)searchTermToken);
-					if (!CheckVisibility(property))
+					if (!CheckVisibility(property) || !IsInNamespaceOrAssembly(property))
 						break;
 					OnFoundResult(property);
 					break;
@@ -73,7 +92,7 @@ namespace ICSharpCode.ILSpy.Search
 					if (row < 1 || row > module.Metadata.EventDefinitions.Count)
 						break;
 					var @event = metadataModule.GetDefinition((EventDefinitionHandle)searchTermToken);
-					if (!CheckVisibility(@event))
+					if (!CheckVisibility(@event) || !IsInNamespaceOrAssembly(@event))
 						break;
 					OnFoundResult(@event);
 					break;

--- a/ILSpy/Search/NamespaceSearchStrategy.cs
+++ b/ILSpy/Search/NamespaceSearchStrategy.cs
@@ -1,13 +1,24 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Metadata;
 using System.Threading;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.TypeSystem;
@@ -17,13 +28,8 @@ namespace ICSharpCode.ILSpy.Search
 {
 	class NamespaceSearchStrategy : AbstractSearchStrategy
 	{
-		public NamespaceSearchStrategy(string term, IProducerConsumerCollection<SearchResult> resultQueue)
-			: this(resultQueue, new[] { term })
-		{
-		}
-
-		public NamespaceSearchStrategy(IProducerConsumerCollection<SearchResult> resultQueue, string[] terms)
-			: base(resultQueue, terms)
+		public NamespaceSearchStrategy(SearchRequest request, IProducerConsumerCollection<SearchResult> resultQueue)
+			: base(request, resultQueue)
 		{
 		}
 

--- a/ILSpy/Search/ResourceSearchStrategy.cs
+++ b/ILSpy/Search/ResourceSearchStrategy.cs
@@ -1,15 +1,27 @@
-﻿using System;
+﻿// Copyright (c) 2011 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 using ICSharpCode.Decompiler.Metadata;
-using ICSharpCode.Decompiler.TypeSystem;
-using ICSharpCode.Decompiler.Util;
 using ICSharpCode.ILSpy.TreeNodes;
 using ICSharpCode.TreeView;
 
@@ -20,13 +32,8 @@ namespace ICSharpCode.ILSpy.Search
 		protected readonly bool searchInside;
 		protected readonly ApiVisibility apiVisibility;
 
-		public ResourceSearchStrategy(ApiVisibility apiVisibility, IProducerConsumerCollection<SearchResult> resultQueue, string term)
-			: this(apiVisibility, resultQueue, new[] { term })
-		{
-		}
-
-		public ResourceSearchStrategy(ApiVisibility apiVisibility, IProducerConsumerCollection<SearchResult> resultQueue, string[] terms)
-			: base(resultQueue, terms)
+		public ResourceSearchStrategy(ApiVisibility apiVisibility, SearchRequest request, IProducerConsumerCollection<SearchResult> resultQueue)
+			: base(request, resultQueue)
 		{
 			this.apiVisibility = apiVisibility;
 			this.searchInside = true;


### PR DESCRIPTION
Implements features requested in #828 and #1175:

* `innamespace:` and `inassembly:` predicates in the search text box
* "scope to this namespace/assembly" command for tree nodes and search results, allowing to generate `innamespace:` and `inassembly:` predicates