### PR TITLE
Add progress reporting to PortablePdbWriter

### DIFF
--- a/ICSharpCode.Decompiler.PowerShell/GetDecompiledProjectCmdlet.cs
+++ b/ICSharpCode.Decompiler.PowerShell/GetDecompiledProjectCmdlet.cs
@@ -33,8 +33,8 @@ namespace ICSharpCode.Decompiler.PowerShell
 			lock (syncObject)
 			{
 				completed++;
-				progress = new ProgressRecord(1, "Decompiling " + fileName, $"Completed {completed} of {value.TotalNumberOfFiles}: {value.Status}") {
-					PercentComplete = (int)(completed * 100.0 / value.TotalNumberOfFiles)
+				progress = new ProgressRecord(1, "Decompiling " + fileName, $"Completed {completed} of {value.TotalUnits}: {value.Status}") {
+					PercentComplete = (int)(completed * 100.0 / value.TotalUnits)
 				};
 			}
 		}

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -312,6 +312,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="TestCases\PdbGen\ProgressReporting.xml" />
     <Content Include="TestCases\PdbGen\ForLoopTests.xml" />
     <Content Include="TestCases\PdbGen\CustomPdbId.xml" />
     <Content Include="TestCases\PdbGen\HelloWorld.xml" />

--- a/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
@@ -81,17 +81,17 @@ namespace ICSharpCode.Decompiler.Tests
 			var lastFilesWritten = 0;
 			var totalFiles = -1;
 
-			Action<WritePortablePdbProgress> reportFunc = progress => {
+			Action<DecompilationProgress> reportFunc = progress => {
 				if (totalFiles == -1)
 				{
 					// Initialize value on first call
-					totalFiles = progress.TotalFiles;
+					totalFiles = progress.TotalUnits;
 				}
 
-				Assert.AreEqual(progress.TotalFiles, totalFiles);
-				Assert.AreEqual(progress.FilesWritten, lastFilesWritten + 1);
+				Assert.AreEqual(progress.TotalUnits, totalFiles);
+				Assert.AreEqual(progress.UnitsCompleted, lastFilesWritten + 1);
 
-				lastFilesWritten = progress.FilesWritten;
+				lastFilesWritten = progress.UnitsCompleted;
 			};
 
 			using (FileStream pdbStream = File.Open(Path.Combine(TestCasePath, nameof(ProgressReporting) + ".pdb"), FileMode.OpenOrCreate, FileAccess.ReadWrite))
@@ -107,16 +107,16 @@ namespace ICSharpCode.Decompiler.Tests
 			Assert.AreEqual(totalFiles, lastFilesWritten);
 		}
 
-		private class TestProgressReporter : IProgress<WritePortablePdbProgress>
+		private class TestProgressReporter : IProgress<DecompilationProgress>
 		{
-			private Action<WritePortablePdbProgress> reportFunc;
+			private Action<DecompilationProgress> reportFunc;
 
-			public TestProgressReporter(Action<WritePortablePdbProgress> reportFunc)
+			public TestProgressReporter(Action<DecompilationProgress> reportFunc)
 			{
 				this.reportFunc = reportFunc;
 			}
 
-			public void Report(WritePortablePdbProgress value)
+			public void Report(DecompilationProgress value)
 			{
 				reportFunc(value);
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/CustomPdbId.xml
+++ b/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/CustomPdbId.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <symbols>
   <files>
-    <file id="1" name="ICSharpCode.Decompiler.Tests.TestCases.PdbGen\HelloWorld.cs" language="C#" checksumAlgorithm="SHA256"><![CDATA[using System;
+    <file id="1" name="ICSharpCode.Decompiler.Tests.TestCases.PdbGen\CustomPdbId.cs" language="C#" checksumAlgorithm="SHA256"><![CDATA[using System;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.PdbGen;
 
-public class HelloWorld
+public class CustomPdbId
 {
 	public static void Main(string[] args)
 	{

--- a/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/ProgressReporting.xml
+++ b/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/ProgressReporting.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<symbols>
+  <files>
+    <file id="1" name="ICSharpCode.Decompiler.Tests.TestCases.PdbGen\ProgressReporting.cs" language="C#" checksumAlgorithm="SHA256">
+	<![CDATA[using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.PdbGen;
+
+public class ProgressReporting
+{
+	public static void Main(string[] args)
+	{
+		Console.ReadKey();
+		Console.WriteLine("Hello World!");
+		Console.ReadKey();
+	}
+}
+
+public class Class1
+{
+	public static void Test()
+	{
+		Console.WriteLine("Class1");
+	}
+}
+
+public class Class2
+{
+	public static void Test()
+	{
+		Console.WriteLine("Class2");
+	}
+}
+
+public class Class3
+{
+	public static void Test()
+	{
+		Console.WriteLine("Class3");
+	}
+}
+]]></file>
+  </files>
+</symbols>

--- a/ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs
@@ -41,12 +41,6 @@ using ICSharpCode.Decompiler.Util;
 
 namespace ICSharpCode.Decompiler.DebugInfo
 {
-	public struct WritePortablePdbProgress
-	{
-		public int TotalFiles { get; internal set; }
-		public int FilesWritten { get; internal set; }
-	}
-
 	public class PortablePdbWriter
 	{
 		static readonly FileVersionInfo decompilerVersion = FileVersionInfo.GetVersionInfo(typeof(CSharpDecompiler).Assembly.Location);
@@ -63,7 +57,7 @@ namespace ICSharpCode.Decompiler.DebugInfo
 			Stream targetStream,
 			bool noLogo = false,
 			BlobContentId? pdbId = null,
-			IProgress<WritePortablePdbProgress> progress = null)
+			IProgress<DecompilationProgress> progress = null)
 		{
 			MetadataBuilder metadata = new MetadataBuilder();
 			MetadataReader reader = file.Metadata;
@@ -87,9 +81,10 @@ namespace ICSharpCode.Decompiler.DebugInfo
 			}
 
 			var sourceFiles = reader.GetTopLevelTypeDefinitions().GroupBy(BuildFileNameFromTypeName).ToList();
-			WritePortablePdbProgress currentProgress = new WritePortablePdbProgress() {
-				TotalFiles = sourceFiles.Count,
-				FilesWritten = 0
+			DecompilationProgress currentProgress = new() {
+				TotalUnits = sourceFiles.Count,
+				UnitsCompleted = 0,
+				Title = "Generating portable PDB..."
 			};
 
 			foreach (var sourceFile in sourceFiles)
@@ -99,7 +94,7 @@ namespace ICSharpCode.Decompiler.DebugInfo
 
 				if (progress != null)
 				{
-					currentProgress.FilesWritten++;
+					currentProgress.UnitsCompleted++;
 					progress.Report(currentProgress);
 				}
 

--- a/ICSharpCode.Decompiler/DecompilationProgress.cs
+++ b/ICSharpCode.Decompiler/DecompilationProgress.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2022 AlphaSierraPapa for the SharpDevelop Team
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+namespace ICSharpCode.Decompiler
+{
+	/// <summary>
+	/// Information used for (optional) progress reporting by the decompiler.
+	/// </summary>
+	public struct DecompilationProgress
+	{
+		/// <summary>
+		/// The total number of units to process. If set to a value &lt;= 0, an indeterminate progress bar is displayed.
+		/// </summary>
+		public int TotalUnits;
+
+		/// <summary>
+		/// The number of units currently completed. Should be a positive number.
+		/// </summary>
+		public int UnitsCompleted;
+
+		/// <summary>
+		/// Optional information displayed alongside the progress bar.
+		/// </summary>
+		public string? Status;
+
+		/// <summary>
+		/// Optional custom title for the operation.
+		/// </summary>
+		public string? Title;
+	}
+}

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -90,6 +90,7 @@
     <Compile Include="CSharp\Annotations.cs" />
     <Compile Include="CSharp\CallBuilder.cs" />
     <Compile Include="CSharp\CSharpLanguageVersion.cs" />
+    <Compile Include="DecompilationProgress.cs" />
     <Compile Include="NRTAttributes.cs" />
     <Compile Include="PartialTypeInfo.cs" />
     <Compile Include="CSharp\ProjectDecompiler\IProjectFileWriter.cs" />

--- a/ILSpy/Commands/GeneratePdbContextMenuEntry.cs
+++ b/ILSpy/Commands/GeneratePdbContextMenuEntry.cs
@@ -75,12 +75,14 @@ namespace ICSharpCode.ILSpy
 			Docking.DockWorkspace.Instance.RunWithCancellation(ct => Task<AvalonEditTextOutput>.Factory.StartNew(() => {
 				AvalonEditTextOutput output = new AvalonEditTextOutput();
 				Stopwatch stopwatch = Stopwatch.StartNew();
+				options.CancellationToken = ct;
 				using (FileStream stream = new FileStream(fileName, FileMode.OpenOrCreate, FileAccess.Write))
 				{
 					try
 					{
 						var decompiler = new CSharpDecompiler(file, assembly.GetAssemblyResolver(), options.DecompilerSettings);
-						PortablePdbWriter.WritePdb(file, decompiler, options.DecompilerSettings, stream);
+						decompiler.CancellationToken = ct;
+						PortablePdbWriter.WritePdb(file, decompiler, options.DecompilerSettings, stream, progress: options.Progress);
 					}
 					catch (OperationCanceledException)
 					{

--- a/ILSpy/DecompilationOptions.cs
+++ b/ILSpy/DecompilationOptions.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Threading;
 
+using ICSharpCode.Decompiler;
 using ICSharpCode.ILSpy.Options;
 using ICSharpCode.ILSpyX;
 
@@ -54,6 +55,14 @@ namespace ICSharpCode.ILSpy
 		/// to allow for cooperative cancellation of the decompilation task.
 		/// </remarks>
 		public CancellationToken CancellationToken { get; set; }
+
+		/// <summary>
+		/// Gets the progress reporter.
+		/// </summary>
+		/// <remarks>
+		/// If decompilers do not implement progress reporting, an indeterminate wait bar is displayed.
+		/// </remarks>
+		public IProgress<DecompilationProgress> Progress { get; set; }
 
 		/// <summary>
 		/// Gets the settings for the decompiler.

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -404,6 +404,7 @@ namespace ICSharpCode.ILSpy
 					options.DecompilerSettings.UseSdkStyleProjectFormat = false;
 				}
 				var decompiler = new ILSpyWholeProjectDecompiler(assembly, options);
+				decompiler.ProgressIndicator = options.Progress;
 				return decompiler.DecompileProject(module, options.SaveAsProjectDirectory, new TextOutputWriter(output), options.CancellationToken);
 			}
 			else

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -105,7 +105,11 @@ namespace ICSharpCode.ILSpy
 
 		public DisplaySettings CurrentDisplaySettings { get; internal set; }
 
-		public DecompilationOptions CreateDecompilationOptions() => new DecompilationOptions(CurrentLanguageVersion, CurrentDecompilerSettings, CurrentDisplaySettings);
+		public DecompilationOptions CreateDecompilationOptions()
+		{
+			var decompilerView = DockWorkspace.Instance.ActiveTabPage.Content as IProgress<DecompilationProgress>;
+			return new DecompilationOptions(CurrentLanguageVersion, CurrentDecompilerSettings, CurrentDisplaySettings) { Progress = decompilerView };
+		}
 
 		public MainWindow()
 		{

--- a/ILSpy/TextView/DecompilerTextView.xaml
+++ b/ILSpy/TextView/DecompilerTextView.xaml
@@ -20,8 +20,7 @@
 				               folding:FoldingMargin.FoldingMarkerBackgroundBrush="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
 				               folding:FoldingMargin.SelectedFoldingMarkerBackgroundBrush="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
 				               folding:FoldingMargin.FoldingMarkerBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"
-				               folding:FoldingMargin.SelectedFoldingMarkerBrush="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-				               >
+				               folding:FoldingMargin.SelectedFoldingMarkerBrush="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
 					<ae:TextEditor.Resources>
 						<!-- prevent App-wide button style from applying to the buttons in the search box -->
 						<Style TargetType="{x:Type Button}">
@@ -78,11 +77,19 @@
 					</ae:TextEditor.Template>
 				</ae:TextEditor>
 				<Border Name="waitAdorner" Background="{StaticResource waitAdornerBackgoundBrush}" Visibility="Collapsed">
-					<StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-						<TextBlock FontSize="14pt" Text="{x:Static properties:Resources.Decompiling}"/>
-						<ProgressBar Name="progressBar" Height="16" Margin="0, 4" />
-						<Button Click="CancelButton_Click" HorizontalAlignment="Center"  Content="{x:Static properties:Resources.Cancel}"/>
-					</StackPanel>
+					<Grid>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="2*" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+						<StackPanel Grid.Column="1" VerticalAlignment="Center">
+							<TextBlock Name="progressTitle" FontSize="14pt" Text="{x:Static properties:Resources.Decompiling}" Margin="3"/>
+							<ProgressBar Name="progressBar" Height="16" />
+							<TextBlock Name="progressText" Visibility="Collapsed" Margin="3" />
+							<Button Click="CancelButton_Click" HorizontalAlignment="Center" Margin="3" Content="{x:Static properties:Resources.Cancel}"/>
+						</StackPanel>
+					</Grid>
 				</Border>
 			</Grid>
 		</Border>


### PR DESCRIPTION
### Problem
As discussed in #2801, the Visual Studio debugger would like to be able to provide better progress feedback to users while a decompilation operation is in progress.

### Solution
This commit adds a new parameter to `PortablePdbWriter.WritePdb` that allows the caller to provide an implementation of `IProgress<>` to receive status updates on the pdb generation process.  Currently, the progress reports include the number of files generated so far and the total number of files.

#2801 mentions adding progress reporting to `WholeProjectDecompiler` as well, but that appears to already be present - see: https://github.com/icsharpcode/ILSpy/blob/master/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs#L256

* [x] At least one test covering the code changed

