### PR TITLE
Include assembly name in decompiled code

### DIFF
--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -156,6 +156,7 @@ namespace ICSharpCode.ILSpy
 			CSharpDecompiler decompiler = CreateDecompiler(assembly, options);
 			AddReferenceAssemblyWarningMessage(assembly, output);
 			AddReferenceWarningMessage(assembly, output);
+			WriteCommentLine(output, assembly.FullName);
 			WriteCommentLine(output, TypeToString(method.DeclaringType, includeNamespace: true));
 			var methodDefinition = decompiler.TypeSystem.MainModule.ResolveEntity(method.MetadataToken) as IMethod;
 			if (methodDefinition.IsConstructor && methodDefinition.DeclaringType.IsReferenceType != false)
@@ -237,6 +238,7 @@ namespace ICSharpCode.ILSpy
 			CSharpDecompiler decompiler = CreateDecompiler(assembly, options);
 			AddReferenceAssemblyWarningMessage(assembly, output);
 			AddReferenceWarningMessage(assembly, output);
+			WriteCommentLine(output, assembly.FullName);
 			WriteCommentLine(output, TypeToString(property.DeclaringType, includeNamespace: true));
 			WriteCode(output, options.DecompilerSettings, decompiler.Decompile(property.MetadataToken), decompiler.TypeSystem);
 		}
@@ -247,6 +249,7 @@ namespace ICSharpCode.ILSpy
 			CSharpDecompiler decompiler = CreateDecompiler(assembly, options);
 			AddReferenceAssemblyWarningMessage(assembly, output);
 			AddReferenceWarningMessage(assembly, output);
+			WriteCommentLine(output, assembly.FullName);
 			WriteCommentLine(output, TypeToString(field.DeclaringType, includeNamespace: true));
 			if (field.IsConst)
 			{
@@ -315,6 +318,7 @@ namespace ICSharpCode.ILSpy
 			CSharpDecompiler decompiler = CreateDecompiler(assembly, options);
 			AddReferenceAssemblyWarningMessage(assembly, output);
 			AddReferenceWarningMessage(assembly, output);
+			WriteCommentLine(output, assembly.FullName);
 			WriteCommentLine(output, TypeToString(@event.DeclaringType, includeNamespace: true));
 			WriteCode(output, options.DecompilerSettings, decompiler.Decompile(@event.MetadataToken), decompiler.TypeSystem);
 		}
@@ -325,6 +329,7 @@ namespace ICSharpCode.ILSpy
 			CSharpDecompiler decompiler = CreateDecompiler(assembly, options);
 			AddReferenceAssemblyWarningMessage(assembly, output);
 			AddReferenceWarningMessage(assembly, output);
+			WriteCommentLine(output, assembly.FullName);
 			WriteCommentLine(output, TypeToString(type, includeNamespace: true));
 			WriteCode(output, options.DecompilerSettings, decompiler.Decompile(type.MetadataToken), decompiler.TypeSystem);
 		}


### PR DESCRIPTION
### Problem

When exploring decompiled methods and other members and jumping all around through analysis tree, inheritance etc., it is difficult to figure out to which assembly the currently displayed code belongs. On has to scroll the treeview to an exact narrow position, or just keep collapsing it manually.

### Solution

The proposed solution is to include the assembly name as a comment above the existing comment containing full type name.

Another approach would be to include it with the type comment in `CSharpAmbience.ConvertSymbol`, possibly using `ConversionFlags.UseAssemblyName`, but that seemed unnecessarily complex.

Namespaces do not show assembly because it is not readily available around.


This does not come with tests, happy to add some if deemed necessary and given some pointers whereabouts are similar tests e.g. for the type comment. `assembly` cannot be null because `CreateDecompiler` already dereferences it.