### PR TITLE
Add optimized implementation of HasAttribute and GetAttribute to IEntity.

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1491,7 +1491,7 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		EnumValueDisplayMode DetectBestEnumValueDisplayMode(ITypeDefinition typeDef, PEFile module)
 		{
-			if (typeDef.HasAttribute(KnownAttribute.Flags, inherit: false))
+			if (typeDef.HasAttribute(KnownAttribute.Flags))
 				return EnumValueDisplayMode.AllHex;
 			bool first = true;
 			long firstValue = 0, previousValue = 0;
@@ -1917,7 +1917,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		{
 			type = null;
 			elementCount = 0;
-			IAttribute attr = field.GetAttribute(KnownAttribute.FixedBuffer, inherit: false);
+			IAttribute attr = field.GetAttribute(KnownAttribute.FixedBuffer);
 			if (attr != null && attr.FixedArguments.Length == 2)
 			{
 				if (attr.FixedArguments[0].Value is IType trr && attr.FixedArguments[1].Value is int length)

--- a/ICSharpCode.Decompiler/CSharp/Resolver/CSharpOperators.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/CSharpOperators.cs
@@ -156,10 +156,9 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 				get { return SymbolKind.Operator; }
 			}
 
-			IEnumerable<IAttribute> IEntity.GetAttributes()
-			{
-				return EmptyList<IAttribute>.Instance;
-			}
+			IEnumerable<IAttribute> IEntity.GetAttributes() => EmptyList<IAttribute>.Instance;
+			bool IEntity.HasAttribute(KnownAttribute attribute) => false;
+			IAttribute? IEntity.GetAttribute(KnownAttribute attribute) => null;
 
 			Accessibility IEntity.Accessibility {
 				get { return Accessibility.Public; }

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1196,7 +1196,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		bool IsFlagsEnum(ITypeDefinition type)
 		{
-			return type.HasAttribute(KnownAttribute.Flags, inherit: false);
+			return type.HasAttribute(KnownAttribute.Flags);
 		}
 
 		Expression ConvertEnumValue(IType type, long val)

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1154,7 +1154,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			return true;
 		}
 
-		Dictionary<object, (KnownTypeCode Type, string Member)> specialConstants = new Dictionary<object, (KnownTypeCode Type, string Member)>() {
+		static readonly Dictionary<object, (KnownTypeCode Type, string Member)> specialConstants = new Dictionary<object, (KnownTypeCode Type, string Member)>() {
 			// byte:
 			{ byte.MaxValue, (KnownTypeCode.Byte, "MaxValue") },
 			// sbyte:

--- a/ICSharpCode.Decompiler/TypeSystem/ComHelper.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ComHelper.cs
@@ -34,7 +34,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		{
 			return typeDefinition != null
 				&& typeDefinition.Kind == TypeKind.Interface
-				&& typeDefinition.HasAttribute(KnownAttribute.ComImport, inherit: false);
+				&& typeDefinition.HasAttribute(KnownAttribute.ComImport);
 		}
 
 		/// <summary>
@@ -46,7 +46,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		{
 			if (typeDefinition == null)
 				return SpecialType.UnknownType;
-			var coClassAttribute = typeDefinition.GetAttribute(KnownAttribute.CoClass, inherit: false);
+			var coClassAttribute = typeDefinition.GetAttribute(KnownAttribute.CoClass);
 			if (coClassAttribute != null && coClassAttribute.FixedArguments.Length == 1)
 			{
 				if (coClassAttribute.FixedArguments[0].Value is IType ty)

--- a/ICSharpCode.Decompiler/TypeSystem/IEntity.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/IEntity.cs
@@ -68,6 +68,10 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// </summary>
 		IEnumerable<IAttribute> GetAttributes();
 
+		bool HasAttribute(KnownAttribute attribute);
+
+		IAttribute? GetAttribute(KnownAttribute attribute);
+
 		/// <summary>
 		/// Gets the accessibility of this entity.
 		/// </summary>

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/FakeMember.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/FakeMember.cs
@@ -61,6 +61,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		IModule IEntity.ParentModule => DeclaringType?.GetDefinition()?.ParentModule;
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => EmptyList<IAttribute>.Instance;
+		bool IEntity.HasAttribute(KnownAttribute attribute) => false;
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => null;
 
 		public Accessibility Accessibility { get; set; } = Accessibility.Public;
 

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -107,7 +107,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		PreserveBaseOverrides,
 	}
 
-	static class KnownAttributes
+	public static class KnownAttributes
 	{
 		internal const int Count = (int)KnownAttribute.PreserveBaseOverrides + 1;
 
@@ -196,6 +196,31 @@ namespace ICSharpCode.Decompiler.TypeSystem
 					return (KnownAttribute)i;
 			}
 			return KnownAttribute.None;
+		}
+
+		public static bool IsCustomAttribute(this KnownAttribute knownAttribute)
+		{
+			switch (knownAttribute)
+			{
+				case KnownAttribute.Serializable:
+				case KnownAttribute.ComImport:
+				case KnownAttribute.StructLayout:
+				case KnownAttribute.DllImport:
+				case KnownAttribute.PreserveSig:
+				case KnownAttribute.MethodImpl:
+				case KnownAttribute.FieldOffset:
+				case KnownAttribute.NonSerialized:
+				case KnownAttribute.MarshalAs:
+				case KnownAttribute.PermissionSet:
+				case KnownAttribute.Optional:
+				case KnownAttribute.In:
+				case KnownAttribute.Out:
+				case KnownAttribute.IndexerName:
+				case KnownAttribute.SpecialName:
+					return false;
+				default:
+					return true;
+			}
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/LocalFunctionMethod.cs
@@ -145,6 +145,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		public IType DeclaringType => baseMethod.DeclaringType;
 		public IModule ParentModule => baseMethod.ParentModule;
 		IEnumerable<IAttribute> IEntity.GetAttributes() => baseMethod.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => baseMethod.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => baseMethod.GetAttribute(attribute);
 		IEnumerable<IAttribute> IMethod.GetReturnTypeAttributes() => baseMethod.GetReturnTypeAttributes();
 		bool IMethod.ReturnTypeIsRefReadOnly => baseMethod.ReturnTypeIsRefReadOnly;
 		bool IMethod.ThisIsRefReadOnly => baseMethod.ThisIsRefReadOnly;

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataEvent.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataEvent.cs
@@ -123,6 +123,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			b.Add(eventDef.GetCustomAttributes(), SymbolKind.Event);
 			return b.Build();
 		}
+
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetEventDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Event);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetEventDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Event);
+		}
 		#endregion
 
 		public Accessibility Accessibility => AnyAccessor?.Accessibility ?? Accessibility.None;

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -162,6 +163,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			b.Add(fieldDef.GetCustomAttributes(), SymbolKind.Field);
 
 			return b.Build();
+		}
+
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetFieldDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Field);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetFieldDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.Field);
 		}
 
 		public string FullName => $"{DeclaringType?.FullName}.{Name}";

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataMethod.cs
@@ -463,6 +463,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 
 			return b.Build();
 		}
+
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetMethodDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, symbolKind);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetMethodDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, symbolKind);
+		}
 		#endregion
 
 		#region Return type attributes

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
@@ -432,6 +432,30 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			return b.Build();
 		}
 
+		public bool HasAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().Any(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetTypeDefinition(handle);
+			return b.HasAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.TypeDefinition);
+		}
+
+		public IAttribute GetAttribute(KnownAttribute attribute)
+		{
+			if (!attribute.IsCustomAttribute())
+			{
+				return GetAttributes().FirstOrDefault(attr => attr.AttributeType.IsKnownType(attribute));
+			}
+			var b = new AttributeListBuilder(module);
+			var metadata = module.metadata;
+			var def = metadata.GetTypeDefinition(handle);
+			return b.GetAttribute(metadata, def.GetCustomAttributes(), attribute, SymbolKind.TypeDefinition);
+		}
+
 		public string DefaultMemberName {
 			get {
 				string defaultMemberName = LazyInit.VolatileRead(ref this.defaultMemberName);

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MinimalCorlib.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MinimalCorlib.cs
@@ -258,10 +258,9 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				return EmptyList<IMethod>.Instance;
 			}
 
-			IEnumerable<IAttribute> IEntity.GetAttributes()
-			{
-				return EmptyList<IAttribute>.Instance;
-			}
+			IEnumerable<IAttribute> IEntity.GetAttributes() => EmptyList<IAttribute>.Instance;
+			bool IEntity.HasAttribute(KnownAttribute attribute) => false;
+			IAttribute IEntity.GetAttribute(KnownAttribute attribute) => null;
 
 			IEnumerable<IMethod> IType.GetConstructors(Predicate<IMethod> filter, GetMemberOptions options)
 			{

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/SpecializedMember.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/SpecializedMember.cs
@@ -162,6 +162,9 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		}
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => baseMember.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => baseMember.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => baseMember.GetAttribute(attribute);
+
 
 		public IEnumerable<IMember> ExplicitlyImplementedInterfaceMembers {
 			get {

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/SyntheticRangeIndexer.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/SyntheticRangeIndexer.cs
@@ -126,6 +126,8 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		}
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => underlyingMethod.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => underlyingMethod.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => underlyingMethod.GetAttribute(attribute);
 
 		IEnumerable<IAttribute> IMethod.GetReturnTypeAttributes() => underlyingMethod.GetReturnTypeAttributes();
 

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -485,7 +485,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		#region IEntity.GetAttribute
 		/// <summary>
-		/// Gets whether the entity has an attribute of the specified attribute type (or derived attribute types).
+		/// Gets whether the entity has an attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="entity">The entity on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>
@@ -494,13 +494,16 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// (if the given <paramref name="entity"/> in an <c>override</c>)
 		/// should be returned.
 		/// </param>
-		public static bool HasAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit = false)
+		public static bool HasAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit)
 		{
+			if (!inherit)
+				return entity.HasAttribute(attributeType);
+
 			return GetAttribute(entity, attributeType, inherit) != null;
 		}
 
 		/// <summary>
-		/// Gets the attribute of the specified attribute type (or derived attribute types).
+		/// Gets the attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="entity">The entity on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>
@@ -514,9 +517,27 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// If inherit is true, an from the entity itself will be returned if possible;
 		/// and the base entity will only be searched if none exists.
 		/// </returns>
-		public static IAttribute GetAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit = false)
+		public static IAttribute GetAttribute(this IEntity entity, KnownAttribute attributeType, bool inherit)
 		{
-			return GetAttributes(entity, inherit).FirstOrDefault(a => a.AttributeType.IsKnownType(attributeType));
+			if (inherit)
+			{
+				if (entity is ITypeDefinition td)
+				{
+					return InheritanceHelper.GetAttribute(td, attributeType);
+				}
+				else if (entity is IMember m)
+				{
+					return InheritanceHelper.GetAttribute(m, attributeType);
+				}
+				else
+				{
+					throw new NotSupportedException("Unknown entity type");
+				}
+			}
+			else
+			{
+				return entity.GetAttribute(attributeType);
+			}
 		}
 
 		/// <summary>
@@ -559,7 +580,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		#region IParameter.GetAttribute
 		/// <summary>
-		/// Gets whether the parameter has an attribute of the specified attribute type (or derived attribute types).
+		/// Gets whether the parameter has an attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="parameter">The parameter on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>
@@ -569,7 +590,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		/// <summary>
-		/// Gets the attribute of the specified attribute type (or derived attribute types).
+		/// Gets the attribute of the specified attribute type.
 		/// </summary>
 		/// <param name="parameter">The parameter on which the attributes are declared.</param>
 		/// <param name="attributeType">The attribute type to look for.</param>

--- a/ICSharpCode.Decompiler/TypeSystem/VarArgInstanceMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/VarArgInstanceMethod.cs
@@ -118,6 +118,9 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		IEnumerable<IAttribute> IEntity.GetAttributes() => baseMethod.GetAttributes();
+		bool IEntity.HasAttribute(KnownAttribute attribute) => baseMethod.HasAttribute(attribute);
+		IAttribute IEntity.GetAttribute(KnownAttribute attribute) => baseMethod.GetAttribute(attribute);
+
 		IEnumerable<IAttribute> IMethod.GetReturnTypeAttributes() => baseMethod.GetReturnTypeAttributes();
 		bool IMethod.ReturnTypeIsRefReadOnly => baseMethod.ReturnTypeIsRefReadOnly;
 		bool IMethod.ThisIsRefReadOnly => baseMethod.ThisIsRefReadOnly;

--- a/ILSpy/Analyzers/Builtin/AttributeAppliedToAnalyzer.cs
+++ b/ILSpy/Analyzers/Builtin/AttributeAppliedToAnalyzer.cs
@@ -51,26 +51,7 @@ namespace ICSharpCode.ILSpy.Analyzers.Builtin
 		bool IsBuiltinAttribute(ITypeDefinition attributeType, out KnownAttribute knownAttribute)
 		{
 			knownAttribute = attributeType.IsBuiltinAttribute();
-			switch (knownAttribute)
-			{
-				case KnownAttribute.Serializable:
-				case KnownAttribute.ComImport:
-				case KnownAttribute.StructLayout:
-				case KnownAttribute.DllImport:
-				case KnownAttribute.PreserveSig:
-				case KnownAttribute.MethodImpl:
-				case KnownAttribute.FieldOffset:
-				case KnownAttribute.NonSerialized:
-				case KnownAttribute.MarshalAs:
-				case KnownAttribute.PermissionSet:
-				case KnownAttribute.Optional:
-				case KnownAttribute.In:
-				case KnownAttribute.Out:
-				case KnownAttribute.IndexerName:
-					return true;
-				default:
-					return false;
-			}
+			return !knownAttribute.IsCustomAttribute();
 		}
 
 		IEnumerable<IEnumerable<ISymbol>> HandleBuiltinAttribute(KnownAttribute attribute, AnalyzerScope scope, CancellationToken ct)


### PR DESCRIPTION
See #1204

Time spent in `AddDefinesForConditionalAttributes` is reduced from 136ms to 60ms. For the overall decompilation time this is not a significant change.