### PR TITLE
Adjusts Max path lengths

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -554,16 +554,16 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 						var value = (int?)fileSystem.GetValue("LongPathsEnabled");
 						if (value == 1)
 						{
-							return (true, int.MaxValue, 255);
+							return (true, int.MaxValue, 32767);
 						}
-						return (false, 200, 30);
+						return (false, 200, 260);
 					default:
-						return (false, 200, 30);
+						return (false, 200, 255);
 				}
 			}
 			catch
 			{
-				return (false, 200, 30);
+				return (false, 200, 255);
 			}
 		}
 


### PR DESCRIPTION
#2707 (reviews over #2038)

### Problem
I believe the registry setting was misunderstood and the original problem triggered because windows could store 260-characters-long file names and linux/macos would only be able to handle 255.

In fact, the registry setting being used to set 255 limit on Windows actually [raises limits to over 30,000 characters](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd)!

This change should make ILSpy handle it nicely across OSes. Mac M1's (using Apple silicon, or ARM architecture) should fit this limitation nicely, I really think that we would need to look up .NET supported platforms and their respective file systems whether a given filesystem-architecture combination allows less than 255 chars. It really looks like 255 is a safe value for the time being.

### Solution
- Raised max file length limit to 260 when `LongPathsEnabled` is not set in registry in Windows Systems.
- Raised max file length limit to 32,767 when `LongPathsEnabled` is set in registry in Windows Systems.
- Set default/failover file length limit to 255. Should be safe in other supported .NET architectures.

### To-do!

Given the [Microsoft documentation on maximum path limit feature](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd):

1. it suggests the feature was supported prior to Windows 10, just in another mechanism, so perhaps checking by the registry key alone wouldn't do.
2. application manifest's `LongPathAware` should be used in order to allow the built Windows binaries to fully use the real long path support feature (or to correctly use it?)

