### PR TITLE
Add more theme colors

### DIFF
--- a/ILSpy/TextView/BracketHighlightRenderer.cs
+++ b/ILSpy/TextView/BracketHighlightRenderer.cs
@@ -114,6 +114,8 @@ namespace ICSharpCode.ILSpy.TextView
 			BackgroundGeometryBuilder builder = new BackgroundGeometryBuilder();
 
 			builder.CornerRadius = 1;
+			builder.AlignToWholePixels = true;
+			builder.BorderThickness = borderPen?.Thickness ?? 0;
 
 			builder.AddSegment(textView, new TextSegment() { StartOffset = result.OpeningBracketOffset, Length = result.OpeningBracketLength });
 			builder.CloseFigure(); // prevent connecting the two segments

--- a/ILSpy/TextView/DecompilerTextView.cs
+++ b/ILSpy/TextView/DecompilerTextView.cs
@@ -143,6 +143,8 @@ namespace ICSharpCode.ILSpy.TextView
 			ContextMenuProvider.Add(this);
 
 			textEditor.TextArea.TextView.SetResourceReference(ICSharpCode.AvalonEdit.Rendering.TextView.LinkTextForegroundBrushProperty, ResourceKeys.LinkTextForegroundBrush);
+			textEditor.TextArea.TextView.SetResourceReference(ICSharpCode.AvalonEdit.Rendering.TextView.CurrentLineBackgroundProperty, ResourceKeys.CurrentLineBackgroundBrush);
+			textEditor.TextArea.TextView.SetResourceReference(ICSharpCode.AvalonEdit.Rendering.TextView.CurrentLineBorderProperty, ResourceKeys.CurrentLineBorderPen);
 
 			this.DataContextChanged += DecompilerTextView_DataContextChanged;
 		}

--- a/ILSpy/TextView/DecompilerTextView.xaml
+++ b/ILSpy/TextView/DecompilerTextView.xaml
@@ -34,6 +34,7 @@
 				<ae:TextEditor Name="textEditor" AutomationProperties.Name="Decompilation"  FontFamily="Consolas" FontSize="10pt" IsReadOnly="True"
 				               Background="{DynamicResource {x:Static themes:ResourceKeys.TextBackgroundBrush}}"
 				               Foreground="{DynamicResource {x:Static themes:ResourceKeys.TextForegroundBrush}}"
+				               LineNumbersForeground="{DynamicResource {x:Static themes:ResourceKeys.LineNumbersForegroundBrush}}"
 				               folding:FoldingMargin.FoldingMarkerBackgroundBrush="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
 				               folding:FoldingMargin.SelectedFoldingMarkerBackgroundBrush="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
 				               folding:FoldingMargin.FoldingMarkerBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"

--- a/ILSpy/Themes/Base.Dark.xaml
+++ b/ILSpy/Themes/Base.Dark.xaml
@@ -9,6 +9,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="Black" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#995A23" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 
 	<Color x:Key="{x:Static SystemColors.ControlLightLightColorKey}">#333337</Color>
 	<Color x:Key="{x:Static SystemColors.ControlLightColorKey}">#464646</Color>

--- a/ILSpy/Themes/Base.Dark.xaml
+++ b/ILSpy/Themes/Base.Dark.xaml
@@ -9,6 +9,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="Black" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#995A23" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 

--- a/ILSpy/Themes/Base.Dark.xaml
+++ b/ILSpy/Themes/Base.Dark.xaml
@@ -12,6 +12,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#443399FF" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#883399FF" Thickness="1" />
 
 	<Color x:Key="{x:Static SystemColors.ControlLightLightColorKey}">#333337</Color>
 	<Color x:Key="{x:Static SystemColors.ControlLightColorKey}">#464646</Color>
@@ -35,9 +37,6 @@
 	<Color x:Key="{x:Static SystemColors.InactiveCaptionColorKey}">#2D2D30</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveBorderColorKey}">#434346</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveCaptionTextColorKey}">#808080</Color>
-
-	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#443399FF" />
-	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#883399FF" Thickness="1" />
 
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightLightBrushKey}" Color="#333337" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightBrushKey}" Color="#464646" />

--- a/ILSpy/Themes/Base.Light.xaml
+++ b/ILSpy/Themes/Base.Light.xaml
@@ -8,7 +8,9 @@
 
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="Black" />
-	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}">LightGreen</SolidColorBrush>
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="LightGreen" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 
 	<Color x:Key="{x:Static SystemColors.ControlLightLightColorKey}">#FCFCFC</Color>
 	<Color x:Key="{x:Static SystemColors.ControlLightColorKey}">#D8D8E0</Color>

--- a/ILSpy/Themes/Base.Light.xaml
+++ b/ILSpy/Themes/Base.Light.xaml
@@ -12,6 +12,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#160000FF" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#340000FF" Thickness="1" />
 
 	<Color x:Key="{x:Static SystemColors.ControlLightLightColorKey}">#FCFCFC</Color>
 	<Color x:Key="{x:Static SystemColors.ControlLightColorKey}">#D8D8E0</Color>
@@ -33,9 +35,6 @@
 	<Color x:Key="{x:Static SystemColors.InactiveCaptionColorKey}">#EEEEF2</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveBorderColorKey}">#CCCEDB</Color>
 	<Color x:Key="{x:Static SystemColors.InactiveCaptionTextColorKey}">#808080</Color>
-
-	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#160000FF" />
-	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#340000FF" Thickness="1" />
 
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightLightBrushKey}" Color="#FCFCFC" />
 	<SolidColorBrush x:Key="{x:Static SystemColors.ControlLightBrushKey}" Color="#D8D8E0" />

--- a/ILSpy/Themes/Base.Light.xaml
+++ b/ILSpy/Themes/Base.Light.xaml
@@ -9,6 +9,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="Black" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="LightGreen" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 

--- a/ILSpy/Themes/ResourceKeys.cs
+++ b/ILSpy/Themes/ResourceKeys.cs
@@ -30,6 +30,7 @@ namespace ICSharpCode.ILSpy.Themes
 		public static ResourceKey LinkTextForegroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(LinkTextForegroundBrush));
 		public static ResourceKey BracketHighlightBackgroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(BracketHighlightBackgroundBrush));
 		public static ResourceKey BracketHighlightBorderPen = new ComponentResourceKey(typeof(ResourceKeys), nameof(BracketHighlightBorderPen));
+		public static ResourceKey LineNumbersForegroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(LineNumbersForegroundBrush));
 		public static ResourceKey CurrentLineBackgroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(CurrentLineBackgroundBrush));
 		public static ResourceKey CurrentLineBorderPen = new ComponentResourceKey(typeof(ResourceKeys), nameof(CurrentLineBorderPen));
 		public static ResourceKey ThemeAwareButtonEffect = new ComponentResourceKey(typeof(ResourceKeys), nameof(ThemeAwareButtonEffect));

--- a/ILSpy/Themes/ResourceKeys.cs
+++ b/ILSpy/Themes/ResourceKeys.cs
@@ -30,6 +30,8 @@ namespace ICSharpCode.ILSpy.Themes
 		public static ResourceKey LinkTextForegroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(LinkTextForegroundBrush));
 		public static ResourceKey BracketHighlightBackgroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(BracketHighlightBackgroundBrush));
 		public static ResourceKey BracketHighlightBorderPen = new ComponentResourceKey(typeof(ResourceKeys), nameof(BracketHighlightBorderPen));
+		public static ResourceKey CurrentLineBackgroundBrush = new ComponentResourceKey(typeof(ResourceKeys), nameof(CurrentLineBackgroundBrush));
+		public static ResourceKey CurrentLineBorderPen = new ComponentResourceKey(typeof(ResourceKeys), nameof(CurrentLineBorderPen));
 		public static ResourceKey ThemeAwareButtonEffect = new ComponentResourceKey(typeof(ResourceKeys), nameof(ThemeAwareButtonEffect));
 	}
 }

--- a/ILSpy/Themes/Theme.Dark.xaml
+++ b/ILSpy/Themes/Theme.Dark.xaml
@@ -8,6 +8,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="#333337" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="#F1F1F1" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#995A23" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 

--- a/ILSpy/Themes/Theme.Dark.xaml
+++ b/ILSpy/Themes/Theme.Dark.xaml
@@ -8,6 +8,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="#333337" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="#F1F1F1" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#995A23" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 
 	<!-- ILAsm -->
 	<themes:SyntaxColor x:Key="SyntaxColor.ILAsm.Comment" Foreground="#FF57A64A" />

--- a/ILSpy/Themes/Theme.Dark.xaml
+++ b/ILSpy/Themes/Theme.Dark.xaml
@@ -11,6 +11,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#443399FF" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#883399FF" Thickness="1" />
 
 	<!-- ILAsm -->
 	<themes:SyntaxColor x:Key="SyntaxColor.ILAsm.Comment" Foreground="#FF57A64A" />

--- a/ILSpy/Themes/Theme.Light.xaml
+++ b/ILSpy/Themes/Theme.Light.xaml
@@ -11,6 +11,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#160000FF" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#340000FF" Thickness="1" />
 
 	<!-- ILAsm -->
 	<themes:SyntaxColor x:Key="SyntaxColor.ILAsm.Comment" Foreground="Green" />

--- a/ILSpy/Themes/Theme.Light.xaml
+++ b/ILSpy/Themes/Theme.Light.xaml
@@ -8,6 +8,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="{DynamicResource {x:Static SystemColors.InfoColorKey}}" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="{DynamicResource {x:Static SystemColors.InfoTextColorKey}}" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="LightGreen" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 
 	<!-- ILAsm -->
 	<themes:SyntaxColor x:Key="SyntaxColor.ILAsm.Comment" Foreground="Green" />

--- a/ILSpy/Themes/Theme.Light.xaml
+++ b/ILSpy/Themes/Theme.Light.xaml
@@ -8,6 +8,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="{DynamicResource {x:Static SystemColors.InfoColorKey}}" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="{DynamicResource {x:Static SystemColors.InfoTextColorKey}}" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="LightGreen" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="Gray" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#1614DCE0" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#3400FF6E" Thickness="1" />
 

--- a/ILSpy/Themes/Theme.RSharpDark.xaml
+++ b/ILSpy/Themes/Theme.RSharpDark.xaml
@@ -10,6 +10,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="#1E1E1E" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="#DCDCDC" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#995A23" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#2B91AF" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#0F0F0F" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" />
 

--- a/ILSpy/Themes/Theme.RSharpDark.xaml
+++ b/ILSpy/Themes/Theme.RSharpDark.xaml
@@ -9,7 +9,9 @@
 
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="#1E1E1E" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="#DCDCDC" />
-	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}">#995A23</SolidColorBrush>
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#995A23" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#0F0F0F" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#483D8B</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#800000</Color>

--- a/ILSpy/Themes/Theme.RSharpDark.xaml
+++ b/ILSpy/Themes/Theme.RSharpDark.xaml
@@ -13,6 +13,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#2B91AF" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#0F0F0F" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#0E4583" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#483D8B</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#800000</Color>

--- a/ILSpy/Themes/Theme.RSharpLight.xaml
+++ b/ILSpy/Themes/Theme.RSharpLight.xaml
@@ -9,7 +9,9 @@
 
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="Black" />
-	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}">#F6B94D</SolidColorBrush>
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#F6B94D"/>
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#F7F7F7" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#87CEFA</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#FFB6C1</Color>

--- a/ILSpy/Themes/Theme.RSharpLight.xaml
+++ b/ILSpy/Themes/Theme.RSharpLight.xaml
@@ -13,6 +13,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#85A8AF" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#F7F7F7" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#C4D5DB" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#87CEFA</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#FFB6C1</Color>

--- a/ILSpy/Themes/Theme.RSharpLight.xaml
+++ b/ILSpy/Themes/Theme.RSharpLight.xaml
@@ -10,6 +10,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="Black" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#F6B94D"/>
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#85A8AF" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" Color="#F7F7F7" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" />
 

--- a/ILSpy/Themes/Theme.VSCodeDarkPlus.xaml
+++ b/ILSpy/Themes/Theme.VSCodeDarkPlus.xaml
@@ -18,6 +18,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#858585" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#282828" Thickness="2" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#1B251B" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#888888" Thickness="1" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#264F78</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#343A40</Color>

--- a/ILSpy/Themes/Theme.VSCodeDarkPlus.xaml
+++ b/ILSpy/Themes/Theme.VSCodeDarkPlus.xaml
@@ -15,6 +15,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="#1E1E1E" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="#D4D4D4" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#613214" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#858585" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#282828" Thickness="2" />
 

--- a/ILSpy/Themes/Theme.VSCodeDarkPlus.xaml
+++ b/ILSpy/Themes/Theme.VSCodeDarkPlus.xaml
@@ -15,6 +15,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="#1E1E1E" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="#D4D4D4" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#613214" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#282828" Thickness="2" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#264F78</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#343A40</Color>

--- a/ILSpy/Themes/Theme.VSCodeLightPlus.xaml
+++ b/ILSpy/Themes/Theme.VSCodeLightPlus.xaml
@@ -15,6 +15,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="Black" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#F8C9AB" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#EEEEEE" Thickness="2" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#ADD6FF</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#D6EAFF</Color>

--- a/ILSpy/Themes/Theme.VSCodeLightPlus.xaml
+++ b/ILSpy/Themes/Theme.VSCodeLightPlus.xaml
@@ -18,6 +18,8 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#237893" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#EEEEEE" Thickness="2" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.BracketHighlightBackgroundBrush}" Color="#E5EFE5" />
+	<Pen x:Key="{x:Static themes:ResourceKeys.BracketHighlightBorderPen}" Brush="#B9B9B9" Thickness="1" />
 
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerBackgroundColor}">#ADD6FF</Color>
 	<Color x:Key="{x:Static themes:ResourceKeys.TextMarkerDefinitionBackgroundColor}">#D6EAFF</Color>

--- a/ILSpy/Themes/Theme.VSCodeLightPlus.xaml
+++ b/ILSpy/Themes/Theme.VSCodeLightPlus.xaml
@@ -15,6 +15,7 @@
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextBackgroundBrush}" Color="White" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.TextForegroundBrush}" Color="Black" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.SearchResultBackgroundBrush}" Color="#F8C9AB" />
+	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.LineNumbersForegroundBrush}" Color="#237893" />
 	<SolidColorBrush x:Key="{x:Static themes:ResourceKeys.CurrentLineBackgroundBrush}" />
 	<Pen x:Key="{x:Static themes:ResourceKeys.CurrentLineBorderPen}" Brush="#EEEEEE" Thickness="2" />
 


### PR DESCRIPTION
### Problem

I missed a few items which themes should have customized in #2906:

- The current line highlight
- The line numbers
- The matching brackets

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.

  The changes are pretty straightforward.

* Which part of this PR is most in need of attention/improvement?

  I also aligned the borders of highlighted brackets to whole pixels, as they were blurry otherwise.


Render examples:

![image](https://user-images.githubusercontent.com/7913492/230478484-1aa23a71-73fb-4842-87f1-5fb2456eb849.png) ![image](https://user-images.githubusercontent.com/7913492/230478608-cc7d5cb9-1006-493f-afaf-a90d5bda4e7a.png)

