### PR TITLE
Add support for VB.NET cached delegate initialization with closures

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
@@ -261,7 +261,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			{
 				return false;
 			}
-			if (s.Kind != VariableKind.StackSlot || s.StoreCount != 2 || s.LoadCount != 1)
+			if (s.Kind != VariableKind.StackSlot || s.StoreCount != 2)
 				return false;
 			if (!(falseInitValue is StObj stobj) || !(trueInitValue is LdObj ldobj))
 				return false;

--- a/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
@@ -257,7 +257,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (trueInst.Instructions.Count != 1 || falseInst.Instructions.Count != 1)
 				return false;
 			if (!(trueInst.Instructions[0].MatchStLoc(out var s, out var trueInitValue)
-			      && falseInst.Instructions[0].MatchStLoc(s, out var falseInitValue)))
+				  && falseInst.Instructions[0].MatchStLoc(s, out var falseInitValue)))
 			{
 				return false;
 			}
@@ -268,8 +268,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (!(stobj.Value is NewObj delegateConstruction))
 				return false;
 			if (!stobj.Target.MatchLdFlda(out var target1, out var field1)
-			    || !ldobj.Target.MatchLdFlda(out var target2, out var field2)
-			    || !field1.Equals(field2) || !target1.Match(target2).Success)
+				|| !ldobj.Target.MatchLdFlda(out var target2, out var field2)
+				|| !field1.Equals(field2) || !target1.Match(target2).Success)
 			{
 				return false;
 			}

--- a/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
@@ -218,7 +218,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			{
 				return false;
 			}
-			if (s.Kind != VariableKind.StackSlot || s.StoreCount != 2 || s.LoadCount != 1)
+			if (s.Kind != VariableKind.StackSlot || s.StoreCount != 2)
 				return false;
 			if (!(trueInitValue is StObj stobj) || !(falseInitValue is LdObj ldobj))
 				return false;

--- a/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/CachedDelegateInitialization.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011-2016 Siegfried Pammer
+// Copyright (c) 2011-2016 Siegfried Pammer
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -52,6 +52,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						continue;
 					}
 					if (CachedDelegateInitializationVB(inst))
+					{
+						continue;
+					}
+					if (CachedDelegateInitializationVBWithClosure(inst))
 					{
 						continue;
 					}
@@ -233,6 +237,49 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (!DelegateConstruction.MatchDelegateConstruction(delegateConstruction, out _, out _, out _, true))
 				return false;
 			context.Step("CachedDelegateInitializationVB", inst);
+			inst.ReplaceWith(new StLoc(s, delegateConstruction));
+			return true;
+		}
+
+		/// <summary>
+		/// if (comp.o(ldobj delegateType(ldflda CachedAnonMethodDelegate(ldloc closure)) != ldnull)) Block {
+		/// 	stloc s(ldobj delegateType(ldflda CachedAnonMethodDelegate(ldloc closure)))
+		/// } else Block {
+		/// 	stloc s(stobj delegateType(ldflda CachedAnonMethodDelegate(ldloc closure), DelegateConstruction))
+		/// }
+		/// =>
+		///	stloc s(DelegateConstruction)
+		/// </summary>
+		bool CachedDelegateInitializationVBWithClosure(IfInstruction inst)
+		{
+			if (!(inst.TrueInst is Block trueInst && inst.FalseInst is Block falseInst))
+				return false;
+			if (trueInst.Instructions.Count != 1 || falseInst.Instructions.Count != 1)
+				return false;
+			if (!(trueInst.Instructions[0].MatchStLoc(out var s, out var trueInitValue)
+			      && falseInst.Instructions[0].MatchStLoc(s, out var falseInitValue)))
+			{
+				return false;
+			}
+			if (s.Kind != VariableKind.StackSlot || s.StoreCount != 2 || s.LoadCount != 1)
+				return false;
+			if (!(falseInitValue is StObj stobj) || !(trueInitValue is LdObj ldobj))
+				return false;
+			if (!(stobj.Value is NewObj delegateConstruction))
+				return false;
+			if (!stobj.Target.MatchLdFlda(out var target1, out var field1)
+			    || !ldobj.Target.MatchLdFlda(out var target2, out var field2)
+			    || !field1.Equals(field2) || !target1.Match(target2).Success)
+			{
+				return false;
+			}
+			if (!inst.Condition.MatchCompNotEqualsNull(out ILInstruction left))
+				return false;
+			if (!ldobj.Match(left).Success)
+				return false;
+			if (!DelegateConstruction.MatchDelegateConstruction(delegateConstruction, out _, out _, out _, true))
+				return false;
+			context.Step("CachedDelegateInitializationVBWithClosure", inst);
 			inst.ReplaceWith(new StLoc(s, delegateConstruction));
 			return true;
 		}


### PR DESCRIPTION
Link to issue(s) this covers:
https://github.com/icsharpcode/ILSpy/issues/2199

### Problem
The `CachedDelegateInitialization` transform did not fully support VB cached delegate initialization. The pattern emitted when an anonymous function uses a local from a display class/closure was not supported. This can be seen by decompiling `Class5.method_0()` from the sample provided in the aforementioned issue report. This can be seen in the code inside the first try region.

Before:
```csharp
private void method_0(ClassHttpRequest classHttpRequest_0, string string_0)
{
	string text = "";
	if (!bool_1)
	{
		text = "請先進行登入認證~";
		return;
	}
	ClassHttpRequest val = classHttpRequest_0;
	_Closure$__35-0 arg = new _Closure$__35-0(arg);
	arg.$VB$Local_totp_code = "";
	arg.$VB$Local_frm = new Form();
	Form $VB$Local_frm = arg.$VB$Local_frm;
	_Closure$__35-1 arg2 = default(_Closure$__35-1);
	_Closure$__35-1 CS$<>8__locals0 = new _Closure$__35-1(arg2);
	CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2 = arg;
	$VB$Local_frm.ShowIcon = false;
	$VB$Local_frm.StartPosition = FormStartPosition.CenterScreen;
	$VB$Local_frm.Text = "提示";
	$VB$Local_frm.Size = new Size(new Point(100, 120));
	$VB$Local_frm.FormBorderStyle = FormBorderStyle.FixedSingle;
	$VB$Local_frm.MaximizeBox = false;
	$VB$Local_frm.MinimizeBox = false;
	Label label = new Label();
	$VB$Local_frm.Controls.Add(label);
	label.Dock = DockStyle.Top;
	label.BringToFront();
	label.Text = "請打開手機露天代碼產生器應用程式，並輸入驗證碼。";
	label.AutoSize = false;
	label.Height = checked(label.Font.Height * 3);
	CS$<>8__locals0.$VB$Local_TextBox1 = new TextBox();
	$VB$Local_frm.Controls.Add(CS$<>8__locals0.$VB$Local_TextBox1);
	TextBox $VB$Local_TextBox = CS$<>8__locals0.$VB$Local_TextBox1;
	$VB$Local_TextBox.Dock = DockStyle.Top;
	$VB$Local_TextBox.BringToFront();
	Button button = new Button();
	$VB$Local_frm.Controls.Add(button);
	button.Dock = DockStyle.Top;
	button.BringToFront();
	button.Height = 30;
	button.Text = "確認";
	button.Click += [SpecialName] (object a0, EventArgs a1) =>
	{
		CS$<>8__locals0._Lambda$__0();
	};
	$VB$Local_frm.AcceptButton = button;
	IEnumerator enumerator = default(IEnumerator);
	try
	{
		enumerator = Application.OpenForms.GetEnumerator();
		if (enumerator.MoveNext())
		{
			((Form)enumerator.Current).Invoke((CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2.$I1 == null) ? (CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2.$I1 = [SpecialName] () =>
			{
				CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2.$VB$Local_frm.ShowDialog();
			}) : CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2.$I1);
		}
	}
	finally
	{
		if (enumerator is IDisposable)
		{
			(enumerator as IDisposable).Dispose();
		}
	}
	if (arg.$VB$Local_totp_code.Length < 1)
	{
		text += "~請輸入驗證碼!";
	}
	else
	{
		string text2 = "https://member.ruten.com.tw/totp/do_login_validation.php";
		string text3 = "totp_code=" + arg.$VB$Local_totp_code + "&remember_code=true";
		val.Referer = text2;
		string hTML = val.GetHTML((MethodHTTP)1, text2, (object)text3);
		ClassMy.Savefile(string.Format(Application.StartupPath + "\\test\\login\\ruten\\" + string_0 + "\\{0}.htm", "do_login_validation"), hTML);
		string text4;
		if (hTML.Trim().Length > 0 && hTML.Trim().StartsWith("{\"is_success\":true,"))
		{
			text4 = "~認證成功!";
			List<string> list = new List<string>();
			IEnumerator enumerator2 = default(IEnumerator);
			try
			{
				enumerator2 = val.CookieContainerclass.GetCookies(new Uri("https://mybid.ruten.com.tw/upload/step1.htm")).GetEnumerator();
				while (enumerator2.MoveNext())
				{
					Cookie cookie = (Cookie)enumerator2.Current;
					list.Add(cookie.Name + "=" + cookie.Value);
				}
			}
			finally
			{
				if (enumerator2 is IDisposable)
				{
					(enumerator2 as IDisposable).Dispose();
				}
			}
			if (list.Count > 0)
			{
				ClassMy.Savefile(Class4.string_0 + "\\" + string_0 + ".txt", string.Join(";", list.ToArray()));
			}
		}
		else
		{
			text4 = "~認證失敗!";
			text4 = ((!hTML.Contains("VALIDATE_FAILED")) ? (text4 + "\r\n" + Strings.Left(ClassMy.CheckHTML(hTML).ToString().Trim(), 100)) : (text4 + "\r\n可能驗證碼超時，請重試！"));
		}
		text += text4;
	}
	val = null;
}
```
After:
```csharp
private void method_0(ClassHttpRequest classHttpRequest_0, string string_0)
{
	string text = "";
	if (!bool_1)
	{
		text = "請先進行登入認證~";
		return;
	}
	ClassHttpRequest val = classHttpRequest_0;
	_Closure$__35-0 arg = new _Closure$__35-0(arg);
	arg.$VB$Local_totp_code = "";
	arg.$VB$Local_frm = new Form();
	Form $VB$Local_frm = arg.$VB$Local_frm;
	_Closure$__35-1 arg2 = default(_Closure$__35-1);
	_Closure$__35-1 CS$<>8__locals0 = new _Closure$__35-1(arg2);
	CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2 = arg;
	$VB$Local_frm.ShowIcon = false;
	$VB$Local_frm.StartPosition = FormStartPosition.CenterScreen;
	$VB$Local_frm.Text = "提示";
	$VB$Local_frm.Size = new Size(new Point(100, 120));
	$VB$Local_frm.FormBorderStyle = FormBorderStyle.FixedSingle;
	$VB$Local_frm.MaximizeBox = false;
	$VB$Local_frm.MinimizeBox = false;
	Label label = new Label();
	$VB$Local_frm.Controls.Add(label);
	label.Dock = DockStyle.Top;
	label.BringToFront();
	label.Text = "請打開手機露天代碼產生器應用程式，並輸入驗證碼。";
	label.AutoSize = false;
	label.Height = checked(label.Font.Height * 3);
	CS$<>8__locals0.$VB$Local_TextBox1 = new TextBox();
	$VB$Local_frm.Controls.Add(CS$<>8__locals0.$VB$Local_TextBox1);
	TextBox $VB$Local_TextBox = CS$<>8__locals0.$VB$Local_TextBox1;
	$VB$Local_TextBox.Dock = DockStyle.Top;
	$VB$Local_TextBox.BringToFront();
	Button button = new Button();
	$VB$Local_frm.Controls.Add(button);
	button.Dock = DockStyle.Top;
	button.BringToFront();
	button.Height = 30;
	button.Text = "確認";
	button.Click += [SpecialName] (object a0, EventArgs a1) =>
	{
		CS$<>8__locals0._Lambda$__0();
	};
	$VB$Local_frm.AcceptButton = button;
	IEnumerator enumerator = default(IEnumerator);
	try
	{
		enumerator = Application.OpenForms.GetEnumerator();
		if (enumerator.MoveNext())
		{
			((Form)enumerator.Current).Invoke((VB$AnonymousDelegate_0)([SpecialName] () =>
			{
				CS$<>8__locals0.$VB$NonLocal_$VB$Closure_2.$VB$Local_frm.ShowDialog();
			}));
		}
	}
	finally
	{
		if (enumerator is IDisposable)
		{
			(enumerator as IDisposable).Dispose();
		}
	}
	if (arg.$VB$Local_totp_code.Length < 1)
	{
		text += "~請輸入驗證碼!";
	}
	else
	{
		string text2 = "https://member.ruten.com.tw/totp/do_login_validation.php";
		string text3 = "totp_code=" + arg.$VB$Local_totp_code + "&remember_code=true";
		val.Referer = text2;
		string hTML = val.GetHTML((MethodHTTP)1, text2, (object)text3);
		ClassMy.Savefile(string.Format(Application.StartupPath + "\\test\\login\\ruten\\" + string_0 + "\\{0}.htm", "do_login_validation"), hTML);
		string text4;
		if (hTML.Trim().Length > 0 && hTML.Trim().StartsWith("{\"is_success\":true,"))
		{
			text4 = "~認證成功!";
			List<string> list = new List<string>();
			IEnumerator enumerator2 = default(IEnumerator);
			try
			{
				enumerator2 = val.CookieContainerclass.GetCookies(new Uri("https://mybid.ruten.com.tw/upload/step1.htm")).GetEnumerator();
				while (enumerator2.MoveNext())
				{
					Cookie cookie = (Cookie)enumerator2.Current;
					list.Add(cookie.Name + "=" + cookie.Value);
				}
			}
			finally
			{
				if (enumerator2 is IDisposable)
				{
					(enumerator2 as IDisposable).Dispose();
				}
			}
			if (list.Count > 0)
			{
				ClassMy.Savefile(Class4.string_0 + "\\" + string_0 + ".txt", string.Join(";", list.ToArray()));
			}
		}
		else
		{
			text4 = "~認證失敗!";
			text4 = ((!hTML.Contains("VALIDATE_FAILED")) ? (text4 + "\r\n" + Strings.Left(ClassMy.CheckHTML(hTML).ToString().Trim(), 100)) : (text4 + "\r\n可能驗證碼超時，請重試！"));
		}
		text += text4;
	}
	val = null;
}
```

Smaller code to reproduce the issue:
```vb
Dim t As String = "hello"
Dim collection As List(Of String) = New List(Of String)
For Each element In collection.Where(Function(x) x = t)
	Console.WriteLine(element)
Next
```

### Solution
Implement support for the pattern seen in this sample.
A unit test was not added as ILSpy does not currently support VB.NET closures/display classes as they differ in structure from the C# ones. This lack of support makes it impossible to create pretty C# decompilation while testing this pattern.
