### PR TITLE
Include property and event return types in `RequiredNamespaceCollector`

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/RequiredNamespaceCollector.cs
+++ b/ICSharpCode.Decompiler/CSharp/RequiredNamespaceCollector.cs
@@ -137,11 +137,13 @@ namespace ICSharpCode.Decompiler.CSharp
 					break;
 				case IProperty property:
 					HandleAttributes(property.GetAttributes());
+					CollectNamespacesForTypeReference(property.ReturnType);
 					CollectNamespaces(property.Getter, module, mappingInfo);
 					CollectNamespaces(property.Setter, module, mappingInfo);
 					break;
 				case IEvent @event:
 					HandleAttributes(@event.GetAttributes());
+					CollectNamespacesForTypeReference(@event.ReturnType);
 					CollectNamespaces(@event.AddAccessor, module, mappingInfo);
 					CollectNamespaces(@event.RemoveAccessor, module, mappingInfo);
 					break;


### PR DESCRIPTION
Link to issue(s) this covers:
https://github.com/icsharpcode/ILSpy/issues/2842

### Problem
The `ZennoLab.Structures.Properties.Resources` class contained a property that had it's return type set to `System.Globalization.CultureInfo` but the accessor parameters used `System.Object`. This caused the `RequiredNamespaceCollector` not to detect the `System.Globalization` namespace. This led to the assertion mentioned in the issue.

### Solution
Include return types of properties and events in the analysis done by `RequiredNamespaceCollector`.

fixes #2842