### PR TITLE
Try to resolve overspecified method references

### DIFF
--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -443,9 +443,7 @@ namespace ICSharpCode.Decompiler.Tests
 				decompiledOutputFile = await Tester.CompileCSharp(decompiledCodeFile, options).ConfigureAwait(false);
 
 				await Tester.RunAndCompareOutput(testFileName, outputFile.PathToAssembly, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
-
 				Tester.RepeatOnIOError(() => File.Delete(decompiledCodeFile));
-				Tester.RepeatOnIOError(() => File.Delete(decompiledOutputFile.PathToAssembly));
 			}
 			finally
 			{
@@ -473,9 +471,7 @@ namespace ICSharpCode.Decompiler.Tests
 				decompiledOutputFile = await Tester.CompileCSharp(decompiledCodeFile, options).ConfigureAwait(false);
 
 				await Tester.RunAndCompareOutput(testFileName, outputFile.PathToAssembly, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
-
 				Tester.RepeatOnIOError(() => File.Delete(decompiledCodeFile));
-				Tester.RepeatOnIOError(() => File.Delete(decompiledOutputFile.PathToAssembly));
 			}
 			finally
 			{
@@ -499,9 +495,7 @@ namespace ICSharpCode.Decompiler.Tests
 				decompiledOutputFile = await Tester.CompileCSharp(decompiledCodeFile, options).ConfigureAwait(false);
 
 				await Tester.RunAndCompareOutput(testFileName, outputFile, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0).ConfigureAwait(false);
-
 				Tester.RepeatOnIOError(() => File.Delete(decompiledCodeFile));
-				Tester.RepeatOnIOError(() => File.Delete(decompiledOutputFile.PathToAssembly));
 			}
 			finally
 			{

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
@@ -47,7 +47,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			if ((flags & CompilerOptions.UseMcsMask) == 0)
 			{
 				CompilerResults results = new CompilerResults();
-				results.PathToAssembly = outputFileName ?? Path.GetTempFileName();
+				results.PathToAssembly = outputFileName;
 
 				var (roslynVersion, languageVersion) = (flags & CompilerOptions.UseRoslynMask) switch {
 					0 => ("legacy", "11"),

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -278,6 +278,7 @@ namespace ICSharpCode.Decompiler.Tests
 			var decompiled = await Tester.DecompileCSharp(executable, settings).ConfigureAwait(false);
 
 			CodeAssert.FilesAreEqual(csFile, decompiled);
+			Tester.RepeatOnIOError(() => File.Delete(decompiled));
 		}
 
 		static readonly object copyLock = new object();

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -745,6 +745,7 @@ namespace ICSharpCode.Decompiler.Tests
 
 			// 3. Compile
 			CodeAssert.FilesAreEqual(csFile, decompiled, Tester.GetPreprocessorSymbols(cscOptions).ToArray());
+			Tester.RepeatOnIOError(() => File.Delete(decompiled));
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
@@ -163,6 +163,7 @@ namespace ICSharpCode.Decompiler.Tests
 			var decompiled = await Tester.DecompileCSharp(executable, decompilerSettings).ConfigureAwait(false);
 
 			CodeAssert.FilesAreEqual(expectedFile, decompiled, Tester.GetPreprocessorSymbols(cscOptions).ToArray());
+			Tester.RepeatOnIOError(() => File.Delete(decompiled));
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
@@ -139,6 +139,7 @@ namespace ICSharpCode.Decompiler.Tests
 			var decompiled = await Tester.DecompileCSharp(executable.PathToAssembly, settings).ConfigureAwait(false);
 
 			CodeAssert.FilesAreEqual(csFile, decompiled, Tester.GetPreprocessorSymbols(options).ToArray());
+			Tester.RepeatOnIOError(() => File.Delete(decompiled));
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1491,7 +1491,7 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		EnumValueDisplayMode DetectBestEnumValueDisplayMode(ITypeDefinition typeDef, PEFile module)
 		{
-			if (typeDef.HasAttribute(KnownAttribute.Flags, inherit: false))
+			if (typeDef.HasAttribute(KnownAttribute.Flags))
 				return EnumValueDisplayMode.AllHex;
 			bool first = true;
 			long firstValue = 0, previousValue = 0;
@@ -1917,7 +1917,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		{
 			type = null;
 			elementCount = 0;
-			IAttribute attr = field.GetAttribute(KnownAttribute.FixedBuffer, inherit: false);
+			IAttribute attr = field.GetAttribute(KnownAttribute.FixedBuffer);
 			if (attr != null && attr.FixedArguments.Length == 2)
 			{
 				if (attr.FixedArguments[0].Value is IType trr && attr.FixedArguments[1].Value is int length)

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -508,6 +508,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			typeSystemAstBuilder.SupportInitAccessors = settings.InitAccessors;
 			typeSystemAstBuilder.SupportRecordClasses = settings.RecordClasses;
 			typeSystemAstBuilder.SupportRecordStructs = settings.RecordStructs;
+			typeSystemAstBuilder.AlwaysUseGlobal = settings.AlwaysUseGlobal;
 			return typeSystemAstBuilder;
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -100,6 +100,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			this.astBuilder.AddResolveResultAnnotations = true;
 			this.astBuilder.ShowAttributes = true;
 			this.astBuilder.UseNullableSpecifierForValueTypes = settings.LiftNullables;
+			this.astBuilder.AlwaysUseGlobal = settings.AlwaysUseGlobal;
 			this.typeInference = new TypeInference(compilation) { Algorithm = TypeInferenceAlgorithm.Improved };
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/Resolver/CSharpOperators.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/CSharpOperators.cs
@@ -156,10 +156,9 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 				get { return SymbolKind.Operator; }
 			}
 
-			IEnumerable<IAttribute> IEntity.GetAttributes()
-			{
-				return EmptyList<IAttribute>.Instance;
-			}
+			IEnumerable<IAttribute> IEntity.GetAttributes() => EmptyList<IAttribute>.Instance;
+			bool IEntity.HasAttribute(KnownAttribute attribute) => false;
+			IAttribute? IEntity.GetAttribute(KnownAttribute attribute) => null;
 
 			Accessibility IEntity.Accessibility {
 				get { return Accessibility.Public; }

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1196,7 +1196,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		bool IsFlagsEnum(ITypeDefinition type)
 		{
-			return type.HasAttribute(KnownAttribute.Flags, inherit: false);
+			return type.HasAttribute(KnownAttribute.Flags);
 		}
 
 		Expression ConvertEnumValue(IType type, long val)

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1154,7 +1154,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			return true;
 		}
 
-		Dictionary<object, (KnownTypeCode Type, string Member)> specialConstants = new Dictionary<object, (KnownTypeCode Type, string Member)>() {
+		static readonly Dictionary<object, (KnownTypeCode Type, string Member)> specialConstants = new Dictionary<object, (KnownTypeCode Type, string Member)>() {
 			// byte:
 			{ byte.MaxValue, (KnownTypeCode.Byte, "MaxValue") },
 			// sbyte:

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -224,6 +224,11 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		/// Controls whether C# 10 "record" struct types are supported.
 		/// </summary>
 		public bool SupportRecordStructs { get; set; }
+
+		/// <summary>
+		/// Controls whether all fully qualified type names should be prefixed with "global::".
+		/// </summary>
+		public bool AlwaysUseGlobal { get; set; }
 		#endregion
 
 		#region Convert Type
@@ -535,7 +540,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				else
 				{
 					result.Target = ConvertNamespace(genericType.Namespace,
-						out _, genericType.Namespace == genericType.Name);
+						out _, AlwaysUseGlobal || genericType.Namespace == genericType.Name);
 				}
 			}
 			result.MemberName = genericType.Name;

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceUsingDeclarations.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceUsingDeclarations.cs
@@ -170,6 +170,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 
 				return new TypeSystemAstBuilder(resolver) {
 					UseNullableSpecifierForValueTypes = settings.LiftNullables,
+					AlwaysUseGlobal = settings.AlwaysUseGlobal,
 					AddResolveResultAnnotations = true,
 					UseAliases = true
 				};

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1915,6 +1915,24 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		bool alwaysUseGlobal = false;
+
+		/// <summary>
+		/// Always fully qualify namespaces using the "global::" prefix.
+		/// </summary>
+		[Category("DecompilerSettings.Other")]
+		[Description("DecompilerSettings.AlwaysUseGlobal")]
+		public bool AlwaysUseGlobal {
+			get { return alwaysUseGlobal; }
+			set {
+				if (alwaysUseGlobal != value)
+				{
+					alwaysUseGlobal = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		CSharpFormattingOptions csharpFormattingOptions;
 
 		[Browsable(false)]

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -39,6 +39,8 @@
     <DebugSymbols>true</DebugSymbols>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <CodeAnalysisRuleSet>ICSharpCode.Decompiler.ruleset</CodeAnalysisRuleSet>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -57,9 +59,13 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <!-- Inject ILSpyUpdateAssemblyInfo as dependency of the GetPackageVersion
+    target so Pack uses the generated version when evaluating project references. -->
   <PropertyGroup>
-    <CodeAnalysisRuleSet>ICSharpCode.Decompiler.ruleset</CodeAnalysisRuleSet>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GetPackageVersionDependsOn>
+      ILSpyUpdateAssemblyInfo;
+      $(GetPackageVersionDependsOn)
+    </GetPackageVersionDependsOn>
   </PropertyGroup>
 
   <Import Project="..\packages.props" />

--- a/ICSharpCode.Decompiler/TypeSystem/ComHelper.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ComHelper.cs
@@ -34,7 +34,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		{
 			return typeDefinition != null
 				&& typeDefinition.Kind == TypeKind.Interface
-				&& typeDefinition.HasAttribute(KnownAttribute.ComImport, inherit: false);
+				&& typeDefinition.HasAttribute(KnownAttribute.ComImport);
 		}
 
 		/// <summary>
@@ -46,7 +46,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		{
 			if (typeDefinition == null)
 				return SpecialType.UnknownType;
-			var coClassAttribute = typeDefinition.GetAttribute(KnownAttribute.CoClass, inherit: false);
+			var coClassAttribute = typeDefinition.GetAttribute(KnownAttribute.CoClass);
 			if (coClassAttribute != null && coClassAttribute.FixedArguments.Length == 1)
 			{
 				if (coClassAttribute.FixedArguments[0].Value is IType ty)

--- a/ICSharpCode.Decompiler/TypeSystem/IEntity.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/IEntity.cs
@@ -68,6 +68,10 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// </summary>
 		IEnumerable<IAttribute> GetAttributes();
 
+		bool HasAttribute(KnownAttribute attribute);
+
+		IAttribute? GetAttribute(KnownAttribute attribute);
+
 		/// <summary>
 		/// Gets the accessibility of this entity.
 		/// </summary>

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/FakeMember.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/FakeMember.cs
@@ -61,6 +61,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		IModule IEntity.ParentModule => DeclaringType?.GetDefinition()?.ParentModule;
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => EmptyList<IAttribute>.Instance;
+		bool IEntity.HasAttribute(KnownAttribute attribute) => false;
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => null;
 
 		public Accessibility Accessibility { get; set; } = Accessibility.Public;
 

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -107,7 +107,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		PreserveBaseOverrides,
 	}
 
-	static class KnownAttributes
+	public static class KnownAttributes
 	{
 		internal const int Count = (int)KnownAttribute.PreserveBaseOverrides + 1;
 
@@ -196,6 +196,31 @@ namespace ICSharpCode.Decompiler.TypeSystem
 					return (KnownAttribute)i;
 			}
 			return KnownAttribute.None;
+		}
+
+		public static bool IsCustomAttribute(this KnownAttribute knownAttribute)
+		{
+			switch (knownAttribute)
+			{
+				case KnownAttribute.Serializable:
+				case KnownAttribute.ComImport:
+				case KnownAttribute.StructLayout:
+				case KnownAttribute.DllImport:
+				case KnownAttribute.PreserveSig:
+				case KnownAttribute.MethodImpl:
+				case KnownAttribute.FieldOffset:
+				case KnownAttribute.NonSerialized:
+				case KnownAttribute.MarshalAs:
+				case KnownAttribute.PermissionSet:
+				case KnownAttribute.Optional:
+				case KnownAttribute.In:
+				case KnownAttribute.Out:
+				case KnownAttribute.IndexerName:
+				case KnownAttribute.SpecialName:
+					return false;
+				default:
+					return true;
+			}
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
@@ -145,6 +145,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		public IType DeclaringType => baseMethod.DeclaringType;
 		public IModule ParentModule => baseMethod.ParentModule;
 		IEnumerable<IAttribute> IEntity.GetAttributes() => baseMethod.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => baseMethod.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => baseMethod.GetAttribute(attribute);
 		IEnumerable<IAttribute> IMethod.GetReturnTypeAttributes() => baseMethod.GetReturnTypeAttributes();
 		bool IMethod.ReturnTypeIsRefReadOnly => baseMethod.ReturnTypeIsRefReadOnly;
 		bool IMethod.ThisIsRefReadOnly => baseMethod.ThisIsRefReadOnly;

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataEvent.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataEvent.cs
@@ -123,6 +123,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			b.Add(eventDef.GetCustomAttributes(), SymbolKind.Event);
 			return b.Build();
 		}
+
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetEventDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Event);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetEventDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Event);
+		}
 		#endregion
 
 		public Accessibility Accessibility => AnyAccessor?.Accessibility ?? Accessibility.None;

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -162,6 +163,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			b.Add(fieldDef.GetCustomAttributes(), SymbolKind.Field);
 
 			return b.Build();
+		}
+
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetFieldDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Field);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetFieldDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Field);
 		}
 
 		public string FullName => $"{DeclaringType?.FullName}.{Name}";

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataMethod.cs
@@ -463,6 +463,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 
 			return b.Build();
 		}
+
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetMethodDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, symbolKind);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetMethodDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, symbolKind);
+		}
 		#endregion
 
 		#region Return type attributes

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
@@ -432,6 +432,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			return b.Build();
 		}
 
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetTypeDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.TypeDefinition);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetTypeDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.TypeDefinition);
+		}
+
 		public string DefaultMemberName {
 			get {
 				string defaultMemberName = LazyInit.VolatileRead(ref this.defaultMemberName);

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MinimalCorlib.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MinimalCorlib.cs
@@ -258,10 +258,9 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				return EmptyList<IMethod>.Instance;
 			}
 
-			IEnumerable<IAttribute> IEntity.GetAttributes()
-			{
-				return EmptyList<IAttribute>.Instance;
-			}
+			IEnumerable<IAttribute> IEntity.GetAttributes() => EmptyList<IAttribute>.Instance;
+			bool IEntity.HasAttribute(KnownAttribute attribute) => false;
+			IAttribute IEntity.GetAttribute(KnownAttribute attribute) => null;
 
 			IEnumerable<IMethod> IType.GetConstructors(Predicate<IMethod> filter, GetMemberOptions options)
 			{

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/SpecializedMember.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/SpecializedMember.cs
@@ -162,6 +162,9 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		}
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => baseMember.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => baseMember.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => baseMember.GetAttribute(attribute);
+
 
 		public IEnumerable<IMember> ExplicitlyImplementedInterfaceMembers {
 			get {

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/SyntheticRangeIndexer.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/SyntheticRangeIndexer.cs
@@ -126,6 +126,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		}
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => underlyingMethod.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => underlyingMethod.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => underlyingMethod.GetAttribute(attribute);
 
 		IEnumerable<IAttribute> IMethod.GetReturnTypeAttributes() => underlyingMethod.GetReturnTypeAttributes();
 

--- a/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
@@ -491,6 +491,11 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				var statedDeclaringType = ResolveDeclaringType(memberRef.Parent, context);
 				var statedDeclaringTypeDefinition = statedDeclaringType.GetDefinition();
 
+				// Note: statedDeclaringType might be parameterized, but the signature is for the original method definition.
+				// We'll have to search the member directly on statedDeclaringTypeDefinition.
+				signature = memberRef.DecodeMethodSignature(TypeProvider,
+					new GenericContext(statedDeclaringTypeDefinition?.TypeParameters));
+
 				if (statedDeclaringTypeDefinition != null)
 				{
 					var candidateDeclaringTypes = statedDeclaringType.GetAllBaseTypes().ToList();
@@ -506,10 +511,10 @@ namespace ICSharpCode.Decompiler.TypeSystem
 						{
 							classTypeArguments = declaringType.TypeArguments;
 						}
-						// Note: declaringType might be parameterized, but the signature is for the original method definition.
-						// We'll have to search the member directly on declaringTypeDefinition.
+
 						signature = memberRef.DecodeMethodSignature(TypeProvider,
 							new GenericContext(declaringTypeDefinition?.TypeParameters));
+
 						if (declaringTypeDefinition != null)
 						{
 							// Find the set of overloads to search:

--- a/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
@@ -493,18 +493,14 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 				if (statedDeclaringTypeDefinition != null)
 				{
-					var candidateDeclaringTypes = new List<IType>() { statedDeclaringType };
+					var candidateDeclaringTypes = statedDeclaringType.GetAllBaseTypes().ToList();
 
-					// Search through type hierarchy of declaring type, traversing up the chain.
-					if (statedDeclaringTypeDefinition.DirectBaseTypes?.Any() == true)
-					{
-						candidateDeclaringTypes.AddRange(statedDeclaringTypeDefinition.DirectBaseTypes);
-					}
-
-					for (int i = 0; i < candidateDeclaringTypes.Count; i++)
+					// GetAllBaseTypes() returns types ordered from base -> specific. Traverse the list in reverse
+					// to check in the opposite direction (most specific to least specific).
+					for (int i = candidateDeclaringTypes.Count; i >= 0; i--)
 					{
 						var declaringType = candidateDeclaringTypes[i];
-						var declaringTypeDefinition = i == 0 ? statedDeclaringTypeDefinition : candidateDeclaringTypes[i].GetDefinition();
+						var declaringTypeDefinition = declaringType.GetDefinition();
 
 						if (declaringType.TypeArguments.Count > 0)
 						{

--- a/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
@@ -497,7 +497,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 					// GetAllBaseTypes() returns types ordered from base -> specific. Traverse the list in reverse
 					// to check in the opposite direction (most specific to least specific).
-					for (int i = candidateDeclaringTypes.Count; i >= 0; i--)
+					for (int i = candidateDeclaringTypes.Count - 1; i >= 0; i--)
 					{
 						var declaringType = candidateDeclaringTypes[i];
 						var declaringTypeDefinition = declaringType.GetDefinition();

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -485,7 +485,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		#region IEntity.GetAttribute
 		/// <summary>
-		/// Gets whether the entity has an attribute of the specified attribute type (or derived attribute types).
+		/// Gets whether the entity has an attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="entity">The entity on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>
@@ -494,13 +494,16 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// (if the given <paramref name="entity"/> in an <c>override</c>)
 		/// should be returned.
 		/// </param>
-		public static bool HasAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit = false)
+		public static bool HasAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit)
 		{
+			if (!inherit)
+				return entity.HasAttribute(attributeType);
+
 			return GetAttribute(entity, attributeType, inherit) != null;
 		}
 
 		/// <summary>
-		/// Gets the attribute of the specified attribute type (or derived attribute types).
+		/// Gets the attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="entity">The entity on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>
@@ -514,9 +517,27 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// If inherit is true, an from the entity itself will be returned if possible;
 		/// and the base entity will only be searched if none exists.
 		/// </returns>
-		public static IAttribute GetAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit = false)
+		public static IAttribute GetAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit)
 		{
-			return GetAttributes(entity, inherit).FirstOrDefault(a => a.AttributeType.IsKnownType(attributeType));
+			if (inherit)
+			{
+				if (entity is ITypeDefinition td)
+				{
+					return InheritanceHelper.GetAttribute(td, attributeType);
+				}
+				else if (entity is IMember m)
+				{
+					return InheritanceHelper.GetAttribute(m, attributeType);
+				}
+				else
+				{
+					throw new NotSupportedException("Unknown entity type");
+				}
+			}
+			else
+			{
+				return entity.GetAttribute(attributeType);
+			}
 		}
 
 		/// <summary>
@@ -559,7 +580,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		#region IParameter.GetAttribute
 		/// <summary>
-		/// Gets whether the parameter has an attribute of the specified attribute type (or derived attribute types).
+		/// Gets whether the parameter has an attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="parameter">The parameter on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>
@@ -569,7 +590,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		/// <summary>
-		/// Gets the attribute of the specified attribute type (or derived attribute types).
+		/// Gets the attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="parameter">The parameter on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>

--- a/ICSharpCode.Decompiler/TypeSystem/VarArgInstanceMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/VarArgInstanceMethod.cs
@@ -118,6 +118,9 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => baseMethod.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => baseMethod.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => baseMethod.GetAttribute(attribute);
+
 		IEnumerable<IAttribute> IMethod.GetReturnTypeAttributes() => baseMethod.GetReturnTypeAttributes();
 		bool IMethod.ReturnTypeIsRefReadOnly => baseMethod.ReturnTypeIsRefReadOnly;
 		bool IMethod.ThisIsRefReadOnly => baseMethod.ThisIsRefReadOnly;

--- a/ICSharpCode.ILSpyX/ICSharpCode.ILSpyX.csproj
+++ b/ICSharpCode.ILSpyX/ICSharpCode.ILSpyX.csproj
@@ -53,6 +53,15 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <!-- Inject ILSpyUpdateAssemblyInfo as dependency of the GetPackageVersion
+    target so Pack uses the generated version when evaluating project references. -->
+  <PropertyGroup>
+    <GetPackageVersionDependsOn>
+      ILSpyUpdateAssemblyInfo;
+      $(GetPackageVersionDependsOn)
+    </GetPackageVersionDependsOn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />

--- a/ILSpy.AddIn.VS2022/ILSpy.AddIn.VS2022.csproj
+++ b/ILSpy.AddIn.VS2022/ILSpy.AddIn.VS2022.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.0.1" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/ILSpy.AddIn/ILSpy.AddIn.csproj
+++ b/ILSpy.AddIn/ILSpy.AddIn.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.4.0" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ILSpy/Analyzers/Builtin/AttributeAppliedToAnalyzer.cs
+++ b/ILSpy/Analyzers/Builtin/AttributeAppliedToAnalyzer.cs
@@ -51,26 +51,7 @@ namespace ICSharpCode.ILSpy.Analyzers.Builtin
 		bool IsBuiltinAttribute(ITypeDefinition attributeType, out KnownAttribute knownAttribute)
 		{
 			knownAttribute = attributeType.IsBuiltinAttribute();
-			switch (knownAttribute)
-			{
-				case KnownAttribute.Serializable:
-				case KnownAttribute.ComImport:
-				case KnownAttribute.StructLayout:
-				case KnownAttribute.DllImport:
-				case KnownAttribute.PreserveSig:
-				case KnownAttribute.MethodImpl:
-				case KnownAttribute.FieldOffset:
-				case KnownAttribute.NonSerialized:
-				case KnownAttribute.MarshalAs:
-				case KnownAttribute.PermissionSet:
-				case KnownAttribute.Optional:
-				case KnownAttribute.In:
-				case KnownAttribute.Out:
-				case KnownAttribute.IndexerName:
-					return true;
-				default:
-					return false;
-			}
+			return !knownAttribute.IsCustomAttribute();
 		}
 
 		IEnumerable<IEnumerable<ISymbol>> HandleBuiltinAttribute(KnownAttribute attribute, AnalyzerScope scope, CancellationToken ct)

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -119,7 +119,7 @@
     <SortResXStamp Include="obj\sort-resx.stamp" />
   </ItemGroup>
 
-  <Target Name="SortResX" BeforeTargets="BeforeBuild" Inputs="@(SortResXInput)" Outputs="@(SortResXStamp)">
+  <Target Name="SortResX" BeforeTargets="BeforeBuild" Inputs="@(SortResXInput)" Outputs="@(SortResXStamp)" Condition="'$(GITHUB_ACTIONS)' != 'true'">
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
       <SortResX>powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/sort-resx.ps1</SortResX>
     </PropertyGroup>

--- a/ILSpy/Languages/ILLanguage.cs
+++ b/ILSpy/Languages/ILLanguage.cs
@@ -195,27 +195,33 @@ namespace ICSharpCode.ILSpy
 		{
 			var output = new AvalonEditTextOutput() { IgnoreNewLineAndIndent = true };
 			var disasm = CreateDisassembler(output, new DecompilationOptions());
+			PEFile module = entity.ParentModule?.PEFile;
+			if (module == null)
+			{
+				return null;
+			}
+
 			switch (entity.SymbolKind)
 			{
 				case SymbolKind.TypeDefinition:
-					disasm.DisassembleTypeHeader(entity.ParentModule.PEFile, (TypeDefinitionHandle)entity.MetadataToken);
+					disasm.DisassembleTypeHeader(module, (TypeDefinitionHandle)entity.MetadataToken);
 					break;
 				case SymbolKind.Field:
-					disasm.DisassembleFieldHeader(entity.ParentModule.PEFile, (FieldDefinitionHandle)entity.MetadataToken);
+					disasm.DisassembleFieldHeader(module, (FieldDefinitionHandle)entity.MetadataToken);
 					break;
 				case SymbolKind.Property:
 				case SymbolKind.Indexer:
-					disasm.DisassemblePropertyHeader(entity.ParentModule.PEFile, (PropertyDefinitionHandle)entity.MetadataToken);
+					disasm.DisassemblePropertyHeader(module, (PropertyDefinitionHandle)entity.MetadataToken);
 					break;
 				case SymbolKind.Event:
-					disasm.DisassembleEventHeader(entity.ParentModule.PEFile, (EventDefinitionHandle)entity.MetadataToken);
+					disasm.DisassembleEventHeader(module, (EventDefinitionHandle)entity.MetadataToken);
 					break;
 				case SymbolKind.Method:
 				case SymbolKind.Operator:
 				case SymbolKind.Constructor:
 				case SymbolKind.Destructor:
 				case SymbolKind.Accessor:
-					disasm.DisassembleMethodHeader(entity.ParentModule.PEFile, (MethodDefinitionHandle)entity.MetadataToken);
+					disasm.DisassembleMethodHeader(module, (MethodDefinitionHandle)entity.MetadataToken);
 					break;
 				default:
 					output.Write(GetDisplayName(entity, true, true, true));

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -739,6 +739,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always fully qualify namespaces using the &quot;global::&quot; prefix.
+        /// </summary>
+        public static string DecompilerSettings_AlwaysUseGlobal {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.AlwaysUseGlobal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply Windows Runtime projections on loaded assemblies.
         /// </summary>
         public static string DecompilerSettings_ApplyWindowsRuntimeProjectionsOnLoadedAssemblies {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -270,6 +270,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.AlwaysUseBraces" xml:space="preserve">
     <value>Always use braces</value>
   </data>
+  <data name="DecompilerSettings.AlwaysUseGlobal" xml:space="preserve">
+    <value>Always fully qualify namespaces using the "global::" prefix</value>
+  </data>
   <data name="DecompilerSettings.ApplyWindowsRuntimeProjectionsOnLoadedAssemblies" xml:space="preserve">
     <value>Apply Windows Runtime projections on loaded assemblies</value>
   </data>

--- a/ILSpy/TextView/DecompilerTextView.cs
+++ b/ILSpy/TextView/DecompilerTextView.cs
@@ -441,6 +441,11 @@ namespace ICSharpCode.ILSpy.TextView
 			Language currentLanguage = MainWindow.Instance.CurrentLanguage;
 			DocumentationUIBuilder renderer = new DocumentationUIBuilder(new CSharpAmbience(), currentLanguage.SyntaxHighlighting);
 			RichText richText = currentLanguage.GetRichTextTooltip(resolved);
+			if (richText == null)
+			{
+				return null;
+			}
+
 			renderer.AddSignatureBlock(richText.Text, richText.ToRichTextModel());
 			try
 			{

--- a/ILSpy/TreeNodes/AssemblyReferenceTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyReferenceTreeNode.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		public IAssemblyReference AssemblyNameReference => r;
 
 		public override object Text {
-			get { return r.Name + GetSuffixString(r.Handle); }
+			get { return Language.EscapeName(r.Name) + GetSuffixString(r.Handle); }
 		}
 
 		public override object Icon => Images.Assembly;

--- a/ILSpy/TreeNodes/ModuleReferenceTreeNode.cs
+++ b/ILSpy/TreeNodes/ModuleReferenceTreeNode.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			this.metadata = module;
 			this.handle = r;
 			this.reference = module.GetModuleReference(r);
-			this.moduleName = metadata.GetString(reference.Name);
+			this.moduleName = Language.EscapeName(metadata.GetString(reference.Name));
 
 			foreach (var h in module.AssemblyFiles)
 			{

--- a/ILSpy/TreeNodes/ResourceNodes/ResourceEntryNode.cs
+++ b/ILSpy/TreeNodes/ResourceNodes/ResourceEntryNode.cs
@@ -36,7 +36,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		private readonly string key;
 		private readonly Func<Stream> openStream;
 
-		public override object Text => this.key;
+		public override object Text => Language.EscapeName(key);
 
 		public override object Icon => Images.Resource;
 

--- a/ILSpy/TreeNodes/ResourceNodes/ResourceTreeNode.cs
+++ b/ILSpy/TreeNodes/ResourceNodes/ResourceTreeNode.cs
@@ -51,7 +51,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public Resource Resource { get; }
 
-		public override object Text => Resource.Name;
+		public override object Text => Language.EscapeName(Resource.Name);
 
 		public override object Icon => Images.Resource;
 


### PR DESCRIPTION
Link to issue(s) this covers

N/A

### Problem
When certain method calls* are compiled with netstandard1.x, the emitted `callvirt` instruction references a member that does not exist. At runtime, these accesses are resolved to members of base types, however ILSpy fails to do so, and fake members are generated instead.

\* = calls to methods that belong to a base type of a class. Example: [TypeInfo.Assembly](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.typeinfo?view=net-6.0#properties), which is an inherited member from Type. When an expression like `typeof(object).GetTypeInfo().Assembly` is compiled with a netstandard1.x target, the emitted instruction is:

    callvirt instance class [System.Reflection]System.Reflection.Assembly [System.Reflection]System.Reflection.TypeInfo::get_Assembly()

whereas on other targets (ex. net6.0), this is emitted:

    callvirt instance class [System.Runtime]System.Reflection.Assembly [System.Runtime]System.Type::get_Assembly()

At runtime, the former member reference is correctly resolved to Type::get_Assembly, but ILSpy's type system fails to do so. See the following screenshots for how this impacts the generated AST:

pre-patch:

![incorrectly_resolved](https://user-images.githubusercontent.com/5571189/182242580-5aa6d023-be7e-4d8c-8fbd-4099ec436819.PNG)

post-patch:

![correctly_resolved](https://user-images.githubusercontent.com/5571189/182242593-da1ace31-ba2d-4db2-b393-49eefad943dc.PNG)

This problem was encountered while decompiling an Autofac build that targets netstandard1.1 ([link](https://github.com/autofac/Autofac/releases/download/v4.8.1/autofac.4.8.1.nupkg)), so there definitely are examples of this weird IL out in the wild.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.

This solution may slightly degrade method resolution performance for references that can't be resolved, although this is an operation performed once per method reference. I do not anticipate a regression for valid/runnable IL, however it is possible that previously invalid method calls (perhaps due to access modifiers) may be resolved to inaccessible members in the target type hierarchy. This would require incorrect IL to be provided, though.

These method references are found only in callvirt instructions (as call would fail with this overspecified reference), but ResolveMethodReference is oblivious to what IL instruction contains the reference. A cleaner solution would only execute this logic when resolving callvirt references, though I'm not sure that this is possible to begin with, as member reference resolution is deduplicated across the entire module from what I can tell.

* Which part of this PR is most in need of attention/improvement?

Further testing to ensure no regressions.

* [x] At least one test covering the code changed

The existing TypeSystem tests cover ResolveMethodReference. I wanted to add a test specifically for this IL, but I couldn't figure out where exactly to place it in the test hierarchy, as this is a pretty vertical testcase where handmade IL is provided and later the AST must be analyzed.

Looking forward to any feedback.