### PR TITLE
Use latest VS SDK

### DIFF
--- a/ILSpy.AddIn.VS2022/ILSpy.AddIn.VS2022.csproj
+++ b/ILSpy.AddIn.VS2022/ILSpy.AddIn.VS2022.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.0.1" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/ILSpy.AddIn/ILSpy.AddIn.csproj
+++ b/ILSpy.AddIn/ILSpy.AddIn.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="2.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.4.0" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Update https://www.nuget.org/packages/Microsoft.VSSDK.BuildTools to 7.3.2093 to match https://github.com/actions/runner-images/blob/af3dd14fe039b539ac16336e571f761173676b3e/images/win/Windows2022-Readme.md 

Matching VS Build number to version: https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?preserve-view=true&view=vs-2022

Now both projects need latest VSSDK.