### PR TITLE
remove CodeView check on pdb create

### DIFF
--- a/ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs
@@ -26,10 +26,8 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Runtime;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 
 using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.OutputVisitor;
@@ -236,9 +234,16 @@ namespace ICSharpCode.Decompiler.DebugInfo
 
 			if (pdbId == null)
 			{
-				var debugDir = file.Reader.ReadDebugDirectory().FirstOrDefault(dir => dir.Type == DebugDirectoryEntryType.CodeView);
-				var portable = file.Reader.ReadCodeViewDebugDirectoryData(debugDir);
-				pdbId = new BlobContentId(portable.Guid, debugDir.Stamp);
+				if (PortablePdbWriter.HasCodeViewDebugDirectoryEntry(file))
+				{
+					var debugDir = file.Reader.ReadDebugDirectory().FirstOrDefault(dir => dir.Type == DebugDirectoryEntryType.CodeView);
+					var portable = file.Reader.ReadCodeViewDebugDirectoryData(debugDir);
+					pdbId = new BlobContentId(portable.Guid, debugDir.Stamp);
+				}
+				else
+				{
+					pdbId = new BlobContentId(Guid.NewGuid(), 0);
+				}
 			}
 
 			PortablePdbBuilder serializer = new PortablePdbBuilder(metadata, GetRowCounts(reader), entrypointHandle, blobs => pdbId.Value);

--- a/ILSpy/Commands/GeneratePdbContextMenuEntry.cs
+++ b/ILSpy/Commands/GeneratePdbContextMenuEntry.cs
@@ -21,7 +21,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows;
 
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
@@ -58,12 +57,6 @@ namespace ICSharpCode.ILSpy
 
 		internal static void GeneratePdbForAssembly(LoadedAssembly assembly)
 		{
-			var file = assembly.GetPEFileOrNull();
-			if (!PortablePdbWriter.HasCodeViewDebugDirectoryEntry(file))
-			{
-				MessageBox.Show(string.Format(Resources.CannotCreatePDBFile, Path.GetFileName(assembly.FileName)));
-				return;
-			}
 			SaveFileDialog dlg = new SaveFileDialog();
 			dlg.FileName = WholeProjectDecompiler.CleanUpFileName(assembly.ShortName) + ".pdb";
 			dlg.Filter = Resources.PortablePDBPdbAllFiles;
@@ -80,6 +73,7 @@ namespace ICSharpCode.ILSpy
 				{
 					try
 					{
+						var file = assembly.GetPEFileOrNull();
 						var decompiler = new CSharpDecompiler(file, assembly.GetAssemblyResolver(), options.DecompilerSettings);
 						decompiler.CancellationToken = ct;
 						PortablePdbWriter.WritePdb(file, decompiler, options.DecompilerSettings, stream, progress: options.Progress);

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -459,15 +459,6 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot create PDB file for {0}, because it does not contain a PE Debug Directory Entry of type &apos;CodeView&apos;..
-        /// </summary>
-        public static string CannotCreatePDBFile {
-            get {
-                return ResourceManager.GetString("CannotCreatePDBFile", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Check again.
         /// </summary>
         public static string CheckAgain {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -174,9 +174,6 @@ Are you sure you want to continue?</value>
   <data name="CannotAnalyzeMissingRef" xml:space="preserve">
     <value>Entity could not be resolved. Cannot analyze entities from missing assembly references. Add the missing reference and try again.</value>
   </data>
-  <data name="CannotCreatePDBFile" xml:space="preserve">
-    <value>Cannot create PDB file for {0}, because it does not contain a PE Debug Directory Entry of type 'CodeView'.</value>
-  </data>
   <data name="CheckAgain" xml:space="preserve">
     <value>Check again</value>
   </data>

--- a/ILSpy/Properties/Resources.zh-Hans.resx
+++ b/ILSpy/Properties/Resources.zh-Hans.resx
@@ -174,9 +174,6 @@
   <data name="CannotAnalyzeMissingRef" xml:space="preserve">
     <value>无法解析实体。可能是由于缺少程序集引用。请添加缺少的程序集并重试。</value>
   </data>
-  <data name="CannotCreatePDBFile" xml:space="preserve">
-    <value>无法创建为{0}创建PDB文件,因为它不包含PE调试目录类型 'CodeView'.</value>
-  </data>
   <data name="CheckAgain" xml:space="preserve">
     <value>再次检查</value>
   </data>


### PR DESCRIPTION
try to fix https://github.com/icsharpcode/ILSpy/issues/2973

### Problem
No CodeView blocks pdb generation.

### Solution
Generate a guid with zeroed timestamp in case no CodeView exists.