### PR TITLE
Extend `EliminateRedundantTryFinally` in `ReduceNestingTransform`

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/ReduceNestingTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ReduceNestingTransform.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Siegfried Pammer
+// Copyright (c) 2018 Siegfried Pammer
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -637,10 +637,25 @@ namespace ICSharpCode.Decompiler.IL
 			// Finally is empty and redundant. But we'll delete the block only if there's a PinnedRegion.
 			if (!(tryFinally.TryBlock is BlockContainer tryContainer))
 				return;
-			if (tryContainer.SingleInstruction() is PinnedRegion pinnedRegion)
+			if (tryContainer.Blocks.Count != 1)
+				return;
+			var tryBlock = tryContainer.Blocks[0];
+			if (tryBlock.Instructions.Count == 1)
 			{
-				context.Step("Removing try-finally around PinnedRegion", pinnedRegion);
-				tryFinally.ReplaceWith(pinnedRegion);
+				if (tryBlock.Instructions[0] is PinnedRegion pinnedRegion)
+				{
+					context.Step("Removing try-finally around PinnedRegion", pinnedRegion);
+					tryFinally.ReplaceWith(pinnedRegion);
+				}
+			}
+			else if (tryBlock.Instructions.Count == 2)
+			{
+				if (tryBlock.Instructions[0] is PinnedRegion pinnedRegion &&
+					tryBlock.Instructions[1].MatchLeave(tryContainer))
+				{
+					context.Step("Removing try-finally around PinnedRegion", pinnedRegion);
+					tryFinally.ReplaceWith(pinnedRegion);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
When decompiling `EventPipeMetadataGenerator.GenerateMetadata(int eventId, string eventName, long keywords, uint level, uint version, EventOpcode opcode, EventParameterInfo[] parameters)` from `System.Private.CoreLib` from .NET 7.0.4 the decompiler does not completely clean up try finally regions left over from the pinned region decompilation step.

Before change:
```c#
internal unsafe byte[] GenerateMetadata(int eventId, string eventName, long keywords, uint level, uint version, EventOpcode opcode, EventParameterInfo[] parameters)
{
	byte[] array = null;
	bool flag = false;
	try
	{
		uint num = (uint)(24 + (eventName.Length + 1) * 2);
		uint num2 = 0u;
		uint num3 = num;
		if (parameters.Length == 1 && parameters[0].ParameterType == typeof(EmptyStruct))
		{
			parameters = Array.Empty<EventParameterInfo>();
		}
		EventParameterInfo[] array2 = parameters;
		foreach (EventParameterInfo eventParameterInfo in array2)
		{
			if (!eventParameterInfo.GetMetadataLength(out var size))
			{
				flag = true;
				break;
			}
			num += size;
		}
		if (flag)
		{
			num = num3;
			num2 = 4u;
			EventParameterInfo[] array3 = parameters;
			foreach (EventParameterInfo eventParameterInfo2 in array3)
			{
				if (!eventParameterInfo2.GetMetadataLengthV2(out var size2))
				{
					parameters = Array.Empty<EventParameterInfo>();
					num = num3;
					num2 = 0u;
					flag = false;
					break;
				}
				num2 += size2;
			}
		}
		uint num4 = ((opcode != 0) ? 6u : 0u);
		uint num5 = ((num2 != 0) ? (num2 + 5) : 0u);
		uint num6 = num5 + num4;
		uint num7 = num + num6;
		array = new byte[num7];
		fixed (byte* ptr = array)
		{
			uint offset = 0u;
			WriteToBuffer(ptr, num7, ref offset, (uint)eventId);
			try
			{
				fixed (char* src = eventName)
				{
					WriteToBuffer(ptr, num7, ref offset, (byte*)src, (uint)((eventName.Length + 1) * 2));
				}
			}
			finally
			{
			}
			WriteToBuffer(ptr, num7, ref offset, keywords);
			WriteToBuffer(ptr, num7, ref offset, version);
			WriteToBuffer(ptr, num7, ref offset, level);
			if (flag)
			{
				WriteToBuffer(ptr, num7, ref offset, 0);
			}
			else
			{
				WriteToBuffer(ptr, num7, ref offset, (uint)parameters.Length);
				EventParameterInfo[] array4 = parameters;
				foreach (EventParameterInfo eventParameterInfo3 in array4)
				{
					if (!eventParameterInfo3.GenerateMetadata(ptr, ref offset, num7))
					{
						return GenerateMetadata(eventId, eventName, keywords, level, version, opcode, Array.Empty<EventParameterInfo>());
					}
				}
			}
			if (opcode != 0)
			{
				WriteToBuffer(ptr, num7, ref offset, 1);
				WriteToBuffer(ptr, num7, ref offset, (byte)1);
				WriteToBuffer(ptr, num7, ref offset, (byte)opcode);
			}
			if (flag)
			{
				WriteToBuffer(ptr, num7, ref offset, num2);
				WriteToBuffer(ptr, num7, ref offset, (byte)2);
				WriteToBuffer(ptr, num7, ref offset, (uint)parameters.Length);
				EventParameterInfo[] array5 = parameters;
				foreach (EventParameterInfo eventParameterInfo4 in array5)
				{
					if (!eventParameterInfo4.GenerateMetadataV2(ptr, ref offset, num7))
					{
						return GenerateMetadata(eventId, eventName, keywords, level, version, opcode, Array.Empty<EventParameterInfo>());
					}
				}
				return array;
			}
			return array;
		}
	}
	catch
	{
		return null;
	}
}
```

After change:
```c#
internal unsafe byte[] GenerateMetadata(int eventId, string eventName, long keywords, uint level, uint version, EventOpcode opcode, EventParameterInfo[] parameters)
{
	byte[] array = null;
	bool flag = false;
	try
	{
		uint num = (uint)(24 + (eventName.Length + 1) * 2);
		uint num2 = 0u;
		uint num3 = num;
		if (parameters.Length == 1 && parameters[0].ParameterType == typeof(EmptyStruct))
		{
			parameters = Array.Empty<EventParameterInfo>();
		}
		EventParameterInfo[] array2 = parameters;
		foreach (EventParameterInfo eventParameterInfo in array2)
		{
			if (!eventParameterInfo.GetMetadataLength(out var size))
			{
				flag = true;
				break;
			}
			num += size;
		}
		if (flag)
		{
			num = num3;
			num2 = 4u;
			EventParameterInfo[] array3 = parameters;
			foreach (EventParameterInfo eventParameterInfo2 in array3)
			{
				if (!eventParameterInfo2.GetMetadataLengthV2(out var size2))
				{
					parameters = Array.Empty<EventParameterInfo>();
					num = num3;
					num2 = 0u;
					flag = false;
					break;
				}
				num2 += size2;
			}
		}
		uint num4 = ((opcode != 0) ? 6u : 0u);
		uint num5 = ((num2 != 0) ? (num2 + 5) : 0u);
		uint num6 = num5 + num4;
		uint num7 = num + num6;
		array = new byte[num7];
		fixed (byte* ptr = array)
		{
			uint offset = 0u;
			WriteToBuffer(ptr, num7, ref offset, (uint)eventId);
			fixed (char* src = eventName)
			{
				WriteToBuffer(ptr, num7, ref offset, (byte*)src, (uint)((eventName.Length + 1) * 2));
			}
			WriteToBuffer(ptr, num7, ref offset, keywords);
			WriteToBuffer(ptr, num7, ref offset, version);
			WriteToBuffer(ptr, num7, ref offset, level);
			if (flag)
			{
				WriteToBuffer(ptr, num7, ref offset, 0);
			}
			else
			{
				WriteToBuffer(ptr, num7, ref offset, (uint)parameters.Length);
				EventParameterInfo[] array4 = parameters;
				foreach (EventParameterInfo eventParameterInfo3 in array4)
				{
					if (!eventParameterInfo3.GenerateMetadata(ptr, ref offset, num7))
					{
						return GenerateMetadata(eventId, eventName, keywords, level, version, opcode, Array.Empty<EventParameterInfo>());
					}
				}
			}
			if (opcode != 0)
			{
				WriteToBuffer(ptr, num7, ref offset, 1);
				WriteToBuffer(ptr, num7, ref offset, (byte)1);
				WriteToBuffer(ptr, num7, ref offset, (byte)opcode);
			}
			if (flag)
			{
				WriteToBuffer(ptr, num7, ref offset, num2);
				WriteToBuffer(ptr, num7, ref offset, (byte)2);
				WriteToBuffer(ptr, num7, ref offset, (uint)parameters.Length);
				EventParameterInfo[] array5 = parameters;
				foreach (EventParameterInfo eventParameterInfo4 in array5)
				{
					if (!eventParameterInfo4.GenerateMetadataV2(ptr, ref offset, num7))
					{
						return GenerateMetadata(eventId, eventName, keywords, level, version, opcode, Array.Empty<EventParameterInfo>());
					}
				}
				return array;
			}
			return array;
		}
	}
	catch
	{
		return null;
	}
}
```

The code responsible for removing this redundant try-finally was extended to account for a potential additional `leave` ILAst instruction present in the single block of the try container.

I did not add any unit tests as I was unable to get the compiler to produce an assembly which triggered this bug. In case the assembly I am working with is necessary for easier analysis I have provided it in a zip archive below.

[System.Private.CoreLib.zip](https://github.com/icsharpcode/ILSpy/files/11192916/System.Private.CoreLib.zip)
