### PR TITLE
Fix decompilation of small integer pointer compound assignements

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
@@ -4586,6 +4586,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return *(ptr++);
 		}
 
+		public unsafe int PostIncrementOfSmallIntegerPointerDereference(byte* ptr)
+		{
+			return (*ptr)++ * (*ptr)++;
+		}
+
+		public unsafe int PreIncrementOfSmallIntegerPointerDereference(byte* ptr)
+		{
+			return ++(*ptr) * ++(*ptr);
+		}
+
+		public unsafe int CompoundAssignSmallIntegerPointerDereference(byte* ptr)
+		{
+			return (*ptr += 5) * (*ptr += 5);
+		}
+
 		public int PostDecrementInstanceField()
 		{
 			return M().Field--;

--- a/ICSharpCode.Decompiler/IL/ILTypeExtensions.cs
+++ b/ICSharpCode.Decompiler/IL/ILTypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 // Copyright (c) 2014 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
@@ -75,6 +75,26 @@ namespace ICSharpCode.Decompiler.IL
 					return Sign.Unsigned;
 				default:
 					return Sign.None;
+			}
+		}
+
+		public static bool HasOppositeSign(this PrimitiveType primitiveType)
+		{
+			switch (primitiveType)
+			{
+				case PrimitiveType.I1:
+				case PrimitiveType.I2:
+				case PrimitiveType.I4:
+				case PrimitiveType.I8:
+				case PrimitiveType.U1:
+				case PrimitiveType.U2:
+				case PrimitiveType.U4:
+				case PrimitiveType.U8:
+				case PrimitiveType.I:
+				case PrimitiveType.U:
+					return true;
+				default:
+					return false;
 			}
 		}
 


### PR DESCRIPTION
Link to issue(s) this covers:
Fixes https://github.com/icsharpcode/ILSpy/issues/2620

### Problem
A detailed description of the issue is available here https://github.com/icsharpcode/ILSpy/issues/2620#issuecomment-1424068247.

TLDR: Compiler used `stind` for signed integer type to store the value pushed by a `conv` to an unsigned integer type which resulted in ILSpy failing to successfully introduce compound assignments.

### Solution
* Implementation should be in line with what was discussed in the aforementioned issue.

@dgrunwald Please let me know if these changes are ok and do not violate the semantics of `StObj` or other ILSpy ILAst OpCodes!

