### PR TITLE
Add JetBrain's IDE-specific config files

### DIFF
--- a/.idea/.idea.ILSpy/.idea/.gitignore
+++ b/.idea/.idea.ILSpy/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.ILSpy.iml
+/modules.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/.idea.ILSpy/.idea/encodings.xml
+++ b/.idea/.idea.ILSpy/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.ILSpy/.idea/indexLayout.xml
+++ b/.idea/.idea.ILSpy/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.ILSpy/.idea/vcs.xml
+++ b/.idea/.idea.ILSpy/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
I presume that non-Visual Studio IDE configuration files are allowed uptream.
