### PR TITLE
Refresh ready to run package

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.18.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.0-preview.4.23202.2" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.0-preview.5.23260.1" />
     <!-- ILCompiler.Reflection.ReadyToRun has dependencies on System.Reflection.Metadata and
          System.Runtime.CompilerServices.Unsafe. Because the AddIn compiles into ILSpy's output
          directory, we're at risk of overwriting our dependencies with different versions.

--- a/packages.props
+++ b/packages.props
@@ -5,8 +5,8 @@
 	Note: when updating these, ensure to also adjust the binding redirects in app.config.template appropriately.
 	-->
 	<PropertyGroup>
-		<SystemCollectionsImmutableVersion>6.0.0</SystemCollectionsImmutableVersion>
-		<SystemReflectionMetadataVersion>6.0.1</SystemReflectionMetadataVersion>
+		<SystemCollectionsImmutableVersion>7.0.0</SystemCollectionsImmutableVersion>
+		<SystemReflectionMetadataVersion>7.0.0</SystemReflectionMetadataVersion>
 		<SystemCompilerServicesUnsafeVersion>6.0.0</SystemCompilerServicesUnsafeVersion>
 		<SystemCompositionVersion>6.0.0</SystemCompositionVersion>
 		<!-- Microsoft.NETCore.ILAsm -->


### PR DESCRIPTION
The PR upgrades the ready-to-run package after https://github.com/dotnet/runtime/pull/85738 upgraded its dependent SRM to 7.0.0