### PR TITLE
C# 9 Covariant Returns

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="TestCases\Correctness\DeconstructionTests.cs" />
     <Compile Include="TestCases\Correctness\DynamicTests.cs" />
     <Compile Include="TestCases\Correctness\StringConcat.cs" />
+    <None Include="TestCases\Pretty\CovariantReturns.cs" />
     <Compile Include="TestCases\VBPretty\VBPropertiesTest.cs" />
     <None Include="TestCases\ILPretty\Issue2260SwitchString.cs" />
     <None Include="TestCases\Pretty\Records.cs" />

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -573,6 +573,12 @@ namespace ICSharpCode.Decompiler.Tests
 			RunForLibrary(cscOptions: cscOptions | CompilerOptions.Preview);
 		}
 
+		[Test]
+		public void CovariantReturns([ValueSource(nameof(dotnetCoreOnlyOptions))] CompilerOptions cscOptions)
+		{
+			RunForLibrary(cscOptions: cscOptions | CompilerOptions.Preview);
+		}
+
 		void RunForLibrary([CallerMemberName] string testName = null, AssemblerOptions asmOptions = AssemblerOptions.None, CompilerOptions cscOptions = CompilerOptions.None, DecompilerSettings decompilerSettings = null)
 		{
 			Run(testName, asmOptions | AssemblerOptions.Library, cscOptions | CompilerOptions.Library, decompilerSettings);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CovariantReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CovariantReturns.cs
@@ -1,0 +1,50 @@
+﻿namespace ICSharpCode.Decompiler.Tests.TestCases.CovariantReturns
+{
+	public abstract class Base
+	{
+		public abstract Base Instance { get; }
+
+		public abstract Base this[int index] { get; }
+
+		public virtual Base Build()
+		{
+			throw null;
+		}
+
+		protected abstract Base SetParent(object parent);
+	}
+
+	public class Derived : Base
+	{
+		public override Derived Instance { get; }
+
+		public override Derived this[int index] {
+			get {
+				throw null;
+			}
+		}
+
+		public override Derived Build()
+		{
+			throw null;
+		}
+
+		protected override Derived SetParent(object parent)
+		{
+			throw null;
+		}
+	}
+
+	public class UseSites
+	{
+		public Base Test(Base x)
+		{
+			return x.Build();
+		}
+
+		public Derived Test(Derived x)
+		{
+			return x.Build();
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -139,12 +139,14 @@ namespace ICSharpCode.Decompiler
 				recordClasses = false;
 				withExpressions = false;
 				usePrimaryConstructorSyntax = false;
+				covariantReturns = false;
 			}
 		}
 
 		public CSharp.LanguageVersion GetMinimumRequiredVersion()
 		{
-			if (nativeIntegers || initAccessors || functionPointers || forEachWithGetEnumeratorExtension || recordClasses)
+			if (nativeIntegers || initAccessors || functionPointers || forEachWithGetEnumeratorExtension
+				|| recordClasses || withExpressions || usePrimaryConstructorSyntax || covariantReturns)
 				return CSharp.LanguageVersion.Preview;
 			if (nullableReferenceTypes || readOnlyMethods || asyncEnumerator || asyncUsingAndForEachStatement
 				|| staticLocalFunctions || ranges || switchExpressions)
@@ -188,6 +190,24 @@ namespace ICSharpCode.Decompiler
 				if (nativeIntegers != value)
 				{
 					nativeIntegers = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool covariantReturns = true;
+
+		/// <summary>
+		/// Decompile C# 9 covariant return types.
+		/// </summary>
+		[Category("C# 9.0 / VS 2019.8")]
+		[Description("DecompilerSettings.CovariantReturns")]
+		public bool CovariantReturns {
+			get { return covariantReturns; }
+			set {
+				if (covariantReturns != value)
+				{
+					covariantReturns = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -102,11 +102,12 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		// C# 9 attributes:
 		NativeInteger,
+		PreserveBaseOverrides,
 	}
 
 	static class KnownAttributes
 	{
-		internal const int Count = (int)KnownAttribute.NativeInteger + 1;
+		internal const int Count = (int)KnownAttribute.PreserveBaseOverrides + 1;
 
 		static readonly TopLevelTypeName[] typeNames = new TopLevelTypeName[Count]{
 			default,
@@ -167,6 +168,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			new TopLevelTypeName("System.Security.Permissions", "PermissionSetAttribute"),
 			// C# 9 attributes:
 			new TopLevelTypeName("System.Runtime.CompilerServices", "NativeIntegerAttribute"),
+			new TopLevelTypeName("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute"),
 		};
 
 		public static ref readonly TopLevelTypeName GetTypeName(this KnownAttribute attr)


### PR DESCRIPTION
Adds support for C# 9 covariant return types in methods and getter-only properties and indexers.