### PR TITLE
Keep compiler-generated code that is still referenced

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1442,11 +1442,14 @@ namespace ICSharpCode.Decompiler.CSharp
 				foreach (var node in entityDecl.Descendants)
 				{
 					var rr = node.GetResolveResult();
-					if (rr is MemberResolveResult mrr && mrr.Member.DeclaringTypeDefinition == typeDef)
+					if (rr is MemberResolveResult mrr
+						&& mrr.Member.DeclaringTypeDefinition == typeDef
+						&& !(mrr.Member is IMethod { IsLocalFunction: true }))
 					{
 						workList.Enqueue(mrr.Member);
 					}
-					else if (rr is TypeResolveResult trr && trr.Type.GetDefinition()?.DeclaringTypeDefinition == typeDef)
+					else if (rr is TypeResolveResult trr
+						&& trr.Type.GetDefinition()?.DeclaringTypeDefinition == typeDef)
 					{
 						workList.Enqueue(trr.Type.GetDefinition());
 					}

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -48,6 +48,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		SpecialName,
 		DebuggerHidden,
 		DebuggerStepThrough,
+		DebuggerBrowsable,
 
 		// Assembly attributes:
 		AssemblyVersion,
@@ -124,6 +125,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			new TopLevelTypeName("System.Runtime.CompilerServices", nameof(SpecialNameAttribute)),
 			new TopLevelTypeName("System.Diagnostics", nameof(DebuggerHiddenAttribute)),
 			new TopLevelTypeName("System.Diagnostics", nameof(DebuggerStepThroughAttribute)),
+			new TopLevelTypeName("System.Diagnostics", nameof(DebuggerBrowsableAttribute)),
 			// Assembly attributes:
 			new TopLevelTypeName("System.Reflection", nameof(AssemblyVersionAttribute)),
 			new TopLevelTypeName("System.Runtime.CompilerServices", nameof(InternalsVisibleToAttribute)),

--- a/ICSharpCode.Decompiler/Util/MultiDictionary.cs
+++ b/ICSharpCode.Decompiler/Util/MultiDictionary.cs
@@ -105,7 +105,7 @@ namespace ICSharpCode.Decompiler.Util
 			get { return this[key]; }
 		}
 
-		bool ILookup<TKey, TValue>.Contains(TKey key)
+		public bool Contains(TKey key)
 		{
 			return dict.ContainsKey(key);
 		}


### PR DESCRIPTION
Fixes #1607: The static methods are no longer removed from the decompiled output.