### PR TITLE
Accelerate local builds in Visual Studio

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md

`<ProduceReferenceAssembly>true<ProduceReferenceAssembly>` is necessary in our case because of ics.d being netstandard2.0, otherwise this error shows up for FUTD:

```
4>FastUpToDate: Comparing timestamps of inputs and outputs: (ICSharpCode.ILSpyX)
4>FastUpToDate:     Adding UpToDateCheckBuilt outputs: (ICSharpCode.ILSpyX)
4>FastUpToDate:         D:\GitWorkspace\ILSpy\ICSharpCode.ILSpyX\bin\Debug\net6.0\ICSharpCode.ILSpyX.dll (ICSharpCode.ILSpyX)
4>FastUpToDate: Output 'D:\GitWorkspace\ILSpy\ICSharpCode.ILSpyX\bin\Debug\net6.0\ICSharpCode.ILSpyX.dll' does not exist, not up-to-date. (ICSharpCode.ILSpyX)
4>FastUpToDate: This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': 'D:\GitWorkspace\ILSpy\ICSharpCode.Decompiler\bin\Debug\netstandard2.0\ICSharpCode.Decompiler.dll'. See https://aka.ms/vs-build-acceleration for more information. (ICSharpCode.ILSpyX)
4>FastUpToDate: Up-to-date check completed in 0.3 ms (ICSharpCode.ILSpyX)
```