### PR TITLE
Do not use packages.props for ICS.D.csproj

### DIFF
--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -71,8 +71,8 @@
   <Import Project="..\packages.props" />
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
ICS.D is used downstream with specific package version requirements. ILSpy can use newer version. Currently both share the packages.props file and that way ICS.D could inadvertently pick up a newer version it shouldn't (eg via #2774)

To avoid that issue simply use fixed versions in the csproj and only let the rest of ILSpy pick up from packages.props.