### PR TITLE
Allow user to provide ID when generating a PDB

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -307,6 +307,7 @@
 
   <ItemGroup>
     <Content Include="TestCases\PdbGen\ForLoopTests.xml" />
+    <Content Include="TestCases\PdbGen\CustomPdbId.xml" />
     <Content Include="TestCases\PdbGen\HelloWorld.xml" />
     <Content Include="TestCases\PdbGen\LambdaCapturing.xml" />
   </ItemGroup>

--- a/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
@@ -51,7 +51,7 @@ namespace ICSharpCode.Decompiler.Tests
 		public void CustomPdbId()
 		{
 			// Generate a PDB for an assembly using a randomly-generated ID, then validate that the PDB uses the specified ID
-			(string peFileName, string pdbFileName) = CompileTestCase(nameof(HelloWorld));
+			(string peFileName, string pdbFileName) = CompileTestCase(nameof(CustomPdbId));
 
 			var moduleDefinition = new PEFile(peFileName);
 			var resolver = new UniversalAssemblyResolver(peFileName, false, moduleDefinition.Metadata.DetectTargetFrameworkId(), null, PEStreamOptions.PrefetchEntireImage);

--- a/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -46,18 +47,38 @@ namespace ICSharpCode.Decompiler.Tests
 			TestGeneratePdb();
 		}
 
+		[Test]
+		public void CustomPdbId()
+		{
+			// Generate a PDB for an assembly using a randomly-generated ID, then validate that the PDB uses the specified ID
+			(string peFileName, string pdbFileName) = CompileTestCase(nameof(HelloWorld));
+
+			var moduleDefinition = new PEFile(peFileName);
+			var resolver = new UniversalAssemblyResolver(peFileName, false, moduleDefinition.Metadata.DetectTargetFrameworkId(), null, PEStreamOptions.PrefetchEntireImage);
+			var decompiler = new CSharpDecompiler(moduleDefinition, resolver, new DecompilerSettings());
+			var expectedPdbId = new BlobContentId(Guid.NewGuid(), (uint)Random.Shared.Next());
+
+			using (FileStream pdbStream = File.Open(Path.Combine(TestCasePath, nameof(CustomPdbId) + ".pdb"), FileMode.OpenOrCreate, FileAccess.ReadWrite))
+			{
+				pdbStream.SetLength(0);
+				PortablePdbWriter.WritePdb(moduleDefinition, decompiler, new DecompilerSettings(), pdbStream, noLogo: true, pdbId: expectedPdbId);
+
+				pdbStream.Position = 0;
+				var metadataReader = MetadataReaderProvider.FromPortablePdbStream(pdbStream).GetMetadataReader();
+				var generatedPdbId = new BlobContentId(metadataReader.DebugMetadataHeader.Id);
+
+				Assert.AreEqual(expectedPdbId.Guid, generatedPdbId.Guid);
+				Assert.AreEqual(expectedPdbId.Stamp, generatedPdbId.Stamp);
+			}
+		}
+
 		private void TestGeneratePdb([CallerMemberName] string testName = null)
 		{
 			const PdbToXmlOptions options = PdbToXmlOptions.IncludeEmbeddedSources | PdbToXmlOptions.ThrowOnError | PdbToXmlOptions.IncludeTokens | PdbToXmlOptions.ResolveTokens | PdbToXmlOptions.IncludeMethodSpans;
 
 			string xmlFile = Path.Combine(TestCasePath, testName + ".xml");
-			string xmlContent = File.ReadAllText(xmlFile);
-			XDocument document = XDocument.Parse(xmlContent);
-			var files = document.Descendants("file").ToDictionary(f => f.Attribute("name").Value, f => f.Value);
-			Tester.CompileCSharpWithPdb(Path.Combine(TestCasePath, testName + ".expected"), files);
+			(string peFileName, string pdbFileName) = CompileTestCase(testName);
 
-			string peFileName = Path.Combine(TestCasePath, testName + ".expected.dll");
-			string pdbFileName = Path.Combine(TestCasePath, testName + ".expected.pdb");
 			var moduleDefinition = new PEFile(peFileName);
 			var resolver = new UniversalAssemblyResolver(peFileName, false, moduleDefinition.Metadata.DetectTargetFrameworkId(), null, PEStreamOptions.PrefetchEntireImage);
 			var decompiler = new CSharpDecompiler(moduleDefinition, resolver, new DecompilerSettings());
@@ -85,6 +106,20 @@ namespace ICSharpCode.Decompiler.Tests
 			string generatedFileName = Path.ChangeExtension(xmlFile, ".generated.xml");
 			ProcessXmlFile(generatedFileName);
 			Assert.AreEqual(Normalize(expectedFileName), Normalize(generatedFileName));
+		}
+
+		private (string peFileName, string pdbFileName) CompileTestCase(string testName)
+		{
+			string xmlFile = Path.Combine(TestCasePath, testName + ".xml");
+			string xmlContent = File.ReadAllText(xmlFile);
+			XDocument document = XDocument.Parse(xmlContent);
+			var files = document.Descendants("file").ToDictionary(f => f.Attribute("name").Value, f => f.Value);
+			Tester.CompileCSharpWithPdb(Path.Combine(TestCasePath, testName + ".expected"), files);
+
+			string peFileName = Path.Combine(TestCasePath, testName + ".expected.dll");
+			string pdbFileName = Path.Combine(TestCasePath, testName + ".expected.pdb");
+
+			return (peFileName, pdbFileName);
 		}
 
 		private void ProcessXmlFile(string fileName)

--- a/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/CustomPdbId.xml
+++ b/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/CustomPdbId.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<symbols>
+  <files>
+    <file id="1" name="ICSharpCode.Decompiler.Tests.TestCases.PdbGen\HelloWorld.cs" language="C#" checksumAlgorithm="SHA256"><![CDATA[using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.PdbGen;
+
+public class HelloWorld
+{
+	public static void Main(string[] args)
+	{
+		Console.ReadKey();
+		Console.WriteLine("Hello World!");
+		Console.ReadKey();
+	}
+}
+]]></file>
+  </files>
+</symbols>


### PR DESCRIPTION
### Problem

The Visual Studio debugger's decompiler integration needs to be able to control the ID used for generated PDBs.  There are a couple of scenarios that are interesting to us:

1. Generating a PDB for an assembly that was built without debug info. The PDB writer currently fails in this case, since the input assembly has no debug directory from which to extract the relevant info.  The debugger can provide values that will allow us to load the generated PDB.
2. Generating a PDB for an assembly that has multiple debug directories.  The PDB writer currently uses the first debug directory it finds, but this isn't necessarily the correct one.  The debugger can disambiguate these and provide the correct values.

### Solution

This commit adds a new parameter to `PortablePdbWriter.WritePdb` that allows the caller to specify the exact Guid and timestamp that should be used in the generated PDB.

* [X] At least one test covering the code changed

