### PR TITLE
Support loading compressed Xamarin assemblies, see #2137

### DIFF
--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.31" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.5.5" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.5.5" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -389,7 +389,7 @@ namespace ICSharpCode.ILSpy
 				var descIdx = fileReader.ReadUInt32();
 				var uncLen = fileReader.ReadUInt32();
 				// fileReader stream position is now at compressed module data
-				var src = fileReader.ReadBytes((int)uncLen); // compressed length must be smaller than uncompressed length
+				var src = fileReader.ReadBytes((int)fileStream.Length); // Ensure we read all of compressed data
 				var dst = new byte[(int)uncLen];
 				// Decompress
 				LZ4Codec.Decode(src, 0, src.Length, dst, 0, dst.Length);

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -35,6 +35,8 @@ using ICSharpCode.Decompiler.TypeSystem.Implementation;
 using ICSharpCode.Decompiler.Util;
 using ICSharpCode.ILSpy.Options;
 
+using K4os.Compression.LZ4;
+
 #nullable enable
 
 namespace ICSharpCode.ILSpy
@@ -323,6 +325,15 @@ namespace ICSharpCode.ILSpy
 			{
 				loadAssemblyException = ex;
 			}
+			// Maybe its a compressed Xamarin/Mono assembly, see https://github.com/xamarin/xamarin-android/pull/4686
+			try
+			{
+				return LoadCompressedAssembly(fileName);
+			}
+			catch (InvalidDataException)
+			{
+				// Not a compressed module, try other options below
+			}
 			// If it's not a .NET module, maybe it's a single-file bundle
 			var bundle = LoadedPackage.FromBundle(fileName);
 			if (bundle != null)
@@ -363,6 +374,31 @@ namespace ICSharpCode.ILSpy
 				loadedAssemblies.Add(module, this);
 			}
 			return new LoadResult(module);
+		}
+
+		LoadResult LoadCompressedAssembly(string filename)
+		{
+			const uint CompressedDataMagic = 0x5A4C4158; // Magic used for Xamarin compressed module header ('XALZ', little-endian)
+			using (var fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+			using (var fileReader = new BinaryReader(fileStream))
+			{
+				// Read compressed file header
+				var magic = fileReader.ReadUInt32();
+				if (magic != CompressedDataMagic)
+					throw new InvalidDataException($"Xamarin compressed module header magic {magic} does not match expected {CompressedDataMagic}");
+				var descIdx = fileReader.ReadUInt32();
+				var uncLen = fileReader.ReadUInt32();
+				// fileReader stream position is now at compressed module data
+				var src = fileReader.ReadBytes((int)uncLen); // compressed length must be smaller than uncompressed length
+				var dst = new byte[(int)uncLen];
+				// Decompress
+				LZ4Codec.Decode(src, 0, src.Length, dst, 0, dst.Length);
+				// Load module from decompressed data buffer
+				using (var modData = new MemoryStream(dst, writable: false))
+				{
+					return LoadAssembly(modData, PEStreamOptions.PrefetchEntireImage);
+				}
+			}
 		}
 
 		IDebugInfoProvider? LoadDebugInfo(PEFile module)

--- a/ILSpy/LoadedAssembly.cs
+++ b/ILSpy/LoadedAssembly.cs
@@ -376,7 +376,7 @@ namespace ICSharpCode.ILSpy
 			return new LoadResult(module);
 		}
 
-		LoadResult LoadCompressedAssembly(string filename)
+		LoadResult LoadCompressedAssembly(string fileName)
 		{
 			const uint CompressedDataMagic = 0x5A4C4158; // Magic used for Xamarin compressed module header ('XALZ', little-endian)
 			using (var fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read))

--- a/doc/third-party-notices.txt
+++ b/doc/third-party-notices.txt
@@ -415,6 +415,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+License Notice for K4os.Compression.LZ4 (part of ILSpy)
+---------------------------
+
+https://github.com/MiloszKrajewski/K4os.Compression.LZ4/blob/master/LICENSE
+
+MIT License
+
+Copyright (c) 2017 Milosz Krajewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 License Notice for LightJson (part of ICSharpCode.Decompiler)
 ---------------------------
 


### PR DESCRIPTION
Fixes #2137.

### Problem
Assemblies included in mobile Android apps created with Xamarin can be compressed. This PR detects compressed assemblies and attempts to decompress them in order to correctly load the assembly. This is handy when analyzing mobile apps created with Xamarin using ILSpy.

### Solution
* Extend class ``LoadedAssembly`` to detect and load compressed Xamarin assemblies if direct loading of assembly fails.
* Requires Nuget pkg K4os.Compression.LZ4 for LZ4 decompression.

