### PR TITLE
Make return duplication in `ControlFlowSimplification` less aggressive

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ReduceNesting.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ReduceNesting.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
@@ -565,6 +566,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 					throw;
 				}
 			}
+		}
+
+		private static string DuplicateReturnTest(IDictionary<int, string> dict)
+		{
+			string value;
+			lock (dict)
+			{
+				if (!dict.TryGetValue(1, out value))
+				{
+					value = "test";
+					dict.Add(1, value);
+				}
+			}
+			return value;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ReduceNesting.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ReduceNesting.cs
@@ -568,7 +568,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
-		private static string DuplicateReturnTest(IDictionary<int, string> dict)
+		private static string ShouldNotDuplicateReturnStatementIntoTry(IDictionary<int, string> dict)
 		{
 			string value;
 			lock (dict)

--- a/ICSharpCode.Decompiler/IL/ControlFlow/ControlFlowSimplification.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/ControlFlowSimplification.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 Daniel Grunwald
+// Copyright (c) 2014 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -137,7 +137,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 
 		void SimplifyBranchChains(ILFunction function, ILTransformContext context)
 		{
-			List<(BlockContainer, Block)> blocksToAdd = new List<(BlockContainer, Block)>();
+			List<(Block Block, BlockContainer TargetContainer)> blocksToMove = new List<(Block, BlockContainer)>();
 			HashSet<Block> visitedBlocks = new HashSet<Block>();
 			foreach (var branch in function.Descendants.OfType<Branch>())
 			{
@@ -167,7 +167,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 						context.Step("Replace branch to return with return", branch);
 						branch.ReplaceWith(targetBlock.Instructions[0].Clone());
 					}
-					else if (branch.TargetContainer != branch.Ancestors.OfType<BlockContainer>().First())
+					else if (branch.TargetContainer != branch.Ancestors.OfType<BlockContainer>().First() && targetBlock.IncomingEdgeCount == 1)
 					{
 						// We don't want to always inline the return directly, because this
 						// might force us to place the return within a loop, when it's better
@@ -175,11 +175,9 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 						// But we do want to move the return block into the correct try-finally scope,
 						// so that loop detection at least has the option to put it inside
 						// the loop body.
-						context.Step("Copy return block into try block", branch);
-						Block blockCopy = (Block)branch.TargetBlock.Clone();
+						context.Step("Move return block into try block", branch);
 						BlockContainer localContainer = branch.Ancestors.OfType<BlockContainer>().First();
-						blocksToAdd.Add((localContainer, blockCopy));
-						branch.TargetBlock = blockCopy;
+						blocksToMove.Add((targetBlock, localContainer));
 					}
 				}
 				else if (targetBlock.Instructions.Count == 1 && targetBlock.Instructions[0] is Leave leave && leave.Value.MatchNop())
@@ -194,9 +192,10 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				if (targetBlock.IncomingEdgeCount == 0)
 					targetBlock.Instructions.Clear(); // mark the block for deletion
 			}
-			foreach (var (container, block) in blocksToAdd)
+			foreach ((Block block, BlockContainer targetContainer) in blocksToMove)
 			{
-				container.Blocks.Add(block);
+				block.Remove();
+				targetContainer.Blocks.Add(block);
 			}
 		}
 


### PR DESCRIPTION
Link to issue(s) this covers:
Fixes https://github.com/icsharpcode/ILSpy/issues/2924

### Problem
ILSpy was a bit too aggressive when it came to duplicating return blocks which resulted in unoptimal and confusing code with tons of unnecessary return statements which differed from the original source code used to produce the binary. For examples see https://github.com/icsharpcode/ILSpy/issues/2924#issue-1624058543 and https://github.com/icsharpcode/ILSpy/issues/2924#issuecomment-1502212321.

### Solution
* Make the return block duplication step in `ControlFlowSimplification` less aggressive by effectively making it only perform the duplication if the incoming edge count was 1. This effectively turned it into a simple movement of a block from one container to another.
