### PR TITLE
Add EnableWindowsTargeting propery to csprojs targeting net6.0-windows

### DIFF
--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -14,6 +14,7 @@
     <ExtrasEnableDefaultResourceItems>false</ExtrasEnableDefaultResourceItems>
 
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
+++ b/ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj
@@ -8,6 +8,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <BaseAddress>6488064</BaseAddress>
     <UseWpf>true</UseWpf>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -10,6 +10,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UseWpf>true</UseWpf>
     <IsPackable>false</IsPackable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -19,6 +19,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.snk</AssemblyOriginatorKeyFile>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/SharpTreeView/ICSharpCode.TreeView.csproj
+++ b/SharpTreeView/ICSharpCode.TreeView.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>True</SignAssembly>
     <TargetFramework>net6.0-windows</TargetFramework>
     <AssemblyOriginatorKeyFile>..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.snk</AssemblyOriginatorKeyFile>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/TestPlugin/TestPlugin.csproj
+++ b/TestPlugin/TestPlugin.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <AssemblyName>Test.Plugin</AssemblyName>
     <UseWpf>true</UseWpf>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
On non-Windows platforms, this property eliminates a slew of invalid errors, ranging from being unable to find standard classes, when refactoring source files belonging to csprojs targeting .NET 6 on Windows.

