### PR TITLE
PowerShell module manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ multitargeting.props
 ILSpy.Installer/wix/
 /VERSION
 /ICSharpCode.Decompiler/Properties/DecompilerVersionInfo.cs
+*/.vscode/

--- a/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj
+++ b/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj
@@ -25,4 +25,7 @@
     <Compile Include="..\ICSharpCode.ILSpyX\PdbProvider\DebugInfoUtils.cs" Link="DebugInfoUtils.cs" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="pwsh -Command &quot;Copy-Item $(ProjectDir)manifest.psd1 $(TargetDir)$(TargetName).psd1&quot;" />
+  </Target>
 </Project>

--- a/ICSharpCode.Decompiler.PowerShell/manifest.psd1
+++ b/ICSharpCode.Decompiler.PowerShell/manifest.psd1
@@ -1,0 +1,129 @@
+@{
+  # Script module or binary module file associated with this manifest.
+  RootModule        = 'ICSharpCode.Decompiler.PowerShell.dll'
+
+  # Version number of this module.
+  ModuleVersion     = '8.0.0.0'
+
+  # Supported PSEditions
+  # CompatiblePSEditions = @()
+
+  # ID used to uniquely identify this module
+  GUID              = '198b4312-cbe7-417e-81a7-1aaff467ef06'
+
+  # Author of this module
+  Author            = 'ILSpy Contributors'
+
+  # Company or vendor of this module
+  CompanyName       = 'ic#code'
+
+  # Copyright statement for this module
+  Copyright         = 'Copyright 2011-2023 AlphaSierraPapa'
+
+  # Description of the functionality provided by this module
+  Description       = 'PowerShell front-end for ILSpy'
+
+  # Minimum version of the PowerShell engine required by this module
+  # PowerShellVersion = ''
+
+  # Name of the PowerShell host required by this module
+  # PowerShellHostName = ''
+
+  # Minimum version of the PowerShell host required by this module
+  # PowerShellHostVersion = ''
+
+  # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+  # DotNetFrameworkVersion = ''
+
+  # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+  # ClrVersion = ''
+
+  # Processor architecture (None, X86, Amd64) required by this module
+  # ProcessorArchitecture = ''
+
+  # Modules that must be imported into the global environment prior to importing this module
+  # RequiredModules = @()
+
+  # Assemblies that must be loaded prior to importing this module
+  # RequiredAssemblies = @()
+
+  # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+  # ScriptsToProcess = @()
+
+  # Type files (.ps1xml) to be loaded when importing this module
+  # TypesToProcess = @()
+
+  # Format files (.ps1xml) to be loaded when importing this module
+  # FormatsToProcess = @()
+
+  # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+  # NestedModules = @()
+
+  # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+  FunctionsToExport = @()
+
+  # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+  CmdletsToExport   = @(
+    'Get-DecompiledProject',
+    'Get-DecompiledSource',
+    'Get-DecompiledTypes',
+    'Get-Decompiler',
+    'Get-DecompilerVersion'
+  )
+
+  # Variables to export from this module
+  VariablesToExport = '*'
+
+  # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+  AliasesToExport   = @()
+
+  # DSC resources to export from this module
+  # DscResourcesToExport = @()
+
+  # List of all modules packaged with this module
+  # ModuleList = @()
+
+  # List of all files packaged with this module
+  # FileList = @()
+
+  # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+  PrivateData       = @{
+
+    PSData = @{
+
+      # Tags applied to this module. These help with module discovery in online galleries.
+      # Tags = @()
+
+      # A URL to the license for this module.
+      # LicenseUri = ''
+
+      # A URL to the main website for this project.
+      ProjectUri = 'https://github.com/icsharpcode/ILSpy'
+
+      # A URL to an icon representing this module.
+      # IconUri = ''
+
+      # ReleaseNotes of this module
+      # ReleaseNotes = ''
+
+      # Prerelease string of this module
+      # Prerelease = ''
+
+      # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+      # RequireLicenseAcceptance = $false
+
+      # External dependent modules of this module
+      # ExternalModuleDependencies = @()
+
+    } # End of PSData hashtable
+
+  } # End of PrivateData hashtable
+
+  # HelpInfo URI of this module
+  # HelpInfoURI = ''
+
+  # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+  # DefaultCommandPrefix = ''
+
+}
+


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
Previously, `ICSharpCode.Decompiler.PowerShell` did not contain a module manifest (as stated in the README for the project).

### Solution
Added a module manifest, plus the logic to copy it to the build target folder.

Please note that even with the new manifest, the module would still not be auto-discovered by PowerShell. For that to work, the compiled module (and all its dependencies) need to live in a folder on your `$env:PSModulePath` with the exact same name as the module itself; if the module is published to, and subsequently installed from, the PowerShell gallery, this requirement is automatically taken care of by PowerShellGet. 

Also, I wasn't quite sure which version no. to use in the manifest. The decompiler itself appears to be version 8.0.0.0, so that's what I used. Please feel free to adapt as you see fit. 

P.S.: Forgive me my ignorance, I couldn't get your pre-commit hook to run on Mac OS; it seems very Windows-oriented? 

Thank you for considering my pull request! 