### PR TITLE
Fix #901: Refactor ILReader: only read reachable code + support reimports

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -263,6 +263,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await Run();
 		}
 
+		[Test]
+		public async Task EmptyBodies()
+		{
+			await Run();
+		}
+
 		async Task Run([CallerMemberName] string testName = null, DecompilerSettings settings = null,
 			AssemblerOptions assemblerOptions = AssemblerOptions.Library)
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/StackTypes.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/StackTypes.il
@@ -79,7 +79,34 @@ pointless:
     box native int
     call void [mscorlib]System.Console::WriteLine(string, object)
 
-    /*
+    ldstr "Int32OrNativeReordered(0x7fffffff, false) = {0}"
+    ldc.i4 0x7fffffff
+    ldc.i4 0
+    call native int Program::Int32OrNativeReordered(int32, bool)
+    box native int
+    call void [mscorlib]System.Console::WriteLine(string, object)
+
+    ldstr "Int32OrNativeReordered(0x7fffffff, true) = {0}"
+    ldc.i4 0x7fffffff
+    ldc.i4 1
+    call native int Program::Int32OrNativeReordered(int32, bool)
+    box native int
+    call void [mscorlib]System.Console::WriteLine(string, object)
+
+    ldstr "Int32OrNativeReordered(-1, false) = {0}"
+    ldc.i4.m1
+    ldc.i4 0
+    call native int Program::Int32OrNativeReordered(int32, bool)
+    box native int
+    call void [mscorlib]System.Console::WriteLine(string, object)
+
+    ldstr "Int32OrNativeReordered(-1, true) = {0}"
+    ldc.i4.m1
+    ldc.i4 1
+    call native int Program::Int32OrNativeReordered(int32, bool)
+    box native int
+    call void [mscorlib]System.Console::WriteLine(string, object)
+
     ldstr "Int32OrNativeLoopStyle(0x7fffffff):"
     call void [mscorlib]System.Console::WriteLine(string)
     ldc.i4 0x7fffffff
@@ -101,7 +128,6 @@ pointless:
     call native int Program::Int32OrNativeDeadCode(int32)
     box native int
     call void [mscorlib]System.Console::WriteLine(string, object)
-    */
 
     ldc.i4 0x7fffffff
     call void Program::RunInt32OrNativeMultiUse(int32)
@@ -127,7 +153,6 @@ pointless:
     ret
   }
   
-  /*
   .method public static native int Int32OrNativeReordered(int32 val, bool use_native)
   {
     // The spec is ambiguous whether the addition will be in 32-bits or native size.
@@ -187,7 +212,6 @@ pointless:
     conv.u
     br after_if
   }
-  */
 
   .method public static void RunInt32OrNativeMultiUse(int32 val)
   {

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EmptyBodies.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EmptyBodies.cs
@@ -1,0 +1,14 @@
+internal class EmptyBodies
+{
+	public static void RetVoid()
+	{
+	}
+	public static int RetInt()
+	{
+		return (int)/*Error near IL_0001: Stack underflow*/;
+	}
+	public static void Nop()
+	{
+		/*Error: End of method reached without returning.*/;
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EmptyBodies.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EmptyBodies.cs
@@ -5,7 +5,7 @@ internal class EmptyBodies
 	}
 	public static int RetInt()
 	{
-		return (int)/*Error near IL_0001: Stack underflow*/;
+		/*Error: Method body consists only of 'ret', but nothing is being returned. Decompiled assembly might be a reference assembly.*/;
 	}
 	public static void Nop()
 	{

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EmptyBodies.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EmptyBodies.il
@@ -1,0 +1,45 @@
+#define CORE_ASSEMBLY "System.Runtime"
+
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:0:0:0
+}
+
+.class private auto ansi beforefieldinit EmptyBodies
+    extends [CORE_ASSEMBLY]System.Object
+{
+    // I cannot test a truly empty body because the assembler will automatically add a ret instruction.
+
+    .method public hidebysig static void RetVoid () cil managed 
+    {
+	    .maxstack 8
+		ret
+    }
+
+	.method public hidebysig static int32 RetInt () cil managed 
+    {
+	    .maxstack 8
+		ret
+    }
+
+	.method public hidebysig static void Nop () cil managed 
+    {
+	    .maxstack 8
+		nop
+    }
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor () cil managed 
+    {
+        // Method begins at RVA 0x206e
+        // Code size 8 (0x8)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Private.CoreLib]System.Object::.ctor()
+        IL_0006: nop
+        IL_0007: ret
+    } // end of method Example::.ctor
+
+} // end of class EmptyBodies

--- a/ICSharpCode.Decompiler/IL/BlockBuilder.cs
+++ b/ICSharpCode.Decompiler/IL/BlockBuilder.cs
@@ -129,15 +129,6 @@ namespace ICSharpCode.Decompiler.IL
 		{
 			CreateContainerStructure();
 			mainContainer.SetILRange(new Interval(0, body.GetCodeSize()));
-			if (!basicBlocks.Any())
-			{
-				mainContainer.Blocks.Add(new Block {
-					Instructions = {
-						new InvalidBranch("Empty body found. Decompiled assembly might be a reference assembly.")
-					}
-				});
-				return;
-			}
 
 			currentContainer = mainContainer;
 			foreach (var block in basicBlocks.OrderBy(b => b.StartILOffset))

--- a/ICSharpCode.Decompiler/IL/BlockBuilder.cs
+++ b/ICSharpCode.Decompiler/IL/BlockBuilder.cs
@@ -16,8 +16,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -29,6 +29,11 @@ using ICSharpCode.Decompiler.Util;
 
 namespace ICSharpCode.Decompiler.IL
 {
+	/// <summary>
+	/// Converts the list of basic blocks from ILReader into a BlockContainer structure. 
+	/// This involves creating nested block containers for exception handlers, and creating
+	/// branches between the blocks.
+	/// </summary>
 	class BlockBuilder
 	{
 		readonly MethodBodyBlock body;
@@ -64,7 +69,6 @@ namespace ICSharpCode.Decompiler.IL
 				var tryRange = new Interval(eh.TryOffset, eh.TryOffset + eh.TryLength);
 				var handlerBlock = new BlockContainer();
 				handlerBlock.AddILRange(new Interval(eh.HandlerOffset, eh.HandlerOffset + eh.HandlerLength));
-				handlerBlock.Blocks.Add(new Block());
 				handlerContainers.Add(handlerBlock.StartILOffset, handlerBlock);
 
 				if (eh.Kind == ExceptionRegionKind.Fault || eh.Kind == ExceptionRegionKind.Finally)
@@ -94,7 +98,6 @@ namespace ICSharpCode.Decompiler.IL
 				{
 					var filterBlock = new BlockContainer(expectedResultType: StackType.I4);
 					filterBlock.AddILRange(new Interval(eh.FilterOffset, eh.HandlerOffset));
-					filterBlock.Blocks.Add(new Block());
 					handlerContainers.Add(filterBlock.StartILOffset, filterBlock);
 					filter = filterBlock;
 				}
@@ -117,20 +120,18 @@ namespace ICSharpCode.Decompiler.IL
 		}
 
 		int currentTryIndex;
-		TryInstruction nextTry;
+		TryInstruction? nextTry;
 
-		BlockContainer currentContainer;
-		Block currentBlock;
+		BlockContainer? currentContainer;
 		readonly Stack<BlockContainer> containerStack = new Stack<BlockContainer>();
 
-		public void CreateBlocks(BlockContainer mainContainer, List<ILInstruction> instructions, BitSet incomingBranches, CancellationToken cancellationToken)
+		public void CreateBlocks(BlockContainer mainContainer, IEnumerable<Block> basicBlocks, CancellationToken cancellationToken)
 		{
 			CreateContainerStructure();
 			mainContainer.SetILRange(new Interval(0, body.GetCodeSize()));
-			currentContainer = mainContainer;
-			if (instructions.Count == 0)
+			if (!basicBlocks.Any())
 			{
-				currentContainer.Blocks.Add(new Block {
+				mainContainer.Blocks.Add(new Block {
 					Instructions = {
 						new InvalidBranch("Empty body found. Decompiled assembly might be a reference assembly.")
 					}
@@ -138,97 +139,40 @@ namespace ICSharpCode.Decompiler.IL
 				return;
 			}
 
-			foreach (var inst in instructions)
+			currentContainer = mainContainer;
+			foreach (var block in basicBlocks.OrderBy(b => b.StartILOffset))
 			{
 				cancellationToken.ThrowIfCancellationRequested();
-				int start = inst.StartILOffset;
-				if (currentBlock == null || (incomingBranches[start] && !IsStackAdjustment(inst)))
+				int start = block.StartILOffset;
+				// Leave nested containers if necessary
+				while (start >= currentContainer.EndILOffset)
 				{
-					// Finish up the previous block
-					FinalizeCurrentBlock(start, fallthrough: true);
-					// Leave nested containers if necessary
-					while (start >= currentContainer.EndILOffset)
-					{
-						currentContainer = containerStack.Pop();
-						currentBlock = currentContainer.Blocks.Last();
-						// this container is skipped (i.e. the loop will execute again)
-						// set ILRange to the last instruction offset inside the block.
-						if (start >= currentContainer.EndILOffset)
-						{
-							Debug.Assert(currentBlock.ILRangeIsEmpty);
-							currentBlock.AddILRange(new Interval(currentBlock.StartILOffset, start));
-						}
-					}
-					// Enter a handler if necessary
-					if (handlerContainers.TryGetValue(start, out BlockContainer handlerContainer))
-					{
-						containerStack.Push(currentContainer);
-						currentContainer = handlerContainer;
-						currentBlock = handlerContainer.EntryPoint;
-					}
-					else
-					{
-						FinalizeCurrentBlock(start, fallthrough: false);
-						// Create the new block
-						currentBlock = new Block();
-						currentContainer.Blocks.Add(currentBlock);
-					}
-					currentBlock.SetILRange(new Interval(start, start));
+					currentContainer = containerStack.Pop();
 				}
+				// Enter a handler if necessary
+				if (handlerContainers.TryGetValue(start, out BlockContainer? handlerContainer))
+				{
+					containerStack.Push(currentContainer);
+					currentContainer = handlerContainer;
+				}
+				// Enter a try block if necessary
 				while (nextTry != null && start == nextTry.TryBlock.StartILOffset)
 				{
-					currentBlock.Instructions.Add(nextTry);
+					var blockForTry = new Block();
+					blockForTry.SetILRange(nextTry);
+					blockForTry.Instructions.Add(nextTry);
+					currentContainer.Blocks.Add(blockForTry);
+
 					containerStack.Push(currentContainer);
 					currentContainer = (BlockContainer)nextTry.TryBlock;
-					currentBlock = new Block();
-					currentContainer.Blocks.Add(currentBlock);
-					currentBlock.SetILRange(new Interval(start, start));
 
 					nextTry = tryInstructionList.ElementAtOrDefault(++currentTryIndex);
 				}
-				currentBlock.Instructions.Add(inst);
-				if (inst.HasFlag(InstructionFlags.EndPointUnreachable))
-					FinalizeCurrentBlock(inst.EndILOffset, fallthrough: false);
-				else if (!CreateExtendedBlocks && inst.HasFlag(InstructionFlags.MayBranch))
-					FinalizeCurrentBlock(inst.EndILOffset, fallthrough: true);
+				currentContainer.Blocks.Add(block);
 			}
-			FinalizeCurrentBlock(mainContainer.EndILOffset, fallthrough: false);
-			// Finish up all containers
-			while (containerStack.Count > 0)
-			{
-				currentContainer = containerStack.Pop();
-				currentBlock = currentContainer.Blocks.Last();
-				FinalizeCurrentBlock(mainContainer.EndILOffset, fallthrough: false);
-			}
+			Debug.Assert(currentTryIndex == tryInstructionList.Count && nextTry == null);
 			ConnectBranches(mainContainer, cancellationToken);
 			CreateOnErrorDispatchers();
-		}
-
-		static bool IsStackAdjustment(ILInstruction inst)
-		{
-			return inst is StLoc stloc && stloc.IsStackAdjustment;
-		}
-
-		private void FinalizeCurrentBlock(int currentILOffset, bool fallthrough)
-		{
-			if (currentBlock == null)
-				return;
-			Debug.Assert(currentBlock.ILRangeIsEmpty);
-			currentBlock.SetILRange(new Interval(currentBlock.StartILOffset, currentILOffset));
-			if (fallthrough)
-			{
-				if (currentBlock.Instructions.LastOrDefault() is SwitchInstruction switchInst && switchInst.Sections.Last().Body.MatchNop())
-				{
-					// Instead of putting the default branch after the switch instruction
-					switchInst.Sections.Last().Body = new Branch(currentILOffset);
-					Debug.Assert(switchInst.HasFlag(InstructionFlags.EndPointUnreachable));
-				}
-				else
-				{
-					currentBlock.Instructions.Add(new Branch(currentILOffset));
-				}
-			}
-			currentBlock = null;
 		}
 
 		void ConnectBranches(ILInstruction inst, CancellationToken cancellationToken)
@@ -238,11 +182,15 @@ namespace ICSharpCode.Decompiler.IL
 				case Branch branch:
 					cancellationToken.ThrowIfCancellationRequested();
 					Debug.Assert(branch.TargetBlock == null);
-					branch.TargetBlock = FindBranchTarget(branch.TargetILOffset);
-					if (branch.TargetBlock == null)
+					var targetBlock = FindBranchTarget(branch.TargetILOffset);
+					if (targetBlock == null)
 					{
 						branch.ReplaceWith(new InvalidBranch("Could not find block for branch target "
 							+ Disassembler.DisassemblerHelpers.OffsetToString(branch.TargetILOffset)).WithILRange(branch));
+					}
+					else
+					{
+						branch.TargetBlock = targetBlock;
 					}
 					break;
 				case Leave leave:
@@ -279,7 +227,7 @@ namespace ICSharpCode.Decompiler.IL
 			}
 		}
 
-		Block FindBranchTarget(int targetILOffset)
+		Block? FindBranchTarget(int targetILOffset)
 		{
 			foreach (var container in containerStack)
 			{
@@ -291,7 +239,7 @@ namespace ICSharpCode.Decompiler.IL
 				if (container.SlotInfo == TryCatchHandler.BodySlot)
 				{
 					// catch handler is allowed to branch back into try block (VB On Error)
-					TryCatch tryCatch = (TryCatch)container.Parent.Parent;
+					TryCatch tryCatch = (TryCatch)container.Parent!.Parent!;
 					if (tryCatch.TryBlock.StartILOffset < targetILOffset && targetILOffset < tryCatch.TryBlock.EndILOffset)
 					{
 						return CreateBranchTargetForOnErrorJump(tryCatch, targetILOffset);
@@ -345,7 +293,7 @@ namespace ICSharpCode.Decompiler.IL
 		{
 			foreach (var (tryCatch, dispatch) in onErrorDispatchers)
 			{
-				Block block = (Block)tryCatch.Parent;
+				Block block = (Block)tryCatch.Parent!;
 				// Before the regular entry point of the try-catch, insert an. instruction that resets the dispatcher variable
 				block.Instructions.Insert(tryCatch.ChildIndex, new StLoc(dispatch.Variable, new LdcI4(-1)));
 				// Split the block, so that we can introduce branches that jump directly into the try block
@@ -355,7 +303,7 @@ namespace ICSharpCode.Decompiler.IL
 				newBlock.Instructions.AddRange(block.Instructions.Skip(splitAt));
 				block.Instructions.RemoveRange(splitAt, block.Instructions.Count - splitAt);
 				block.Instructions.Add(new Branch(newBlock));
-				((BlockContainer)block.Parent).Blocks.Add(newBlock);
+				((BlockContainer)block.Parent!).Blocks.Add(newBlock);
 				// Update the branches that jump directly into the try block
 				foreach (var b in dispatch.Branches)
 				{

--- a/ICSharpCode.Decompiler/IL/ControlFlow/ControlFlowSimplification.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/ControlFlowSimplification.cs
@@ -258,7 +258,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			if (targetBlock.StartILOffset < block.StartILOffset && IsDeadTrueStore(block))
 			{
 				// The C# compiler generates a dead store for the condition of while (true) loops.
-				block.Instructions.RemoveRange(block.Instructions.Count - 3, 2);
+				block.Instructions.RemoveAt(block.Instructions.Count - 2);
 			}
 
 			if (block.ILRangeIsEmpty)
@@ -275,15 +275,13 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 		/// </summary>
 		private static bool IsDeadTrueStore(Block block)
 		{
-			if (block.Instructions.Count < 3)
+			if (block.Instructions.Count < 2)
 				return false;
-			if (!(block.Instructions.SecondToLastOrDefault() is StLoc deadStore && block.Instructions[block.Instructions.Count - 3] is StLoc tempStore))
+			if (!(block.Instructions.SecondToLastOrDefault() is StLoc deadStore))
 				return false;
 			if (!(deadStore.Variable.LoadCount == 0 && deadStore.Variable.AddressCount == 0))
 				return false;
-			if (!(deadStore.Value.MatchLdLoc(tempStore.Variable) && tempStore.Variable.IsSingleDefinition && tempStore.Variable.LoadCount == 1))
-				return false;
-			return tempStore.Value.MatchLdcI4(1) && deadStore.Variable.Type.IsKnownType(KnownTypeCode.Boolean);
+			return deadStore.Value.MatchLdcI4(1) && deadStore.Variable.Type.IsKnownType(KnownTypeCode.Boolean);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -514,14 +514,6 @@ namespace ICSharpCode.Decompiler.IL
 					FlushExpressionStack();
 					block.Block.Instructions.Add(inst);
 				}
-				else if (start == block.StartILOffset)
-				{
-					// If this instruction is the first in a new block, avoid it being inlined
-					// into the next instruction.
-					// This is necessary because the BlockBuilder uses inst.StartILOffset to
-					// detect block starts, and doesn't search nested instructions.
-					FlushExpressionStack();
-				}
 
 				if ((!decodedInstruction.PushedOnExpressionStack && IsSequencePointInstruction(inst)) || startedWithEmptyStack)
 				{

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -535,16 +535,25 @@ namespace ICSharpCode.Decompiler.IL
 			if (!block.Block.HasFlag(InstructionFlags.EndPointUnreachable))
 			{
 				// create fall through branch
-				MarkBranchTarget(reader.Offset, isFallThrough: true);
+				ILInstruction branch;
+				if (reader.RemainingBytes > 0)
+				{
+					MarkBranchTarget(reader.Offset, isFallThrough: true);
+					branch = new Branch(reader.Offset);
+				}
+				else
+				{
+					branch = new InvalidBranch("End of method reached without returning.");
+				}
 				if (block.Block.Instructions.LastOrDefault() is SwitchInstruction switchInst && switchInst.Sections.Last().Body.MatchNop())
 				{
 					// Instead of putting the default branch after the switch instruction
-					switchInst.Sections.Last().Body = new Branch(reader.Offset);
+					switchInst.Sections.Last().Body = branch;
 					Debug.Assert(switchInst.HasFlag(InstructionFlags.EndPointUnreachable));
 				}
 				else
 				{
-					block.Block.Instructions.Add(new Branch(reader.Offset));
+					block.Block.Instructions.Add(branch);
 				}
 			}
 		}

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -457,6 +457,13 @@ namespace ICSharpCode.Decompiler.IL
 		{
 			reader.Reset();
 			StoreStackForOffset(0, ImmutableStack<ILVariable>.Empty);
+			if (reader.Length == 0)
+			{
+				blocksByOffset[0].Block.Instructions.Add(
+					new InvalidBranch("Empty body found. Decompiled assembly might be a reference assembly.")
+				);
+				return;
+			}
 			ILParser.SetBranchTargets(ref reader, isBranchTarget);
 			PrepareBranchTargetsAndStacksForExceptionHandlers();
 
@@ -1480,9 +1487,18 @@ namespace ICSharpCode.Decompiler.IL
 		private ILInstruction Return()
 		{
 			if (methodReturnStackType == StackType.Void)
+			{
 				return new IL.Leave(mainContainer);
+			}
+			else if (currentInstructionStart == 0)
+			{
+				Debug.Assert(expressionStack.Count == 0 && currentStack.IsEmpty);
+				return new InvalidBranch("Method body consists only of 'ret', but nothing is being returned. Decompiled assembly might be a reference assembly.");
+			}
 			else
+			{
 				return new IL.Leave(mainContainer, Pop(methodReturnStackType));
+			}
 		}
 
 		private ILInstruction DecodeLdstr()


### PR DESCRIPTION
This makes our logic more similar to that used by the dotnet runtime. This lets us infer correct stack types in edge cases such as #2401. It also improves support for obfuscated control flow such as #2878.