### PR TITLE
PoC Auto-Update with Netsparkle Updater

### DIFF
--- a/ILSpy/AboutPage.cs
+++ b/ILSpy/AboutPage.cs
@@ -218,74 +218,6 @@ namespace ICSharpCode.ILSpy
 			return latestAvailableVersion;
 		}
 
-		sealed class AvailableVersionInfo
-		{
-			public Version Version;
-			public string DownloadUrl;
-		}
-
-		sealed class UpdateSettings : INotifyPropertyChanged
-		{
-			public UpdateSettings(ILSpySettings spySettings)
-			{
-				XElement s = spySettings["UpdateSettings"];
-				this.automaticUpdateCheckEnabled = (bool?)s.Element("AutomaticUpdateCheckEnabled") ?? true;
-				try
-				{
-					this.lastSuccessfulUpdateCheck = (DateTime?)s.Element("LastSuccessfulUpdateCheck");
-				}
-				catch (FormatException)
-				{
-					// avoid crashing on settings files invalid due to
-					// https://github.com/icsharpcode/ILSpy/issues/closed/#issue/2
-				}
-			}
-
-			bool automaticUpdateCheckEnabled;
-
-			public bool AutomaticUpdateCheckEnabled {
-				get { return automaticUpdateCheckEnabled; }
-				set {
-					if (automaticUpdateCheckEnabled != value)
-					{
-						automaticUpdateCheckEnabled = value;
-						Save();
-						OnPropertyChanged(nameof(AutomaticUpdateCheckEnabled));
-					}
-				}
-			}
-
-			DateTime? lastSuccessfulUpdateCheck;
-
-			public DateTime? LastSuccessfulUpdateCheck {
-				get { return lastSuccessfulUpdateCheck; }
-				set {
-					if (lastSuccessfulUpdateCheck != value)
-					{
-						lastSuccessfulUpdateCheck = value;
-						Save();
-						OnPropertyChanged(nameof(LastSuccessfulUpdateCheck));
-					}
-				}
-			}
-
-			public void Save()
-			{
-				XElement updateSettings = new XElement("UpdateSettings");
-				updateSettings.Add(new XElement("AutomaticUpdateCheckEnabled", automaticUpdateCheckEnabled));
-				if (lastSuccessfulUpdateCheck != null)
-					updateSettings.Add(new XElement("LastSuccessfulUpdateCheck", lastSuccessfulUpdateCheck));
-				ILSpySettings.SaveSettings(updateSettings);
-			}
-
-			public event PropertyChangedEventHandler PropertyChanged;
-
-			void OnPropertyChanged(string propertyName)
-			{
-				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-			}
-		}
-
 		/// <summary>
 		/// If automatic update checking is enabled, checks if there are any updates available.
 		/// Returns the download URL if an update is available.
@@ -349,4 +281,73 @@ namespace ICSharpCode.ILSpy
 	{
 		void Write(ISmartTextOutput textOutput);
 	}
+
+	sealed class AvailableVersionInfo
+	{
+		public Version Version;
+		public string DownloadUrl;
+	}
+
+	sealed class UpdateSettings : INotifyPropertyChanged
+	{
+		public UpdateSettings(ILSpySettings spySettings)
+		{
+			XElement s = spySettings["UpdateSettings"];
+			this.automaticUpdateCheckEnabled = (bool?)s.Element("AutomaticUpdateCheckEnabled") ?? true;
+			try
+			{
+				this.lastSuccessfulUpdateCheck = (DateTime?)s.Element("LastSuccessfulUpdateCheck");
+			}
+			catch (FormatException)
+			{
+				// avoid crashing on settings files invalid due to
+				// https://github.com/icsharpcode/ILSpy/issues/closed/#issue/2
+			}
+		}
+
+		bool automaticUpdateCheckEnabled;
+
+		public bool AutomaticUpdateCheckEnabled {
+			get { return automaticUpdateCheckEnabled; }
+			set {
+				if (automaticUpdateCheckEnabled != value)
+				{
+					automaticUpdateCheckEnabled = value;
+					Save();
+					OnPropertyChanged(nameof(AutomaticUpdateCheckEnabled));
+				}
+			}
+		}
+
+		DateTime? lastSuccessfulUpdateCheck;
+
+		public DateTime? LastSuccessfulUpdateCheck {
+			get { return lastSuccessfulUpdateCheck; }
+			set {
+				if (lastSuccessfulUpdateCheck != value)
+				{
+					lastSuccessfulUpdateCheck = value;
+					Save();
+					OnPropertyChanged(nameof(LastSuccessfulUpdateCheck));
+				}
+			}
+		}
+
+		public void Save()
+		{
+			XElement updateSettings = new XElement("UpdateSettings");
+			updateSettings.Add(new XElement("AutomaticUpdateCheckEnabled", automaticUpdateCheckEnabled));
+			if (lastSuccessfulUpdateCheck != null)
+				updateSettings.Add(new XElement("LastSuccessfulUpdateCheck", lastSuccessfulUpdateCheck));
+			ILSpySettings.SaveSettings(updateSettings);
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		void OnPropertyChanged(string propertyName)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+
 }

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageReference Include="DataGridExtensions" Version="2.5.14" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.2.2" />
+    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230604001" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="$(WpfStylesToolboxVersion)" />
   </ItemGroup>
 

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageReference Include="DataGridExtensions" Version="2.5.14" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230604001" />
+    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230605001" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="$(WpfStylesToolboxVersion)" />
   </ItemGroup>
 

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageReference Include="DataGridExtensions" Version="2.5.14" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.2.2" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="$(WpfStylesToolboxVersion)" />
   </ItemGroup>
 

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageReference Include="DataGridExtensions" Version="2.5.14" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230606001" />
+    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230606002" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="$(WpfStylesToolboxVersion)" />
   </ItemGroup>
 

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageReference Include="DataGridExtensions" Version="2.5.14" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
-    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230605001" />
+    <PackageReference Include="NetSparkleUpdater.UI.WPF" Version="2.3.0-preview20230606001" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="$(WpfStylesToolboxVersion)" />
   </ItemGroup>
 

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -930,15 +930,18 @@ namespace ICSharpCode.ILSpy
 			// https://github.com/NetSparkleUpdater/NetSparkle/blob/develop/src/NetSparkle.Samples.NetCore.WPF/MainWindow.xaml.cs
 			string sparkleSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ICSharpCode\\ILSpy-sparkle.json");
 
+			// var icsdasm = typeof(DecompilerVersionInfo).Assembly.FullName;
+
 			_sparkle = new SparkleUpdater(
 				"https://ilspy.net/appcast.xml",
 				new Ed25519Checker(SecurityMode.Strict, "s2P6MPexSRSjod77aWUjgVKj/gKYYAeqgHY/0Gf8b78=")
 			) {
-				UIFactory = new NetSparkleUpdater.UI.WPF.UIFactory(null),
+				UIFactory = new NetSparkleUpdater.UI.WPF.UIFactory(Images.ILSpyIcon),
 				RelaunchAfterUpdate = false,
 				CustomInstallerArguments = "",
-				Configuration = new JSONConfiguration(null, sparkleSettingsPath)
+				Configuration = new JSONConfiguration(new NetSparkleUpdater.AssemblyAccessors.AssemblyReflectionAccessor(null), sparkleSettingsPath)
 			};
+
 			_sparkle.StartLoop(true);
 		}
 

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -957,6 +957,7 @@ namespace ICSharpCode.ILSpy
 						w.Style = (Style)Application.Current.FindResource("DialogWindow");
 					}
 				},
+				ShowsUIOnMainThread = true,
 				RelaunchAfterUpdate = false,
 				CustomInstallerArguments = "",
 				Configuration = new JSONConfiguration(new NetSparkleUpdater.AssemblyAccessors.AssemblyReflectionAccessor(null), sparkleSettingsPath)

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -57,10 +58,10 @@ using ICSharpCode.TreeView;
 
 using Microsoft.Win32;
 
+using NetSparkleUpdater;
+using NetSparkleUpdater.Configurations;
 using NetSparkleUpdater.Enums;
 using NetSparkleUpdater.SignatureVerifiers;
-using NetSparkleUpdater;
-using System.Runtime.InteropServices;
 
 namespace ICSharpCode.ILSpy
 {
@@ -906,9 +907,15 @@ namespace ICSharpCode.ILSpy
 
 			var s = new UpdateSettings(spySettings);
 			bool automaticCheckingEnabled = s.AutomaticUpdateCheckEnabled;
+
+			// TODO: That would need to be way more sophisticated - we ship zip, msi, vsix (actually doing an update-check there is wrong even today)
+			//       Multiple of those could be installed on the same machine in multiple versions (esp. zip)
+			//       Somehow we'd need to "tag" the version running from our msi installer, and only then offering auto-update
+
 #if DEBUG
 			// automaticCheckingEnabled = false;
 #endif
+			// TODO: Additional check if branch version
 
 			if (automaticCheckingEnabled)
 				EnableSparkleUpdateChecking();
@@ -930,7 +937,7 @@ namespace ICSharpCode.ILSpy
 				UIFactory = new NetSparkleUpdater.UI.WPF.UIFactory(null),
 				RelaunchAfterUpdate = false,
 				CustomInstallerArguments = "",
-				// Configuration = new JSONConfiguration(null, sparkleSettingsPath)
+				Configuration = new JSONConfiguration(null, sparkleSettingsPath)
 			};
 			_sparkle.StartLoop(true);
 		}

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -929,6 +929,7 @@ namespace ICSharpCode.ILSpy
 			if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
 				return;
 
+			// This should update with UpdateTheme
 			bool isLightTheme = ThemeManager.Current.Theme.Contains("light", StringComparison.InvariantCultureIgnoreCase);
 
 			var extraHeadAdditionForReleaseNotes = "<style>";
@@ -951,7 +952,10 @@ namespace ICSharpCode.ILSpy
 			) {
 				UIFactory = new UIFactory(Images.ILSpyIcon) {
 					UseStaticUpdateWindowBackgroundColor = false,
-					AdditionalReleaseNotesHeaderHTML = extraHeadAdditionForReleaseNotes
+					AdditionalReleaseNotesHeaderHTML = extraHeadAdditionForReleaseNotes,
+					ProcessWindowAfterInit = (w, f) => {
+						w.Style = (Style)Application.Current.FindResource("DialogWindow");
+					}
 				},
 				RelaunchAfterUpdate = false,
 				CustomInstallerArguments = "",


### PR DESCRIPTION
Motivation - see #2997. This is a PoC only! No intention to merge.

Reason for choosing Netsparkle over others: signature validation of update files (SSL these days doesn't mean a thing, and [evilginx2](https://github.com/kgretzky/evilginx2) and friends are way too easy to use to fake update files)

## Notes for using Netsparkle

Install dotnet tool for Netsparkle

`dotnet tool install --global NetSparkleUpdater.Tools.AppCastGenerator`

Create keys

`netsparkle-generate-appcast --generate-keys --key-path ./signingkeys`

Create appcast 
`
netsparkle-generate-appcast -n "ILSpy" -a ./output -e msi -b ./ -o windows -f true -u https://github.com/icsharpcode/ILSpy/releases/tag/v8.0 --description-tag ".NET Decompiler" --key-path ./signingkeys --change-log-path ./`

This assumes `ILSpy_Installer_8.0.0.7400.msi` and `8.0.0.7400.md` (both files entirely fake) in the root folder where the command is run.

## Notes for deploying the appcast

When you add release notes to the appcast, it will contain newlines, eg https://github.com/icsharpcode/ILSpy/blob/11a5bb50682fdf31c08a01e0937673ab6faa29a7/appcast.xml. When pushing from Windows and consuming as is the case here on Linux, you need `appcast.xml eol=crlf` in https://github.com/icsharpcode/ILSpy/blob/11a5bb50682fdf31c08a01e0937673ab6faa29a7/.gitattributes

## Implementation notes

Comments included address a few of the edge cases found (and some not yet resolved). In general, if going down the route of #2997 we should have one update strategy for checking only, and one for auto-updating (think interface and two implementations that can be used depending on deployment variant)
