### PR TITLE
#2493 make SearchTermMatches virtual for possible FilterSettings extensions

### DIFF
--- a/ILSpy/FilterSettings.cs
+++ b/ILSpy/FilterSettings.cs
@@ -73,7 +73,7 @@ namespace ICSharpCode.ILSpy
 		/// <summary>
 		/// Gets whether a node with the specified text is matched by the current search term.
 		/// </summary>
-		public bool SearchTermMatches(string text)
+		public virtual bool SearchTermMatches(string text)
 		{
 			if (string.IsNullOrEmpty(searchTerm))
 				return true;


### PR DESCRIPTION
https://github.com/icsharpcode/ILSpy/issues/2493

### Problem
It is hard to filter the nodes by a single term, Search should be at least extensible

### Solution
The solution is a semi-hack, since in future class extensions the member `SearchTerm` may or may not be used, but I consider to be the easiest solution that opens the class to extensions

