### PR TITLE
Checks maximum path length using .NET features.

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -132,20 +132,36 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 		public void DecompileProject(PEFile moduleDefinition, string targetDirectory, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			string projectFileName = Path.Combine(targetDirectory, CleanUpFileName(moduleDefinition.Name) + ".csproj");
+			var targetDirectoryInfo = new DirectoryInfo(targetDirectory);
+
+			if (TargetDirectory != targetDirectoryInfo.FullName)
+			{
+				TargetDirectory = targetDirectoryInfo.FullName;
+			}
+
+			string projectFileName = Path.Combine(TargetDirectory, CleanUpFileName(moduleDefinition.Name) + ".csproj");
+
 			using (var writer = MakeStreamWriter(projectFileName))
 			{
-				DecompileProject(moduleDefinition, targetDirectory, writer, cancellationToken);
+				DecompileProject(moduleDefinition, targetDirectoryInfo, writer, cancellationToken);
 			}
 		}
 
-		public ProjectId DecompileProject(PEFile moduleDefinition, string targetDirectory, TextWriter projectFileWriter, CancellationToken cancellationToken = default(CancellationToken))
+		public ProjectId DecompileProject(PEFile moduleDefinition, string targetDirectory, TextWriter projectFileWriter, CancellationToken cancellationToken = default(CancellationToken)) =>
+			DecompileProject(moduleDefinition, new DirectoryInfo(targetDirectory), projectFileWriter, cancellationToken);
+
+		public ProjectId DecompileProject(PEFile moduleDefinition, DirectoryInfo targetDirectory, TextWriter projectFileWriter, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			if (string.IsNullOrEmpty(targetDirectory))
+			if (targetDirectory == null)
 			{
 				throw new InvalidOperationException("Must set TargetDirectory");
 			}
-			TargetDirectory = new DirectoryInfo(targetDirectory).FullName;
+
+			if (TargetDirectory != targetDirectory.FullName)
+			{
+				TargetDirectory = targetDirectory.FullName;
+			}
+
 			directories.Clear();
 			var files = WriteCodeFilesInProject(moduleDefinition, cancellationToken).ToList();
 			files.AddRange(WriteResourceFilesInProject(moduleDefinition));

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -758,7 +758,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 		#region Full path length checking helpers
 
-		static bool UnderWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+		static readonly bool UnderWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
 		private DirectoryInfo CreateDir(string path) => Directory.CreateDirectory(ValidatePath(path, true));
 
@@ -777,8 +777,6 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 			var (supportsLongPaths, maxPathLength, maxSegmentLength) = longPathSupport.Value;
 			if (!Path.IsPathRooted(path))
 				throw new Exception("Non-root path passed to ValidatePath().");
-
-			var onWin = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
 			string dotnetPath;
 			try
@@ -821,7 +819,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 			if (dotnetPath.Length > maxPathLength)
 			{
-				if (onWin && !supportsLongPaths)
+				if (UnderWindows && !supportsLongPaths)
 				{
 					throw new PathTooLongException("Path is too long. Files could be created, but they won't be accessible by most applications." + Environment.NewLine +
 						"Path: " + dotnetPath + Environment.NewLine +


### PR DESCRIPTION
icsharpcode/ILSpy#2706.

### Problem
Okay, this is my best shot. I have heavily simplified `CleanUpName()` method, sacrificing the file truncation functionality in favor of the much more relaxed file name length.

I have tested the edge cases, but by using `new DirectoryInfo(path).FullName` basically I enable any long path support .NET might like, as I could create the files with much longer than 260 characters path during my tests. The problems turns in limitations with Windows applications like Visual Studio, Notepad++, etc. Surprisingly though, puny stock Windows Notepad 
 (`%windir%\system32\notepad.exe`) could read files with very long paths without issues.

Adding the path limit to 258 characters allowed all applications I have to read the generated files (I tested the longest file path the project generated of course), such that if I increased the limit to 259 the applications won't be able to (Visual Studio 2022 actually could, but no longer if I changed it to 260).

I tried also to make very descriptive exceptions when the limit is reached to help users identify it and report if this ever gets accepted mainstream.

### Solution

- rely in `DirectoryInfo` and `FileInfo` classes to validate paths in every write operation
- raise windows hardcoded limits to the absolute maximum usual applications would work with
- no longer truncate -- throw descriptive exceptions pointing the attempted path and its actual length
- use absolute paths on all file operations (expand `TargetDirectory`)

### Disclaimer

This works for me. If you don't fancy the feature or wasting more time on it, feel free to close the pull request on spot.