### PR TITLE
Add support for MCS 2.6.4 pinned region with string variable

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
 // without restriction, including without limitation the rights to use, copy, modify, merge,
 // publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
 // to whom the Software is furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all copies or
 // substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
 // PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
@@ -265,6 +265,12 @@ namespace ICSharpCode.Decompiler.Tests
 
 		[Test]
 		public async Task EmptyBodies()
+		{
+			await Run();
+		}
+
+		[Test]
+		public async Task MonoFixed()
 		{
 			await Run();
 		}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/MonoFixed.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/MonoFixed.cs
@@ -1,0 +1,20 @@
+using System;
+
+public class MonoFixed
+{
+	public unsafe void FixMultipleStrings(string text)
+	{
+		fixed (char* ptr = text)
+		{
+			fixed (char* ptr2 = Environment.UserName)
+			{
+				fixed (char* ptr3 = text)
+				{
+					*ptr = 'c';
+					*ptr2 = 'd';
+					*ptr3 = 'e';
+				}
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/MonoFixed.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/MonoFixed.il
@@ -1,0 +1,74 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly MonoFixed
+{
+  .ver 1:0:0:0
+}
+
+.module MonoFixed.exe
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003 // WindowsCui
+.corflags 0x00000001 // ILOnly
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = (
+	01 00 00 00
+)
+
+.class public auto ansi beforefieldinit MonoFixed
+	   extends [mscorlib]System.Object
+{
+  .method public hidebysig instance void FixMultipleStrings (string text) cil managed
+	{
+		.maxstack 7
+		.locals init (
+			[0] char* pinned,
+			[1] char* pinned,
+			[2] char* pinned,
+			[3] string pinned,
+			[4] string pinned,
+			[5] string pinned
+		)
+
+		IL_0000: ldarg.1
+		IL_0001: stloc.3
+		IL_0002: ldloc.3
+		IL_0003: conv.i
+		IL_0004: call int32 [mscorlib]System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData()
+		IL_0009: add
+		IL_000a: stloc.0
+		IL_000b: call string [mscorlib]System.Environment::get_UserName()
+		IL_0010: stloc.s 4
+		IL_0012: ldloc.s 4
+		IL_0014: conv.i
+		IL_0015: call int32 [mscorlib]System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData()
+		IL_001a: add
+		IL_001b: stloc.1
+		IL_001c: ldarg.1
+		IL_001d: stloc.s 5
+		IL_001f: ldloc.s 5
+		IL_0021: conv.i
+		IL_0022: call int32 [mscorlib]System.Runtime.CompilerServices.RuntimeHelpers::get_OffsetToStringData()
+		IL_0027: add
+		IL_0028: stloc.2
+		IL_0029: ldloc.0
+		IL_002a: ldc.i4.s 99
+		IL_002c: stind.i2
+		IL_002d: ldloc.1
+		IL_002e: ldc.i4.s 100
+		IL_0030: stind.i2
+		IL_0031: ldloc.2
+		IL_0032: ldc.i4.s 101
+		IL_0034: stind.i2
+		IL_0035: ldnull
+		IL_0036: stloc.3
+		IL_0037: ldnull
+		IL_0038: stloc.s 4
+		IL_003a: ldnull
+		IL_003b: stloc.s 5
+		IL_003d: ret
+	}
+}


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
Decompilation of the following code compiled with MCS 2.6.4 was not properly supported and resulted in ugly and invalid code:
```csharp
fixed (char* ptr = text, userName = Environment.UserName, ptr2 = text)
{
	*ptr = 'c';
	*userName = 'd';
	*ptr2 = 'e';
}
```
would result in:
```csharp
fixed (string text2 = text)
{
	fixed (char* ptr = &System.Runtime.CompilerServices.Unsafe.AsRef<char>((char*)((long)(IntPtr)text2 + (long)RuntimeHelpers.OffsetToStringData)))
	{
		fixed (string text3 = Environment.UserName)
		{
			fixed (char* ptr2 = &System.Runtime.CompilerServices.Unsafe.AsRef<char>((char*)((long)(IntPtr)text3 + (long)RuntimeHelpers.OffsetToStringData)))
			{
				fixed (string text4 = text)
				{
					fixed (char* ptr3 = &System.Runtime.CompilerServices.Unsafe.AsRef<char>((char*)((long)(IntPtr)text4 + (long)RuntimeHelpers.OffsetToStringData)))
					{
						*ptr = 'c';
						*ptr2 = 'd';
						*ptr3 = 'e';
					}
				}
			}
		}
	}
}
text3 = null;
text4 = null;
```

The code is now decompiled as:
```csharp
fixed (char* ptr = text)
{
	fixed (char* ptr2 = Environment.UserName)
	{
		fixed (char* ptr3 = text)
		{
			*ptr = 'c';
			*ptr2 = 'd';
			*ptr3 = 'e';
		}
	}
}
```

### Solution
* Adjusted login in the `DetectPinnedRegion` transform to handle the alternate code generation from the MCS 2.6.4 compiler.
* No unit test was added as the current `Pretty` tests don't support the MCS 2.6.4 compiler.

