### PR TITLE
Fix missing x:Static and x:Type in decompiled BAML

### DIFF
--- a/ILSpy.BamlDecompiler.Tests/BamlTestRunner.cs
+++ b/ILSpy.BamlDecompiler.Tests/BamlTestRunner.cs
@@ -148,6 +148,12 @@ namespace ILSpy.BamlDecompiler.Tests
 			RunTest("cases/issue2097");
 		}
 
+		[Test]
+		public void Issue2116()
+		{
+			RunTest("cases/issue2116");
+		}
+
 		#region RunTest
 		void RunTest(string name)
 		{

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
@@ -5,5 +5,8 @@
       <Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
     </ResourceDictionary>
   </FrameworkElement.Resources>
-  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+	<Grid>
+	  <Grid Style="{StaticResource TestStyle1}" />
+	  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+	</Grid>
 </UserControl>

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
@@ -1,12 +1,15 @@
 ﻿<UserControl x:Class="ILSpy.BamlDecompiler.Tests.Cases.Issue2116" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:local="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
-  <FrameworkElement.Resources>
-    <ResourceDictionary>
-      <Style x:Key="TestStyle1" />
-      <Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
-    </ResourceDictionary>
-  </FrameworkElement.Resources>
+	<FrameworkElement.Resources>
+		<ResourceDictionary>
+			<Style x:Key="TestStyle1" />
+			<Style x:Key="TestStyle2" BasedOn="{StaticResource TestStyle1}" />
+			<Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Type local:Issue2116}}" />
+			<Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+		</ResourceDictionary>
+	</FrameworkElement.Resources>
 	<Grid>
-	  <Grid Style="{StaticResource TestStyle1}" />
-	  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+		<Grid Style="{StaticResource TestStyle1}" />
+		<Grid Style="{StaticResource {x:Type local:Issue2116}}" />
+		<Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
 	</Grid>
 </UserControl>

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml
@@ -1,0 +1,9 @@
+﻿<UserControl x:Class="ILSpy.BamlDecompiler.Tests.Cases.Issue2116" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:local="clr-namespace:ILSpy.BamlDecompiler.Tests.Cases" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <FrameworkElement.Resources>
+    <ResourceDictionary>
+      <Style x:Key="TestStyle1" />
+      <Style x:Key="TestStyle2" BasedOn="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+    </ResourceDictionary>
+  </FrameworkElement.Resources>
+  <Grid Style="{StaticResource {x:Static local:Issue2116.StyleKey1}}" />
+</UserControl>

--- a/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml.cs
+++ b/ILSpy.BamlDecompiler.Tests/Cases/Issue2116.xaml.cs
@@ -1,0 +1,16 @@
+﻿namespace ILSpy.BamlDecompiler.Tests.Cases
+{
+	using System.Windows;
+	using System.Windows.Controls;
+
+	public partial class Issue2116 : UserControl
+	{
+		public static ComponentResourceKey StyleKey1 => new ComponentResourceKey(typeof(Issue2116), "TestStyle1");
+		public static ComponentResourceKey StyleKey2 => new ComponentResourceKey(typeof(Issue2116), "TestStyle2");
+
+		public Issue2116()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Cases\CustomControl.cs" />
     <Compile Include="Cases\Issue1547.xaml.cs" />
     <Compile Include="Cases\Issue2097.xaml.cs" />
+    <Compile Include="Cases\Issue2116.xaml.cs" />
     <Compile Include="Cases\MyControl.xaml.cs">
       <DependentUpon>MyControl.xaml</DependentUpon>
     </Compile>
@@ -97,6 +98,9 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Cases\Issue2097.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Cases\Issue2116.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Cases\Issue775.xaml">

--- a/ILSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
+++ b/ILSpy.BamlDecompiler/Handlers/Records/PropertyWithExtensionHandler.cs
@@ -47,7 +47,12 @@ namespace ILSpy.BamlDecompiler.Handlers
 			if (valTypeExt || extTypeId == (short)KnownTypes.TypeExtension)
 			{
 				var value = ctx.ResolveType(record.ValueId);
-				ext.Initializer = new object[] { ctx.ToString(parent.Xaml, value) };
+
+				object[] initializer = new object[] { ctx.ToString(parent.Xaml, value) };
+				if (valTypeExt)
+					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfd4d)) { Initializer = initializer } }; // Known type - TypeExtension
+
+				ext.Initializer = initializer;
 			}
 			else if (extTypeId == (short)KnownTypes.TemplateBindingExtension)
 			{
@@ -97,7 +102,12 @@ namespace ILSpy.BamlDecompiler.Handlers
 
 					attrName = ctx.ToString(parent.Xaml, xName);
 				}
-				ext.Initializer = new object[] { attrName };
+
+				object[] initializer = new object[] { attrName };
+				if (valStaticExt)
+					initializer = new object[] { new XamlExtension(ctx.ResolveType(0xfda6)) { Initializer = initializer } }; // Known type - StaticExtension
+
+				ext.Initializer = initializer;
 			}
 			else
 			{


### PR DESCRIPTION
Link to issue(s) this covers
https://github.com/icsharpcode/ILSpy/issues/2116

### Problem
issue https://github.com/icsharpcode/ILSpy/issues/2116 and another old pr https://github.com/icsharpcode/ILSpy/pull/2229

this also fixes missing x:Type

before:
![image](https://user-images.githubusercontent.com/27536652/140541389-69eb690e-ab79-4578-b184-6838018c1425.png)

after:
![image](https://user-images.githubusercontent.com/27536652/140541404-e079d47f-c8ac-4910-98b1-527619d30577.png)
