### PR TITLE
TransformInlineAssignmentStObjOrCall: Make sure no dead store is produced by the transform.

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue684.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue684.cs
@@ -25,7 +25,8 @@ public static class Issue684
 				Console.WriteLine(num3);
 				for (; i <= num; i += num3)
 				{
-					int num4 = (array[i] = 1);
+					int num4 = 1;
+					array[i] = num4;
 				}
 				i = num3;
 				while (true)

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformAssignment.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformAssignment.cs
@@ -122,6 +122,13 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				local = inst.Variable;
 				localStore = null;
 				nextPos = pos + 1;
+
+				if (local.LoadCount == 1 && local.AddressCount == 0)
+				{
+					// inline assignment would produce a dead store in this case, which is ugly
+					// and causes problems with the deconstruction transform.
+					return false;
+				}
 			}
 			if (block.Instructions[nextPos] is StObj stobj)
 			{


### PR DESCRIPTION
### Problem
Fully merge deconstruction-fixes, which was found in the wiki

