### PR TITLE
support backticks in FQ name when searching for type #2522

### DIFF
--- a/ILSpy/Search/AbstractSearchStrategy.cs
+++ b/ILSpy/Search/AbstractSearchStrategy.cs
@@ -27,9 +27,13 @@ namespace ICSharpCode.ILSpy.Search
 				string search = terms[0];
 				omitGenerics = !(search.Contains("<") || search.Contains("`"));
 				if (TryParseRegex(search, out regex))
+				{
 					fullNameSearch = search.Contains("\\.");
+				}
 				else
+				{
 					fullNameSearch = search.Contains(".");
+				}
 			}
 			searchTerm = terms;
 		}


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
#2522

### Solution
also consider backticks "`" in search term when evaluating if generics should be omitted

