### PR TITLE
Fix null check in BamlDecompilerTypeSystem.HasType

### DIFF
--- a/ILSpy.BamlDecompiler/BamlDecompilerTypeSystem.cs
+++ b/ILSpy.BamlDecompiler/BamlDecompilerTypeSystem.cs
@@ -128,11 +128,11 @@ namespace ILSpy.BamlDecompiler
 			bool HasType(KnownTypeCode code)
 			{
 				TopLevelTypeName name = KnownTypeReference.Get(code).TypeName;
-				if (mainModule.GetTypeDefinition(name) != null)
+				if (!mainModule.GetTypeDefinition(name).IsNil)
 					return true;
 				foreach (var file in referencedAssemblies)
 				{
-					if (file.GetTypeDefinition(name) != null)
+					if (!file.GetTypeDefinition(name).IsNil)
 						return true;
 				}
 				return false;


### PR DESCRIPTION
Fix CS8073: `The result of the expression is always 'true' since a value of type 'TypeDefinitionHandle' is never equal to 'null' of type 'TypeDefinitionHandle?'`

`TypeDefinitionHandle` is an struct and can never be null.