### PR TITLE
Fix #2763: Improve enum

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/Switch.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/Switch.cs
@@ -37,6 +37,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			SwitchWithGoto(2);
 			SwitchWithGoto(3);
 			SwitchWithGoto(4);
+			SwitchWithEnum(5);
 		}
 
 		static void TestCase<T>(Func<T, string> target, params T[] args)
@@ -244,6 +245,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 					Console.WriteLine("default");
 					break;
 			}
+		}
+
+		public static void SwitchWithEnum(int i)
+		{
+			Console.WriteLine("SwitchWithEnum: " + i);
+			var color = (KnownColor)i;
+			switch (color)
+			{
+				case KnownColor.DarkBlue:
+					Console.WriteLine("one");
+					break;
+				case KnownColor.DarkCyan:
+					Console.WriteLine("two");
+					break;
+				default:
+					Console.WriteLine("default");
+					break;
+			}
+		}
+		
+		public enum KnownColor
+		{
+			DarkBlue = 749,
+			DarkCyan = 750,
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/ILVariable.cs
+++ b/ICSharpCode.Decompiler/IL/ILVariable.cs
@@ -199,6 +199,28 @@ namespace ICSharpCode.Decompiler.IL
 		public bool HasGeneratedName { get; set; }
 
 		/// <summary>
+		/// Is the variable declaration the casting of one type to another.
+		/// </summary>
+		public bool IsCast
+		{
+			get
+			{
+				if (StoreInstructions.Count != 1)
+					return false;
+				if (LoadInstructions.Count != 1)
+					return false;
+				var stLoc = StoreInstructions[0] as StLoc;
+				if (stLoc == null)
+					return false;
+				var ldLoc = stLoc.Value as LdLoc;
+				if (ldLoc == null)
+					return false;
+
+				return !HasGeneratedName && LoadInstructions[0].Variable.Type != ldLoc.Variable.Type;
+			}
+		}
+
+		/// <summary>
 		/// Gets the function in which this variable is declared.
 		/// </summary>
 		/// <remarks>

--- a/ICSharpCode.Decompiler/IL/Transforms/CopyPropagation.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CopyPropagation.cs
@@ -143,6 +143,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		static void DoPropagate(ILVariable v, ILInstruction copiedExpr, Block block, ref int i, ILTransformContext context)
 		{
 			context.Step($"Copy propagate {v.Name}", copiedExpr);
+
+			if (v.IsCast)
+				return;
+
 			// un-inline the arguments of the ldArg instruction
 			ILVariable[] uninlinedArgs = new ILVariable[copiedExpr.Children.Count];
 			for (int j = 0; j < uninlinedArgs.Length; j++)

--- a/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
@@ -179,6 +179,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return false;
 			if (v.LoadCount > 1 || v.LoadCount + v.AddressCount != 1)
 				return false;
+			if (v.IsCast)
+				return false;
 			// TODO: inlining of small integer types might be semantically incorrect,
 			// but we can't avoid it this easily without breaking lots of tests.
 			//if (v.Type.IsSmallIntegerType())


### PR DESCRIPTION
Enum in switch was replaced with the int incorrectly in some cases.

#2763

### Problem
The issue is related to the code that inlines multiple ldarg-stloc pairs in IL code into one variable (the classes ILInlining and CopyPropagation).
The following code samples were used to reproduce the issue
```csharp
public class TestClass
{
    public enum KnownColor
    {
        DarkBlue = 749,
        DarkCyan = 750,
    }

    public static void EnumReplacedWithIntIncorrectly(int intValue)
    {
        var color = (KnownColor)intValue;
        switch (color)
        {
            case KnownColor.DarkBlue:
                Console.WriteLine("DarkBlue");
                break;
            case KnownColor.DarkCyan:
                Console.WriteLine("DarkCyan");
                break;
        }
    }

    public static void EnumReplacedWithIntIncorrectly_AndIncorrectConditionGenerated_AndUnusedVariables(int intValue)
    {
        var color = (KnownColor)intValue;
        var color2 = (KnownColor)intValue;
        var color3 = (KnownColor)intValue;
        if (color == KnownColor.DarkBlue)
        {

        }

        if (color2 == KnownColor.DarkBlue)
        {

        }
    }

    public static void WorkedCorrectlyBefore(int intValue)
    {
        var color = (KnownColor)intValue;
        switch (color)
        {
            case KnownColor.DarkBlue:
                Console.WriteLine("DarkBlue: " + color);
                break;
            case KnownColor.DarkCyan:
                Console.WriteLine("DarkCyan: " + color);
                break;
        }
    }

    public static void WorkedCorrectlyBefore2(KnownColor color)
    {
        switch (color)
        {
            case KnownColor.DarkBlue:
                Console.WriteLine("DarkBlue");
                break;
            case KnownColor.DarkCyan:
                Console.WriteLine("DarkCyan");
                break;
        }
    }
}
```

### Solution
* Added a method `IsCast` that detects when the casting of types happens instead of just assignment.
* The `IsCast` method is called in ILInlining and CopyPropagation classes.
* Added `SwitchWithEnum` to Switch.cs (doesn't fail even before the changes, so need a piece of advice here).