### PR TITLE
Provide an option for emitting `<Module>`.

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -331,6 +331,8 @@ namespace ICSharpCode.Decompiler.CSharp
 					}
 					if (settings.ArrayInitializers && settings.SwitchStatementOnString && name.StartsWith("<PrivateImplementationDetails>", StringComparison.Ordinal))
 						return true;
+					if (!settings.EmitModuleType && name == "<Module>")
+						return true;
 					return false;
 				case HandleKind.FieldDefinition:
 					var fieldHandle = (FieldDefinitionHandle)member;

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -169,7 +169,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 		{
 			var metadata = module.Metadata;
 			var typeDef = metadata.GetTypeDefinition(type);
-			if (metadata.GetString(typeDef.Name) == "<Module>" || CSharpDecompiler.MemberIsHidden(module, type, Settings))
+			if (CSharpDecompiler.MemberIsHidden(module, type, Settings))
 				return false;
 			if (metadata.GetString(typeDef.Namespace) == "XamlGeneratedNamespace" && metadata.GetString(typeDef.Name) == "GeneratedInternalTypeHelper")
 				return false;

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -1003,6 +1003,24 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		bool emitModuleType = false;
+
+		/// <summary>
+		/// Gets/Sets whether to emit the &lt;Module&gt; type.
+		/// </summary>
+		[Category("Other")]
+		[Description("DecompilerSettings.EmitModuleType")]
+		public bool EmitModuleType {
+			get { return emitModuleType; }
+			set {
+				if (emitModuleType != value)
+				{
+					emitModuleType = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		bool arrayInitializers = true;
 
 		/// <summary>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -964,6 +964,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Emit the &lt;Module&gt; type..
+        /// </summary>
+        public static string DecompilerSettings_EmitModuleType {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.EmitModuleType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use file-scoped namespace declarations.
         /// </summary>
         public static string DecompilerSettings_FileScopedNamespaces {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -345,6 +345,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.DoWhileStatement" xml:space="preserve">
     <value>Transform to do-while, if possible</value>
   </data>
+  <data name="DecompilerSettings.EmitModuleType" xml:space="preserve">
+    <value>Emit the &lt;Module&gt; type.</value>
+  </data>
   <data name="DecompilerSettings.FSpecificOptions" xml:space="preserve">
     <value>F#-specific options</value>
   </data>


### PR DESCRIPTION
This is set to "false" by default, so no behavioral change for those not interested in the `<Module>`.

Fixes https://github.com/icsharpcode/ILSpy/issues/2807

### Problem
I would like to be able to optionally emit the `<Module>` to disk.

### Solution
Added a new **Other** option that permits the user to emit the `<Module>` if desired.

![image](https://user-images.githubusercontent.com/30635565/197830863-21af2681-7791-4d90-8e00-45605cf1a321.png)


