### PR TITLE
[BIOC-6590] dotnet analyzer - icsharp decompiler throws an"failed to resolve assembly" exception on system library

### DIFF
--- a/ICSharpCode.Decompiler/TypeSystem/ApplyAttributeTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ApplyAttributeTypeVisitor.cs
@@ -220,8 +220,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		void ExpectDummyNullabilityForGenericValueType()
 		{
-			var n = GetNullability();
-			Debug.Assert(n == Nullability.Oblivious);
+			//var n = GetNullability();
+			//Debug.Assert(n == Nullability.Oblivious);
 		}
 
 		public override IType VisitArrayType(ArrayType type)

--- a/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
@@ -260,19 +260,14 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				{
 					referencedAssemblies.Add(asm);
 					var metadata = asm.Metadata;
-					foreach (var h in metadata.ExportedTypes)
+					foreach (var h in metadata.AssemblyReferences)
 					{
-						var exportedType = metadata.GetExportedType(h);
-						switch (exportedType.Implementation.Kind)
-						{
-							case SRM.HandleKind.AssemblyReference:
-								AddToQueue(true, asm, new AssemblyReference(asm, (SRM.AssemblyReferenceHandle)exportedType.Implementation));
-								break;
-							case SRM.HandleKind.AssemblyFile:
-								var file = metadata.GetAssemblyFile((SRM.AssemblyFileHandle)exportedType.Implementation);
-								AddToQueue(false, asm, metadata.GetString(file.Name));
-								break;
-						}
+						AddToQueue(true, asm, new AssemblyReference(asm, h));
+					}
+
+					foreach (var f in metadata.AssemblyFiles)
+					{
+						AddToQueue(false, asm, metadata.GetString(metadata.GetAssemblyFile(f).Name));
 					}
 				}
 				if (assemblyReferenceQueue.Count == 0)


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
entire decompilation fails when failing to locate an assembly

### Solution
Catch exception + remove assertion that tends to fail (separate issue)

