### PR TITLE
Fix dynamic type index calculation in `ApplyAttributeTypeVisitor`

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
@@ -47,6 +47,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 
 		private static dynamic field;
+		private static volatile dynamic volatileField;
 		private static object objectField;
 		public dynamic Property { get; set; }
 

--- a/ICSharpCode.Decompiler/TypeSystem/ApplyAttributeTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ApplyAttributeTypeVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Daniel Grunwald
+// Copyright (c) 2018 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -40,8 +40,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			SRM.MetadataReader metadata,
 			TypeSystemOptions options,
 			Nullability nullableContext,
-			bool typeChildrenOnly = false,
-			bool isSignatureReturnType = false)
+			bool typeChildrenOnly = false)
 		{
 			bool hasDynamicAttribute = false;
 			bool[] dynamicAttributeData = null;
@@ -134,14 +133,6 @@ namespace ICSharpCode.Decompiler.TypeSystem
 					options, tupleElementNames,
 					nullability, nullableAttributeData
 				);
-				if (isSignatureReturnType && hasDynamicAttribute
-					&& inputType.SkipModifiers().Kind == TypeKind.ByReference
-					&& attributes.Value.HasKnownAttribute(metadata, KnownAttribute.IsReadOnly))
-				{
-					// crazy special case: `ref readonly` return takes one dynamic index more than
-					// a non-readonly `ref` return.
-					visitor.dynamicTypeIndex++;
-				}
 				if (typeChildrenOnly)
 				{
 					return inputType.VisitChildren(visitor);
@@ -190,6 +181,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		public override IType VisitModOpt(ModifiedType type)
 		{
+			dynamicTypeIndex++;
 			if ((options & TypeSystemOptions.KeepModifiers) != 0)
 				return base.VisitModOpt(type);
 			else
@@ -198,6 +190,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		public override IType VisitModReq(ModifiedType type)
 		{
+			dynamicTypeIndex++;
 			if ((options & TypeSystemOptions.KeepModifiers) != 0)
 				return base.VisitModReq(type);
 			else

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Daniel Grunwald
+// Copyright (c) 2018 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -225,7 +225,6 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				if (ty is ModifiedType mod && mod.Modifier.Name == "IsVolatile" && mod.Modifier.Namespace == "System.Runtime.CompilerServices")
 				{
 					Volatile.Write(ref this.isVolatile, true);
-					ty = mod.ElementType;
 				}
 				ty = ApplyAttributeTypeVisitor.ApplyAttributesToType(ty, Compilation,
 					fieldDef.GetCustomAttributes(), metadata, module.OptionsForEntity(this),

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataMethod.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataMethod.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Daniel Grunwald
+// Copyright (c) 2018 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -271,8 +271,7 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			}
 			Debug.Assert(i == parameters.Length);
 			var returnType = ApplyAttributeTypeVisitor.ApplyAttributesToType(signature.ReturnType,
-				module.Compilation, returnTypeAttributes, metadata, typeSystemOptions, nullableContext,
-				isSignatureReturnType: true);
+				module.Compilation, returnTypeAttributes, metadata, typeSystemOptions, nullableContext);
 			return (returnType, parameters, signature.ReturnType as ModifiedType);
 		}
 		#endregion


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
ILSpy did not correctly decompile `volatile dynamic` fields.

Example:
```csharp
static volatile dynamic volatileField;
```
would decompile to:
```csharp
static volatile object volatileField;
```
The issue lies in the implementation of `ApplyAttributeTypeVisitor`. This class did not properly handle modifier signatures (`CModOpt` and `CModReqd`) which are used to indicate that a field is volatile.

Roslyn implementation: https://github.com/dotnet/roslyn/blob/29cdbf9a70ae83e6b7b914182fc78a7ed122a0a0/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs#L850

### Solution
Modifier signatures are now correctly handled. The `dynamicTypeIndex` is incremented for every modifier type to match Roslyn's behavior when it generates the `DynamicAttribute` attributes. The "crazy special case" for readonly return types has been removed as those include a modifier signature of `InAttribute`.

The `dynamic` "pretty" test was extended to include a `dynamic volatile` field.

