### PR TITLE
Update ready to run

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.13.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="6.0.0-preview.5.21224.4" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="6.0.0-rc.2.21424.11" />
     <!-- ILCompiler.Reflection.ReadyToRun has dependencies on System.Reflection.Metadata and
          System.Runtime.CompilerServices.Unsafe. Because the AddIn compiles into ILSpy's output
          directory, we're at risk of overwriting our dependencies with different versions.

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -243,7 +243,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 						{
 							// This could happen if the compiler is generating bogus variable info mapping record that covers 0 instructions
 							// See https://github.com/dotnet/runtime/issues/47202
-							Debug.Assert(false);
+							// Debug.Assert(false);
 							continue;
 						}
 						switch (varLoc.VariableLocation.VarLocType)


### PR DESCRIPTION
This change updates the `ILCompiler.Reflection.ReadyToRun` version that so it can disassemble the ready to run binaries generated by .NET 6. The version is tested under the `STRESS` mode [here](https://github.com/icsharpcode/ILSpy/blob/dd1621a811459da26b8fc2d993ec50c2f2b50704/ILSpy.ReadyToRun/ReadyToRunLanguage.cs#L19) and the test passed.

I have to turn off the assertion because of https://github.com/dotnet/runtime/issues/47202. It was fine because `USING_VARIABLE_LIVE_RANGE` was off, but now it is on after https://github.com/dotnet/runtime/pull/50162.