### PR TITLE
Support disassembling ReadyToRun binaries compiled using composite mode

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.18.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="7.0.4-servicing.23115.8" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.0-preview.4.23202.2" />
     <!-- ILCompiler.Reflection.ReadyToRun has dependencies on System.Reflection.Metadata and
          System.Runtime.CompilerServices.Unsafe. Because the AddIn compiles into ILSpy's output
          directory, we're at risk of overwriting our dependencies with different versions.

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -137,8 +137,8 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				output.Write(tempOutput.ToStringAndReset());
 				DecorateUnwindInfo(unwindInfo, baseInstrIP, instr);
 				DecorateDebugInfo(instr, debugInfo, baseInstrIP);
-
 				DecorateCallSite(currentFile, showMetadataTokens, showMetadataTokensInBase10, instr);
+				output.WriteLine();
 			}
 			output.WriteLine();
 		}
@@ -451,15 +451,10 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 							methodRefToken.WriteTo(currentFile, output, default);
 							break;
 						default:
-							output.WriteLine(reader.ImportSignatures[importCellAddress].ToString(new SignatureFormattingOptions()));
+							output.Write(reader.ImportSignatures[importCellAddress].ToString(new SignatureFormattingOptions()));
 							break;
 					}
-					output.WriteLine();
 				}
-			}
-			else
-			{
-				output.WriteLine();
 			}
 		}
 	}

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,6 @@
   <packageSources>
     <add key="Nuget Official" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet7-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7-transport/nuget/v3/index.json" />
+    <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This late PR added the support for disassembling ReadyToRun binaries compiled using composite mode introduced officially in .NET 6.

By virtue of using the latest version, this version also supports disassembling binaries compiled using the experimental hot-cold-splitting mode introduced [here](https://github.com/dotnet/runtime/pull/74963).

Thanks @eduardo-vp for introducing the `OwnerCompositeExecutable` to make this work possible.

FYI @amanasifkhalid, @EugenioPena, this will fix https://github.com/dotnet/runtimelab/issues/1910.


