### PR TITLE
Implement a fix for #2736

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/CSharpResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2013 AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) 2010-2013 AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -1760,7 +1760,7 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 			}
 			// then look for a type
 			ITypeDefinition def = n.GetTypeDefinition(identifier, k);
-			if (def != null)
+			if (def != null && TopLevelTypeDefinitionIsAccessible(def))
 			{
 				IType result = def;
 				if (parameterizeResultType && k > 0)


### PR DESCRIPTION
Link to issue(s) this covers
https://github.com/icsharpcode/ILSpy/issues/2736

### Problem
CSharpResolver had a bug that would result in it returning an inaccessible type.

### Solution
* Check if the type is accessible before returning it.

fixes #2736