### PR TITLE
Copy key/value/names ContextMenu for resource tables

### DIFF
--- a/ILSpy/Controls/ResourceObjectTable.xaml
+++ b/ILSpy/Controls/ResourceObjectTable.xaml
@@ -26,9 +26,9 @@
 					<Setter.Value>
 						<ContextMenu>
 							<MenuItem Header="_Copy" Command="ApplicationCommands.Copy" />
-							<MenuItem Header="Copy _name" Command="ApplicationCommands.Copy" CommandParameter="Key" />
-							<MenuItem Header="Copy _value" Command="ApplicationCommands.Copy" CommandParameter="Value" />
-							<MenuItem Header="Copy _type" Command="ApplicationCommands.Copy" CommandParameter="Type" />
+							<MenuItem Header="Copy _name" Command="ApplicationCommands.Copy" CommandParameter="Key" InputGestureText=" " />
+							<MenuItem Header="Copy _value" Command="ApplicationCommands.Copy" CommandParameter="Value" InputGestureText=" " />
+							<MenuItem Header="Copy _type" Command="ApplicationCommands.Copy" CommandParameter="Type" InputGestureText=" " />
 						</ContextMenu>
 					</Setter.Value>
 				</Setter>

--- a/ILSpy/Controls/ResourceObjectTable.xaml
+++ b/ILSpy/Controls/ResourceObjectTable.xaml
@@ -22,6 +22,16 @@
 						Value="{Binding RelativeSource={RelativeSource Self},
 					 Path=(ItemsControl.AlternationIndex),
 					 Converter={StaticResource BackgroundConverter}}" />
+				<Setter Property="ContextMenu">
+					<Setter.Value>
+						<ContextMenu>
+							<MenuItem Header="_Copy" Command="ApplicationCommands.Copy" />
+							<MenuItem Header="Copy _name" Command="ApplicationCommands.Copy" CommandParameter="Key" />
+							<MenuItem Header="Copy _value" Command="ApplicationCommands.Copy" CommandParameter="Value" />
+							<MenuItem Header="Copy _type" Command="ApplicationCommands.Copy" CommandParameter="Type" />
+						</ContextMenu>
+					</Setter.Value>
+				</Setter>
 			</Style>
 		</Grid.Resources>
 		<Grid.RowDefinitions>

--- a/ILSpy/Controls/ResourceObjectTable.xaml.cs
+++ b/ILSpy/Controls/ResourceObjectTable.xaml.cs
@@ -81,6 +81,27 @@ namespace ICSharpCode.ILSpy.Controls
 			StringBuilder sb = new StringBuilder();
 			foreach (var item in resourceListView.SelectedItems)
 			{
+				if (item is TreeNodes.ResourcesFileTreeNode.SerializedObjectRepresentation so)
+				{
+					switch (args.Parameter)
+					{
+						case "Key":
+							sb.AppendLine(so.Key);
+							continue;
+
+						case "Value":
+							sb.AppendLine(so.Value);
+							continue;
+
+						case "Type":
+							sb.AppendLine(so.Type);
+							continue;
+
+						default:
+							sb.AppendLine($"{so.Key}\t{so.Value}\t{so.Type}");
+							continue;
+					}
+				}
 				sb.AppendLine(item.ToString());
 			}
 			Clipboard.SetText(sb.ToString());

--- a/ILSpy/Controls/ResourceStringTable.xaml
+++ b/ILSpy/Controls/ResourceStringTable.xaml
@@ -26,8 +26,8 @@
 					<Setter.Value>
 						<ContextMenu>
 							<MenuItem Header="_Copy" Command="ApplicationCommands.Copy" />
-							<MenuItem Header="Copy _name" Command="ApplicationCommands.Copy" CommandParameter="Key" />
-							<MenuItem Header="Copy _value" Command="ApplicationCommands.Copy" CommandParameter="Value" />
+							<MenuItem Header="Copy _name" Command="ApplicationCommands.Copy" CommandParameter="Key" InputGestureText=" " />
+							<MenuItem Header="Copy _value" Command="ApplicationCommands.Copy" CommandParameter="Value" InputGestureText=" " />
 						</ContextMenu>
 					</Setter.Value>
 				</Setter>

--- a/ILSpy/Controls/ResourceStringTable.xaml
+++ b/ILSpy/Controls/ResourceStringTable.xaml
@@ -22,6 +22,15 @@
 						Value="{Binding RelativeSource={RelativeSource Self},
 					 Path=(ItemsControl.AlternationIndex),
 					 Converter={StaticResource BackgroundConverter}}" />
+				<Setter Property="ContextMenu">
+					<Setter.Value>
+						<ContextMenu>
+							<MenuItem Header="_Copy" Command="ApplicationCommands.Copy" />
+							<MenuItem Header="Copy _name" Command="ApplicationCommands.Copy" CommandParameter="Key" />
+							<MenuItem Header="Copy _value" Command="ApplicationCommands.Copy" CommandParameter="Value" />
+						</ContextMenu>
+					</Setter.Value>
+				</Setter>
 			</Style>
 		</Grid.Resources>
 		<Grid.RowDefinitions>

--- a/ILSpy/Controls/ResourceStringTable.xaml.cs
+++ b/ILSpy/Controls/ResourceStringTable.xaml.cs
@@ -81,6 +81,23 @@ namespace ICSharpCode.ILSpy.Controls
 			StringBuilder sb = new StringBuilder();
 			foreach (var item in resourceListView.SelectedItems)
 			{
+				if (item is KeyValuePair<string, string> pair)
+				{
+					switch (args.Parameter)
+					{
+						case "Key":
+							sb.AppendLine(pair.Key);
+							continue;
+
+						case "Value":
+							sb.AppendLine(pair.Value);
+							continue;
+
+						default:
+							sb.AppendLine($"{pair.Key}\t{pair.Value}");
+							continue;
+					}
+				}
 				sb.AppendLine(item.ToString());
 			}
 			Clipboard.SetText(sb.ToString());


### PR DESCRIPTION
Fixes #3023 

### Problem
The resource tables show document context menu that does not allow copying items.

### Solution
This PR adds a context menu with a few copy options.

It also fixes the issue that the normal copy uses simple ToString() which
* for object table is not overloaded and just copies the internal ILSpy type name 
* for string table it used [Key, Value] syntax

Now it separates the columns by tabs so that they can be pasted into Excel etc.

Before:
<img width="191" alt="image" src="https://github.com/icsharpcode/ILSpy/assets/10546952/515b0c31-1775-44df-9bf5-b235522e6370">

After:
<img width="194" alt="image" src="https://github.com/icsharpcode/ILSpy/assets/10546952/6767bab0-f326-4ad1-90ff-8919031dc64f">