### PR TITLE
Add option to always fully qualify type names with global::

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -508,6 +508,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			typeSystemAstBuilder.SupportInitAccessors = settings.InitAccessors;
 			typeSystemAstBuilder.SupportRecordClasses = settings.RecordClasses;
 			typeSystemAstBuilder.SupportRecordStructs = settings.RecordStructs;
+			typeSystemAstBuilder.AlwaysUseGlobal = settings.AlwaysUseGlobal;
 			return typeSystemAstBuilder;
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -100,6 +100,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			this.astBuilder.AddResolveResultAnnotations = true;
 			this.astBuilder.ShowAttributes = true;
 			this.astBuilder.UseNullableSpecifierForValueTypes = settings.LiftNullables;
+			this.astBuilder.AlwaysUseGlobal = settings.AlwaysUseGlobal;
 			this.typeInference = new TypeInference(compilation) { Algorithm = TypeInferenceAlgorithm.Improved };
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -224,6 +224,11 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		/// Controls whether C# 10 "record" struct types are supported.
 		/// </summary>
 		public bool SupportRecordStructs { get; set; }
+
+		/// <summary>
+		/// Controls whether all fully qualified type names should be prefixed with "global::".
+		/// </summary>
+		public bool AlwaysUseGlobal { get; set; }
 		#endregion
 
 		#region Convert Type
@@ -535,7 +540,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				else
 				{
 					result.Target = ConvertNamespace(genericType.Namespace,
-						out _, genericType.Namespace == genericType.Name);
+						out _, AlwaysUseGlobal || genericType.Namespace == genericType.Name);
 				}
 			}
 			result.MemberName = genericType.Name;

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceUsingDeclarations.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceUsingDeclarations.cs
@@ -170,6 +170,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 
 				return new TypeSystemAstBuilder(resolver) {
 					UseNullableSpecifierForValueTypes = settings.LiftNullables,
+					AlwaysUseGlobal = settings.AlwaysUseGlobal,
 					AddResolveResultAnnotations = true,
 					UseAliases = true
 				};

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1915,6 +1915,24 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		bool alwaysUseGlobal = false;
+
+		/// <summary>
+		/// Always fully qualify namespaces using the "global::" prefix.
+		/// </summary>
+		[Category("DecompilerSettings.Other")]
+		[Description("DecompilerSettings.AlwaysUseGlobal")]
+		public bool AlwaysUseGlobal {
+			get { return alwaysUseGlobal; }
+			set {
+				if (alwaysUseGlobal != value)
+				{
+					alwaysUseGlobal = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		CSharpFormattingOptions csharpFormattingOptions;
 
 		[Browsable(false)]

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -119,7 +119,7 @@
     <SortResXStamp Include="obj\sort-resx.stamp" />
   </ItemGroup>
 
-  <Target Name="SortResX" BeforeTargets="BeforeBuild" Inputs="@(SortResXInput)" Outputs="@(SortResXStamp)">
+  <Target Name="SortResX" BeforeTargets="BeforeBuild" Inputs="@(SortResXInput)" Outputs="@(SortResXStamp)" Condition="'$(GITHUB_ACTIONS)' != 'true'">
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
       <SortResX>powershell -NoProfile -ExecutionPolicy Bypass -File BuildTools/sort-resx.ps1</SortResX>
     </PropertyGroup>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -739,6 +739,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always fully qualify namespaces using the &quot;global::&quot; prefix.
+        /// </summary>
+        public static string DecompilerSettings_AlwaysUseGlobal {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.AlwaysUseGlobal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply Windows Runtime projections on loaded assemblies.
         /// </summary>
         public static string DecompilerSettings_ApplyWindowsRuntimeProjectionsOnLoadedAssemblies {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -270,6 +270,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.AlwaysUseBraces" xml:space="preserve">
     <value>Always use braces</value>
   </data>
+  <data name="DecompilerSettings.AlwaysUseGlobal" xml:space="preserve">
+    <value>Always fully qualify namespaces using the "global::" prefix</value>
+  </data>
   <data name="DecompilerSettings.ApplyWindowsRuntimeProjectionsOnLoadedAssemblies" xml:space="preserve">
     <value>Apply Windows Runtime projections on loaded assemblies</value>
   </data>


### PR DESCRIPTION
Link to issue(s) this covers
N/A

### Problem
There is no option to always fully qualify type names to the strongest extent: even AlwaysQualifyMemberReferences | !UsingDeclarations omits the use of global::. This can be a problem when dealing with name confusion such as in [this SO answer](https://stackoverflow.com/a/72318963). I haven't been able to quickly generate a repro case, but anecdotally, using this option has resolved a number of cases in which the ILSpy generated code will not compile. In general, when compilability of generated code is a goal, this option seems like it would be handy to have.

Of note is that StringInterpolation will probably need to be set to false when this option is enabled, as the C# compiler confuses the colon in "global::" for a formatting specifier. Perhaps it's possible to also emit surrounding braces when global:: is used inside of a string interpolation argument, which is a consideration regardless of this option.