### PR TITLE
Add support for VB.NET automatic events

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -110,6 +110,8 @@
     <Compile Include="Output\InsertParenthesesVisitorTests.cs" />
     <Compile Include="ProjectDecompiler\TargetFrameworkTests.cs" />
     <Compile Include="TestAssemblyResolver.cs" />
+    <None Include="TestCases\VBPretty\VBAutomaticEvents.vb" />
+    <Compile Include="TestCases\VBPretty\VBAutomaticEvents.cs" />
     <Compile Include="TypeSystem\ReflectionHelperTests.cs" />
     <None Include="TestCases\Pretty\MetadataAttributes.cs" />
     <None Include="TestCases\Correctness\ComInterop.cs" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAutomaticEvents.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAutomaticEvents.cs
@@ -1,0 +1,14 @@
+﻿public class VBAutomaticEvents
+{
+	public delegate void EventWithParameterEventHandler(int EventNumber);
+	public delegate void EventWithoutParameterEventHandler();
+
+	public event EventWithParameterEventHandler EventWithParameter;
+	public event EventWithoutParameterEventHandler EventWithoutParameter;
+
+	public void RaiseEvents()
+	{
+		EventWithParameter?.Invoke(1);
+		EventWithoutParameter?.Invoke();
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAutomaticEvents.vb
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAutomaticEvents.vb
@@ -1,0 +1,9 @@
+Public Class VBAutomaticEvents
+	Event EventWithParameter(ByVal EventNumber As Integer)
+	Event EventWithoutParameter()
+
+	Sub RaiseEvents()
+		RaiseEvent EventWithParameter(1)
+		RaiseEvent EventWithoutParameter()
+	End Sub
+End Class

--- a/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -121,6 +121,12 @@ namespace ICSharpCode.Decompiler.Tests
 
 		[Test]
 		public async Task VBPropertiesTest([ValueSource(nameof(defaultOptions))] CompilerOptions options)
+		{
+			await Run(options: options | CompilerOptions.Library);
+		}
+
+		[Test]
+		public async Task VBAutomaticEvents([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
 			await Run(options: options | CompilerOptions.Library);
 		}


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
ILSpy did not properly support automatic events generated by the Visual Basic compiler. The backing field naming convention used by the Visual Basic compiler is different than the one used by the C# one. Instead of the field having the same name as the event, it uses the events name and appends the `Event` suffix to it. This different naming convention caused ILSpy to fail to detect automatic events and the decompiled code was very messy.

Before:
```csharp
public class VBAutomaticEvents
{
	public delegate void EventWithParameterEventHandler(int EventNumber);

	public delegate void EventWithoutParameterEventHandler();

	[CompilerGenerated]
	private EventWithParameterEventHandler EventWithParameterEvent;

	[CompilerGenerated]
	private EventWithoutParameterEventHandler EventWithoutParameterEvent;

	public event EventWithParameterEventHandler EventWithParameter
	{
		[CompilerGenerated]
		add
		{
			EventWithParameterEventHandler eventWithParameterEventHandler = EventWithParameterEvent;
			EventWithParameterEventHandler eventWithParameterEventHandler2;
			do
			{
				eventWithParameterEventHandler2 = eventWithParameterEventHandler;
				EventWithParameterEventHandler value2 = (EventWithParameterEventHandler)Delegate.Combine(eventWithParameterEventHandler2, value);
				eventWithParameterEventHandler = Interlocked.CompareExchange(ref EventWithParameterEvent, value2, eventWithParameterEventHandler2);
			}
			while ((object)eventWithParameterEventHandler != eventWithParameterEventHandler2);
		}
		[CompilerGenerated]
		remove
		{
			EventWithParameterEventHandler eventWithParameterEventHandler = EventWithParameterEvent;
			EventWithParameterEventHandler eventWithParameterEventHandler2;
			do
			{
				eventWithParameterEventHandler2 = eventWithParameterEventHandler;
				EventWithParameterEventHandler value2 = (EventWithParameterEventHandler)Delegate.Remove(eventWithParameterEventHandler2, value);
				eventWithParameterEventHandler = Interlocked.CompareExchange(ref EventWithParameterEvent, value2, eventWithParameterEventHandler2);
			}
			while ((object)eventWithParameterEventHandler != eventWithParameterEventHandler2);
		}
	}

	public event EventWithoutParameterEventHandler EventWithoutParameter
	{
		[CompilerGenerated]
		add
		{
			EventWithoutParameterEventHandler eventWithoutParameterEventHandler = EventWithoutParameterEvent;
			EventWithoutParameterEventHandler eventWithoutParameterEventHandler2;
			do
			{
				eventWithoutParameterEventHandler2 = eventWithoutParameterEventHandler;
				EventWithoutParameterEventHandler value2 = (EventWithoutParameterEventHandler)Delegate.Combine(eventWithoutParameterEventHandler2, value);
				eventWithoutParameterEventHandler = Interlocked.CompareExchange(ref EventWithoutParameterEvent, value2, eventWithoutParameterEventHandler2);
			}
			while ((object)eventWithoutParameterEventHandler != eventWithoutParameterEventHandler2);
		}
		[CompilerGenerated]
		remove
		{
			EventWithoutParameterEventHandler eventWithoutParameterEventHandler = EventWithoutParameterEvent;
			EventWithoutParameterEventHandler eventWithoutParameterEventHandler2;
			do
			{
				eventWithoutParameterEventHandler2 = eventWithoutParameterEventHandler;
				EventWithoutParameterEventHandler value2 = (EventWithoutParameterEventHandler)Delegate.Remove(eventWithoutParameterEventHandler2, value);
				eventWithoutParameterEventHandler = Interlocked.CompareExchange(ref EventWithoutParameterEvent, value2, eventWithoutParameterEventHandler2);
			}
			while ((object)eventWithoutParameterEventHandler != eventWithoutParameterEventHandler2);
		}
	}

	public void RaiseEvents()
	{
		EventWithParameterEvent?.Invoke(1);
		EventWithoutParameterEvent?.Invoke();
	}
}
```
After:
```csharp
public class VBAutomaticEvents
{
	public delegate void EventWithParameterEventHandler(int EventNumber);

	public delegate void EventWithoutParameterEventHandler();

	public event EventWithParameterEventHandler EventWithParameter;

	public event EventWithoutParameterEventHandler EventWithoutParameter;

	public void RaiseEvents()
	{
		EventWithParameter?.Invoke(1);
		EventWithoutParameter?.Invoke();
	}
}
```
Original VB code
```vb
Public Class VBAutomaticEvents
	Event EventWithParameter(ByVal EventNumber As Integer)
	Event EventWithoutParameter()

	Sub RaiseEvents()
		RaiseEvent EventWithParameter(1)
		RaiseEvent EventWithoutParameter()
	End Sub
End Class
```

### Solution
I adapted the code for handling automatic events to support the naming convention used by the Visual Basic compiler.
A VBPretty test was added to test this newly added behavior.

