### PR TITLE
Fix #2954

### DIFF
--- a/packages.props
+++ b/packages.props
@@ -17,7 +17,7 @@
 		<RoslynVersion>4.4.0</RoslynVersion>
 		<MonoCecilVersion>0.11.4</MonoCecilVersion>
 		<AvalonEditVersion>6.3.0.90</AvalonEditVersion>
-		<WpfStylesToolboxVersion>2.8.6</WpfStylesToolboxVersion>
+		<WpfStylesToolboxVersion>2.8.7</WpfStylesToolboxVersion>
 		<NUnitVersion>3.13.3</NUnitVersion>
 		<NUnitAdapterVersion>4.4.2</NUnitAdapterVersion>
 		<JUnitXmlTestLoggerVersion>3.0.124</JUnitXmlTestLoggerVersion>

--- a/packages.props
+++ b/packages.props
@@ -17,7 +17,7 @@
 		<RoslynVersion>4.4.0</RoslynVersion>
 		<MonoCecilVersion>0.11.4</MonoCecilVersion>
 		<AvalonEditVersion>6.3.0.90</AvalonEditVersion>
-		<WpfStylesToolboxVersion>2.8.5</WpfStylesToolboxVersion>
+		<WpfStylesToolboxVersion>2.8.6</WpfStylesToolboxVersion>
 		<NUnitVersion>3.13.3</NUnitVersion>
 		<NUnitAdapterVersion>4.4.2</NUnitAdapterVersion>
 		<JUnitXmlTestLoggerVersion>3.0.124</JUnitXmlTestLoggerVersion>


### PR DESCRIPTION
Link to issue(s) this covers
#2954

### Problem
Layout Options context menu over maximize button is not visible on Win11

### Solution
Update dependencies, see https://github.com/tom-englert/TomsToolbox/issues/16


