### PR TITLE
Fix initialization of FakeProperty with setter 

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
@@ -15,9 +15,8 @@ namespace ClassLibrary1
 			//IL_0007: Expected O, but got Unknown
 			UnknownClass val = new UnknownClass();
 			int? unknownProperty = val.UnknownProperty;
-			int? num = unknownProperty.GetValueOrDefault();
-			val.UnknownProperty = num;
-			int? num2 = num;
+			int? num2 = (val.UnknownProperty = unknownProperty.GetValueOrDefault());
+			int? num3 = num2;
 			List<object> list = new List<object> {
 			val[unknownProperty.Value] ?? "",
 			val.NotProperty,
@@ -51,10 +50,9 @@ namespace ClassLibrary1
 			//IL_00e1: Expected O, but got Unknown
 			//IL_00e1: Expected O, but got Unknown
 			UnknownGenericClass<UnknownEventArgs> val = new UnknownGenericClass<UnknownEventArgs>();
-			UnknownEventArgs unknownProperty = val.UnknownProperty;
-			val.UnknownProperty = unknownProperty;
+			UnknownEventArgs val2 = (val.UnknownProperty = val.UnknownProperty);
 			List<object> list = new List<object> {
-				val[((object)unknownProperty).GetHashCode()] ?? "",
+				val[((object)val2).GetHashCode()] ?? "",
 				val.NotProperty,
 				val.get_NotPropertyWithGeneric<string>(42),
 				val[42],
@@ -63,18 +61,17 @@ namespace ClassLibrary1
 			};
 			val.OnEvent += Instance_OnEvent;
 			val.OnEvent -= Instance_OnEvent;
-			UnknownEventArgs val2 = val[(UnknownEventArgs)null];
-			val[new UnknownEventArgs()] = val2;
-			UnknownEventArgs val3 = val[new UnknownEventArgs(), new UnknownEventArgs()];
-			val[new UnknownEventArgs(), new UnknownEventArgs()] = val3;
+			UnknownEventArgs val3 = val[(UnknownEventArgs)null];
+			val[new UnknownEventArgs()] = val3;
+			UnknownEventArgs val4 = val[new UnknownEventArgs(), new UnknownEventArgs()];
+			val[new UnknownEventArgs(), new UnknownEventArgs()] = val4;
 		}
 
 		public void MethodUnknownStatic()
 		{
-			int? unknownProperty = UnknownStaticClass.UnknownProperty;
-			UnknownStaticClass.UnknownProperty = unknownProperty;
+			int? num = (UnknownStaticClass.UnknownProperty = UnknownStaticClass.UnknownProperty);
 			List<object> list = new List<object> {
-				UnknownStaticClass[unknownProperty.Value] ?? "",
+				UnknownStaticClass[num.Value] ?? "",
 				UnknownStaticClass.NotProperty,
 				UnknownStaticClass.get_NotPropertyWithGeneric<string>(42),
 				UnknownStaticClass[42],
@@ -87,10 +84,9 @@ namespace ClassLibrary1
 
 		public void MethodUnknownStaticGeneric()
 		{
-			string unknownProperty = UnknownStaticGenericClass<string>.UnknownProperty;
-			UnknownStaticGenericClass<string>.UnknownProperty = unknownProperty;
+			string text = (UnknownStaticGenericClass<string>.UnknownProperty = UnknownStaticGenericClass<string>.UnknownProperty);
 			List<object> list = new List<object> {
-				UnknownStaticGenericClass<string>[unknownProperty.Length] ?? "",
+				UnknownStaticGenericClass<string>[text.Length] ?? "",
 				UnknownStaticGenericClass<string>.NotProperty,
 				UnknownStaticGenericClass<string>.get_NotPropertyWithGeneric<string>(42),
 				UnknownStaticGenericClass<string>[42],

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
@@ -97,6 +97,15 @@ namespace ClassLibrary1
 			UnknownStaticGenericClass<string>.OnEvent -= Instance_OnEvent;
 		}
 
+		public void MethodUnknownIndexerInitializer()
+		{
+			//IL_0006: Unknown result type (might be due to invalid IL or missing references)
+			new UnknownClass {
+				["a"] = 1,
+				["b"] = 2
+			};
+		}
+
 		private void Instance_OnEvent(object sender, EventArgs e)
 		{
 			throw new NotImplementedException();

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.il
@@ -378,6 +378,28 @@
 		IL_0098: ret
 	} // end of method UnknownClassTest::MethodUnknownStaticGeneric
 
+	.method public hidebysig 
+		instance void MethodUnknownIndexerInitializer () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Code size 32 (0x20)
+		.maxstack 8
+
+		IL_0000: nop
+		IL_0001: newobj instance void [UnknownAssembly]UnknownNamespace.UnknownClass::.ctor()
+		IL_0006: dup
+		IL_0007: ldstr "a"
+		IL_000c: ldc.i4.1
+		IL_000d: callvirt instance void [UnknownAssembly]UnknownNamespace.UnknownClass::set_Item(string, int32)
+		IL_0012: nop
+		IL_0013: ldstr "b"
+		IL_0018: ldc.i4.2
+		IL_0019: callvirt instance void [UnknownAssembly]UnknownNamespace.UnknownClass::set_Item(string, int32)
+		IL_001e: nop
+		IL_001f: ret
+	} // end of method C::MethodUnknownIndexerInitializer
+
+
 	.method /* 100663301 */ private hidebysig 
 		instance void Instance_OnEvent (
 			object sender,

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -539,6 +539,8 @@ namespace ICSharpCode.Decompiler.CSharp
 		public ExpressionWithResolveResult BuildDictionaryInitializerExpression(OpCode callOpCode, IMethod method,
 			InitializedObjectResolveResult target, IReadOnlyList<ILInstruction> indices, ILInstruction value = null)
 		{
+			if (method is null)
+				throw new ArgumentNullException(nameof(method));
 			ExpectedTargetDetails expectedTargetDetails = new ExpectedTargetDetails { CallOpCode = callOpCode };
 
 			var callArguments = new List<ILInstruction>();

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -3340,6 +3340,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						{
 							var property = (IProperty)lastElement.Member;
 							Debug.Assert(property.IsIndexer);
+							Debug.Assert(property.Setter != null, $"Indexer property {property} has no setter");
 							elementsStack.Peek().Add(
 								new CallBuilder(this, typeSystem, settings)
 									.BuildDictionaryInitializerExpression(lastElement.OpCode, property.Setter, initObjRR, GetIndices(lastElement.Indices, indexVariables).ToList(), info.Values.Single())

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/FakeMember.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/FakeMember.cs
@@ -199,6 +199,16 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 		public bool IsIndexer { get; set; }
 		public bool ReturnTypeIsRefReadOnly => false;
 		public IReadOnlyList<IParameter> Parameters { get; set; }
+
+		public override string ToString() =>
+			"FakeProperty " + ReturnType + " " + DeclaringType.Name + "." + Name +
+				(Parameters.Count == 0
+					? ""
+					: "[" + string.Join(", ", Parameters) + "]") +
+				" { " +
+					(CanGet ? "get; " : "") +
+					(CanSet ? "set; " : "") +
+				"}";
 	}
 
 	sealed class FakeEvent : FakeMember, IEvent

--- a/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
@@ -670,7 +670,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 					m.AccessorKind = MethodSemanticsAttributes.Setter;
 					m.AccessorOwner = fakeProperty;
-					fakeProperty.Getter = m;
+					fakeProperty.Setter = m;
 					fakeProperty.ReturnType = parameters.Last().Type;
 					fakeProperty.IsIndexer = parameters.Count > 1;
 					fakeProperty.Parameters = parameters.SkipLast(1).ToArray();


### PR DESCRIPTION
ILSpy crashed with NullReferenceException when it couldn't resolve some dependency (Newtonsoft.Json in my case, the problem was around `JObject.Item[string]` indexer)

Seems like a typo when FakeProperty is initialized - the setter method was assigned to the Getter property
### Solution

First commit contains the actual fix.

In the second commit I included some asserts and a ToString implementation I used to debug the problem. I'm guessing that more asserts would be welcome, but if you don't like it, just merge only the first commit.


* [x] At least one test covering the code changed
  - Sorry, but I couldn't make the tests run on Linux, is there any way?
  - I also don't know how to replicate this problem in unit tests - I'd have to compile a dll against some library which the decompiler won't see at runtime.

