### PR TITLE
Add option to display row numbers in hex

### DIFF
--- a/ILSpy/Metadata/Helpers.cs
+++ b/ILSpy/Metadata/Helpers.cs
@@ -94,11 +94,22 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		internal static void View_AutoGeneratingColumn(object sender, DataGridAutoGeneratingColumnEventArgs e)
 		{
+			var displaySettings = MainWindow.Instance.CurrentDisplaySettings;
 			var binding = new Binding(e.PropertyName) { Mode = BindingMode.OneWay };
 			e.Column = GetColumn();
 			switch (e.PropertyName)
 			{
 				case "RID":
+					if (displaySettings.ShowRowNumbersInBase16)
+					{
+						binding.StringFormat = "X";
+						e.Column.SetTemplate((ControlTemplate)MetadataTableViews.Instance["HexFilter"]);
+					}
+					else
+					{
+						e.Column.SetTemplate((ControlTemplate)MetadataTableViews.Instance["DefaultFilter"]);
+					}
+					break;
 				case "Meaning":
 					e.Column.SetTemplate((ControlTemplate)MetadataTableViews.Instance["DefaultFilter"]);
 					break;

--- a/ILSpy/Options/DisplaySettings.cs
+++ b/ILSpy/Options/DisplaySettings.cs
@@ -117,6 +117,19 @@ namespace ICSharpCode.ILSpy.Options
 			}
 		}
 
+		bool showRowNumbersInBase16;
+
+		public bool ShowRowNumbersInBase16 {
+			get { return showRowNumbersInBase16; }
+			set {
+				if (showRowNumbersInBase16 != value)
+				{
+					showRowNumbersInBase16 = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		bool enableWordWrap;
 
 		public bool EnableWordWrap {
@@ -319,6 +332,7 @@ namespace ICSharpCode.ILSpy.Options
 			this.ShowLineNumbers = s.showLineNumbers;
 			this.ShowMetadataTokens = s.showMetadataTokens;
 			this.ShowMetadataTokensInBase10 = s.showMetadataTokensInBase10;
+			this.ShowRowNumbersInBase16 = s.showRowNumbersInBase16;
 			this.ShowDebugInfo = s.showDebugInfo;
 			this.EnableWordWrap = s.enableWordWrap;
 			this.SortResults = s.sortResults;

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -97,6 +97,7 @@
 				<StackPanel Margin="3">
 					<CheckBox IsChecked="{Binding SortResults}" Content="{x:Static properties:Resources.SortResultsFitness}"></CheckBox>
 					<CheckBox IsChecked="{Binding StyleWindowTitleBar}" Content="{x:Static properties:Resources.StyleTheWindowTitleBar}"></CheckBox>
+					<CheckBox IsChecked="{Binding ShowRowNumbersInBase16}" Content="{x:Static properties:Resources.ShowRowNumbersInBase16}"></CheckBox>
 				</StackPanel>
 			</GroupBox>
 		</StackPanel>

--- a/ILSpy/Options/DisplaySettingsPanel.xaml.cs
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml.cs
@@ -103,6 +103,7 @@ namespace ICSharpCode.ILSpy.Options
 			s.ShowLineNumbers = (bool?)e.Attribute("ShowLineNumbers") ?? false;
 			s.ShowMetadataTokens = (bool?)e.Attribute("ShowMetadataTokens") ?? false;
 			s.ShowMetadataTokensInBase10 = (bool?)e.Attribute("ShowMetadataTokensInBase10") ?? false;
+			s.ShowRowNumbersInBase16 = (bool?)e.Attribute("ShowRowNumbersInBase16") ?? false;
 			s.ShowDebugInfo = (bool?)e.Attribute("ShowDebugInfo") ?? false;
 			s.EnableWordWrap = (bool?)e.Attribute("EnableWordWrap") ?? false;
 			s.SortResults = (bool?)e.Attribute("SortResults") ?? true;
@@ -132,6 +133,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("ShowLineNumbers", s.ShowLineNumbers);
 			section.SetAttributeValue("ShowMetadataTokens", s.ShowMetadataTokens);
 			section.SetAttributeValue("ShowMetadataTokensInBase10", s.ShowMetadataTokensInBase10);
+			section.SetAttributeValue("ShowRowNumbersInBase16", s.ShowRowNumbersInBase16);
 			section.SetAttributeValue("ShowDebugInfo", s.ShowDebugInfo);
 			section.SetAttributeValue("EnableWordWrap", s.EnableWordWrap);
 			section.SetAttributeValue("SortResults", s.SortResults);

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -2539,6 +2539,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show row numbers in base 16.
+        /// </summary>
+        public static string ShowRowNumbersInBase16 {
+            get {
+                return ResourceManager.GetString("ShowRowNumbersInBase16", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show state after this step.
         /// </summary>
         public static string ShowStateAfterThisStep {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -862,6 +862,9 @@ Do you want to continue?</value>
   <data name="ShowRawOffsetsAndBytesBeforeInstruction" xml:space="preserve">
     <value>Show raw offsets and bytes before each instruction</value>
   </data>
+  <data name="ShowRowNumbersInBase16" xml:space="preserve">
+    <value>Show row numbers in base 16</value>
+  </data>
   <data name="ShowStateAfterThisStep" xml:space="preserve">
     <value>Show state after this step</value>
   </data>


### PR DESCRIPTION
Link to issue(s) this covers
https://github.com/icsharpcode/ILSpy/issues/2204 maybe? Not exactly clear what that issue is asking for.

### Problem
I'm preparing a talk about metadata tables, and showing lots of screenshots of ILSpy, and it struck me as odd that I could point to a metadata token of `0600000C` but when looking at the Method table, there was no row that had a RID of `C`.

### Solution
Looks like this:
![ILSpyHexRowNumbers](https://user-images.githubusercontent.com/754264/194037141-cfe0273e-d217-4ea6-b866-965792bf9c3a.gif)

Couldn't see any relevant tests for this area, but let me know if I missed something.