### PR TITLE
Fixes solution name when output directory is a relative path.

### DIFF
--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -134,7 +134,13 @@ Examples:
 						ProjectId projectId = DecompileAsProject(file, projectFileName);
 						projects.Add(new ProjectItem(projectFileName, projectId.PlatformName, projectId.Guid, projectId.TypeGuid));
 					}
-					SolutionCreator.WriteSolutionFile(Path.Combine(Environment.CurrentDirectory, OutputDirectory, Path.GetFileNameWithoutExtension(OutputDirectory) + ".sln"), projects);
+
+					var fullOutputPath = Path.Combine(Environment.CurrentDirectory, OutputDirectory);
+					fullOutputPath = new DirectoryInfo(fullOutputPath).FullName;
+
+					var solutionName = Path.GetFileNameWithoutExtension(fullOutputPath);
+
+					SolutionCreator.WriteSolutionFile(Path.Combine(fullOutputPath, solutionName + ".sln"), projects);
 					return 0;
 				}
 				else


### PR DESCRIPTION
It will always use the output directory name as the solution name.

#2707 

### Problem
Solution file name becomes `.sln` if `--outputdir` is `.`.

### Solution

Uses `System.IO.DirectoryInfo` to expand and resolve the output path before trying to infer what file name to use as solution name.
