### PR TITLE
Merge GitHub's Dependabot automatic version bumps

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,6 +8,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
+
       - uses: dessant/lock-threads@v4.0.1
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
### Problem
Merge GitHub's Dependabot automatic version bumps

### Solution
If there is some way to squash the merge messages on GitHub's web interface, do tell me...

