### PR TITLE
Fix the ordering of COM interface methods, properties, and events to appear in their originally defined order

### DIFF
--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -72,6 +72,20 @@ namespace ICSharpCode.Decompiler.Tests
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		};
 
+		static readonly CompilerOptions[] net40OnlyOptions =
+		{
+			CompilerOptions.None,
+			CompilerOptions.Optimize,
+			CompilerOptions.UseRoslyn1_3_2 | CompilerOptions.TargetNet40,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn1_3_2 | CompilerOptions.TargetNet40,
+			CompilerOptions.UseRoslyn2_10_0 | CompilerOptions.TargetNet40,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn2_10_0 | CompilerOptions.TargetNet40,
+			CompilerOptions.UseRoslyn3_11_0 | CompilerOptions.TargetNet40,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn3_11_0 | CompilerOptions.TargetNet40,
+			CompilerOptions.UseRoslynLatest | CompilerOptions.TargetNet40,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest | CompilerOptions.TargetNet40
+		};
+
 		static readonly CompilerOptions[] defaultOptions =
 		{
 			CompilerOptions.None,
@@ -392,7 +406,7 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
-		public async Task ComInterop([ValueSource(nameof(noMonoOptions))] CompilerOptions options)
+		public async Task ComInterop([ValueSource(nameof(net40OnlyOptions))] CompilerOptions options)
 		{
 			await RunCS(options: options);
 		}

--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -391,6 +391,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await RunCS(options: options);
 		}
 
+		[Test]
+		public async Task ComInterop([ValueSource(nameof(noMonoOptions))] CompilerOptions options)
+		{
+			await RunCS(options: options);
+		}
+
 		async Task RunCS([CallerMemberName] string testName = null, CompilerOptions options = CompilerOptions.UseDebug)
 		{
 			if ((options & CompilerOptions.UseRoslynMask) != 0 && (options & CompilerOptions.TargetNet40) == 0)

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Output\InsertParenthesesVisitorTests.cs" />
     <Compile Include="ProjectDecompiler\TargetFrameworkTests.cs" />
     <Compile Include="TestAssemblyResolver.cs" />
+    <Compile Include="TestCases\Correctness\ComInterop.cs" />
     <Compile Include="TestCases\Correctness\DeconstructionTests.cs" />
     <Compile Include="TestCases\Correctness\DynamicTests.cs" />
     <Compile Include="TestCases\Correctness\StringConcat.cs" />

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -106,7 +106,7 @@
     <Compile Include="Output\InsertParenthesesVisitorTests.cs" />
     <Compile Include="ProjectDecompiler\TargetFrameworkTests.cs" />
     <Compile Include="TestAssemblyResolver.cs" />
-    <Compile Include="TestCases\Correctness\ComInterop.cs" />
+    <None Include="TestCases\Correctness\ComInterop.cs" />
     <Compile Include="TestCases\Correctness\DeconstructionTests.cs" />
     <Compile Include="TestCases\Correctness\DynamicTests.cs" />
     <Compile Include="TestCases\Correctness\StringConcat.cs" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ComInterop.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ComInterop.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
+{
+	public class ComInterop
+	{
+		public static void Main()
+		{
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetMethod("MyMethod1")));
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetProperty("MyProperty1").GetMethod));
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetMethod("MyMethod2")));
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetProperty("MyProperty2").GetMethod));
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetProperty("MyProperty2").SetMethod));
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetEvent("MyEvent1").AddMethod));
+			Console.WriteLine(Marshal.GetComSlotForMethodInfo(typeof(IMixedPropsAndMethods).GetEvent("MyEvent1").RemoveMethod));
+		}
+
+
+		[Guid("761618B8-3994-449A-A96B-F1FF2795EA85")]
+		[ComImport]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface IMixedPropsAndMethods
+		{
+			int MyMethod1();
+
+			int MyProperty1 { get; }
+
+			int MyMethod2();
+
+			int MyProperty2 { get; set; }
+
+			event EventHandler MyEvent1;
+
+			int MyMethod3();
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ComInterop.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ComInterop.cs
@@ -29,14 +29,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			int MyMethod1();
 
 			int MyProperty1 { get; }
+			int MyOverload();
 
 			int MyMethod2();
 
 			int MyProperty2 { get; set; }
 
+			int MyOverload(int x);
+
 			event EventHandler MyEvent1;
 
 			int MyMethod3();
+
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ComInterop.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ComInterop.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 {


### PR DESCRIPTION
… This was resulting in fatal crashes while running decompiled COM interop code.

#2638

### Problem
See #2638 for more details on the problem being solved

### Solution
* I have factored out the problem of determining whether native member ordering is required into its own function. If it's not required, ILSpy will still group the members by kind (fields, properties, methods, events).
* Added a new correctness unit test that validates COM V-table ordering does not change across a decompile loop
