### PR TITLE
Fix empty parameter names in delegate declarations (fixes #2908)

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1288,6 +1288,11 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				typeSystemAstBuilder = CreateAstBuilder(decompileRun.Settings);
 				var entityDecl = typeSystemAstBuilder.ConvertEntity(typeDef);
+				if (entityDecl is DelegateDeclaration delegateDeclaration)
+				{
+					// Fix empty parameter names in delegate declarations
+					FixParameterNames(delegateDeclaration);
+				}
 				var typeDecl = entityDecl as TypeDeclaration;
 				if (typeDecl == null)
 				{


### PR DESCRIPTION
Link to issue(s) this covers:
Fixes #2908

### Problem
Obfuscated IL code to lead to delegate declarations with empty parameter names being produced.

### Solution
* Replace the empty parameter names with default parameter names following the naming convention used by ILReader.

