### PR TITLE
Search box for resource tables

### DIFF
--- a/ILSpy/Controls/ResourceObjectTable.xaml
+++ b/ILSpy/Controls/ResourceObjectTable.xaml
@@ -27,16 +27,22 @@
 		<Grid.RowDefinitions>
 			<RowDefinition />
 			<RowDefinition />
+			<RowDefinition />
 		</Grid.RowDefinitions>
 		<Label Content="{x:Static properties:Resources.OtherResources}"
 			   FontFamily="Segoe UI"
 			   FontWeight="Bold"
 			   FontSize="12pt" />
+		<local:SearchBox x:Name="resourceFilterBox" 
+			   FontFamily="Segoe UI"
+			   FontSize="9pt"
+			   Grid.Row="1"
+			   TextChanged="OnFilterTextChanged" />
 		<ListView Name="resourceListView"
 				  FontFamily="Segoe UI"
 				  FontSize="9pt"
 				  Foreground="Black"
-				  Grid.Row="1"
+				  Grid.Row="2"
 				  AlternationCount="2"
 				  ItemContainerStyle="{StaticResource alternatingWithBinding}"
 				  local:SortableGridViewColumn.SortMode="Automatic">

--- a/ILSpy/Controls/ResourceObjectTable.xaml.cs
+++ b/ILSpy/Controls/ResourceObjectTable.xaml.cs
@@ -18,9 +18,12 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace ICSharpCode.ILSpy.Controls
@@ -30,6 +33,9 @@ namespace ICSharpCode.ILSpy.Controls
 	/// </summary>
 	public partial class ResourceObjectTable : UserControl
 	{
+		ICollectionView filteredView;
+		string filter;
+
 		public ResourceObjectTable(IEnumerable resources, FrameworkElement container)
 		{
 			InitializeComponent();
@@ -38,7 +44,22 @@ namespace ICSharpCode.ILSpy.Controls
 			if (!double.IsNaN(container.ActualWidth))
 				Width = Math.Max(container.ActualWidth - 45, 0);
 			MaxHeight = container.ActualHeight;
-			resourceListView.ItemsSource = resources;
+
+			filteredView = CollectionViewSource.GetDefaultView(resources);
+			filteredView.Filter = OnResourceFilter;
+			resourceListView.ItemsSource = filteredView;
+		}
+
+		private bool OnResourceFilter(object obj)
+		{
+			if (string.IsNullOrEmpty(filter))
+				return true;
+
+			if (obj is TreeNodes.ResourcesFileTreeNode.SerializedObjectRepresentation item)
+				return item.Key?.Contains(filter, StringComparison.OrdinalIgnoreCase) == true ||
+					   item.Value?.Contains(filter, StringComparison.OrdinalIgnoreCase) == true;
+
+			return false; // make it obvious search is not working
 		}
 
 		private void OnParentSizeChanged(object sender, SizeChangedEventArgs e)
@@ -47,6 +68,12 @@ namespace ICSharpCode.ILSpy.Controls
 				Width = Math.Max(e.NewSize.Width - 45, 0);
 			if (e.HeightChanged)
 				MaxHeight = e.NewSize.Height;
+		}
+
+		private void OnFilterTextChanged(object sender, TextChangedEventArgs e)
+		{
+			filter = resourceFilterBox.Text;
+			filteredView?.Refresh();
 		}
 
 		void ExecuteCopy(object sender, ExecutedRoutedEventArgs args)

--- a/ILSpy/Controls/ResourceStringTable.xaml
+++ b/ILSpy/Controls/ResourceStringTable.xaml
@@ -27,15 +27,21 @@
 		<Grid.RowDefinitions>
 			<RowDefinition />
 			<RowDefinition />
+			<RowDefinition />
 		</Grid.RowDefinitions>
 		<Label Content="{x:Static properties:Resources.StringTable}"
 			   FontFamily="Segoe UI"
 			   FontWeight="Bold"
 			   FontSize="12pt" />
+		<local:SearchBox x:Name="resourceFilterBox" 
+			   FontFamily="Segoe UI"
+			   FontSize="9pt"
+			   Grid.Row="1"
+			   TextChanged="OnFilterTextChanged" />
 		<ListView Name="resourceListView"
 			  FontFamily="Segoe UI"
 			  FontSize="9pt"
-			  Grid.Row="1"
+			  Grid.Row="2"
 			  AlternationCount="2"
 			  ItemContainerStyle="{StaticResource alternatingWithBinding}"
 			  local:SortableGridViewColumn.SortMode="Automatic">

--- a/ILSpy/Controls/ResourceStringTable.xaml.cs
+++ b/ILSpy/Controls/ResourceStringTable.xaml.cs
@@ -18,9 +18,12 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace ICSharpCode.ILSpy.Controls
@@ -30,6 +33,9 @@ namespace ICSharpCode.ILSpy.Controls
 	/// </summary>
 	public partial class ResourceStringTable : UserControl
 	{
+		ICollectionView filteredView;
+		string filter;
+
 		public ResourceStringTable(IEnumerable strings, FrameworkElement container)
 		{
 			InitializeComponent();
@@ -38,7 +44,22 @@ namespace ICSharpCode.ILSpy.Controls
 			if (!double.IsNaN(container.ActualWidth))
 				Width = Math.Max(container.ActualWidth - 45, 0);
 			MaxHeight = container.ActualHeight;
-			resourceListView.ItemsSource = strings;
+
+			filteredView = CollectionViewSource.GetDefaultView(strings);
+			filteredView.Filter = OnResourceFilter;
+			resourceListView.ItemsSource = filteredView;
+		}
+
+		private bool OnResourceFilter(object obj)
+		{
+			if (string.IsNullOrEmpty(filter))
+				return true;
+
+			if (obj is KeyValuePair<string, string> item)
+				return item.Key?.Contains(filter, StringComparison.OrdinalIgnoreCase) == true || 
+					   item.Value?.Contains(filter, StringComparison.OrdinalIgnoreCase) == true;
+
+			return false; // make it obvious search is not working
 		}
 
 		private void OnParentSizeChanged(object sender, SizeChangedEventArgs e)
@@ -47,6 +68,12 @@ namespace ICSharpCode.ILSpy.Controls
 				Width = Math.Max(e.NewSize.Width - 45, 0);
 			if (e.HeightChanged)
 				MaxHeight = e.NewSize.Height;
+		}
+
+		private void OnFilterTextChanged(object sender, TextChangedEventArgs e)
+		{
+			filter = resourceFilterBox.Text;
+			filteredView?.Refresh();
 		}
 
 		void ExecuteCopy(object sender, ExecutedRoutedEventArgs args)


### PR DESCRIPTION
Implements #2967 

### Problem
Unable to search for resource keys or values inside decompiled .resource files.

### Solution
Allow filtering of the string and object tables:

<img src="https://user-images.githubusercontent.com/10546952/233334615-a202c7ce-192f-41d9-a1ed-4494888b854e.png"/>

String tables: filters key and value
Object tables: filters key and value string, not type

Filtering is by simple case-insensitive substring. There are no tests covering the user control as far as I can tell, let me know if I missed them. Object table for testing purposes can be found e.g. in System.Windows.Forms.

There is no watermark in the search box, it feels obvious, but happy to add one if needed.