### PR TITLE
Enable tests which no longer fail

### DIFF
--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -560,12 +560,6 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task TupleTests([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
 		{
-			if (cscOptions.HasFlag(CompilerOptions.UseRoslynLatest))
-			{
-				Assert.Ignore("DefaultInterpolatedStringHandler is not yet supported!");
-				return;
-			}
-
 			await RunForLibrary(cscOptions: cscOptions);
 		}
 

--- a/ICSharpCode.Decompiler.Tests/Semantics/OverloadResolutionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/OverloadResolutionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2013 AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) 2010-2013 AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -104,7 +104,7 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.AreSame(c1, r.BestCandidate);
 		}
 
-		[Test, Ignore("Broken after migration to ICS.Decompiler")]
+		[Test]
 		public void NullableIntAndNullableUIntIsAmbiguous()
 		{
 			OverloadResolution r = new OverloadResolution(compilation, MakeArgumentList(typeof(ushort?)));
@@ -300,7 +300,7 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.AreEqual(OverloadResolutionErrors.None, r.BestCandidateErrors);
 		}
 
-		[Test, Ignore("Broken on SRM branch???")]
+		[Test]
 		public void Lambda_DelegateAndExpressionTreeOverloadsAreAmbiguous()
 		{
 			var m1 = MakeMethod(typeof(Func<int>));


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
The ICSharpCode.Decompiler.Tests project contained a few tests that were marked to be ignored due to them being broken when in reality they pass without any issues!

### Solution
* Re-enable said tests

