### PR TITLE
Update Check for ilspycmd dotnet tool

### DIFF
--- a/ICSharpCode.ILSpyCmd/DotNetToolUpdateChecker.cs
+++ b/ICSharpCode.ILSpyCmd/DotNetToolUpdateChecker.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace ICSharpCode.ILSpyCmd
+{
+	// Idea from https://github.com/ErikEJ/EFCorePowerTools/blob/master/src/GUI/efcpt/Services/PackageService.cs
+	internal static class DotNetToolUpdateChecker
+	{
+		static NuGetVersion CurrentPackageVersion()
+		{
+			return new NuGetVersion(Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!
+				.InformationalVersion);
+		}
+
+		public static async Task CheckForPackageUpdateAsync(string packageId)
+		{
+			try
+			{
+				using var cache = new SourceCacheContext();
+				var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+				var resource = await repository.GetResourceAsync<FindPackageByIdResource>().ConfigureAwait(false);
+
+				var versions = await resource.GetAllVersionsAsync(
+					packageId,
+					cache,
+					new NullLogger(),
+					CancellationToken.None).ConfigureAwait(false);
+
+				var latestVersion = versions.Where(v => v.Release == "").MaxBy(v => v);
+				if (latestVersion > CurrentPackageVersion())
+				{
+					Console.WriteLine("You are not using the latest version of the tool, please update.");
+					Console.WriteLine($"Latest version is '{latestVersion}'");
+				}
+			}
+#pragma warning disable RCS1075 // Avoid empty catch clause that catches System.Exception.
+			catch (Exception)
+			{
+			}
+#pragma warning restore RCS1075 // Avoid empty catch clause that catches System.Exception.
+		}
+	}
+}

--- a/ICSharpCode.ILSpyCmd/DotNetToolUpdateChecker.cs
+++ b/ICSharpCode.ILSpyCmd/DotNetToolUpdateChecker.cs
@@ -20,7 +20,7 @@ namespace ICSharpCode.ILSpyCmd
 				.InformationalVersion);
 		}
 
-		public static async Task CheckForPackageUpdateAsync(string packageId)
+		public static async Task<NuGetVersion> CheckForPackageUpdateAsync(string packageId)
 		{
 			try
 			{
@@ -37,8 +37,7 @@ namespace ICSharpCode.ILSpyCmd
 				var latestVersion = versions.Where(v => v.Release == "").MaxBy(v => v);
 				if (latestVersion > CurrentPackageVersion())
 				{
-					Console.WriteLine("You are not using the latest version of the tool, please update.");
-					Console.WriteLine($"Latest version is '{latestVersion}'");
+					return latestVersion;
 				}
 			}
 #pragma warning disable RCS1075 // Avoid empty catch clause that catches System.Exception.
@@ -46,6 +45,8 @@ namespace ICSharpCode.ILSpyCmd
 			{
 			}
 #pragma warning restore RCS1075 // Avoid empty catch clause that catches System.Exception.
+
+			return null;
 		}
 	}
 }

--- a/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
+++ b/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
@@ -49,11 +49,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
   </ItemGroup>
 
   <Target Name="ILSpyUpdateAssemblyInfo" AfterTargets="ResolveProjectReferences">

--- a/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
+++ b/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
@@ -49,7 +49,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include=" McMaster.Extensions.Hosting.CommandLine" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 
   <Target Name="ILSpyUpdateAssemblyInfo" AfterTargets="ResolveProjectReferences">

--- a/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
+++ b/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <PackageReference Include=" McMaster.Extensions.Hosting.CommandLine" Version="4.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
   </ItemGroup>
 
   <Target Name="ILSpyUpdateAssemblyInfo" AfterTargets="ResolveProjectReferences">

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -22,6 +22,8 @@ using ICSharpCode.ILSpyX.PdbProvider;
 
 using McMaster.Extensions.CommandLineUtils;
 
+using Microsoft.Extensions.Hosting;
+
 namespace ICSharpCode.ILSpyCmd
 {
 	[Command(Name = "ilspycmd", Description = "dotnet tool for decompiling .NET assemblies and generating portable PDBs",
@@ -49,7 +51,7 @@ Examples:
 		MemberName = nameof(DecompilerVersion))]
 	class ILSpyCmdProgram
 	{
-		public static Task<int> Main(string[] args) => CommandLineApplication.ExecuteAsync<ILSpyCmdProgram>(args);
+		public static Task<int> Main(string[] args) => new HostBuilder().RunCommandLineApplicationAsync<ILSpyCmdProgram>(args);
 
 		[FilesExist]
 		[Required]
@@ -106,6 +108,12 @@ Examples:
 
 		[Option("--nested-directories", "Use nested directories for namespaces.", CommandOptionType.NoValue)]
 		public bool NestedDirectories { get; }
+
+		private readonly IHostEnvironment _env;
+		public ILSpyCmdProgram(IHostEnvironment env)
+		{
+			_env = env;
+		}
 
 		private Task<int> OnExecuteAsync(CommandLineApplication app)
 		{

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Threading;
+using System.Threading.Tasks;
 
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
@@ -48,7 +49,7 @@ Examples:
 		MemberName = nameof(DecompilerVersion))]
 	class ILSpyCmdProgram
 	{
-		public static int Main(string[] args) => CommandLineApplication.Execute<ILSpyCmdProgram>(args);
+		public static Task<int> Main(string[] args) => CommandLineApplication.ExecuteAsync<ILSpyCmdProgram>(args);
 
 		[FilesExist]
 		[Required]
@@ -106,7 +107,7 @@ Examples:
 		[Option("--nested-directories", "Use nested directories for namespaces.", CommandOptionType.NoValue)]
 		public bool NestedDirectories { get; }
 
-		private int OnExecute(CommandLineApplication app)
+		private Task<int> OnExecuteAsync(CommandLineApplication app)
 		{
 			TextWriter output = System.Console.Out;
 			string outputDirectory = ResolveOutputDirectory(OutputDirectory);
@@ -124,7 +125,7 @@ Examples:
 					{
 						string projectFileName = Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(InputAssemblyNames[0]) + ".csproj");
 						DecompileAsProject(InputAssemblyNames[0], projectFileName);
-						return 0;
+						return Task.FromResult(0);
 					}
 					var projects = new List<ProjectItem>();
 					foreach (var file in InputAssemblyNames)
@@ -135,7 +136,7 @@ Examples:
 						projects.Add(new ProjectItem(projectFileName, projectId.PlatformName, projectId.Guid, projectId.TypeGuid));
 					}
 					SolutionCreator.WriteSolutionFile(Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(outputDirectory) + ".sln"), projects);
-					return 0;
+					return Task.FromResult(0);
 				}
 				else
 				{
@@ -143,15 +144,15 @@ Examples:
 					{
 						int result = PerformPerFileAction(file);
 						if (result != 0)
-							return result;
+							return Task.FromResult(result);
 					}
-					return 0;
+					return Task.FromResult(0);
 				}
 			}
 			catch (Exception ex)
 			{
 				app.Error.WriteLine(ex.ToString());
-				return ProgramExitCodes.EX_SOFTWARE;
+				return Task.FromResult(ProgramExitCodes.EX_SOFTWARE);
 			}
 			finally
 			{

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -51,6 +51,8 @@ Examples:
 		MemberName = nameof(DecompilerVersion))]
 	class ILSpyCmdProgram
 	{
+		// https://natemcmaster.github.io/CommandLineUtils/docs/advanced/generic-host.html
+		// https://github.com/natemcmaster/CommandLineUtils/blob/main/docs/samples/dependency-injection/generic-host/Program.cs
 		public static Task<int> Main(string[] args) => new HostBuilder().RunCommandLineApplicationAsync<ILSpyCmdProgram>(args);
 
 		[FilesExist]
@@ -95,7 +97,7 @@ Examples:
 
 		[DirectoryExists]
 		[Option("-r|--referencepath <path>", "Path to a directory containing dependencies of the assembly that is being decompiled.", CommandOptionType.MultipleValue)]
-		public string[] ReferencePaths { get; } = new string[0];
+		public string[] ReferencePaths { get; }
 
 		[Option("--no-dead-code", "Remove dead code.", CommandOptionType.NoValue)]
 		public bool RemoveDeadCode { get; }
@@ -103,7 +105,7 @@ Examples:
 		[Option("--no-dead-stores", "Remove dead stores.", CommandOptionType.NoValue)]
 		public bool RemoveDeadStores { get; }
 
-		[Option("-d|--dump-package", "Dump package assembiles into a folder. This requires the output directory option.", CommandOptionType.NoValue)]
+		[Option("-d|--dump-package", "Dump package assemblies into a folder. This requires the output directory option.", CommandOptionType.NoValue)]
 		public bool DumpPackageFlag { get; }
 
 		[Option("--nested-directories", "Use nested directories for namespaces.", CommandOptionType.NoValue)]
@@ -117,6 +119,8 @@ Examples:
 
 		private Task<int> OnExecuteAsync(CommandLineApplication app)
 		{
+			// await DotNetToolUpdateChecker.CheckForPackageUpdateAsync("ilspycmd");
+
 			TextWriter output = System.Console.Out;
 			string outputDirectory = ResolveOutputDirectory(OutputDirectory);
 
@@ -249,7 +253,7 @@ Examples:
 		{
 			var module = new PEFile(assemblyFileName);
 			var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Metadata.DetectTargetFrameworkId());
-			foreach (var path in ReferencePaths)
+			foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
 			{
 				resolver.AddSearchDirectory(path);
 			}
@@ -287,7 +291,7 @@ Examples:
 		{
 			var module = new PEFile(assemblyFileName);
 			var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Metadata.DetectTargetFrameworkId());
-			foreach (var path in ReferencePaths)
+			foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
 			{
 				resolver.AddSearchDirectory(path);
 			}


### PR DESCRIPTION
* Update McMaster.Extensions.CommandLineUtils to 4.0.1 (actually switch to McMaster.Extensions.Hosting.CommandLine for generic host support)
* Fix [DirectoryExists] for ReferencePaths due to subtle change in 3.1.0 -> 4.0.1 upgrade
* Add DotNetToolUpdateChecker.CheckForPackageUpdateAsync inspired by efcpt dotnet tool