### PR TITLE
Change theme selection UI

### DIFF
--- a/ILSpy/Commands/ILSpyCommands.cs
+++ b/ILSpy/Commands/ILSpyCommands.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 
 using ICSharpCode.ILSpy.Analyzers;
+using ICSharpCode.ILSpy.Commands;
 
 namespace ICSharpCode.ILSpy
 {
@@ -31,5 +32,6 @@ namespace ICSharpCode.ILSpy
 	{
 		public static readonly AnalyzeCommand Analyze = new AnalyzeCommand();
 		public static readonly ManageAssemblyListsCommand ManageAssemblyListsCommand = new ManageAssemblyListsCommand();
+		public static readonly SetThemeCommand SetTheme = new SetThemeCommand();
 	}
 }

--- a/ILSpy/Commands/SetThemeCommand.cs
+++ b/ILSpy/Commands/SetThemeCommand.cs
@@ -1,0 +1,11 @@
+﻿namespace ICSharpCode.ILSpy.Commands
+{
+	public class SetThemeCommand : SimpleCommand
+	{
+		public override void Execute(object parameter)
+		{
+			if (parameter is string theme)
+				MainWindow.Instance.SessionSettings.Theme = theme;
+		}
+	}
+}

--- a/ILSpy/MainWindow.xaml
+++ b/ILSpy/MainWindow.xaml
@@ -20,6 +20,7 @@
 	xmlns:styles="urn:TomsToolbox.Wpf.Styles"
 	xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
 	xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
+	xmlns:toms="urn:TomsToolbox"
 	d:DataContext="{d:DesignInstance local:MainWindowViewModel}"
 >
 	<Window.Resources>
@@ -138,6 +139,23 @@
 				<MenuItem Header="{x:Static properties:Resources.Show_internalTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicAndInternal}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_allTypesAndMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisAll}" />
 				<Separator/>
+				<MenuItem Header="{x:Static properties:Resources.Theme}" ItemsSource="{x:Static themes:ThemeManager.AllThemes}">
+					<MenuItem.ItemContainerStyle>
+						<Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+							<Setter Property="Command" Value="{x:Static local:ILSpyCommands.SetTheme}" />
+							<Setter Property="CommandParameter" Value="{Binding}" />
+							<Setter Property="IsCheckable" Value="True" /> <!-- Required by AvalonDock's MenuItem style to show the checkmark -->
+							<Setter Property="IsChecked">
+								<Setter.Value>
+									<MultiBinding Converter="{x:Static toms:BinaryOperationConverter.Equality}" Mode="OneWay">
+										<Binding />
+										<Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:MainWindow}}" Path="SessionSettings.Theme" />
+									</MultiBinding>
+								</Setter.Value>
+							</Setter>
+						</Style>
+					</MenuItem.ItemContainerStyle>
+				</MenuItem>
 				<MenuItem Header="{x:Static properties:Resources.UILanguage}">
 					<MenuItem Header="{x:Static properties:Resources.UILanguage_System}" IsCheckable="True" IsChecked="{Binding SessionSettings.CurrentCulture, Converter={StaticResource cultureSelectionConverter}, ConverterParameter={x:Null}}" />
 					<MenuItem Header="English" IsCheckable="True" IsChecked="{Binding SessionSettings.CurrentCulture, Converter={StaticResource cultureSelectionConverter}, ConverterParameter=en-US}" />

--- a/ILSpy/MainWindow.xaml
+++ b/ILSpy/MainWindow.xaml
@@ -220,10 +220,6 @@
 					  IsEnabled="{Binding Workspace.ActiveTabPage.SupportsLanguageSwitching}"
 			          ItemsSource="{Binding SelectedItem.LanguageVersions, ElementName=languageComboBox, UpdateSourceTrigger=PropertyChanged}"
 			          SelectedItem="{Binding Workspace.ActiveTabPage.FilterSettings.LanguageVersion, UpdateSourceTrigger=PropertyChanged}"/>
-			<Separator />
-			<ComboBox Width="100" MaxDropDownHeight="Auto" ToolTip="{x:Static properties:Resources.Theme}"
-			          ItemsSource="{x:Static themes:ThemeManager.AllThemes}"
-			          SelectedItem="{Binding SessionSettings.Theme}"/>
 		</ToolBar>
 		<Border DockPanel.Dock="Top" BorderBrush="Black" BorderThickness="1" Name="updatePanel" Visibility="Collapsed">
 			<DockPanel KeyboardNavigation.TabNavigation="Contained">

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -6,12 +6,17 @@
 			 xmlns:system="clr-namespace:System;assembly=mscorlib"
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
 			 d:DataContext="{d:DesignInstance local:DisplaySettingsViewModel}">
 	<UserControl.Resources>
 		<local:FontSizeConverter x:Key="fontSizeConv" />
 	</UserControl.Resources>
 	<ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
 		<StackPanel Orientation="Vertical">
+			<DockPanel>
+				<Label DockPanel.Dock="Left" Content="{x:Static properties:Resources.DisplaySettingsPanel_Theme}" />
+				<ComboBox ItemsSource="{x:Static themes:ThemeManager.AllThemes}" SelectedItem="{Binding Theme}" VerticalContentAlignment="Center" Margin="0,0,8,0" />
+			</DockPanel>
 			<GroupBox Header="{x:Static properties:Resources.Font}">
 				<Grid>
 					<Grid.ColumnDefinitions>

--- a/ILSpy/Options/DisplaySettingsPanel.xaml.cs
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml.cs
@@ -121,6 +121,8 @@ namespace ICSharpCode.ILSpy.Options
 			s.ShowRawOffsetsAndBytesBeforeInstruction = (bool?)e.Attribute("ShowRawOffsetsAndBytesBeforeInstruction") ?? false;
 			s.StyleWindowTitleBar = (bool?)e.Attribute("StyleWindowTitleBar") ?? false;
 
+			s.Theme = MainWindow.Instance.SessionSettings.Theme;
+
 			return s;
 		}
 
@@ -150,13 +152,22 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("ShowRawOffsetsAndBytesBeforeInstruction", s.ShowRawOffsetsAndBytesBeforeInstruction);
 			section.SetAttributeValue("StyleWindowTitleBar", s.StyleWindowTitleBar);
 
-			XElement existingElement = root.Element("DisplaySettings");
-			if (existingElement != null)
-				existingElement.ReplaceWith(section);
-			else
-				root.Add(section);
+			MainWindow.Instance.SessionSettings.Theme = s.Theme;
+			var sessionSettings = MainWindow.Instance.SessionSettings.ToXml();
 
 			MainWindow.Instance.CurrentDisplaySettings.CopyValues(s);
+
+			Update(section);
+			Update(sessionSettings);
+
+			void Update(XElement element)
+			{
+				var existingElement = root.Element(element.Name);
+				if (existingElement != null)
+					existingElement.ReplaceWith(element);
+				else
+					root.Add(element);
+			}
 		}
 
 		private void TextBox_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)

--- a/ILSpy/Options/DisplaySettingsViewModel.cs
+++ b/ILSpy/Options/DisplaySettingsViewModel.cs
@@ -20,6 +20,8 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Media;
 
+using ICSharpCode.ILSpy.Themes;
+
 namespace ICSharpCode.ILSpy.Options
 {
 	/// <summary>
@@ -29,6 +31,7 @@ namespace ICSharpCode.ILSpy.Options
 	{
 		public DisplaySettingsViewModel()
 		{
+			this.theme = ThemeManager.Current.DefaultTheme;
 			this.selectedFont = new FontFamily("Consolas");
 			this.selectedFontSize = 10.0 * 4 / 3;
 			this.sortResults = true;
@@ -51,6 +54,19 @@ namespace ICSharpCode.ILSpy.Options
 			OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
 		}
 		#endregion
+
+		string theme;
+
+		public string Theme {
+			get { return theme; }
+			set {
+				if (theme != value)
+				{
+					theme = value;
+					OnPropertyChanged();
+				}
+			}
+		}
 
 		FontFamily selectedFont;
 
@@ -314,6 +330,7 @@ namespace ICSharpCode.ILSpy.Options
 
 		public void CopyValues(DisplaySettingsViewModel s)
 		{
+			this.Theme = s.Theme;
 			this.SelectedFont = s.selectedFont;
 			this.SelectedFontSize = s.selectedFontSize;
 			this.ShowLineNumbers = s.showLineNumbers;

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1559,6 +1559,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Theme:.
+        /// </summary>
+        public static string DisplaySettingsPanel_Theme {
+            get {
+                return ResourceManager.GetString("DisplaySettingsPanel_Theme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Download.
         /// </summary>
         public static string Download {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -540,6 +540,9 @@ Are you sure you want to continue?</value>
   <data name="DisplaySettingsPanel_Font" xml:space="preserve">
     <value>Font:</value>
   </data>
+  <data name="DisplaySettingsPanel_Theme" xml:space="preserve">
+	  <value>Theme:</value>
+  </data>
   <data name="Download" xml:space="preserve">
     <value>Download</value>
   </data>

--- a/ILSpy/SessionSettings.cs
+++ b/ILSpy/SessionSettings.cs
@@ -127,7 +127,7 @@ namespace ICSharpCode.ILSpy
 
 		public DockLayoutSettings DockLayout { get; private set; }
 
-		public void Save()
+		public XElement ToXml()
 		{
 			XElement doc = new XElement("SessionSettings");
 			doc.Add(this.FilterSettings.SaveAsXml());
@@ -161,7 +161,12 @@ namespace ICSharpCode.ILSpy
 				dockLayoutElement.Add(DockLayout.SaveAsXml());
 			}
 			doc.Add(dockLayoutElement);
+			return doc;
+		}
 
+		public void Save()
+		{
+			var doc = ToXml();
 			ILSpySettings.SaveSettings(doc);
 		}
 


### PR DESCRIPTION
Closes #2929 

### Problem

The theme selector combobox in the toolbar seems out of place.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.

  This replaces the theme selector in the toolbar with a menu item and a setting in the options:

  ![image](https://user-images.githubusercontent.com/7913492/226489287-3858515a-a132-46eb-a463-a939fd1ee020.png)

  ![image](https://user-images.githubusercontent.com/7913492/226489359-555e23b0-2747-41ad-b046-c9ab6983d17e.png)

* Which part of this PR is most in need of attention/improvement?

  The theme is currently saved in the `SessionSettings`, and this PR doesn't change that. But this leads to updating the `SessionSettings` from the `DisplaySettings` panel.

  An alternative would be to move the theme to `DisplaySettings`, but that would require updating it when switching the theme from the main menu and saving it on exit just like the `SessionSettings`, so I'm not sure if that would be better in the end.
