### PR TITLE
Add support for record structs in `CSharpAmbience` (fixes #2910)

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpAmbience.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpAmbience.cs
@@ -83,6 +83,10 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 						case ClassType.RecordClass:
 							writer.WriteKeyword(Roles.RecordKeyword, "record");
 							break;
+						case ClassType.RecordStruct:
+							writer.WriteKeyword(Roles.RecordKeyword, "record");
+							writer.WriteKeyword(Roles.StructKeyword, "struct");
+							break;
 						default:
 							throw new Exception("Invalid value for ClassType");
 					}


### PR DESCRIPTION
Link to issue(s) this covers:
Fixes #2910

### Problem
`CSharpAmbience` did not support record structs.

### Solution
* Add support for record structs to `CSharpAmbience` basing the new code on `CSharpOutputVisitor`

