### PR TITLE
Use SRM metadata to check if a type is nested.

### DIFF
--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Daniel Grunwald
+// Copyright (c) 2018 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -72,7 +72,7 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			this.fullTypeName = td.GetFullTypeName(metadata);
 			this.MetadataName = metadata.GetString(td.Name);
 			// Find DeclaringType + KnownTypeCode:
-			if (fullTypeName.IsNested)
+			if (td.IsNested)
 			{
 				this.DeclaringTypeDefinition = module.GetDefinition(td.GetDeclaringType());
 


### PR DESCRIPTION
Link to issue(s) this covers
N/A

### Problem
The implementation of `MetadataTypeDefinition` relied on the type name in order to check whether a type was nested or not. This implementation works fine for normal files. A problem occurs if someone deliberately modifies the type names in order to break ILSpy. This can be done by inserting a malicious nested type delimiter into the type name which could result in incorrect behavior during decompilation.

### Solution
The solution is rather quite simple. The information on whether a type is nested can be read straight from metadata instead of relying on type names. In this PR, I changed the code to use the `TypeDefinition.IsNested` property provided by SRM.

