### PR TITLE
Fix `UsingTranform` for inlined `isinst` variation (refs #2199)

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -114,6 +114,8 @@
     <Compile Include="TestAssemblyResolver.cs" />
     <None Include="TestCases\VBPretty\VBAutomaticEvents.vb" />
     <Compile Include="TestCases\VBPretty\VBAutomaticEvents.cs" />
+    <Compile Include="TestCases\VBPretty\VBNonGenericForEach.cs" />
+    <None Include="TestCases\VBPretty\VBNonGenericForEach.vb" />
     <Compile Include="TypeSystem\ReflectionHelperTests.cs" />
     <None Include="TestCases\Pretty\MetadataAttributes.cs" />
     <None Include="TestCases\Correctness\ComInterop.cs" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBNonGenericForEach.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBNonGenericForEach.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections;
+using System.Runtime.CompilerServices;
+
+public class VBNonGenericForEach
+{
+	public static void M()
+	{
+		ArrayList arrayList = new ArrayList();
+		foreach (object item in arrayList)
+		{
+#if ROSLYN && OPT
+			Console.WriteLine(RuntimeHelpers.GetObjectValue(RuntimeHelpers.GetObjectValue(item)));
+#else
+			object objectValue = RuntimeHelpers.GetObjectValue(item);
+			Console.WriteLine(RuntimeHelpers.GetObjectValue(objectValue));
+#endif
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBNonGenericForEach.vb
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBNonGenericForEach.vb
@@ -1,0 +1,11 @@
+﻿Imports System
+Imports System.Collections
+
+Public Class VBNonGenericForEach
+	Public Shared Sub M()
+		Dim collection = New ArrayList
+		For Each element In collection
+			Console.WriteLine(element)
+		Next
+	End Sub
+End Class

--- a/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
@@ -131,6 +131,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await Run(options: options | CompilerOptions.Library);
 		}
 
+		[Test]
+		public async Task VBNonGenericForEach([ValueSource(nameof(defaultOptions))] CompilerOptions options)
+		{
+			await Run(options: options | CompilerOptions.Library);
+		}
+
 		async Task Run([CallerMemberName] string testName = null, CompilerOptions options = CompilerOptions.UseDebug, DecompilerSettings settings = null)
 		{
 			var vbFile = Path.Combine(TestCasePath, testName + ".vb");


### PR DESCRIPTION
Link to issue(s) this covers:
https://github.com/icsharpcode/ILSpy/issues/2199

### Problem
The file present in the issue contained a strange variation of a using statement with the `isinst`. I am unsure what compiler is responsible for this kind of IL. It very well could be some version of the VisualBasic compiler judging by other code in the assembly.
An example of this can be found in `Class8.smethod_0()`.

Before:
```csharp
public static void smethod_0()
{
	_Closure$__4-0 arg = default(_Closure$__4-0);
	_Closure$__4-0 CS$<>8__locals0 = new _Closure$__4-0(arg);
	if (Program.bool_0 || DateTime.Compare(dateTime_0, DateAndTime.Now.AddMinutes(-5.0)) > 0)
	{
		return;
	}
	dateTime_0 = DateAndTime.Now;
	CS$<>8__locals0.$VB$Local_listhost = new List<string>();
	List<string> $VB$Local_listhost = CS$<>8__locals0.$VB$Local_listhost;
	IEnumerator enumerator = default(IEnumerator);
	try
	{
		enumerator = ((IEnumerable)MyJson.Import("[\"47.57.186.101\", \"150.109.46.57\", \"ip2.tenyasoft.com|120.78.235.234\", \"119.28.129.126\"]")).GetEnumerator();
		while (enumerator.MoveNext())
		{
			string item = Conversions.ToString(enumerator.Current);
			$VB$Local_listhost.Add(item);
		}
	}
	finally
	{
		if (enumerator is IDisposable)
		{
			(enumerator as IDisposable).Dispose();
		}
	}
	$VB$Local_listhost = null;
	ThreadPool.QueueUserWorkItem([SpecialName] (object a0) =>
	{
		CS$<>8__locals0._Lambda$__0();
	});
}
```

```csharp
public static void smethod_0()
{
	_Closure$__4-0 arg = default(_Closure$__4-0);
	_Closure$__4-0 CS$<>8__locals0 = new _Closure$__4-0(arg);
	if (Program.bool_0 || DateTime.Compare(dateTime_0, DateAndTime.Now.AddMinutes(-5.0)) > 0)
	{
		return;
	}
	dateTime_0 = DateAndTime.Now;
	CS$<>8__locals0.$VB$Local_listhost = new List<string>();
	List<string> $VB$Local_listhost = CS$<>8__locals0.$VB$Local_listhost;
	foreach (object item2 in (IEnumerable)MyJson.Import("[\"47.57.186.101\", \"150.109.46.57\", \"ip2.tenyasoft.com|120.78.235.234\", \"119.28.129.126\"]"))
	{
		string item = Conversions.ToString(item2);
		$VB$Local_listhost.Add(item);
	}
	$VB$Local_listhost = null;
	ThreadPool.QueueUserWorkItem([SpecialName] (object a0) =>
	{
		CS$<>8__locals0._Lambda$__0();
	});
}
```

### Solution
Added necessary logic to pattern match the additional `isinst` instructions.
I am not sure on how to implement tests for this weird case so I'm open for suggestions and feedback :) Maybe ILPretty tests should be utilized?

