### PR TITLE
Roslyn 4.6

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ValueTypeCall.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ValueTypeCall.cs
@@ -238,16 +238,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		static void ToStringGeneric<T>(ref T mutRef, in T immutableRef) where T : struct
 		{
 			Console.WriteLine("ToStringGeneric:");
-			mutRef.ToString();
-			mutRef.ToString();
+			Console.WriteLine(mutRef.ToString());
+			Console.WriteLine(mutRef.ToString());
 			T copyFromMut = mutRef;
-			copyFromMut.ToString();
-			immutableRef.ToString();
-			immutableRef.ToString();
+			Console.WriteLine(copyFromMut.ToString());
+			Console.WriteLine(immutableRef.ToString());
+			Console.WriteLine(immutableRef.ToString());
 			T copyFromImmutable = immutableRef;
-			copyFromImmutable.ToString();
-			mutRef.ToString();
-			immutableRef.ToString();
+			Console.WriteLine(copyFromImmutable.ToString());
+			Console.WriteLine(mutRef.ToString());
+			Console.WriteLine(immutableRef.ToString());
 		}
 #endif
 	}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ValueTypeCall.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/ValueTypeCall.cs
@@ -16,6 +16,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		public void Dispose()
 		{
 			Console.WriteLine("MutValueType disposed on {0}", val);
+			val = val + 1;
 		}
 
 		public override string ToString()
@@ -67,6 +68,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			gvt.Call(ref gvt);
 			new ValueTypeCall().InstanceFieldTests();
 			ForEach();
+#if CS73
+			DisposeMultipleTimes(ref m, in m);
+			ToStringGeneric(ref m, in m);
+#endif
 		}
 
 		static void RefParameter(ref MutValueType m)
@@ -213,5 +218,37 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			}
 			Console.WriteLine("after: " + list[0].val);
 		}
+
+#if CS73
+		static void DisposeMultipleTimes<T>(ref T mutRef, in T immutableRef) where T : struct, IDisposable
+		{
+			Console.WriteLine("DisposeMultipleTimes:");
+			mutRef.Dispose();
+			mutRef.Dispose();
+			T copyFromMut = mutRef;
+			copyFromMut.Dispose();
+			immutableRef.Dispose();
+			immutableRef.Dispose();
+			T copyFromImmutable = immutableRef;
+			copyFromImmutable.Dispose();
+			mutRef.Dispose();
+			immutableRef.Dispose();
+		}
+
+		static void ToStringGeneric<T>(ref T mutRef, in T immutableRef) where T : struct
+		{
+			Console.WriteLine("ToStringGeneric:");
+			mutRef.ToString();
+			mutRef.ToString();
+			T copyFromMut = mutRef;
+			copyFromMut.ToString();
+			immutableRef.ToString();
+			immutableRef.ToString();
+			T copyFromImmutable = immutableRef;
+			copyFromImmutable.ToString();
+			mutRef.ToString();
+			immutableRef.ToString();
+		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -378,6 +378,7 @@ namespace ICSharpCode.Decompiler
 		}
 
 		[Obsolete("Renamed to ScopedRef. This property will be removed in a future version of the decompiler.")]
+		[Browsable(false)]
 		public bool LifetimeAnnotations {
 			get { return ScopedRef; }
 			set { ScopedRef = value; }

--- a/packages.props
+++ b/packages.props
@@ -27,10 +27,10 @@
 		<MoqVersion>4.18.4</MoqVersion>
 		<DiffLibVersion>2017.7.26.1241</DiffLibVersion>
 		<!-- Microsoft.CodeAnalysis.* -->
-		<RoslynVersion>4.4.0</RoslynVersion>
+		<RoslynVersion>4.6.0</RoslynVersion>
 		<!-- Microsoft.NETCore.ILAsm -->
-		<ILAsmVersion>6.0.0</ILAsmVersion>
+		<ILAsmVersion>7.0.0</ILAsmVersion>
 		<!-- Microsoft.NETCore.ILDAsm -->
-		<ILDAsmVersion>6.0.0</ILDAsmVersion>
+		<ILDAsmVersion>7.0.0</ILDAsmVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Test failures:
  Records(UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  Records(Optimize, UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  Switch(TargetNet40, UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  Switch(Optimize, TargetNet40, UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  Switch(UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  Switch(Optimize, UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  SwitchExpressions(UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
  SwitchExpressions(Optimize, UseRoslynLatest): ICSharpCode.Decompiler.Tests.PrettyTestRunner
