### PR TITLE
Add support for `lock` statements within yield return state machines

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/YieldReturn.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/YieldReturn.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -101,24 +101,23 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			yield return 2;
 		}
 
-#if TODO
-		// TODO: adjust lock-pattern for this case
 		public static IEnumerable<int> YieldReturnInLock1(object o)
 		{
-			lock (o) {
+			lock (o)
+			{
 				yield return 1;
 			}
 		}
 
 		public static IEnumerable<int> YieldReturnInLock2(object o)
 		{
-			lock (o) {
+			lock (o)
+			{
 				yield return 1;
 				o = null;
 				yield return 2;
 			}
 		}
-#endif
 
 		public static IEnumerable<string> YieldReturnWithNestedTryFinally(bool breakInMiddle)
 		{


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
ILSpy did not properly decompile `lock` statements in yield return state machines generated by the legacy C# compiler. This was due to a variation in the ILAst pattern. The difference is an extra variable.

Before changes:
```csharp
public static IEnumerable<int> YieldReturnInLock1(object o)
{
	bool lockTaken = false;
	object obj2 = default(object);
	try
	{
		object obj;
		obj2 = (obj = o);
		Monitor.Enter(obj, ref lockTaken);
		yield return 1;
	}
	finally
	{
		if (lockTaken)
		{
			Monitor.Exit(obj2);
		}
	}
}
```

After changes:
```csharp
public static IEnumerable<int> YieldReturnInLock1(object o)
{
	lock (o)
	{
		yield return 1;
	}
}
```
### Solution
* Added support for the ILAst pattern mentioned above
* Enabled the previously disabled test cases for `lock` statements in yield return state machines.

