### PR TITLE
Update readme .NET SDK -> 7.0 Unix/Mac section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If this problem occurs, please manually install the .NET 6.0 SDK from [here](htt
 
 #### Unix / Mac:
 
-- Make sure [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) is installed.
+- Make sure [.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0) is installed.
 - Make sure [PowerShell](https://github.com/PowerShell/PowerShell) is installed (formerly known as PowerShell Core)
 - Clone the repository using git.
 - Execute `git submodule update --init --recursive` to download the ILSpy-Tests submodule (used by some test cases).


### PR DESCRIPTION
### Problem
When building on macos, I got an error when using the steps from the readme.
<img width="827" alt="image" src="https://github.com/icsharpcode/ILSpy/assets/22493187/bf53847d-f816-4454-a76a-956e73df0c6e">


### Solution
* Update readme file to version 7 .NET SDK.

