### PR TITLE
Use Directory.Build.props.template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _ReSharper*/
 multitargeting.props
 ILSpy.Installer/wix/
 ILSpy.Installer/AppPackage.cs
+/ICSharpCode.Decompiler.Console/Directory.Build.props

--- a/BuildTools/update-assemblyinfo.ps1
+++ b/BuildTools/update-assemblyinfo.ps1
@@ -77,7 +77,8 @@ $templateFiles = (
     @{Input="ILSpy/Properties/app.config.template"; Output = "ILSpy/app.config"},
     @{Input="ILSpy.AddIn/source.extension.vsixmanifest.template"; Output = "ILSpy.AddIn/source.extension.vsixmanifest"},
     @{Input="ILSpy.AddIn.VS2022/source.extension.vsixmanifest.template"; Output = "ILSpy.AddIn.VS2022/source.extension.vsixmanifest"},
-    @{Input="ILSpy.Installer/AppPackage.cs.template"; Output = "ILSpy.Installer/AppPackage.cs"}
+    @{Input="ILSpy.Installer/AppPackage.cs.template"; Output = "ILSpy.Installer/AppPackage.cs"},
+	@{Input="ICSharpCode.Decompiler.Console/Directory.Build.props.template"; Output = "ICSharpCode.Decompiler.Console/Directory.Build.props"}
 );
 
 $appxmanifestFiles = (	

--- a/ICSharpCode.Decompiler.Console/Directory.Build.props.template
+++ b/ICSharpCode.Decompiler.Console/Directory.Build.props.template
@@ -1,0 +1,8 @@
+<Project>
+ <PropertyGroup>
+   <Version>$INSERTVERSION$$INSERTVERSIONNAMEPOSTFIX$$INSERTBUILDCONFIG$</Version>
+   <AssemblyVersion>$INSERTVERSION$</AssemblyVersion>
+   <FileVersion>$INSERTVERSION$</FileVersion>
+   <Copyright>Copyright 2011-$INSERTYEAR$ AlphaSierraPapa</Copyright>
+ </PropertyGroup>
+</Project>

--- a/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
+++ b/ICSharpCode.Decompiler.Console/ICSharpCode.Decompiler.Console.csproj
@@ -10,11 +10,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <AssemblyName>ilspycmd</AssemblyName>
     <ToolCommandName>ilspycmd</ToolCommandName>
-    <Version>7.2.0.6702-preview2</Version>
-    <AssemblyVersion>7.2.0.0</AssemblyVersion>
-    <FileVersion>7.2.0.0</FileVersion>
     <Description>Command-line decompiler using the ILSpy decompilation engine</Description>
-    <Copyright>Copyright 2011-2021 AlphaSierraPapa</Copyright>
     <PackageProjectUrl>https://github.com/icsharpcode/ILSpy/</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>ILSpyCmdNuGetPackageIcon.png</PackageIcon>

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -7,7 +7,7 @@
     <Description>IL decompiler engine</Description>
     <Company>ic#code</Company>
     <Product>ILSpy</Product>
-    <Copyright>Copyright 2011-2021 AlphaSierraPapa for the SharpDevelop Team</Copyright>
+    <Copyright>Copyright 2011-$([System.DateTime]::Now.Year) AlphaSierraPapa for the SharpDevelop Team</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GenerateAssemblyVersionAttribute>False</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>False</GenerateAssemblyFileVersionAttribute>


### PR DESCRIPTION
dotnet build -> Version 1.0.0 via ilspycmd.exe. Build again, it picks up the newly written Directory.Build.props. How to fix?