### PR TITLE
Submenu support

### DIFF
--- a/ILSpy/AboutPage.cs
+++ b/ILSpy/AboutPage.cs
@@ -38,7 +38,7 @@ using ICSharpCode.ILSpy.Themes;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._Help), Header = nameof(Resources._About), MenuOrder = 99999)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._Help), Header = nameof(Resources._About), MenuOrder = 99999)]
 	sealed class AboutPage : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/CheckForUpdatesCommand.cs
+++ b/ILSpy/Commands/CheckForUpdatesCommand.cs
@@ -21,7 +21,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._Help), Header = nameof(Resources._CheckUpdates), MenuOrder = 5000)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._Help), Header = nameof(Resources._CheckUpdates), MenuOrder = 5000)]
 	sealed class CheckForUpdatesCommand : SimpleCommand
 	{
 		public override bool CanExecute(object parameter)

--- a/ILSpy/Commands/DecompileAllCommand.cs
+++ b/ILSpy/Commands/DecompileAllCommand.cs
@@ -30,7 +30,7 @@ using ICSharpCode.ILSpy.TextView;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.DEBUGDecompile), MenuCategory = nameof(Resources.Open), MenuOrder = 2.5)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.DEBUGDecompile), MenuCategory = nameof(Resources.Open), MenuOrder = 2.5)]
 	sealed class DecompileAllCommand : SimpleCommand
 	{
 		public override bool CanExecute(object parameter)
@@ -79,7 +79,7 @@ namespace ICSharpCode.ILSpy
 		}
 	}
 
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.DEBUGDecompile100x), MenuCategory = nameof(Resources.Open), MenuOrder = 2.6)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.DEBUGDecompile100x), MenuCategory = nameof(Resources.Open), MenuOrder = 2.6)]
 	sealed class Decompile100TimesCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/DisassembleAllCommand.cs
+++ b/ILSpy/Commands/DisassembleAllCommand.cs
@@ -28,7 +28,7 @@ using ICSharpCode.ILSpy.TextView;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.DEBUGDisassemble), MenuCategory = nameof(Resources.Open), MenuOrder = 2.5)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.DEBUGDisassemble), MenuCategory = nameof(Resources.Open), MenuOrder = 2.5)]
 	sealed class DisassembleAllCommand : SimpleCommand
 	{
 		public override bool CanExecute(object parameter)

--- a/ILSpy/Commands/ExitCommand.cs
+++ b/ILSpy/Commands/ExitCommand.cs
@@ -19,7 +19,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.E_xit), MenuOrder = 99999, MenuCategory = nameof(Resources.Exit))]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.E_xit), MenuOrder = 99999, MenuCategory = nameof(Resources.Exit))]
 	sealed class ExitCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/ExportCommandAttribute.cs
+++ b/ILSpy/Commands/ExportCommandAttribute.cs
@@ -52,8 +52,11 @@ namespace ICSharpCode.ILSpy
 	#region Main Menu
 	public interface IMainMenuCommandMetadata
 	{
+		string MenuID { get; }
 		string MenuIcon { get; }
 		string Header { get; }
+		string ParentMenuID { get; }
+		[Obsolete("Please use ParentMenuID instead. We decided to rename the property for clarity. It will be removed in ILSpy 8.0.")]
 		string Menu { get; }
 		string MenuCategory { get; }
 		string InputGestureText { get; }
@@ -65,22 +68,36 @@ namespace ICSharpCode.ILSpy
 	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 	public class ExportMainMenuCommandAttribute : ExportAttribute, IMainMenuCommandMetadata
 	{
-		bool isEnabled = true;
-
 		public ExportMainMenuCommandAttribute()
 			: base("MainMenuCommand", typeof(ICommand))
 		{
 		}
-
+		/// <summary>
+		/// Gets/Sets the ID of this menu item. Menu entries are not required to have an ID,
+		/// however, setting it allows to declare nested menu structures.
+		/// The built-in menus have the IDs "_File", "_View", "_Window" and "_Help".
+		/// Plugin authors are advised to use GUIDs as identifiers to prevent conflicts.
+		/// <para/>
+		/// NOTE: Defining cycles (for example by accidentally setting <see cref="MenuID"/> equal to <see cref="ParentMenuID"/>)
+		/// will lead to a stack-overflow and crash of ILSpy at startup.
+		/// </summary>
+		public string MenuID { get; set; }
 		public string MenuIcon { get; set; }
 		public string Header { get; set; }
-		public string Menu { get; set; }
+		/// <summary>
+		/// Gets/Sets the parent of this menu item. All menu items sharing the same parent will be displayed as sub-menu items.
+		/// If this property is set to <see langword="null"/>, the menu item is displayed in the top-level menu.
+		/// The built-in menus have the IDs "_File", "_View", "_Window" and "_Help".
+		/// <para/>
+		/// NOTE: Defining cycles (for example by accidentally setting <see cref="MenuID"/> equal to <see cref="ParentMenuID"/>)
+		/// will lead to a stack-overflow and crash of ILSpy at startup.
+		/// </summary>
+		public string ParentMenuID { get; set; }
+		[Obsolete("Please use ParentMenuID instead. We decided to rename the property for clarity. It will be removed in ILSpy 8.0.")]
+		public string Menu { get => ParentMenuID; set => ParentMenuID = value; }
 		public string MenuCategory { get; set; }
 		public string InputGestureText { get; set; }
-		public bool IsEnabled {
-			get { return isEnabled; }
-			set { isEnabled = value; }
-		}
+		public bool IsEnabled { get; set; } = true;
 		public double MenuOrder { get; set; }
 	}
 	#endregion

--- a/ILSpy/Commands/GeneratePdbContextMenuEntry.cs
+++ b/ILSpy/Commands/GeneratePdbContextMenuEntry.cs
@@ -98,7 +98,7 @@ namespace ICSharpCode.ILSpy
 		}
 	}
 
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.GeneratePortable), MenuCategory = nameof(Resources.Save))]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.GeneratePortable), MenuCategory = nameof(Resources.Save))]
 	class GeneratePdbMainMenuEntry : SimpleCommand
 	{
 		public override bool CanExecute(object parameter)

--- a/ILSpy/Commands/ManageAssemblyListsCommand.cs
+++ b/ILSpy/Commands/ManageAssemblyListsCommand.cs
@@ -21,7 +21,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.ManageAssembly_Lists), MenuIcon = "Images/AssemblyList", MenuCategory = nameof(Resources.Open), MenuOrder = 1.7)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.ManageAssembly_Lists), MenuIcon = "Images/AssemblyList", MenuCategory = nameof(Resources.Open), MenuOrder = 1.7)]
 	sealed class ManageAssemblyListsCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/OpenCommand.cs
+++ b/ILSpy/Commands/OpenCommand.cs
@@ -23,7 +23,7 @@ using ICSharpCode.ILSpy.Properties;
 namespace ICSharpCode.ILSpy
 {
 	[ExportToolbarCommand(ToolTip = nameof(Resources.Open), ToolbarIcon = "Images/Open", ToolbarCategory = nameof(Resources.Open), ToolbarOrder = 0)]
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources._Open), MenuIcon = "Images/Open", MenuCategory = nameof(Resources.Open), MenuOrder = 0)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources._Open), MenuIcon = "Images/Open", MenuCategory = nameof(Resources.Open), MenuOrder = 0)]
 	sealed class OpenCommand : CommandWrapper
 	{
 		public OpenCommand()

--- a/ILSpy/Commands/OpenFromGacCommand.cs
+++ b/ILSpy/Commands/OpenFromGacCommand.cs
@@ -19,7 +19,7 @@
 using ICSharpCode.ILSpy.Properties;
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.OpenFrom_GAC), MenuIcon = "Images/AssemblyListGAC", MenuCategory = nameof(Resources.Open), MenuOrder = 1)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.OpenFrom_GAC), MenuIcon = "Images/AssemblyListGAC", MenuCategory = nameof(Resources.Open), MenuOrder = 1)]
 	sealed class OpenFromGacCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/Commands/Pdb2XmlCommand.cs
+++ b/ILSpy/Commands/Pdb2XmlCommand.cs
@@ -33,7 +33,7 @@ using Microsoft.DiaSymReader.Tools;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources.DEBUGDumpPDBAsXML), MenuCategory = nameof(Resources.Open), MenuOrder = 2.6)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.DEBUGDumpPDBAsXML), MenuCategory = nameof(Resources.Open), MenuOrder = 2.6)]
 	sealed class Pdb2XmlCommand : SimpleCommand
 	{
 		public override bool CanExecute(object parameter)

--- a/ILSpy/Commands/RefreshCommand.cs
+++ b/ILSpy/Commands/RefreshCommand.cs
@@ -23,7 +23,7 @@ using ICSharpCode.ILSpy.Properties;
 namespace ICSharpCode.ILSpy
 {
 	[ExportToolbarCommand(ToolTip = nameof(Resources.RefreshCommand_ReloadAssemblies), ToolbarIcon = "Images/Refresh", ToolbarCategory = nameof(Resources.Open), ToolbarOrder = 2)]
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources._Reload), MenuIcon = "Images/Refresh", MenuCategory = nameof(Resources.Open), MenuOrder = 2)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources._Reload), MenuIcon = "Images/Refresh", MenuCategory = nameof(Resources.Open), MenuOrder = 2)]
 	sealed class RefreshCommand : CommandWrapper
 	{
 		public RefreshCommand()

--- a/ILSpy/Commands/RemoveAssembliesWithLoadErrors.cs
+++ b/ILSpy/Commands/RemoveAssembliesWithLoadErrors.cs
@@ -24,7 +24,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources._RemoveAssembliesWithLoadErrors), MenuCategory = nameof(Resources.Remove), MenuOrder = 2.6)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources._RemoveAssembliesWithLoadErrors), MenuCategory = nameof(Resources.Remove), MenuOrder = 2.6)]
 	class RemoveAssembliesWithLoadErrors : SimpleCommand
 	{
 		public override bool CanExecute(object parameter)

--- a/ILSpy/Commands/SaveCommand.cs
+++ b/ILSpy/Commands/SaveCommand.cs
@@ -22,7 +22,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._File), Header = nameof(Resources._SaveCode), MenuIcon = "Images/Save", MenuCategory = nameof(Resources.Save), MenuOrder = 0)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources._SaveCode), MenuIcon = "Images/Save", MenuCategory = nameof(Resources.Save), MenuOrder = 0)]
 	sealed class SaveCommand : CommandWrapper
 	{
 		public SaveCommand()

--- a/ILSpy/Commands/SortAssemblyListCommand.cs
+++ b/ILSpy/Commands/SortAssemblyListCommand.cs
@@ -24,7 +24,7 @@ using ICSharpCode.TreeView;
 
 namespace ICSharpCode.ILSpy
 {
-	[ExportMainMenuCommand(Menu = nameof(Resources._View), Header = nameof(Resources.SortAssembly_listName), MenuIcon = "Images/Sort", MenuCategory = nameof(Resources.View))]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._View), Header = nameof(Resources.SortAssembly_listName), MenuIcon = "Images/Sort", MenuCategory = nameof(Resources.View))]
 	[ExportToolbarCommand(ToolTip = nameof(Resources.SortAssemblyListName), ToolbarIcon = "Images/Sort", ToolbarCategory = nameof(Resources.View))]
 	sealed class SortAssemblyListCommand : SimpleCommand, IComparer<LoadedAssembly>
 	{
@@ -40,7 +40,7 @@ namespace ICSharpCode.ILSpy
 		}
 	}
 
-	[ExportMainMenuCommand(Menu = nameof(Resources._View), Header = nameof(Resources._CollapseTreeNodes), MenuIcon = "Images/CollapseAll", MenuCategory = nameof(Resources.View))]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._View), Header = nameof(Resources._CollapseTreeNodes), MenuIcon = "Images/CollapseAll", MenuCategory = nameof(Resources.View))]
 	[ExportToolbarCommand(ToolTip = nameof(Resources.CollapseTreeNodes), ToolbarIcon = "Images/CollapseAll", ToolbarCategory = nameof(Resources.View))]
 	sealed class CollapseAllCommand : SimpleCommand
 	{

--- a/ILSpy/Docking/CloseAllDocumentsCommand.cs
+++ b/ILSpy/Docking/CloseAllDocumentsCommand.cs
@@ -8,7 +8,7 @@ using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy.Docking
 {
-	[ExportMainMenuCommand(Header = nameof(Resources.Window_CloseAllDocuments), Menu = nameof(Resources._Window))]
+	[ExportMainMenuCommand(Header = nameof(Resources.Window_CloseAllDocuments), ParentMenuID = nameof(Resources._Window))]
 	class CloseAllDocumentsCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)
@@ -17,7 +17,7 @@ namespace ICSharpCode.ILSpy.Docking
 		}
 	}
 
-	[ExportMainMenuCommand(Header = nameof(Resources.Window_ResetLayout), Menu = nameof(Resources._Window))]
+	[ExportMainMenuCommand(Header = nameof(Resources.Window_ResetLayout), ParentMenuID = nameof(Resources._Window))]
 	class ResetLayoutCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/ILSpy/ExtensionMethods.cs
+++ b/ILSpy/ExtensionMethods.cs
@@ -112,20 +112,12 @@ namespace ICSharpCode.ILSpy
 			}
 		}
 
-		/*
-		public static bool IsCustomAttribute(this TypeDefinition type)
+		internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
 		{
-			while (type.FullName != "System.Object") {
-				var resolvedBaseType = type.BaseType.Resolve();
-				if (resolvedBaseType == null)
-					return false;
-				if (resolvedBaseType.FullName == "System.Attribute")
-					return true;
-				type = resolvedBaseType;
-			}
-			return false;
+			key = pair.Key;
+			value = pair.Value;
 		}
-		*/
+
 		public static string ToSuffixString(this System.Reflection.Metadata.EntityHandle handle)
 		{
 			if (!DisplaySettingsPanel.CurrentDisplaySettings.ShowMetadataTokens)

--- a/ILSpy/MainWindow.xaml
+++ b/ILSpy/MainWindow.xaml
@@ -132,9 +132,9 @@
 	<DockPanel>
 		<!-- Main menu -->
 		<Menu DockPanel.Dock="Top" Name="mainMenu" Height="23" KeyboardNavigation.TabNavigation="None">
-			<MenuItem Header="{x:Static properties:Resources._File}" />
+			<MenuItem Header="{x:Static properties:Resources._File}" Tag="_File" />
 			<!-- contents of file menu are added using MEF -->
-			<MenuItem Header="{x:Static properties:Resources._View}">
+			<MenuItem Header="{x:Static properties:Resources._View}" Tag="_View">
 				<MenuItem Header="{x:Static properties:Resources.Show_publiconlyTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicOnly}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_internalTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicAndInternal}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_allTypesAndMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisAll}" />
@@ -145,7 +145,7 @@
 					<MenuItem Header="中文" IsCheckable="True" IsChecked="{Binding SessionSettings.CurrentCulture, Converter={StaticResource cultureSelectionConverter}, ConverterParameter=zh-Hans}" />
 				</MenuItem>
 			</MenuItem>
-			<MenuItem Header="{x:Static properties:Resources._Window}" />
+			<MenuItem Header="{x:Static properties:Resources._Window}" Tag="_Window" />
 		</Menu>
 		<!-- ToolBar -->
 		<ToolBar

--- a/ILSpy/Options/OptionsDialog.xaml.cs
+++ b/ILSpy/Options/OptionsDialog.xaml.cs
@@ -121,7 +121,7 @@ namespace ICSharpCode.ILSpy.Options
 		public int Order { get; set; }
 	}
 
-	[ExportMainMenuCommand(Menu = nameof(Resources._View), Header = nameof(Resources._Options), MenuCategory = nameof(Resources.Options), MenuOrder = 999)]
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._View), Header = nameof(Resources._Options), MenuCategory = nameof(Resources.Options), MenuOrder = 999)]
 	sealed class ShowOptionsCommand : SimpleCommand
 	{
 		public override void Execute(object parameter)

--- a/TestPlugin/MainMenuCommand.cs
+++ b/TestPlugin/MainMenuCommand.cs
@@ -10,7 +10,7 @@ namespace TestPlugin
 	// Header: text on the menu item
 	// MenuCategory: optional, used for grouping related menu items together. A separator is added between different groups.
 	// MenuOrder: controls the order in which the items appear (items are sorted by this value)
-	[ExportMainMenuCommand(Menu = "_File", MenuIcon = "Clear.png", Header = "_Clear List", MenuCategory = "Open", MenuOrder = 1.5)]
+	[ExportMainMenuCommand(ParentMenuID = "_File", MenuIcon = "Clear.png", Header = "_Clear List", MenuCategory = "Open", MenuOrder = 1.5)]
 	// ToolTip: the tool tip
 	// ToolbarIcon: The icon. Must be embedded as "Resource" (WPF-style resource) in the same assembly as the command type.
 	// ToolbarCategory: optional, used for grouping related toolbar items together. A separator is added between different groups.


### PR DESCRIPTION
### Problem
See #2605 and #2604

### Solution

I added one resp. two new properties to our main menu/context menu attributes:

Main menus now can define IDs, which should be unique across the whole application. And by using the already existing Menu property, the submenu item can be connected to its parent item.
Context menus can do the same:

Examples:

	// Adds a sub menu to the file menu
	[ExportMainMenuCommand(Menu = "_File", Header = "Sub Menu", ID = "SubMenuParent")]
	sealed class DummyMenuItem
	{
	}

	[ExportMainMenuCommand(Menu = "SubMenuParent", Header = "SubItem")]
	sealed class TestCommand : SimpleCommand
	{
		public override void Execute(object parameter)
		{
			throw new NotImplementedException();
		}
	}

	// Adds a sub menu to all context menus
	[ExportContextMenuEntry(Header = "Sub Menu", ID = "SubMenuParent")]
	sealed class ContextDummyMenuItem : IContextMenuEntry
	{
		public void Execute(TextViewContext context)
		{
		}

		public bool IsEnabled(TextViewContext context)
		{
			return true; // display menu in all context menus
		}

		public bool IsVisible(TextViewContext context)
		{
			return true; // display menu in all context menus
		}
	}


	[ExportContextMenuEntry(Menu = "SubMenuParent", Header = "SubItem")]
	sealed class ContextTestCommand : IContextMenuEntry
	{
		public void Execute(TextViewContext context)
		{
		}

		public bool IsEnabled(TextViewContext context)
		{
			return true;
		}

		public bool IsVisible(TextViewContext context)
		{
			return true;
		}
	}

@sailro @psmacchia would this solution work for you? Please provide feedback. Thanks!