### PR TITLE
Fix #3025: Annotate nested types

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -538,6 +538,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			{
 				// Handle nested types
 				result.Target = ConvertTypeHelper(genericType.DeclaringType, typeArguments);
+				AddTypeAnnotation(result.Target, genericType.DeclaringType);
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #3025

### Problem

- #3025

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.

Normally, `AddTypeAnnotation` is called right after `ConvertTypeHelper` in the `ConvertType` method:

https://github.com/icsharpcode/ILSpy/blob/bf0d74d0c713a0ae231a7f650cc19d06a56c784c/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs#L244-L245

But in the case of nested types, `ConvertTypeHelper` calls itself recursively for declaring types, and therefore `AddTypeAnnotation` was never called for these nodes.

* Which part of this PR is most in need of attention/improvement?

This is a very simple change.

* [ ] At least one test covering the code changed

I couldn't find any existing unit tests which check for type annotations (`ResolveResult`), so I wasn't sure where to put this. If you'd like me to add a unit test, please tell me in which way you'd like for type annotations to be tested.
