### PR TITLE
Allow decompile C++/CLI assemblies

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetServices.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetServices.cs
@@ -78,7 +78,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 				if (frameworkVersion != null)
 				{
-					versionNumber = int.Parse(frameworkVersion.Substring(VersionToken.Length + 1).Replace(".", ""));
+					versionNumber = int.Parse(frameworkVersion.Substring(VersionToken.Length).Replace("v", "").Replace(".", ""));
 					if (versionNumber < 100)
 						versionNumber *= 10;
 				}


### PR DESCRIPTION
When C++/CLI project produce assembly it generates target attribute like this
```
[assembly: TargetFramework(".NETCoreApp,Version=7.0", FrameworkDisplayName = "")]
```
when C# generates `TargetFrameworkAttribute` it produce slightly different format
```
[assembly: TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = "")]
```

Link to issue(s) this covers

### Problem
Link to, or brief information about the issue

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
* Which part of this PR is most in need of attention/improvement?
* [ ] At least one test covering the code changed

