### PR TITLE
Consider constructor type when lifting decimal constants

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DecimalFields.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DecimalFields.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) 2014 AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -36,7 +36,27 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			Console.WriteLine(field2);
 			Console.WriteLine(field3);
 			Console.WriteLine(field4);
+			Console.WriteLine(IntToDecimal());
+			Console.WriteLine(UIntToDecimal());
+			Console.WriteLine(LongToDecimal());
+			Console.WriteLine(ULongToDecimal());
 			return 0;
+		}
+
+		public static decimal IntToDecimal() {
+			return (decimal)int.MaxValue;
+		}
+
+		public static decimal UIntToDecimal() {
+			return (decimal)uint.MaxValue;
+		}
+
+		public static decimal LongToDecimal() {
+			return (decimal)long.MaxValue;
+		}
+
+		public static decimal ULongToDecimal() {
+			return (decimal)ulong.MaxValue;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DecimalFields.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DecimalFields.cs
@@ -43,19 +43,23 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			return 0;
 		}
 
-		public static decimal IntToDecimal() {
+		public static decimal IntToDecimal()
+		{
 			return (decimal)int.MaxValue;
 		}
 
-		public static decimal UIntToDecimal() {
+		public static decimal UIntToDecimal()
+		{
 			return (decimal)uint.MaxValue;
 		}
 
-		public static decimal LongToDecimal() {
+		public static decimal LongToDecimal()
+		{
 			return (decimal)long.MaxValue;
 		}
 
-		public static decimal ULongToDecimal() {
+		public static decimal ULongToDecimal()
+		{
 			return (decimal)ulong.MaxValue;
 		}
 	}

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -433,10 +433,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				{
 					var paramType = inst.Method.Parameters[0].Type.GetDefinition()?.KnownTypeCode;
 					result = paramType switch {
-						KnownTypeCode.Int32 => new LdcDecimal(new decimal((int)val)),
-						KnownTypeCode.UInt32 => new LdcDecimal(new decimal((uint)val)),
+						KnownTypeCode.Int32 => new LdcDecimal(new decimal(unchecked((int)val))),
+						KnownTypeCode.UInt32 => new LdcDecimal(new decimal(unchecked((uint)val))),
 						KnownTypeCode.Int64 => new LdcDecimal(new decimal(val)),
-						KnownTypeCode.UInt64 => new LdcDecimal(new decimal((ulong)val)),
+						KnownTypeCode.UInt64 => new LdcDecimal(new decimal(unchecked((ulong)val))),
 						_ => null
 					};
 					return result is not null;

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014-2017 Daniel Grunwald
+// Copyright (c) 2014-2017 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -428,11 +428,18 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			var args = inst.Arguments;
 			if (args.Count == 1)
 			{
-				int val;
-				if (args[0].MatchLdcI4(out val))
+				long val;
+				if (args[0].MatchLdcI(out val))
 				{
-					result = new LdcDecimal(val);
-					return true;
+					var paramType = inst.Method.Parameters[0].Type.GetDefinition()?.KnownTypeCode;
+					result = paramType switch {
+						KnownTypeCode.Int32 => new LdcDecimal(new decimal((int)val)),
+						KnownTypeCode.UInt32 => new LdcDecimal(new decimal((uint)val)),
+						KnownTypeCode.Int64 => new LdcDecimal(new decimal(val)),
+						KnownTypeCode.UInt64 => new LdcDecimal(new decimal((ulong)val)),
+						_ => null
+					};
+					return result is not null;
 				}
 			}
 			else if (args.Count == 5)


### PR DESCRIPTION
Link to issue(s) this covers:
Fixes #2949 

### Problem
ILSpy did not use the proper `decimal` constructor when transforming the `LdcI4` instruction into a `LdcDecimal` instruction. Furthermore, the constructors with parameter type `long` and `ulong` were not supported at all as the pattern did not account for `LdcI8`.

Code to reproduce the missing constructor issue:
```csharp
public static decimal LongToDecimal() {
	return (decimal)long.MaxValue;
}

public static decimal ULongToDecimal() {
	return (decimal)ulong.MaxValue;
}
```

### Solution
* Ensure the correct decimal constructor is used when creating `LdcDecimal` instructions.
* Add support for the two aforementioned previously unsupported constructors.
