### PR TITLE
Fix decompilation of record with missing base type

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/RecordDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/RecordDecompiler.cs
@@ -53,8 +53,8 @@ namespace ICSharpCode.Decompiler.CSharp
 			this.settings = settings;
 			this.cancellationToken = cancellationToken;
 			this.baseClass = recordTypeDef.DirectBaseTypes.FirstOrDefault(b => b.Kind == TypeKind.Class);
-			this.isStruct = baseClass.IsKnownType(KnownTypeCode.ValueType);
-			this.isInheritedRecord = !isStruct && !baseClass.IsKnownType(KnownTypeCode.Object);
+			this.isStruct = baseClass?.IsKnownType(KnownTypeCode.ValueType) ?? false;
+			this.isInheritedRecord = !isStruct && !(baseClass?.IsKnownType(KnownTypeCode.Object) ?? false);
 			this.isSealed = recordTypeDef.IsSealed;
 			DetectAutomaticProperties();
 			this.orderedMembers = DetectMemberOrder(recordTypeDef, backingFieldToAutoProperty);
@@ -292,7 +292,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						// virtual bool Equals(R? other): generated unless user-declared
 						return IsGeneratedEquals(method);
 					}
-					else if (isInheritedRecord && NormalizeTypeVisitor.TypeErasure.EquivalentTypes(paramType, baseClass) && method.IsOverride)
+					else if (isInheritedRecord && baseClass != null && NormalizeTypeVisitor.TypeErasure.EquivalentTypes(paramType, baseClass) && method.IsOverride)
 					{
 						// override bool Equals(BaseClass? obj): always generated
 						return true;
@@ -772,7 +772,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						return false;
 					if (!(conditions[pos] is Call { Method: { Name: "Equals" } } call))
 						return false;
-					if (!NormalizeTypeVisitor.TypeErasure.EquivalentTypes(call.Method.DeclaringType, baseClass))
+					if (baseClass != null && !NormalizeTypeVisitor.TypeErasure.EquivalentTypes(call.Method.DeclaringType, baseClass))
 						return false;
 					if (call.Arguments.Count != 2)
 						return false;


### PR DESCRIPTION
### Problem
As described in #3020, the decompiler fails with a NullReferenceException when attempting to decompile a record type whose base type cannot be determined (e.g. because the base type is defined in another assembly that is not loaded).

### Solution
This commit updates `RecordDecompiler` to null check the `baseClass` field before making use of it.  With this fix, the null ref is avoided, but the generated code for the record will contain unnecessary `[CompilerGenerated]` members:

```
internal record RemovedSettingRegistration : SettingRegistration
{
	public RemovedSettingRegistration(SettingRegistration original)
		: base(original)
	{
	}

	[CompilerGenerated]
	public override string ToString() { ... }

	[CompilerGenerated]
	protected override bool PrintMembers(StringBuilder builder) { ... }

	[CompilerGenerated]
	public override int GetHashCode() { ... }

	[CompilerGenerated]
	public sealed override bool Equals(SettingRegistration? other) { ... }

	[CompilerGenerated]
	public virtual bool Equals(RemovedSettingRegistration? other) { ... }

	[CompilerGenerated]
	protected RemovedSettingRegistration(RemovedSettingRegistration original)
		: base((SettingRegistration)(object)original)
	{
	}
}
```

