### PR TITLE
Use `.interfaceimpl type` syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _ReSharper*/
 *.ReSharper
 *.patch
 .vs/
+.idea/
 /ILSpy.AddIn*/Packages/*
 /ILSpy.AddIn*/source.extension.vsixmanifest
 /ICSharpCode.Decompiler.Tests/TestCases/Disassembler/Pretty/*.dll

--- a/ICSharpCode.Decompiler.Tests/DisassemblerPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/DisassemblerPrettyTestRunner.cs
@@ -64,6 +64,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await Run(ilExpectedFile: Path.Combine(TestCasePath, "SortMembers.expected.il"), asmOptions: AssemblerOptions.SortedOutput);
 		}
 
+		[Test]
+		public async Task InterfaceImplAttributes()
+		{
+			await Run();
+		}
+
 		async Task Run([CallerMemberName] string testName = null, string ilExpectedFile = null, AssemblerOptions asmOptions = AssemblerOptions.None)
 		{
 			var ilInputFile = Path.Combine(TestCasePath, testName + ".il");

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -73,6 +73,7 @@
     <None Include="TestCases\Correctness\StackTests.il" />
     <None Include="TestCases\Correctness\StackTypes.il" />
     <None Include="TestCases\Correctness\Uninit.vb" />
+    <None Include="TestCases\Disassembler\Pretty\InterfaceImplAttributes.il" />
     <None Include="TestCases\Disassembler\Pretty\SortMembers.expected.il" />
     <None Include="TestCases\Disassembler\Pretty\SortMembers.il" />
     <None Include="TestCases\ILPretty\GuessAccessors.cs" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/Disassembler/Pretty/InterfaceImplAttributes.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Disassembler/Pretty/InterfaceImplAttributes.il
@@ -1,0 +1,75 @@
+.assembly extern mscorlib
+{
+	.publickeytoken = (
+		b7 7a 5c 56 19 34 e0 89
+	)
+	.ver 4:0:0:0
+}
+.assembly InterfaceImplAttributes
+{
+	.custom instance void [mscorlib]System.Reflection.AssemblyFileVersionAttribute::.ctor(string) = (
+		01 00 07 31 2e 30 2e 30 2e 30 00 00
+	)
+	.hash algorithm 0x00008004 // SHA1
+	.ver 1:0:0:0
+}
+
+.module InterfaceImplAttributes.dll
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003 // WindowsCui
+.corflags 0x00000001 // ILOnly
+
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi beforefieldinit TestType
+	extends [mscorlib]System.Object
+	implements ITestInterfaceA
+{
+	.interfaceimpl type ITestInterfaceA
+	.custom instance void TestAttributeA::.ctor() = (
+		01 00 00 00
+	)
+
+	// Methods
+	.method public hidebysig specialname rtspecialname
+		instance void .ctor () cil managed
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [mscorlib]System.Object::.ctor()
+		IL_0006: ret
+	} // end of method TestType::.ctor
+
+} // end of class TestType
+
+.class interface public auto ansi abstract ITestInterfaceA
+{
+} // end of class ITestInterfaceA
+
+.class public auto ansi beforefieldinit TestAttributeA
+	extends [mscorlib]System.Attribute
+{
+	// Methods
+	.method public hidebysig specialname rtspecialname
+		instance void .ctor () cil managed
+	{
+		// Method begins at RVA 0x2058
+		// Header size: 1
+		// Code size: 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [mscorlib]System.Attribute::.ctor()
+		IL_0006: ret
+	} // end of method TestAttributeA::.ctor
+
+} // end of class TestAttributeA
+

--- a/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
+++ b/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
@@ -1577,7 +1577,6 @@ namespace ICSharpCode.Decompiler.Disassembler
 						output.Write("           ");
 					first = false;
 					var iface = module.Metadata.GetInterfaceImplementation(i);
-					WriteAttributes(module, iface.GetCustomAttributes());
 					iface.Interface.WriteTo(module, output, genericContext, ILNameSyntax.TypeName);
 				}
 				output.WriteLine();
@@ -1600,6 +1599,19 @@ namespace ICSharpCode.Decompiler.Disassembler
 				output.WriteLine(".pack {0}", layout.PackingSize);
 				output.WriteLine(".size {0}", layout.Size);
 				output.WriteLine();
+			}
+			foreach (var ifaceHandle in interfaces)
+			{
+				var iface = module.Metadata.GetInterfaceImplementation(ifaceHandle);
+				var customAttributes = iface.GetCustomAttributes();
+				if (customAttributes.Count != 0)
+				{
+					output.Write(".interfaceimpl type ");
+					iface.Interface.WriteTo(module, output, genericContext, ILNameSyntax.TypeName);
+					output.WriteLine();
+					WriteAttributes(module, customAttributes);
+					output.WriteLine();
+				}
 			}
 			var nestedTypes = Process(module, typeDefinition.GetNestedTypes());
 			if (nestedTypes.Any())

--- a/ILSpy/TextView/ILAsm-Mode-Dark.xshd
+++ b/ILSpy/TextView/ILAsm-Mode-Dark.xshd
@@ -518,6 +518,10 @@
 			<Begin>"</Begin>
 			<End>"</End>
 		</Span>
+		<Span>
+			<Begin>'</Begin>
+			<End>'</End>
+		</Span>
 	</RuleSet>
 	<RuleSet name="CommentMarkerSet" ignoreCase="false">
 		<Keywords foreground="#FFFF0000" fontWeight="bold">

--- a/ILSpy/TextView/ILAsm-Mode-Dark.xshd
+++ b/ILSpy/TextView/ILAsm-Mode-Dark.xshd
@@ -356,6 +356,7 @@
 			<Word>true</Word>
 			<Word>false</Word>
 			<Word>strict</Word>
+			<Word>type</Word>
 		</Keywords>
 		<Keywords color="Directives">
 			<Word>.class</Word>
@@ -385,6 +386,7 @@
 			<Word>.permissionset</Word>
 			<Word>.line</Word>
 			<Word>.language</Word>
+			<Word>.interfaceimpl</Word>
 			<Word>#line</Word>
 		</Keywords>
 		<Keywords color="Security">

--- a/ILSpy/TextView/ILAsm-Mode.xshd
+++ b/ILSpy/TextView/ILAsm-Mode.xshd
@@ -518,6 +518,10 @@
 			<Begin>"</Begin>
 			<End>"</End>
 		</Span>
+		<Span>
+			<Begin>'</Begin>
+			<End>'</End>
+		</Span>
 	</RuleSet>
 	<RuleSet name="CommentMarkerSet" ignoreCase="false">
 		<Keywords foreground="#FFFF0000" fontWeight="bold">

--- a/ILSpy/TextView/ILAsm-Mode.xshd
+++ b/ILSpy/TextView/ILAsm-Mode.xshd
@@ -356,6 +356,7 @@
 			<Word>true</Word>
 			<Word>false</Word>
 			<Word>strict</Word>
+			<Word>type</Word>
 		</Keywords>
 		<Keywords color="Directives">
 			<Word>.class</Word>
@@ -385,6 +386,7 @@
 			<Word>.permissionset</Word>
 			<Word>.line</Word>
 			<Word>.language</Word>
+			<Word>.interfaceimpl</Word>
 			<Word>#line</Word>
 		</Keywords>
 		<Keywords color="Security">


### PR DESCRIPTION
### Problem

I noticed the following output when decompiling an assembly:

![image](https://user-images.githubusercontent.com/7913492/219972190-f68753f1-7783-41fc-8313-00ec60ac2f79.png)

That `implements .custom` part seemed wrong, and indeed, `ildasm` uses another syntax instead: `.interfaceimpl type` ([see here](https://github.com/dotnet/runtime/blob/7908e8ef62c7d5ebdcd6459faccd755b9b10d369/src/coreclr/ildasm/dasm.cpp#L4847-L4870)).

Here is the result:

![image](https://user-images.githubusercontent.com/7913492/219973525-81877e20-069a-49d5-adb7-5985d16ec45f.png)

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.

  This PR moves the custom attributes on interface implementations inside the type body and adds one `.interfaceimpl type` declaration for each interface implementation which has a custom attribute.

* Which part of this PR is most in need of attention/improvement?

  While implementing this, I noticed that `ilasm` is inconsistent with `ildasm` when multiple attributes are applied to an interface implementation. I believe `ilasm` is wrong here, and reported the following issue:  
  https://github.com/dotnet/runtime/issues/82373

  Because of this, the unit test only applies a single attribute on the interface implementation. I didn't want to add an additional `.expected.il` file just because of this inconsistency.

  This PR implements the same behavior as in `ildasm`.

  As for the UI, I wasn't sure if I should highlight the `type` keyword in green (which looked wrong) or in blue (which could lead to many false positives), so I left it as-is.

* [x] At least one test covering the code changed

