### PR TITLE
Add MethodSignatureProvider and PEFileExtensions

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -109,6 +109,7 @@
   <ItemGroup>
     <Compile Include="DisassemblerPrettyTestRunner.cs" />
     <Compile Include="Helpers\RoslynToolset.cs" />
+    <Compile Include="MethodSignatureProviderTest.cs" />
     <Compile Include="Output\InsertParenthesesVisitorTests.cs" />
     <Compile Include="ProjectDecompiler\TargetFrameworkTests.cs" />
     <Compile Include="TestAssemblyResolver.cs" />

--- a/ICSharpCode.Decompiler.Tests/MethodSignatureProviderTest.cs
+++ b/ICSharpCode.Decompiler.Tests/MethodSignatureProviderTest.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) 2022 Tom-Englert
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+
+using ICSharpCode.Decompiler.Disassembler;
+using ICSharpCode.Decompiler.Metadata;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.Decompiler.Tests
+{
+	[TestFixture, Parallelizable(ParallelScope.All)]
+	public class MethodSignatureProviderTest
+	{
+		[TestCase("ICSharpCode.Decompiler.Tests.MethodSignatureProviderTest", nameof(Method1), "uint", new[] { "string", "int", "double", "string[]", "int[,]", "ref ICSharpCode.Decompiler.Disassembler.IMethodSignature", "ICSharpCode.Decompiler.Tests.MethodSignatureProviderTest", "System.Func<int, double>" })]
+		[TestCase("ICSharpCode.Decompiler.Tests.MethodSignatureProviderTest", "Method1`1", "object", new[] { "string", "int" })]
+		[TestCase("ICSharpCode.Decompiler.Tests.MethodSignatureProviderTest", nameof(Method3), "void", new[] { "ref string", "ref string", "ref string" })]
+		[TestCase("ICSharpCode.Decompiler.Tests.MethodSignatureProviderTest.GenericClass`1", "Method1`1", "void", new[] { "TOuter", "TInner", "System.Func<TOuter, TInner>", "ICSharpCode.Decompiler.Tests.MethodSignatureProviderTest.GenericClass<TInner>" })]
+		public void GetCorrectMethodSignature(string typeName, string methodName, string returnType, string[] parameterTypes)
+		{
+			using var module = new PEFile(typeof(MethodSignatureProviderTest).Assembly.Location);
+
+			var method = module.FindMethod(typeName, methodName);
+
+			var signature = method.GetMethodSignature(module);
+
+			Assert.AreEqual(methodName, signature.Name);
+			Assert.AreEqual(returnType, signature.ReturnType);
+			Assert.AreEqual(string.Join(", ", parameterTypes), string.Join(", ", signature.ArgumentTypes));
+		}
+
+		[Test]
+		public void FindOverloadedMethodByCondition()
+		{
+			using var module = new PEFile(typeof(MethodSignatureProviderTest).Assembly.Location);
+
+			Assert.Throws<InvalidOperationException>(() => module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1"));
+			Assert.Throws<InvalidOperationException>(() => module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1", signature => signature.ArgumentTypes.Count == 2));
+
+			var method = module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1", signature => signature.ArgumentTypes.Count == 2 && signature.ArgumentTypes[1] == "double");
+
+			Assert.NotNull(method);
+		}
+
+#pragma warning disable CA1822 // Mark members as static
+
+		private UInt32 Method1(string s, int i, double d, string[] arr, int[,] arr2, ref IMethodSignature refStruct, MethodSignatureProviderTest type, Func<int, double> func)
+		{
+			return default;
+		}
+
+		private object Method1<T>(string s, int i)
+		{
+			return default;
+		}
+
+		private object Method2<T>(string s, int i)
+		{
+			return default;
+		}
+
+		private void Method2<T>(string s, double i)
+		{
+		}
+
+		private void Method2<T>(string s, double i, byte b)
+		{
+		}
+
+		private void Method3(in string a, out string b, ref string c)
+		{
+			b = string.Empty;
+		}
+
+		private class GenericClass<TOuter>
+		{
+			public void Method1<TInner>(TOuter a, TInner b, Func<TOuter, TInner> c, GenericClass<TInner> d)
+			{
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/MethodSignatureProviderTest.cs
+++ b/ICSharpCode.Decompiler.Tests/MethodSignatureProviderTest.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.Decompiler.Tests
 
 			Assert.AreEqual(methodName, signature.Name);
 			Assert.AreEqual(returnType, signature.ReturnType);
-			Assert.AreEqual(string.Join(", ", parameterTypes), string.Join(", ", signature.ArgumentTypes));
+			Assert.AreEqual(string.Join(", ", parameterTypes), string.Join(", ", signature.ParameterTypes));
 		}
 
 		[Test]
@@ -51,9 +51,9 @@ namespace ICSharpCode.Decompiler.Tests
 			using var module = new PEFile(typeof(MethodSignatureProviderTest).Assembly.Location);
 
 			Assert.Throws<InvalidOperationException>(() => module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1"));
-			Assert.Throws<InvalidOperationException>(() => module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1", signature => signature.ArgumentTypes.Count == 2));
+			Assert.Throws<InvalidOperationException>(() => module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1", signature => signature.ParameterTypes.Count == 2));
 
-			var method = module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1", signature => signature.ArgumentTypes.Count == 2 && signature.ArgumentTypes[1] == "double");
+			var method = module.FindMethod(typeof(MethodSignatureProviderTest).FullName, "Method2`1", signature => signature.ParameterTypes.Count == 2 && signature.ParameterTypes[1] == "double");
 
 			Assert.NotNull(method);
 		}

--- a/ICSharpCode.Decompiler/Disassembler/CSharpSignatureTypeProvider.cs
+++ b/ICSharpCode.Decompiler/Disassembler/CSharpSignatureTypeProvider.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) 2022 Tom-Englert
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.Decompiler.Disassembler
+{
+	public class CSharpSignatureTypeProvider : ISignatureTypeProvider<Action<ITextOutput>, MetadataGenericContext>
+	{
+		public Action<ITextOutput> GetArrayType(Action<ITextOutput> elementType, ArrayShape shape)
+		{
+			return output => {
+				elementType(output);
+				output.Write('[');
+				for (int i = 1; i < shape.Rank; i++)
+				{
+					output.Write(",");
+				}
+				output.Write(']');
+			};
+		}
+
+		public Action<ITextOutput> GetByReferenceType(Action<ITextOutput> elementType)
+		{
+			return output => {
+				output.Write("ref ");
+				elementType(output);
+			};
+		}
+
+		public Action<ITextOutput> GetFunctionPointerType(MethodSignature<Action<ITextOutput>> signature)
+		{
+			return output => {
+				signature.ReturnType(output);
+				output.Write(" *(");
+				for (int i = 0; i < signature.ParameterTypes.Length; i++)
+				{
+					if (i > 0)
+						output.Write(", ");
+					signature.ParameterTypes[i](output);
+				}
+				output.Write(')');
+			};
+		}
+
+		public Action<ITextOutput> GetGenericInstantiation(Action<ITextOutput> genericType, ImmutableArray<Action<ITextOutput>> typeArguments)
+		{
+			return output => {
+				genericType(output);
+				output.Write('<');
+				for (int i = 0; i < typeArguments.Length; i++)
+				{
+					if (i > 0)
+						output.Write(", ");
+					typeArguments[i](output);
+				}
+				output.Write('>');
+			};
+		}
+
+		public Action<ITextOutput> GetGenericMethodParameter(MetadataGenericContext genericContext, int index)
+		{
+			return output => WriteTypeParameter(genericContext.Metadata, genericContext.GetGenericMethodTypeParameterHandleOrNull(index), index, output);
+		}
+
+		public Action<ITextOutput> GetGenericTypeParameter(MetadataGenericContext genericContext, int index)
+		{
+			return output => WriteTypeParameter(genericContext.Metadata, genericContext.GetGenericTypeParameterHandleOrNull(index), index, output);
+		}
+
+		private static void WriteTypeParameter(MetadataReader metadata, GenericParameterHandle paramRef, int index, ITextOutput output)
+		{
+			if (paramRef.IsNil)
+			{
+				output.Write(index.ToString());
+			}
+			else
+			{
+				var param = metadata.GetGenericParameter(paramRef);
+				output.Write(param.Name.IsNil ? param.Index.ToString() : DisassemblerHelpers.Escape(metadata.GetString(param.Name)));
+			}
+		}
+
+		public Action<ITextOutput> GetModifiedType(Action<ITextOutput> modifier, Action<ITextOutput> unmodifiedType, bool isRequired)
+		{
+			return unmodifiedType;
+		}
+
+		public Action<ITextOutput> GetPinnedType(Action<ITextOutput> elementType)
+		{
+			return elementType;
+		}
+
+		public Action<ITextOutput> GetPointerType(Action<ITextOutput> elementType)
+		{
+			return output => {
+				elementType(output);
+				output.Write('*');
+			};
+		}
+
+		public Action<ITextOutput> GetPrimitiveType(PrimitiveTypeCode typeCode)
+		{
+			switch (typeCode)
+			{
+				case PrimitiveTypeCode.SByte:
+					return output => output.Write("sbyte");
+				case PrimitiveTypeCode.Int16:
+					return output => output.Write("short");
+				case PrimitiveTypeCode.Int32:
+					return output => output.Write("int");
+				case PrimitiveTypeCode.Int64:
+					return output => output.Write("long");
+				case PrimitiveTypeCode.Byte:
+					return output => output.Write("byte");
+				case PrimitiveTypeCode.UInt16:
+					return output => output.Write("ushort");
+				case PrimitiveTypeCode.UInt32:
+					return output => output.Write("uint");
+				case PrimitiveTypeCode.UInt64:
+					return output => output.Write("ulong");
+				case PrimitiveTypeCode.Single:
+					return output => output.Write("float");
+				case PrimitiveTypeCode.Double:
+					return output => output.Write("double");
+				case PrimitiveTypeCode.Void:
+					return output => output.Write("void");
+				case PrimitiveTypeCode.Boolean:
+					return output => output.Write("bool");
+				case PrimitiveTypeCode.String:
+					return output => output.Write("string");
+				case PrimitiveTypeCode.Char:
+					return output => output.Write("char");
+				case PrimitiveTypeCode.Object:
+					return output => output.Write("object");
+				case PrimitiveTypeCode.IntPtr:
+					return output => output.Write("IntPtr");
+				case PrimitiveTypeCode.UIntPtr:
+					return output => output.Write("UIntPtr");
+				case PrimitiveTypeCode.TypedReference:
+					return output => output.Write("typedref");
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+
+		public Action<ITextOutput> GetSZArrayType(Action<ITextOutput> elementType)
+		{
+			return output => {
+				elementType(output);
+				output.Write("[]");
+			};
+		}
+
+		public Action<ITextOutput> GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+		{
+			return output => output.Write(handle.GetFullTypeName(reader).ToCSharpNameString(true));
+		}
+
+		public Action<ITextOutput> GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+		{
+			return output => output.Write(handle.GetFullTypeName(reader).ToCSharpNameString(true));
+		}
+
+		public Action<ITextOutput> GetTypeFromSpecification(MetadataReader reader, MetadataGenericContext genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+		{
+			return reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/Disassembler/IMethodSignature.cs
+++ b/ICSharpCode.Decompiler/Disassembler/IMethodSignature.cs
@@ -31,5 +31,5 @@ public interface IMethodSignature
 
 	string ReturnType { get; }
 
-	IReadOnlyList<string> ArgumentTypes { get; }
+	IReadOnlyList<string> ParameterTypes { get; }
 }

--- a/ICSharpCode.Decompiler/Disassembler/IMethodSignature.cs
+++ b/ICSharpCode.Decompiler/Disassembler/IMethodSignature.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2022 Tom-Englert
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+
+namespace ICSharpCode.Decompiler.Disassembler;
+
+public interface IMethodSignature
+{
+	MethodDefinitionHandle Handle { get; }
+
+	string Name { get; }
+
+	string ReturnType { get; }
+
+	IReadOnlyList<string> ArgumentTypes { get; }
+}

--- a/ICSharpCode.Decompiler/Disassembler/MethodSignatureProvider.cs
+++ b/ICSharpCode.Decompiler/Disassembler/MethodSignatureProvider.cs
@@ -54,7 +54,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 				return output.ToString();
 			});
 
-			var parameters = new Lazy<IReadOnlyList<string>>(() => {
+			var parameterTypes = new Lazy<IReadOnlyList<string>>(() => {
 				var items = new List<string>(signature.ParameterTypes.Length);
 				foreach (var parameterType in signature.ParameterTypes)
 				{
@@ -65,20 +65,20 @@ namespace ICSharpCode.Decompiler.Disassembler
 				return items.ToImmutableArray();
 			});
 
-			return new MethodSignature(handle, name, returnType, parameters);
+			return new MethodSignature(handle, name, returnType, parameterTypes);
 		}
 
 		private class MethodSignature : IMethodSignature
 		{
 			private readonly Lazy<string> returnType;
-			private readonly Lazy<IReadOnlyList<string>> argumentTypes;
+			private readonly Lazy<IReadOnlyList<string>> parameterTypes;
 
-			public MethodSignature(MethodDefinitionHandle handle, string name, Lazy<string> returnType, Lazy<IReadOnlyList<string>> argumentTypes)
+			public MethodSignature(MethodDefinitionHandle handle, string name, Lazy<string> returnType, Lazy<IReadOnlyList<string>> parameterTypes)
 			{
 				Handle = handle;
 				Name = name;
 				this.returnType = returnType;
-				this.argumentTypes = argumentTypes;
+				this.parameterTypes = parameterTypes;
 			}
 
 			public MethodDefinitionHandle Handle { get; }
@@ -87,7 +87,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 
 			public string ReturnType => returnType.Value;
 
-			public IReadOnlyList<string> ArgumentTypes => argumentTypes.Value;
+			public IReadOnlyList<string> ParameterTypes => parameterTypes.Value;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/Disassembler/MethodSignatureProvider.cs
+++ b/ICSharpCode.Decompiler/Disassembler/MethodSignatureProvider.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) 2022 Tom-Englert
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.Decompiler.Disassembler
+{
+	public static class MethodSignatureProvider
+	{
+		public static IMethodSignature GetMethodSignature(this MethodDefinitionHandle handle, PEFile module)
+		{
+			return GetMethodSignature(handle, module.Metadata, new CSharpSignatureTypeProvider(), new MetadataGenericContext(handle, module));
+		}
+
+		public static IMethodSignature GetMethodSignature<TProvider, TGenericContext>(this MethodDefinitionHandle handle, MetadataReader metadata, TProvider provider, TGenericContext genericContext)
+			where TProvider : ISignatureTypeProvider<Action<ITextOutput>, TGenericContext>
+		{
+			var definition = metadata.GetMethodDefinition(handle);
+			var name = metadata.GetString(definition.Name);
+
+			var signature = definition.DecodeSignature(provider, genericContext);
+
+			var genericParameterCount = signature.GenericParameterCount;
+			if (genericParameterCount > 0)
+			{
+				name += $"`{genericParameterCount}";
+			}
+
+			var returnType = new Lazy<string>(() => {
+				var output = new PlainTextOutput();
+				signature.ReturnType(output);
+				return output.ToString();
+			});
+
+			var parameters = new Lazy<IReadOnlyList<string>>(() => {
+				var items = new List<string>(signature.ParameterTypes.Length);
+				foreach (var parameterType in signature.ParameterTypes)
+				{
+					var output = new PlainTextOutput();
+					parameterType(output);
+					items.Add(output.ToString());
+				}
+				return items.ToImmutableArray();
+			});
+
+			return new MethodSignature(handle, name, returnType, parameters);
+		}
+
+		private class MethodSignature : IMethodSignature
+		{
+			private readonly Lazy<string> returnType;
+			private readonly Lazy<IReadOnlyList<string>> argumentTypes;
+
+			public MethodSignature(MethodDefinitionHandle handle, string name, Lazy<string> returnType, Lazy<IReadOnlyList<string>> argumentTypes)
+			{
+				Handle = handle;
+				Name = name;
+				this.returnType = returnType;
+				this.argumentTypes = argumentTypes;
+			}
+
+			public MethodDefinitionHandle Handle { get; }
+
+			public string Name { get; }
+
+			public string ReturnType => returnType.Value;
+
+			public IReadOnlyList<string> ArgumentTypes => argumentTypes.Value;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/Disassembler/PEFileExtensions.cs
+++ b/ICSharpCode.Decompiler/Disassembler/PEFileExtensions.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) 2022 Tom-Englert
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Reflection.Metadata;
+
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.Decompiler.Disassembler
+{
+	public static class PEFileExtensions
+	{
+		public static TypeDefinitionHandle FindType(this PEFile file, string typeName)
+		{
+			TypeDefinitionHandle type = file.Metadata.TypeDefinitions.SingleOrDefault(handle =>
+				handle.GetFullTypeName(file.Metadata).ToCSharpNameString() == typeName);
+
+			if (type == default)
+			{
+				throw new InvalidOperationException($"Could not find '{typeName}' in '{file.FileName}'");
+			}
+
+			return type;
+		}
+
+		public static PropertyDefinitionHandle FindProperty(this PEFile file, string typeName, string propertyName)
+		{
+			return FindProperty(file, file.FindType(typeName), propertyName);
+		}
+
+		public static PropertyDefinitionHandle FindProperty(this PEFile file, TypeDefinitionHandle type,
+			string propertyName)
+		{
+			MetadataReader metadata = file.Metadata;
+			TypeDefinition typeDefinition = metadata.GetTypeDefinition(type);
+
+			PropertyDefinitionHandle property = typeDefinition.GetProperties().SingleOrDefault(handle => {
+				PropertyDefinition definition = metadata.GetPropertyDefinition(handle);
+				string name = metadata.GetString(definition.Name);
+				return name == propertyName;
+			});
+
+			if (property == default)
+			{
+				throw new InvalidOperationException(
+					$"Could not find '{type.GetFullTypeName(metadata).ToCSharpNameString()}.{propertyName}' in '{file.FileName}'");
+			}
+
+			return property;
+		}
+
+		public static MethodDefinitionHandle FindMethod(this PEFile file, string typeName, string methodName,
+			Func<IMethodSignature, bool>? predicate = null)
+		{
+			return FindMethod(file, file.FindType(typeName), methodName, predicate);
+		}
+
+		public static MethodDefinitionHandle FindMethod(this PEFile file, TypeDefinitionHandle type, string methodName,
+			Func<IMethodSignature, bool>? predicate = null)
+		{
+			MetadataReader metadata = file.Metadata;
+			TypeDefinition typeDefinition = metadata.GetTypeDefinition(type);
+
+			MethodDefinitionHandle handle = typeDefinition.GetMethods()
+				.Select(handle => handle.GetMethodSignature(file))
+				.Where(signature => signature.Name == methodName && predicate?.Invoke(signature) != false)
+				.Select(signature => signature.Handle)
+				.SingleOrDefault();
+
+			if (handle == default)
+			{
+				throw new InvalidOperationException(
+					$"Could not find '{type.GetFullTypeName(metadata).ToCSharpNameString()}.{methodName}' in '{file.FileName}'");
+			}
+
+			return handle;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -92,7 +92,11 @@
     <Compile Include="CSharp\CallBuilder.cs" />
     <Compile Include="CSharp\CSharpLanguageVersion.cs" />
     <Compile Include="DecompilationProgress.cs" />
+    <Compile Include="Disassembler\CSharpSignatureTypeProvider.cs" />
     <Compile Include="Disassembler\IEntityProcessor.cs" />
+    <Compile Include="Disassembler\IMethodSignature.cs" />
+    <Compile Include="Disassembler\MethodSignatureProvider.cs" />
+    <Compile Include="Disassembler\PEFileExtensions.cs" />
     <Compile Include="Disassembler\SortByNameProcessor.cs" />
     <Compile Include="NRTAttributes.cs" />
     <Compile Include="PartialTypeInfo.cs" />

--- a/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
@@ -185,7 +185,9 @@ namespace ICSharpCode.Decompiler.Metadata
 			}
 		}
 
-		public static string ToILNameString(this FullTypeName typeName, bool omitGenerics = false)
+
+
+		public static string ToILNameString(this FullTypeName typeName, bool omitGenerics = false, char nestedTypeDelimiter = '/')
 		{
 			string name;
 			if (typeName.IsNested)
@@ -198,7 +200,7 @@ namespace ICSharpCode.Decompiler.Metadata
 						name += "`" + localTypeParameterCount;
 				}
 				name = Disassembler.DisassemblerHelpers.Escape(name);
-				return $"{typeName.GetDeclaringType().ToILNameString(omitGenerics)}/{name}";
+				return $"{typeName.GetDeclaringType().ToILNameString(omitGenerics)}{nestedTypeDelimiter}{name}";
 			}
 			if (!string.IsNullOrEmpty(typeName.TopLevelTypeName.Namespace))
 			{
@@ -213,6 +215,11 @@ namespace ICSharpCode.Decompiler.Metadata
 					name += "`" + typeName.TypeParameterCount;
 			}
 			return Disassembler.DisassemblerHelpers.Escape(name);
+		}
+
+		public static string ToCSharpNameString(this FullTypeName fullName, bool omitGenerics = false)
+		{
+			return fullName.ToILNameString(omitGenerics, '.');
 		}
 
 		[Obsolete("Use MetadataModule.GetDeclaringModule() instead")]

--- a/ICSharpCode.Decompiler/Metadata/MetadataGenericContext.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataGenericContext.cs
@@ -25,34 +25,35 @@ namespace ICSharpCode.Decompiler.Metadata
 {
 	public readonly struct MetadataGenericContext
 	{
-		readonly MetadataReader? metadata;
 		readonly TypeDefinitionHandle declaringType;
 		readonly MethodDefinitionHandle method;
 
+		public MetadataReader Metadata { get; }
+
 		public MetadataGenericContext(MethodDefinitionHandle method, PEFile module)
 		{
-			this.metadata = module.Metadata;
+			this.Metadata = module.Metadata;
 			this.method = method;
 			this.declaringType = module.Metadata.GetMethodDefinition(method).GetDeclaringType();
 		}
 
 		public MetadataGenericContext(MethodDefinitionHandle method, MetadataReader metadata)
 		{
-			this.metadata = metadata;
+			this.Metadata = metadata;
 			this.method = method;
 			this.declaringType = metadata.GetMethodDefinition(method).GetDeclaringType();
 		}
 
 		public MetadataGenericContext(TypeDefinitionHandle declaringType, PEFile module)
 		{
-			this.metadata = module.Metadata;
+			this.Metadata = module.Metadata;
 			this.method = default;
 			this.declaringType = declaringType;
 		}
 
 		public MetadataGenericContext(TypeDefinitionHandle declaringType, MetadataReader metadata)
 		{
-			this.metadata = metadata;
+			this.Metadata = metadata;
 			this.method = default;
 			this.declaringType = declaringType;
 		}
@@ -60,24 +61,24 @@ namespace ICSharpCode.Decompiler.Metadata
 		public string GetGenericTypeParameterName(int index)
 		{
 			GenericParameterHandle genericParameter = GetGenericTypeParameterHandleOrNull(index);
-			if (genericParameter.IsNil || metadata == null)
+			if (genericParameter.IsNil || Metadata == null)
 				return index.ToString();
-			return metadata.GetString(metadata.GetGenericParameter(genericParameter).Name);
+			return Metadata.GetString(Metadata.GetGenericParameter(genericParameter).Name);
 		}
 
 		public string GetGenericMethodTypeParameterName(int index)
 		{
 			GenericParameterHandle genericParameter = GetGenericMethodTypeParameterHandleOrNull(index);
-			if (genericParameter.IsNil || metadata == null)
+			if (genericParameter.IsNil || Metadata == null)
 				return index.ToString();
-			return metadata.GetString(metadata.GetGenericParameter(genericParameter).Name);
+			return Metadata.GetString(Metadata.GetGenericParameter(genericParameter).Name);
 		}
 
 		public GenericParameterHandle GetGenericTypeParameterHandleOrNull(int index)
 		{
-			if (declaringType.IsNil || index < 0 || metadata == null)
+			if (declaringType.IsNil || index < 0 || Metadata == null)
 				return MetadataTokens.GenericParameterHandle(0);
-			var genericParameters = metadata.GetTypeDefinition(declaringType).GetGenericParameters();
+			var genericParameters = Metadata.GetTypeDefinition(declaringType).GetGenericParameters();
 			if (index >= genericParameters.Count)
 				return MetadataTokens.GenericParameterHandle(0);
 			return genericParameters[index];
@@ -85,9 +86,9 @@ namespace ICSharpCode.Decompiler.Metadata
 
 		public GenericParameterHandle GetGenericMethodTypeParameterHandleOrNull(int index)
 		{
-			if (method.IsNil || index < 0 || metadata == null)
+			if (method.IsNil || index < 0 || Metadata == null)
 				return MetadataTokens.GenericParameterHandle(0);
-			var genericParameters = metadata.GetMethodDefinition(method).GetGenericParameters();
+			var genericParameters = Metadata.GetMethodDefinition(method).GetGenericParameters();
 			if (index >= genericParameters.Count)
 				return MetadataTokens.GenericParameterHandle(0);
 			return genericParameters[index];


### PR DESCRIPTION
Fixes #2862: Provide method signature to distinguish overloaded methods 

### Problem
overloaded methods are not distinguishable, as their parameter types are not available in the first place.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
  - the new code is mainly standalone
* Which part of this PR is most in need of attention/improvement?
  - MethodSignatureProvider
* [x] At least one test covering the code changed

