### PR TITLE
Fix #2409: Styling of windows title bar is now optional.

### DIFF
--- a/ILSpy/AboutPage.cs
+++ b/ILSpy/AboutPage.cs
@@ -34,6 +34,7 @@ using ICSharpCode.AvalonEdit.Rendering;
 using ICSharpCode.Decompiler;
 using ICSharpCode.ILSpy.Properties;
 using ICSharpCode.ILSpy.TextView;
+using ICSharpCode.ILSpy.Themes;
 
 namespace ICSharpCode.ILSpy
 {

--- a/ILSpy/App.xaml
+++ b/ILSpy/App.xaml
@@ -2,12 +2,22 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:styles="urn:TomsToolbox.Wpf.Styles"
+             xmlns:toms="urn:TomsToolbox"
+             xmlns:ilSpy="clr-namespace:ICSharpCode.ILSpy"
+             xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
              StartupUri="MainWindow.xaml">
 	<Application.Resources>
-		<Style x:Key="DialogWindow" TargetType="{x:Type Window}" BasedOn="{StaticResource {x:Static styles:ResourceKeys.WindowStyle}}">
+		<Style x:Key="DialogWindow" TargetType="{x:Type Window}">
 			<Setter Property="ShowInTaskbar" Value="False"/>
 			<Setter Property="UseLayoutRounding" Value="True"/>
 			<Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+			<Setter Property="toms:StyleBindings.Behaviors">
+				<Setter.Value>
+					<toms:BehaviorCollection>
+						<themes:WindowStyleManagerBehavior />
+					</toms:BehaviorCollection>
+				</Setter.Value>
+			</Setter>
 		</Style>
 
 		<Style TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Static styles:ResourceKeys.ButtonStyle}}">

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="OSVersionHelper" Version="1.1.24" />
     <PackageReference Include="DataGridExtensions" Version="2.5.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
-    <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.5.3" />
+    <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.5.5" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 

--- a/ILSpy/ISmartTextOutput.cs
+++ b/ILSpy/ISmartTextOutput.cs
@@ -24,6 +24,7 @@ using System.Windows.Media;
 
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.Decompiler;
+using ICSharpCode.ILSpy.Themes;
 
 namespace ICSharpCode.ILSpy
 {

--- a/ILSpy/MainWindow.xaml
+++ b/ILSpy/MainWindow.xaml
@@ -14,10 +14,11 @@
 	MinHeight="200"
 	UseLayoutRounding="True"
 	TextOptions.TextFormattingMode="Display"
-	Style="{StaticResource {x:Static styles:ResourceKeys.WindowStyle}}"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008" d:DesignHeight="500" d:DesignWidth="500"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
 	xmlns:styles="urn:TomsToolbox.Wpf.Styles"
+	xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+	xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
 	d:DataContext="{d:DesignInstance local:MainWindowDataContext}"
 >
 	<Window.Resources>
@@ -63,6 +64,9 @@
 		<controls:CultureSelectionConverter x:Key="cultureSelectionConverter" />
 
 	</Window.Resources>
+	<b:Interaction.Behaviors>
+		<themes:WindowStyleManagerBehavior />
+	</b:Interaction.Behaviors>
 
 	<Window.CommandBindings>
 		<CommandBinding

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -46,6 +46,7 @@ using ICSharpCode.Decompiler.TypeSystem.Implementation;
 using ICSharpCode.ILSpy.Analyzers;
 using ICSharpCode.ILSpy.Docking;
 using ICSharpCode.ILSpy.TextView;
+using ICSharpCode.ILSpy.Themes;
 using ICSharpCode.ILSpy.TreeNodes;
 using ICSharpCode.ILSpy.ViewModels;
 using ICSharpCode.TreeView;

--- a/ILSpy/Options/DisplaySettings.cs
+++ b/ILSpy/Options/DisplaySettings.cs
@@ -273,6 +273,19 @@ namespace ICSharpCode.ILSpy.Options
 			}
 		}
 
+		private bool styleWindowTitleBar;
+
+		public bool StyleWindowTitleBar {
+			get { return styleWindowTitleBar; }
+			set {
+				if (styleWindowTitleBar != value)
+				{
+					styleWindowTitleBar = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		public void CopyValues(DisplaySettings s)
 		{
 			this.SelectedFont = s.selectedFont;
@@ -292,6 +305,7 @@ namespace ICSharpCode.ILSpy.Options
 			this.HighlightMatchingBraces = s.highlightMatchingBraces;
 			this.HighlightCurrentLine = s.highlightCurrentLine;
 			this.HideEmptyMetadataTables = s.hideEmptyMetadataTables;
+			this.StyleWindowTitleBar = s.styleWindowTitleBar;
 		}
 	}
 }

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -3,7 +3,10 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:properties="clr-namespace:ICSharpCode.ILSpy.Properties"
 			 xmlns:local="clr-namespace:ICSharpCode.ILSpy.Options"
-			 xmlns:system="clr-namespace:System;assembly=mscorlib">
+			 xmlns:system="clr-namespace:System;assembly=mscorlib"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 d:DataContext="{d:DesignInstance local:DisplaySettings}">
 	<UserControl.Resources>
 		<local:FontSizeConverter x:Key="fontSizeConv" />
 	</UserControl.Resources>
@@ -88,6 +91,7 @@
 					<CheckBox IsChecked="{Binding SortResults}" Content="{x:Static properties:Resources.SortResultsFitness}"></CheckBox>
 					<CheckBox IsChecked="{Binding ExpandMemberDefinitions}" Content="{x:Static properties:Resources.ExpandMemberDefinitionsAfterDecompilation}"></CheckBox>
 					<CheckBox IsChecked="{Binding ExpandUsingDeclarations}" Content="{x:Static properties:Resources.ExpandUsingDeclarationsAfterDecompilation}"></CheckBox>
+					<CheckBox IsChecked="{Binding StyleWindowTitleBar}" Content="{x:Static properties:Resources.StyleTheWindowTitleBar}"></CheckBox>
 				</StackPanel>
 			</GroupBox>
 		</Grid>

--- a/ILSpy/Options/DisplaySettingsPanel.xaml.cs
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml.cs
@@ -123,6 +123,7 @@ namespace ICSharpCode.ILSpy.Options
 			s.HighlightMatchingBraces = (bool?)e.Attribute("HighlightMatchingBraces") ?? true;
 			s.HighlightCurrentLine = (bool?)e.Attribute("HighlightCurrentLine") ?? false;
 			s.HideEmptyMetadataTables = (bool?)e.Attribute("HideEmptyMetadataTables") ?? true;
+			s.StyleWindowTitleBar = (bool?)e.Attribute("StyleWindowTitleBar") ?? false;
 
 			return s;
 		}
@@ -149,6 +150,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("HighlightMatchingBraces", s.HighlightMatchingBraces);
 			section.SetAttributeValue("HighlightCurrentLine", s.HighlightCurrentLine);
 			section.SetAttributeValue("HideEmptyMetadataTables", s.HideEmptyMetadataTables);
+			section.SetAttributeValue("StyleWindowTitleBar", s.StyleWindowTitleBar);
 
 			XElement existingElement = root.Element("DisplaySettings");
 			if (existingElement != null)

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1677,6 +1677,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Language.
+        /// </summary>
+        public static string Language {
+            get {
+                return ResourceManager.GetString("Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Are you sure that you want to delete the selected assembly list?.
         /// </summary>
         public static string ListDeleteConfirmation {
@@ -2454,6 +2463,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Style the window title bar.
+        /// </summary>
+        public static string StyleTheWindowTitleBar {
+            get {
+                return ResourceManager.GetString("StyleTheWindowTitleBar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Tab size:.
         /// </summary>
         public static string TabSize {
@@ -2650,11 +2668,5 @@ namespace ICSharpCode.ILSpy.Properties {
                 return ResourceManager.GetString("Window_ResetLayout", resourceCulture);
             }
         }
- 
-        public static string Language {
-            get {
-                return ResourceManager.GetString("Language", resourceCulture);
-            }
-          }
     }
 }

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -849,6 +849,9 @@ Do you want to continue?</value>
   <data name="StringTable" xml:space="preserve">
     <value>String Table</value>
   </data>
+  <data name="StyleTheWindowTitleBar" xml:space="preserve">
+    <value>Style the window title bar</value>
+  </data>
   <data name="TabSize" xml:space="preserve">
     <value>Tab size:</value>
   </data>

--- a/ILSpy/SessionSettings.cs
+++ b/ILSpy/SessionSettings.cs
@@ -27,6 +27,7 @@ using System.Windows;
 using System.Xml.Linq;
 
 using ICSharpCode.ILSpy.Docking;
+using ICSharpCode.ILSpy.Themes;
 
 namespace ICSharpCode.ILSpy
 {

--- a/ILSpy/TextView/DecompilerTextView.cs
+++ b/ILSpy/TextView/DecompilerTextView.cs
@@ -53,6 +53,7 @@ using ICSharpCode.Decompiler.Documentation;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.AvalonEdit;
 using ICSharpCode.ILSpy.Options;
+using ICSharpCode.ILSpy.Themes;
 using ICSharpCode.ILSpy.TreeNodes;
 using ICSharpCode.ILSpy.ViewModels;
 
@@ -60,7 +61,7 @@ using Microsoft.Win32;
 
 using TomsToolbox.Wpf;
 
-using ResourceKeys = ICSharpCode.ILSpy.themes.ResourceKeys;
+using ResourceKeys = ICSharpCode.ILSpy.Themes.ResourceKeys;
 
 namespace ICSharpCode.ILSpy.TextView
 {

--- a/ILSpy/Themes/DarkTheme.xaml
+++ b/ILSpy/Themes/DarkTheme.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:styles="urn:TomsToolbox.Wpf.Styles"
-                    xmlns:themes="clr-namespace:ICSharpCode.ILSpy.themes">
+                    xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes">
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="/AvalonDock.Themes.VS2013;component/darktheme.xaml" />
 	</ResourceDictionary.MergedDictionaries>
@@ -27,7 +27,7 @@
 	<Color x:Key="{x:Static SystemColors.ActiveCaptionTextColorKey}">#F1F1F1</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveCaptionColorKey}">#2D2D30</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveBorderColorKey}">#434346</Color>
-	<Color x:Key="{x:Static SystemColors.InactiveCaptionTextColorKey}">#F1F1F1</Color>
+	<Color x:Key="{x:Static SystemColors.InactiveCaptionTextColorKey}">#808080</Color>
 
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightLightBrushKey}" Color="#333337" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightBrushKey}" Color="#464646" />
@@ -50,7 +50,7 @@
 	<SolidColorBrush x:Key="{x:Static SystemColors.ActiveCaptionTextBrushKey}" Color="#F1F1F1" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveCaptionBrushKey}" Color="#2D2D30" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveBorderBrushKey}" Color="#434346" />
-	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveCaptionTextBrushKey}" Color="#F1F1F1" />
+	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveCaptionTextBrushKey}" Color="#808080" />
 
 	<SolidColorBrush x:Key="{x:Static styles:ResourceKeys.BorderBrush}" Color="#464646" />
 	<SolidColorBrush x:Key="{x:Static styles:ResourceKeys.DisabledBrush}" Color="#2D2D30" />

--- a/ILSpy/Themes/LightTheme.xaml
+++ b/ILSpy/Themes/LightTheme.xaml
@@ -20,11 +20,11 @@
 	<Color x:Key="{x:Static SystemColors.WindowColorKey}">#FFFFFF</Color>
 	<Color x:Key="{x:Static SystemColors.WindowTextColorKey}">#1E1E1E</Color>
 	<Color x:Key="{x:Static SystemColors.ActiveCaptionColorKey}">#EEEEF2</Color>
-	<Color x:Key="{x:Static SystemColors.ActiveBorderColorKey}">#007ACC</Color>
+	<Color x:Key="{x:Static SystemColors.ActiveBorderColorKey}">#71BDE2</Color>
 	<Color x:Key="{x:Static SystemColors.ActiveCaptionTextColorKey}">#1E1E1E</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveCaptionColorKey}">#EEEEF2</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveBorderColorKey}">#CCCEDB</Color>
-	<Color x:Key="{x:Static SystemColors.InactiveCaptionTextColorKey}">#1E1E1E</Color>
+	<Color x:Key="{x:Static SystemColors.InactiveCaptionTextColorKey}">#808080</Color>
 
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightLightBrushKey}" Color="#FCFCFC" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightBrushKey}" Color="#D8D8E0" />
@@ -41,11 +41,11 @@
 	<SolidColorBrush x:Key="{x:Static SystemColors.WindowBrushKey}" Color="#FFFFFF" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.WindowTextBrushKey}" Color="#1E1E1E" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.ActiveCaptionBrushKey}" Color="#EEEEF2" />
-	<SolidColorBrush x:Key="{x:Static SystemColors.ActiveBorderBrushKey}" Color="#007ACC" />
+	<SolidColorBrush x:Key="{x:Static SystemColors.ActiveBorderBrushKey}" Color="#71BDE2" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.ActiveCaptionTextBrushKey}" Color="#1E1E1E" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveCaptionBrushKey}" Color="#EEEEF2" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveBorderBrushKey}" Color="#CCCEDB" />
-	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveCaptionTextBrushKey}" Color="#1E1E1E" />
+	<SolidColorBrush x:Key="{x:Static SystemColors.InactiveCaptionTextBrushKey}" Color="#808080" />
 
 	<SolidColorBrush x:Key="{x:Static styles:ResourceKeys.BorderBrush}" Color="#CCCEDB" />
 	<SolidColorBrush x:Key="{x:Static styles:ResourceKeys.DisabledBrush}" Color="#EEEEF2" />

--- a/ILSpy/Themes/ResourceKeys.cs
+++ b/ILSpy/Themes/ResourceKeys.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows;
 
-namespace ICSharpCode.ILSpy.themes
+namespace ICSharpCode.ILSpy.Themes
 {
 	public static class ResourceKeys
 	{

--- a/ILSpy/Themes/ThemeManager.cs
+++ b/ILSpy/Themes/ThemeManager.cs
@@ -2,7 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 
-namespace ICSharpCode.ILSpy
+namespace ICSharpCode.ILSpy.Themes
 {
 	internal class ThemeManager
 	{

--- a/ILSpy/Themes/WindowStyleManagerBehavior.cs
+++ b/ILSpy/Themes/WindowStyleManagerBehavior.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel;
+using System.Windows;
+
+using ICSharpCode.ILSpy.Options;
+
+using TomsToolbox.Wpf;
+using TomsToolbox.Wpf.Interactivity;
+
+namespace ICSharpCode.ILSpy.Themes
+{
+	public class WindowStyleManagerBehavior : FrameworkElementBehavior<Window>
+	{
+		private static readonly DispatcherThrottle restartNotificationThrottle = new DispatcherThrottle(ShowRestartNotification);
+
+		protected override void OnAttached()
+		{
+			base.OnAttached();
+
+			DisplaySettingsPanel.CurrentDisplaySettings.PropertyChanged += DisplaySettings_PropertyChanged;
+
+			UpdateWindowStyle();
+
+		}
+
+		protected override void OnDetaching()
+		{
+			base.OnDetaching();
+
+			DisplaySettingsPanel.CurrentDisplaySettings.PropertyChanged -= DisplaySettings_PropertyChanged;
+		}
+
+		private void UpdateWindowStyle()
+		{
+			if (!DisplaySettingsPanel.CurrentDisplaySettings.StyleWindowTitleBar)
+			{
+				return;
+			}
+
+			var window = AssociatedObject;
+			window.Style = (Style)window.FindResource(TomsToolbox.Wpf.Styles.ResourceKeys.WindowStyle);
+		}
+
+		private static void ShowRestartNotification()
+		{
+			MessageBox.Show(Properties.Resources.SettingsChangeRestartRequired);
+		}
+
+		private void DisplaySettings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == nameof(DisplaySettings.StyleWindowTitleBar))
+			{
+				if (!DisplaySettingsPanel.CurrentDisplaySettings.StyleWindowTitleBar)
+				{
+					restartNotificationThrottle.Tick();
+					return;
+				}
+
+				UpdateWindowStyle();
+			}
+		}
+	}
+}

--- a/ILSpy/Themes/generic.xaml
+++ b/ILSpy/Themes/generic.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:controls="clr-namespace:ICSharpCode.ILSpy.Controls"
-	xmlns:themes="clr-namespace:ICSharpCode.ILSpy.themes">
+	xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes">
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="../Controls/SearchBoxStyle.xaml" />
 	</ResourceDictionary.MergedDictionaries>

--- a/SharpTreeView/ICSharpCode.TreeView.csproj
+++ b/SharpTreeView/ICSharpCode.TreeView.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.5.3" />
+    <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.5.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #2409: 
If you like to have the title bar styled along with the theme you can now opt via View-Options-Display. 
Default is no styling.
It also fixes the border color mentioned in #2359