### PR TITLE
Fix displaying icons from embedded resources

### DIFF
--- a/ILSpy/TreeNodes/ResourceNodes/IconResourceEntryNode.cs
+++ b/ILSpy/TreeNodes/ResourceNodes/IconResourceEntryNode.cs
@@ -59,7 +59,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				using var data = OpenStream();
 				if (data == null)
 					return false;
-				IconBitmapDecoder decoder = new IconBitmapDecoder(data, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.None);
+				IconBitmapDecoder decoder = new IconBitmapDecoder(data, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
 				foreach (var frame in decoder.Frames)
 				{
 					output.Write(String.Format("{0}x{1}, {2} bit: ", frame.PixelHeight, frame.PixelWidth, frame.Thumbnail.Format.BitsPerPixel));


### PR DESCRIPTION
### Problem

When `BitmapCacheOption.None` is used, icons will not be loaded from the
stream until they are needed to be displayed. In this case, the icon
loading will be triggered when the text box is rendered from the UI thread.
However by that time the steam object will have already been disposed.
This results in no icons being visible.

### Solution

The fix is to eager load the icons while the stream is still alive.

An alternative fix would be to defer disposing the stream to a later time
or not dispose it at all.
