### PR TITLE
Fix attribute application analysis could fail if there are wrong assemblies loaded

### DIFF
--- a/ILSpy/Analyzers/AnalyzerScope.cs
+++ b/ILSpy/Analyzers/AnalyzerScope.cs
@@ -77,7 +77,8 @@ namespace ICSharpCode.ILSpy.Analyzers
 		public IEnumerable<PEFile> GetAllModules()
 		{
 			return AssemblyList.GetAllAssemblies().GetAwaiter().GetResult()
-				.Select(asm => asm.GetPEFileOrNull());
+				.Select(asm => asm.GetPEFileOrNull())
+				.Where(x => x != null);
 		}
 
 		public IEnumerable<ITypeDefinition> GetTypesInScope(CancellationToken ct)


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
Scenario:
- Load `System` assembly together with e.g. unknown assembly which IL Spy cannot read (so it shows error in a tree)
- Find any attribute and Analyze it
- In the Analysis window expand "Applied To" analysis.

The following error occurs:
![image](https://user-images.githubusercontent.com/1074182/131999047-8cab6716-843c-41d6-8068-09de9f48ff62.png)

### Solution

The `AnalyzerScope.GetAllModules()` was not expected to return `null` modules as I can see by the usages around. So I fixed that by filtering out invalid modules from Assembly List
