### PR TITLE
Use actions/cache

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -20,11 +20,19 @@ jobs:
     steps:
     - run: mkdir -p $env:StagingDirectory
       
-
     - uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0
+
+    - name: NuGet package caching
+      uses: actions/cache@v3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.props') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.props') }}
+          ${{ runner.os }}-nuget-
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -29,9 +29,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.props') }}
+        key: ${{ runner.os }}-nuget-${{ matrix.configuration }}-${{ hashFiles('**/*.csproj', '**/packages.props') }}
         restore-keys: |
-          ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/packages.props') }}
+          ${{ runner.os }}-nuget-${{ matrix.configuration }}-
           ${{ runner.os }}-nuget-
 
     - name: Add msbuild to PATH


### PR DESCRIPTION
Looking at the numbers of builds before caching & now those with caching, it seems that the variability in the runner itself for steps Build and Execute Unit Tests are more meaningful than any caching (which itself seems to be roughly in the ballpark of Restore before caching).