### PR TITLE
Optimize ILReader: don't create stack slots if we can directly created inlined ILAst

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -136,7 +136,7 @@ namespace ICSharpCode.Decompiler.CSharp
 							// run interleaved (statement by statement).
 							// Pretty much all transforms that open up new expression inlining
 							// opportunities belong in this category.
-							new ILInlining(),
+							new ILInlining() { options = InliningOptions.AllowInliningOfLdloca },
 							// Inlining must be first, because it doesn't trigger re-runs.
 							// Any other transform that opens up new inlining opportunities should call RequestRerun().
 							new ExpressionTransforms(),

--- a/ICSharpCode.Decompiler/Disassembler/ILParser.cs
+++ b/ICSharpCode.Decompiler/Disassembler/ILParser.cs
@@ -21,6 +21,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 
 using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.Util;
 
 namespace ICSharpCode.Decompiler.Disassembler
 {
@@ -121,6 +122,32 @@ namespace ICSharpCode.Decompiler.Disassembler
 			{
 				// tiny
 				return 1;
+			}
+		}
+
+		public static void SetBranchTargets(ref BlobReader blob, BitSet branchTargets)
+		{
+			while (blob.RemainingBytes > 0)
+			{
+				var opCode = DecodeOpCode(ref blob);
+				if (opCode == ILOpCode.Switch)
+				{
+					foreach (var target in DecodeSwitchTargets(ref blob))
+					{
+						if (target >= 0 && target < blob.Length)
+							branchTargets.Set(target);
+					}
+				}
+				else if (opCode.IsBranch())
+				{
+					int target = DecodeBranchTarget(ref blob, opCode);
+					if (target >= 0 && target < blob.Length)
+						branchTargets.Set(target);
+				}
+				else
+				{
+					SkipOperand(ref blob, opCode);
+				}
 			}
 		}
 	}

--- a/ICSharpCode.Decompiler/IL/BlockBuilder.cs
+++ b/ICSharpCode.Decompiler/IL/BlockBuilder.cs
@@ -123,7 +123,7 @@ namespace ICSharpCode.Decompiler.IL
 		Block currentBlock;
 		readonly Stack<BlockContainer> containerStack = new Stack<BlockContainer>();
 
-		public void CreateBlocks(BlockContainer mainContainer, List<ILInstruction> instructions, BitArray incomingBranches, CancellationToken cancellationToken)
+		public void CreateBlocks(BlockContainer mainContainer, List<ILInstruction> instructions, BitSet incomingBranches, CancellationToken cancellationToken)
 		{
 			CreateContainerStructure();
 			mainContainer.SetILRange(new Interval(0, body.GetCodeSize()));

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -189,7 +189,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			foreach (var block in function.Descendants.OfType<Block>())
 			{
 				// Run inlining, but don't remove dead variables (they might get revived by TranslateFieldsToLocalAccess)
-				ILInlining.InlineAllInBlock(function, block, context);
+				ILInlining.InlineAllInBlock(function, block, InliningOptions.None, context);
 				if (IsAsyncEnumerator)
 				{
 					// Remove lone 'ldc.i4', those are sometimes left over after C# compiler

--- a/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
@@ -60,7 +60,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		public void Run(Block block, int pos, StatementTransformContext context)
 		{
-			InlineOneIfPossible(block, pos, this.options | OptionsForBlock(block, pos, context), context: context);
+			var options = this.options | OptionsForBlock(block, pos, context);
+			while (InlineOneIfPossible(block, pos, options, context: context))
+			{
+				// repeat inlining until nothing changes.
+			}
 		}
 
 		internal static InliningOptions OptionsForBlock(Block block, int pos, ILTransformContext context)


### PR DESCRIPTION
This is a performance optimization: we dramatically reduce the amount of ILVariables created;
and thus need to spend less time in the first ILInlining run.
