### PR TITLE
Refresh ready to run for .NET 7

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.13.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="6.0.0-rc.2.21424.11" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="7.0.0-rc.2.22451.11" />
     <!-- ILCompiler.Reflection.ReadyToRun has dependencies on System.Reflection.Metadata and
          System.Runtime.CompilerServices.Unsafe. Because the AddIn compiles into ILSpy's output
          directory, we're at risk of overwriting our dependencies with different versions.

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -52,7 +52,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		{
 		}
 
-		public void MarkFoldStart(string collapsedText = "...", bool defaultCollapsed = false)
+		public void MarkFoldStart(string collapsedText = "...", bool defaultCollapsed = false, bool isDefinition = false)
 		{
 		}
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,6 @@
   <packageSources>
     <add key="Nuget Official" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
+    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/packages.props
+++ b/packages.props
@@ -6,7 +6,7 @@
 	-->
 	<PropertyGroup>
 		<SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
-		<SystemReflectionMetadataVersion>6.0.0</SystemReflectionMetadataVersion>
+		<SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
 		<SystemCompilerServicesUnsafeVersion>6.0.0</SystemCompilerServicesUnsafeVersion>
 		<SystemCompositionVersion>6.0.0</SystemCompositionVersion>
 		<!-- Microsoft.NETCore.ILAsm -->


### PR DESCRIPTION
This change updates the `ILCompiler.Reflection.ReadyToRun.Experimental` package to a newer version to be compatible with .NET 7.