### PR TITLE
Fix `ResXResourceWriter` support for `MemoryStream` resource element

### DIFF
--- a/ICSharpCode.Decompiler/Util/ResXResourceWriter.cs
+++ b/ICSharpCode.Decompiler/Util/ResXResourceWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Daniel Grunwald
+// Copyright (c) 2018 Daniel Grunwald
 //   This file is based on the Mono implementation of ResXResourceWriter.
 //   It is modified to add support for "ResourceSerializedObject" values.
 //
@@ -261,6 +261,11 @@ namespace ICSharpCode.Decompiler.Util
 			if (value is byte[])
 			{
 				WriteBytes(name, value.GetType(), (byte[])value, comment);
+				return;
+			}
+			if (value is MemoryStream memoryStream)
+			{
+				WriteBytes(name, null, memoryStream.ToArray(), comment);
 				return;
 			}
 			if (value is ResourceSerializedObject rso)


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
In newer runtime versions, MemoryStream is no longer a serializable type like it was in .NET Framework. This leads to an exception when exporting an assembly with resources using a resource element of the `Stream` type code.

### Solution
* Implement explicit support for the `MemoryStream` class instantiated by `ResourcesFile`.

