### PR TITLE
Fix #3031: emit sequence points for expression-bodied properties and indexers

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -325,6 +325,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="TestCases\PdbGen\Members.xml" />
     <Content Include="TestCases\PdbGen\ProgressReporting.xml" />
     <Content Include="TestCases\PdbGen\ForLoopTests.xml" />
     <Content Include="TestCases\PdbGen\CustomPdbId.xml" />

--- a/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
@@ -44,6 +44,13 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		[Ignore("Duplicate sequence points for local function")]
+		public void Members()
+		{
+			TestGeneratePdb();
+		}
+
+		[Test]
 		public void CustomPdbId()
 		{
 			// Generate a PDB for an assembly using a randomly-generated ID, then validate that the PDB uses the specified ID
@@ -155,7 +162,7 @@ namespace ICSharpCode.Decompiler.Tests
 			ProcessXmlFile(expectedFileName);
 			string generatedFileName = Path.ChangeExtension(xmlFile, ".generated.xml");
 			ProcessXmlFile(generatedFileName);
-			Assert.AreEqual(Normalize(expectedFileName), Normalize(generatedFileName));
+			CodeAssert.AreEqual(Normalize(expectedFileName), Normalize(generatedFileName));
 		}
 
 		private (string peFileName, string pdbFileName) CompileTestCase(string testName)

--- a/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/Members.xml
+++ b/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/Members.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<symbols>
+  <files>
+    <file id="1" name="-\C.cs" language="C#" checksumAlgorithm="SHA256">
+	<![CDATA[using System;
+
+internal class C : IDisposable
+{
+	private int ExpressionProperty => 42;
+
+    private int Property 
+    {
+        get
+		{
+			return 0;
+		}
+        set
+		{
+		}
+    }
+
+    private C this[int index] => null;
+
+    private C this[string s]
+    {
+        get
+		{
+			return null;
+		}
+        set
+		{
+		}
+    }
+
+    public event Action Event
+    {
+        add
+        {
+        }
+        remove
+        {
+        }
+    }
+
+    public static implicit operator C(int i)
+    {
+        return null;
+    }
+
+    static C()
+    {
+    }
+
+    public C()
+    {
+		Console.WriteLine();
+    }
+
+    ~C()
+    {
+    }
+
+    void IDisposable.Dispose()
+    {
+    }
+
+    private static void Main()
+    {
+        C c = new C();
+
+        c.Event += delegate
+		{
+		};
+        _ = c.Property;
+        _ = c.ExpressionProperty;
+        _ = c[0];
+        _ = c[""];
+
+        _ = (C)1;
+
+        Local();
+
+        static void Local()
+        {
+			Console.WriteLine();
+        }
+    }
+}
+]]></file>
+  </files>
+  <methods>
+  </methods>
+  <method-spans>
+  </method-spans>
+</symbols>

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1698,10 +1698,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				var function = ilReader.ReadIL((MethodDefinitionHandle)method.MetadataToken, methodBody, cancellationToken: CancellationToken);
 				function.CheckInvariant(ILPhase.Normal);
 
-				if (entityDecl != null)
-				{
-					AddAnnotationsToDeclaration(method, entityDecl, function);
-				}
+				AddAnnotationsToDeclaration(method, entityDecl, function);
 
 				var localSettings = settings.Clone();
 				if (IsWindowsFormsInitializeComponentMethod(method))
@@ -1751,7 +1748,6 @@ namespace ICSharpCode.Decompiler.CSharp
 
 					entityDecl.AddChild(body, Roles.Body);
 				}
-				entityDecl.AddAnnotation(function);
 
 				CleanUpMethodDeclaration(entityDecl, body, function, localSettings.DecompileMemberBodies);
 			}

--- a/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/SequencePointBuilder.cs
@@ -164,6 +164,30 @@ namespace ICSharpCode.Decompiler.CSharp
 			}
 		}
 
+		public override void VisitPropertyDeclaration(PropertyDeclaration propertyDeclaration)
+		{
+			if (!propertyDeclaration.ExpressionBody.IsNull)
+			{
+				VisitAsSequencePoint(propertyDeclaration.ExpressionBody);
+			}
+			else
+			{
+				base.VisitPropertyDeclaration(propertyDeclaration);
+			}
+		}
+
+		public override void VisitIndexerDeclaration(IndexerDeclaration indexerDeclaration)
+		{
+			if (!indexerDeclaration.ExpressionBody.IsNull)
+			{
+				VisitAsSequencePoint(indexerDeclaration.ExpressionBody);
+			}
+			else
+			{
+				base.VisitIndexerDeclaration(indexerDeclaration);
+			}
+		}
+
 		public override void VisitForStatement(ForStatement forStatement)
 		{
 			// Every element of a for-statement is its own sequence point.

--- a/ICSharpCode.Decompiler/CSharp/Transforms/NormalizeBlockStatements.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/NormalizeBlockStatements.cs
@@ -218,6 +218,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				return;
 			propertyDeclaration.Modifiers |= propertyDeclaration.Getter.Modifiers;
 			propertyDeclaration.ExpressionBody = m.Get<Expression>("expression").Single().Detach();
+			propertyDeclaration.CopyAnnotationsFrom(propertyDeclaration.Getter);
 			propertyDeclaration.Getter.Remove();
 		}
 
@@ -230,6 +231,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				return;
 			indexerDeclaration.Modifiers |= indexerDeclaration.Getter.Modifiers;
 			indexerDeclaration.ExpressionBody = m.Get<Expression>("expression").Single().Detach();
+			indexerDeclaration.CopyAnnotationsFrom(indexerDeclaration.Getter);
 			indexerDeclaration.Getter.Remove();
 		}
 	}

--- a/ICSharpCode.Decompiler/DebugInfo/DebugInfoGenerator.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/DebugInfoGenerator.cs
@@ -136,6 +136,30 @@ namespace ICSharpCode.Decompiler.DebugInfo
 			HandleMethod(anonymousMethodExpression);
 		}
 
+		public override void VisitPropertyDeclaration(PropertyDeclaration propertyDeclaration)
+		{
+			if (!propertyDeclaration.ExpressionBody.IsNull)
+			{
+				HandleMethod(propertyDeclaration.ExpressionBody, propertyDeclaration.Annotation<ILFunction>());
+			}
+			else
+			{
+				base.VisitPropertyDeclaration(propertyDeclaration);
+			}
+		}
+
+		public override void VisitIndexerDeclaration(IndexerDeclaration indexerDeclaration)
+		{
+			if (!indexerDeclaration.ExpressionBody.IsNull)
+			{
+				HandleMethod(indexerDeclaration.ExpressionBody, indexerDeclaration.Annotation<ILFunction>());
+			}
+			else
+			{
+				base.VisitIndexerDeclaration(indexerDeclaration);
+			}
+		}
+
 		public override void VisitQueryFromClause(QueryFromClause queryFromClause)
 		{
 			if (queryFromClause.Parent.FirstChild != queryFromClause)


### PR DESCRIPTION
Need to visit properties and indexers in SequencePointBuilder to account for ExpressionBody.

Adds a failing test for all kinds of members. Currently failing with an unrelated duplicate sequence points for a local function body.