### PR TITLE
Remove GetResult from DecompilerTypeSystem to Support WASM Target

### DIFF
--- a/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
@@ -179,6 +179,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		public DecompilerTypeSystem(PEFile mainModule, IAssemblyResolver assemblyResolver, TypeSystemOptions typeSystemOptions)
 		{
+			this.InitializeAsync(mainModule, assemblyResolver, typeSystemOptions).GetAwaiter().GetResult();
 		}
 
 		public async Task InitializeAsync(PEFile mainModule, IAssemblyResolver assemblyResolver, TypeSystemOptions typeSystemOptions)


### PR DESCRIPTION
### Problem
I'm building a web based decompiler with the ILSpy Decompiler. I need to compile it targeting Microsoft.NET.Sdk.BlazorWebAssembly to keep everything client side. Due to the runtime restrictions, we can't call .GetResult() on the task. I'd like to not have to fork the code and instead consume the nuget.

The below issue might shed some more light on it.
https://github.com/dotnet/aspnetcore/issues/26314

I have forked the Decompiler and have a POC website running here: 
https://decompile.spacedoglabs.com/
https://github.com/spacedog-labs/spil

### Solution
This PR extracts the constructor code, and adds a new empty constructor. The idea is that the existing flow will call into the new initializer method as expected; but give the user the option to initialize with the empty constructor and call the new async method themselves - additionally awaiting it to support the runtime.

I'm not entirely sure what other non-breaking changes are possible to get this working, very open to alternatives!

Doesn't seem like I can run the repo's decompiler tests as I am on macOS.

