### PR TITLE
Add TypeDefinitionDocuments to custom debug information data

### DIFF
--- a/ICSharpCode.Decompiler/DebugInfo/KnownGuids.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/KnownGuids.cs
@@ -21,6 +21,7 @@ namespace ICSharpCode.Decompiler.DebugInfo
 		public static readonly Guid CompilationOptions = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
 		public static readonly Guid CompilationMetadataReferences = new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
 		public static readonly Guid TupleElementNames = new Guid("ED9FDF71-8879-4747-8ED3-FE5EDE3CE710");
+		public static readonly Guid TypeDefinitionDocuments = new Guid("932E74BC-DBA9-4478-8D46-0F32A7BAB3D3");
 
 		public static readonly Guid HashAlgorithmSHA1 = new Guid("ff1816ec-aa5e-4d10-87f7-6f4963833460");
 		public static readonly Guid HashAlgorithmSHA256 = new Guid("8829d00f-11b8-4213-878b-770e8597ac16");

--- a/ILSpy/Metadata/DebugTables/CustomDebugInformationTableTreeNode.cs
+++ b/ILSpy/Metadata/DebugTables/CustomDebugInformationTableTreeNode.cs
@@ -125,7 +125,8 @@ namespace ICSharpCode.ILSpy.Metadata
 				MethodSteppingInformation,
 				CompilationOptions,
 				CompilationMetadataReferences,
-				TupleElementNames
+				TupleElementNames,
+				TypeDefinitionDocuments
 			}
 
 			static CustomDebugInformationKind GetKind(MetadataReader metadata, GuidHandle h)
@@ -176,6 +177,10 @@ namespace ICSharpCode.ILSpy.Metadata
 				if (KnownGuids.TupleElementNames == guid)
 				{
 					return CustomDebugInformationKind.TupleElementNames;
+				}
+				if (KnownGuids.TypeDefinitionDocuments == guid)
+				{
+					return CustomDebugInformationKind.TypeDefinitionDocuments;
 				}
 
 				return CustomDebugInformationKind.Unknown;
@@ -250,6 +255,9 @@ namespace ICSharpCode.ILSpy.Metadata
 							break;
 						case CustomDebugInformationKind.TupleElementNames:
 							kindString = $"{MetadataTokens.GetHeapOffset(debugInfo.Kind):X8} - Tuple Element Names (C#) [{ guid}]";
+							break;
+						case CustomDebugInformationKind.TypeDefinitionDocuments:
+							kindString = $"{MetadataTokens.GetHeapOffset(debugInfo.Kind):X8} - Type Definition Documents (C# / VB) [{ guid}]";
 							break;
 						default:
 							kindString = $"{MetadataTokens.GetHeapOffset(debugInfo.Kind):X8} - Unknown [{guid}]";


### PR DESCRIPTION
For .NET 6/C# 10 we added a new CustomDebugInformation type for linking a TypeDef entry to a Document entry, in https://github.com/dotnet/roslyn/pull/56278
This updates ILSpy to correctly display the information.

Before:
![image](https://user-images.githubusercontent.com/754264/145794830-789d3c40-8a54-49be-9a82-2a7481802700.png)

After:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/754264/145794649-93bfc3da-c302-4e75-8352-98b34c4f69db.png">

The `02` in the value is correct, it refers to the 2nd row of the Document table.
 
Sorry I took so long to submit this PR :)