### PR TITLE
Added null checks, for using ilspy appless/windowless

### DIFF
--- a/ILSpy/ILSpySettings.cs
+++ b/ILSpy/ILSpySettings.cs
@@ -126,7 +126,7 @@ namespace ICSharpCode.ILSpy
 
 		static string GetConfigFile()
 		{
-			if (App.CommandLineArguments.ConfigFile != null)
+			if (App.CommandLineArguments?.ConfigFile != null)
 				return App.CommandLineArguments.ConfigFile;
 			string localPath = Path.Combine(Path.GetDirectoryName(typeof(MainWindow).Assembly.Location), "ILSpy.xml");
 			if (File.Exists(localPath))

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -325,7 +325,7 @@ namespace ICSharpCode.ILSpy
 
 		void AddReferenceWarningMessage(PEFile module, ITextOutput output)
 		{
-			var loadedAssembly = MainWindow.Instance.CurrentAssemblyList.GetAssemblies().FirstOrDefault(la => la.GetPEFileOrNull() == module);
+			var loadedAssembly = MainWindow.Instance != null ?  MainWindow.Instance.CurrentAssemblyList.GetAssemblies().FirstOrDefault(la => la.GetPEFileOrNull() == module) : null;
 			if (loadedAssembly == null || !loadedAssembly.LoadedAssemblyReferencesInfo.HasErrors)
 				return;
 			string line1 = Properties.Resources.WarningSomeAssemblyReference;


### PR DESCRIPTION
I am using ILSpy as unpacker in WinMerge and therefore
linking it as a library from c++/cli code running it without any
window/app, resulting in 2 NullReferenceExceptions which I could not
workaround.