### PR TITLE
Switch to using the .NET 6.0 SDK

### DIFF
--- a/.github/workflows/build-frontends.yml
+++ b/.github/workflows/build-frontends.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore ILSpy.XPlat.slnf
     - name: Build

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -42,10 +42,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Install dotnet-format
       run: dotnet tool install dotnet-format --global --version 5.1.225507

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Build
       run: dotnet build ILSpy.XPlat.slnf --configuration Release
 

--- a/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
+++ b/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -221,12 +221,11 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 		static readonly RoslynToolset roslynToolset = new RoslynToolset();
 
 		static readonly string coreRefAsmPath = new DotNetCorePathFinder(TargetFrameworkIdentifier.NET,
-			new Version(5, 0), "Microsoft.NETCore.App")
-				.GetReferenceAssemblyPath(".NETCoreApp, Version = v5.0");
+			new Version(6, 0), "Microsoft.NETCore.App")
+				.GetReferenceAssemblyPath(".NETCoreApp,Version=v6.0");
 
 		static readonly string refAsmPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
 			@"Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2");
-		static readonly string thisAsmPath = Path.GetDirectoryName(typeof(Tester).Assembly.Location);
 
 		static readonly Lazy<IEnumerable<string>> defaultReferences = new Lazy<IEnumerable<string>>(delegate {
 			return new[]
@@ -258,7 +257,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 		const string targetFrameworkAttributeSnippet = @"
 
-[assembly: System.Runtime.Versioning.TargetFramework("".NETCoreApp, Version = v5.0"", FrameworkDisplayName = """")]
+[assembly: System.Runtime.Versioning.TargetFramework("".NETCoreApp,Version=v6.0"", FrameworkDisplayName = """")]
 
 ";
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ How to build
   - Follow Microsoft's instructions for [importing a configuration](https://docs.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2019#import-a-configuration), and import the .vsconfig file located at the root of the solution.
   - Alternatively, you can open the ILSpy solution (ILSpy.sln) and Visual Studio will [prompt you to install the missing components](https://docs.microsoft.com/en-us/visualstudio/install/import-export-installation-configurations?view=vs-2019#automatically-install-missing-components).
   - Finally, you can manually install the necessary components via the Visual Studio Installer. The workloads/components are as follows:
-    - Workload ".NET Desktop Development". This workload includes the .NET Framework 4.8 SDK and the .NET Framework 4.7.2 targeting pack, as well as the [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) (ILSpy.csproj targets .NET 4.7.2, and ILSpy.sln uses SDK-style projects). _Note: The optional components of this workload are not required for ILSpy_
+    - Workload ".NET Desktop Development". This workload includes the .NET Framework 4.8 SDK and the .NET Framework 4.7.2 targeting pack, as well as the [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) (ILSpy.csproj targets .NET 4.7.2, and ILSpy.sln uses SDK-style projects). _Note: The optional components of this workload are not required for ILSpy_
     - Workload "Visual Studio extension development" (ILSpy.sln contains a VS extension project) _Note: The optional components of this workload are not required for ILSpy_
     - Individual Component "MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.23)" (or similar)
       - _The VC++ toolset is optional_; if present it is used for `editbin.exe` to modify the stack size used by ILSpy.exe from 1MB to 16MB, because the decompiler makes heavy use of recursion, where small stack sizes lead to problems in very complex methods.
@@ -63,12 +63,12 @@ How to build
       - ILSpy.AddIn.slnf: for the Visual Studio plugin
 
 **Note:** Visual Studio 16.3 and later include a version of the .NET (Core) SDK that is managed by the Visual Studio installer - once you update, it may get upgraded too.
-Please note that ILSpy is only compatible with the .NET 5.0 SDK and Visual Studio will refuse to load some projects in the solution (and unit tests will fail). 
-If this problem occurs, please manually install the .NET 5.0 SDK from [here](https://dotnet.microsoft.com/download/dotnet/5.0).
+Please note that ILSpy is only compatible with the .NET 6.0 SDK and Visual Studio will refuse to load some projects in the solution (and unit tests will fail). 
+If this problem occurs, please manually install the .NET 6.0 SDK from [here](https://dotnet.microsoft.com/download/dotnet/6.0).
 
 #### Unix / Mac:
 
-- Make sure [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) is installed.
+- Make sure [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) is installed.
 - Make sure [PowerShell](https://github.com/PowerShell/PowerShell) is installed (formerly known as PowerShell Core)
 - Clone the repository using git.
 - Execute `git submodule update --init --recursive` to download the ILSpy-Tests submodule (used by some test cases).

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.0",
+    "version": "6.0.100",
     "rollForward": "major",
     "allowPrerelease": true
   }

--- a/multitargeting.props.template
+++ b/multitargeting.props.template
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copy this file to multitargeting.props and in global.json, change to framework 5.0.100
+  Copy this file to multitargeting.props
 -->
 <Project>
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <TargetFrameworks>net472;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
ILSpy is currently using  the .NET 5.0 SDK. It will be end of support by May 8th, 2022 (see https://dotnet.microsoft.com/platform/support/policy/dotnet-core)

.NET 6 is an LTS release with EOL of November 08, 2024 (one year beyond .NET 8.0). .NET 6 also fixes a bunch of issues for ARM64 platforms, which comes in handy for testing via multitargeting.props.