### PR TITLE
Support for C# 8 pattern matching

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         msbuild ILSpy.Installer.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
         msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU"
-        msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU" /p:DefineConstants="ARM64"
+        msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU" /p:PlatformForInstaller="ARM64"
 
     - name: Build VS Extensions (for 2017-2019 and 2022)
       if: matrix.configuration == 'release'  

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -6,10 +6,14 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 	{
 		public class X
 		{
+			public int? NullableIntField;
+			public S? NullableCustomStructField;
 			public int I { get; set; }
 			public string Text { get; set; }
 			public object Obj { get; set; }
 			public S CustomStruct { get; set; }
+			public int? NullableIntProp { get; set; }
+			public S? NullableCustomStructProp { get; set; }
 		}
 
 		public struct S
@@ -480,6 +484,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			if (obj is X { Text: { Length: var length }, I: 42 } x)
 			{
 				Console.WriteLine("Test " + x.I + ": " + length);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructProp_Const(object obj)
+		{
+			if (obj is X { NullableCustomStructProp: { I: 42, Obj: not null } nullableCustomStructProp })
+			{
+				Console.WriteLine("Test " + nullableCustomStructProp.Text);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -491,6 +491,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_NullableIntField_Const(object obj)
+		{
+			if (obj is X { NullableIntField: 42 } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_NullableCustomStructProp_Const(object obj)
 		{
 			if (obj is X { NullableCustomStructProp: { I: 42, Obj: not null } nullableCustomStructProp })

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -4,6 +4,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
 	public class PatternMatching
 	{
+		public class X
+		{
+			public int A { get; set; }
+			public string B { get; set; }
+			public object C { get; set; }
+		}
+
 		public void SimpleTypePattern(object x)
 		{
 			if (x is string value)
@@ -300,6 +307,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			else
 			{
 				Console.WriteLine("not a string");
+			}
+		}
+
+		public void RecursivePattern_Type(object x)
+		{
+			if (x is X { C: string text })
+			{
+				Console.WriteLine("Test " + text);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
 			}
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -387,6 +387,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				Console.WriteLine("not Test");
 			}
 		}
+
+		public void RecursivePattern_NonTypePattern(object obj)
+		{
+			if (obj is X { A: 42, B: { Length: 0 } } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_VarLengthPattern(object obj)
+		{
+			if (obj is X { A: 42, B: { Length: var length } } x)
+			{
+				Console.WriteLine("Test " + x.A + ": " + length);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
 #endif
 		private bool F()
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -335,6 +335,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_StringConstant(object obj)
+		{
+			if (obj is X { B: "Hello" } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
 #endif
 		private bool F()
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -503,11 +503,83 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+
+		public void RecursivePattern_NullableIntField_Var(object obj)
+		{
+			if (obj is X { NullableIntField: var nullableIntField })
+			{
+				Console.WriteLine("Test " + nullableIntField.Value);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableIntProp_Const(object obj)
+		{
+			if (obj is X { NullableIntProp: 42 } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+		public void RecursivePattern_NullableIntProp_Var(object obj)
+		{
+			if (obj is X { NullableIntProp: var nullableIntProp })
+			{
+				Console.WriteLine("Test " + nullableIntProp.Value);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructField_Const(object obj)
+		{
+			if (obj is X { NullableCustomStructField: { I: 42, Obj: not null } nullableCustomStructField })
+			{
+				Console.WriteLine("Test " + nullableCustomStructField.I);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructField_Var(object obj)
+		{
+			if (obj is X { NullableCustomStructField: var nullableCustomStructField, Obj: null })
+			{
+				Console.WriteLine("Test " + nullableCustomStructField.Value);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_NullableCustomStructProp_Const(object obj)
 		{
 			if (obj is X { NullableCustomStructProp: { I: 42, Obj: not null } nullableCustomStructProp })
 			{
 				Console.WriteLine("Test " + nullableCustomStructProp.Text);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructProp_Var(object obj)
+		{
+			if (obj is X { NullableCustomStructProp: var nullableCustomStructProp, Obj: null })
+			{
+				Console.WriteLine("Test " + nullableCustomStructProp.Value);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -717,6 +717,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_CustomStructNested_EmptyString(object obj)
+		{
+			if (obj is S { S2: { Text: "" } })
+			{
+				Console.WriteLine("Test " + obj);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_CustomStructNested_Float(object obj)
 		{
 			if (obj is S { S2: { F: 3.141f, Obj: null } })

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -331,6 +331,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_TypeAndConst(object x)
+		{
+			if (x is X { Obj: string obj, I: 42 })
+			{
+				Console.WriteLine("Test " + obj);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_Constant(object obj)
 		{
 			if (obj is X { Obj: null } x)
@@ -444,6 +456,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			if (obj is S { I: 42, Text: { Length: var length } } s)
 			{
 				Console.WriteLine("Test " + s.I + ": " + length);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePatternValueType_VarLengthPattern_SwappedProps(object obj)
+		{
+			if (obj is S { Text: { Length: var length }, I: 42 } s)
+			{
+				Console.WriteLine("Test " + s.I + ": " + length);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_VarLengthPattern_SwappedProps(object obj)
+		{
+			if (obj is X { Text: { Length: var length }, I: 42 } x)
+			{
+				Console.WriteLine("Test " + x.I + ": " + length);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -21,6 +21,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public int I;
 			public string Text { get; set; }
 			public object Obj { get; set; }
+			public S2 S2 { get; set; }
+		}
+
+		public struct S2
+		{
+			public int I;
+			public float F;
+			public decimal D;
+			public string Text { get; set; }
+			public object Obj { get; set; }
 		}
 
 		public void SimpleTypePattern(object x)
@@ -676,6 +686,54 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			if (obj is X { NullableCustomStructProp: var nullableCustomStructProp, Obj: null })
 			{
 				Console.WriteLine("Test " + nullableCustomStructProp.Value);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_CustomStructNested_Null(object obj)
+		{
+			if (obj is S { S2: { Obj: null } })
+			{
+				Console.WriteLine("Test " + obj);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_CustomStructNested_TextLengthZero(object obj)
+		{
+			if (obj is S { S2: { Text: { Length: 0 } } })
+			{
+				Console.WriteLine("Test " + obj);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_CustomStructNested_Float(object obj)
+		{
+			if (obj is S { S2: { F: 3.141f, Obj: null } })
+			{
+				Console.WriteLine("Test " + obj);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_CustomStructNested_Decimal(object obj)
+		{
+			if (obj is S { S2: { D: 3.141m, Obj: null } })
+			{
+				Console.WriteLine("Test " + obj);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -6,14 +6,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 	{
 		public class X
 		{
-			public int A { get; set; }
-			public string B { get; set; }
-			public object C { get; set; }
+			public int I { get; set; }
+			public string Text { get; set; }
+			public object Obj { get; set; }
+			public S CustomStruct { get; set; }
 		}
 
 		public struct S
 		{
 			public int I;
+			public string Text { get; set; }
+			public object Obj { get; set; }
 		}
 
 		public void SimpleTypePattern(object x)
@@ -318,9 +321,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if CS80
 		public void RecursivePattern_Type(object x)
 		{
-			if (x is X { C: string c })
+			if (x is X { Obj: string obj })
 			{
-				Console.WriteLine("Test " + c);
+				Console.WriteLine("Test " + obj);
 			}
 			else
 			{
@@ -330,7 +333,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void RecursivePattern_Constant(object obj)
 		{
-			if (obj is X { C: null } x)
+			if (obj is X { Obj: null } x)
 			{
 				Console.WriteLine("Test " + x);
 			}
@@ -342,7 +345,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void RecursivePattern_StringConstant(object obj)
 		{
-			if (obj is X { B: "Hello" } x)
+			if (obj is X { Text: "Hello" } x)
 			{
 				Console.WriteLine("Test " + x);
 			}
@@ -354,7 +357,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void RecursivePattern_MultipleConstants(object obj)
 		{
-			if (obj is X { A: 42, B: "Hello" } x)
+			if (obj is X { I: 42, Text: "Hello" } x)
 			{
 				Console.WriteLine("Test " + x);
 			}
@@ -378,9 +381,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void RecursivePattern_MultipleConstantsMixedWithVar(object x)
 		{
-			if (x is X { A: 42, C: var c, B: "Hello" })
+			if (x is X { I: 42, Obj: var obj, Text: "Hello" })
 			{
-				Console.WriteLine("Test " + c);
+				Console.WriteLine("Test " + obj);
 			}
 			else
 			{
@@ -390,7 +393,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void RecursivePattern_NonTypePattern(object obj)
 		{
-			if (obj is X { A: 42, B: { Length: 0 } } x)
+			if (obj is X { I: 42, Text: { Length: 0 } } x)
 			{
 				Console.WriteLine("Test " + x);
 			}
@@ -400,11 +403,47 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePatternValueType_NonTypePatternTwoProps(object obj)
+		{
+			if (obj is X { I: 42, CustomStruct: { I: 0, Text: "Test" } } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NonTypePatternNotNull(object o)
+		{
+			if (o is X { I: 42, Text: not null, Obj: var obj } x)
+			{
+				Console.WriteLine("Test " + x.I + " " + obj.GetType());
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_VarLengthPattern(object obj)
 		{
-			if (obj is X { A: 42, B: { Length: var length } } x)
+			if (obj is X { I: 42, Text: { Length: var length } } x)
 			{
-				Console.WriteLine("Test " + x.A + ": " + length);
+				Console.WriteLine("Test " + x.I + ": " + length);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePatternValueType_VarLengthPattern(object obj)
+		{
+			if (obj is S { I: 42, Text: { Length: var length } } s)
+			{
+				Console.WriteLine("Test " + s.I + ": " + length);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -11,6 +11,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public object C { get; set; }
 		}
 
+		public struct S
+		{
+			public int I;
+		}
+
 		public void SimpleTypePattern(object x)
 		{
 			if (x is string value)
@@ -340,6 +345,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			if (obj is X { B: "Hello" } x)
 			{
 				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_MultipleConstants(object obj)
+		{
+			if (obj is X { A: 42, B: "Hello" } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_ValueTypeWithField(object obj)
+		{
+			if (obj is S { I: 42 } s)
+			{
+				Console.WriteLine("Test " + s);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -318,9 +318,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if CS80
 		public void RecursivePattern_Type(object x)
 		{
-			if (x is X { C: string text })
+			if (x is X { C: string c })
 			{
-				Console.WriteLine("Test " + text);
+				Console.WriteLine("Test " + c);
 			}
 			else
 			{
@@ -369,6 +369,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			if (obj is S { I: 42 } s)
 			{
 				Console.WriteLine("Test " + s);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_MultipleConstantsMixedWithVar(object x)
+		{
+			if (x is X { A: 42, C: var c, B: "Hello" })
+			{
+				Console.WriteLine("Test " + c);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -503,6 +503,29 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_NullableIntField_Null(object obj)
+		{
+			if (obj is X { NullableIntField: null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableIntField_NotNull(object obj)
+		{
+			if (obj is X { NullableIntField: not null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
 
 		public void RecursivePattern_NullableIntField_Var(object obj)
 		{
@@ -527,6 +550,31 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				Console.WriteLine("not Test");
 			}
 		}
+
+		public void RecursivePattern_NullableIntProp_Null(object obj)
+		{
+			if (obj is X { NullableIntProp: null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableIntProp_NotNull(object obj)
+		{
+			if (obj is X { NullableIntProp: not null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_NullableIntProp_Var(object obj)
 		{
 			if (obj is X { NullableIntProp: var nullableIntProp })
@@ -551,6 +599,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_NullableCustomStructField_Null(object obj)
+		{
+			if (obj is X { NullableCustomStructField: null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructField_NotNull(object obj)
+		{
+			if (obj is X { NullableCustomStructField: not null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
 		public void RecursivePattern_NullableCustomStructField_Var(object obj)
 		{
 			if (obj is X { NullableCustomStructField: var nullableCustomStructField, Obj: null })
@@ -568,6 +640,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			if (obj is X { NullableCustomStructProp: { I: 42, Obj: not null } nullableCustomStructProp })
 			{
 				Console.WriteLine("Test " + nullableCustomStructProp.Text);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructProp_Null(object obj)
+		{
+			if (obj is X { NullableCustomStructProp: null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+		public void RecursivePattern_NullableCustomStructProp_NotNull(object obj)
+		{
+			if (obj is X { NullableCustomStructProp: not null } x)
+			{
+				Console.WriteLine("Test " + x);
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PatternMatching.cs
@@ -310,6 +310,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+#if CS80
 		public void RecursivePattern_Type(object x)
 		{
 			if (x is X { C: string text })
@@ -322,6 +323,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public void RecursivePattern_Constant(object obj)
+		{
+			if (obj is X { C: null } x)
+			{
+				Console.WriteLine("Test " + x);
+			}
+			else
+			{
+				Console.WriteLine("not Test");
+			}
+		}
+
+#endif
 		private bool F()
 		{
 			return true;

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4571,7 +4571,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						}
 						else
 						{
-							Debug.Assert(matchInstruction.CheckNotNull);
+							Debug.Assert(matchInstruction.CheckNotNull || matchInstruction.Variable.Type.IsReferenceType == false);
 						}
 						foreach (var subPattern in matchInstruction.SubPatterns)
 						{

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4641,6 +4641,8 @@ namespace ICSharpCode.Decompiler.CSharp
 						default:
 							throw new InvalidOperationException("Unexpected comparison kind: " + comp.Kind);
 					}
+				case Call call when MatchInstruction.IsCallToString_op_Equality(call):
+					return Translate(call.Arguments[1]);
 				default:
 					throw new NotImplementedException();
 			}

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4657,7 +4657,9 @@ namespace ICSharpCode.Decompiler.CSharp
 						default:
 							throw new InvalidOperationException("Unexpected comparison kind: " + comp.Kind);
 					}
-				case Call call when MatchInstruction.IsCallToString_op_Equality(call):
+				case Call call when MatchInstruction.IsCallToOpEquality(call, KnownTypeCode.String):
+					return Translate(call.Arguments[1]);
+				case Call call when MatchInstruction.IsCallToOpEquality(call, KnownTypeCode.Decimal):
 					return Translate(call.Arguments[1]);
 				default:
 					throw new NotImplementedException();

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4575,7 +4575,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						}
 						foreach (var subPattern in matchInstruction.SubPatterns)
 						{
-							if (!MatchInstruction.IsPatternMatch(subPattern, out var testedOperand))
+							if (!MatchInstruction.IsPatternMatch(subPattern, out var testedOperand, settings))
 							{
 								Debug.Fail("Invalid sub pattern");
 								continue;

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -948,6 +948,40 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			EndNode(declarationExpression);
 		}
 
+		public virtual void VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression)
+		{
+			StartNode(recursivePatternExpression);
+
+			recursivePatternExpression.Type.AcceptVisitor(this);
+			Space();
+			if (recursivePatternExpression.IsPositional)
+			{
+				WriteToken(Roles.LPar);
+			}
+			else
+			{
+				WriteToken(Roles.LBrace);
+			}
+			Space();
+			WriteCommaSeparatedList(recursivePatternExpression.SubPatterns);
+			Space();
+			if (recursivePatternExpression.IsPositional)
+			{
+				WriteToken(Roles.RPar);
+			}
+			else
+			{
+				WriteToken(Roles.RBrace);
+			}
+			if (!recursivePatternExpression.Designation.IsNull)
+			{
+				Space();
+				recursivePatternExpression.Designation.AcceptVisitor(this);
+			}
+
+			EndNode(recursivePatternExpression);
+		}
+
 		public virtual void VisitOutVarDeclarationExpression(OutVarDeclarationExpression outVarDeclarationExpression)
 		{
 			StartNode(outVarDeclarationExpression);

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1302,7 +1302,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			StartNode(unaryOperatorExpression);
 			UnaryOperatorType opType = unaryOperatorExpression.Operator;
 			var opSymbol = UnaryOperatorExpression.GetOperatorRole(opType);
-			if (opType == UnaryOperatorType.Await)
+			if (opType is UnaryOperatorType.Await or UnaryOperatorType.PatternNot)
 			{
 				WriteKeyword(opSymbol);
 				Space();

--- a/ICSharpCode.Decompiler/CSharp/Syntax/DepthFirstAstVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/DepthFirstAstVisitor.cs
@@ -512,6 +512,11 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			VisitChildren(declarationExpression);
 		}
 
+		public virtual void VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression)
+		{
+			VisitChildren(recursivePatternExpression);
+		}
+
 		public virtual void VisitOutVarDeclarationExpression(OutVarDeclarationExpression outVarDeclarationExpression)
 		{
 			VisitChildren(outVarDeclarationExpression);
@@ -1190,6 +1195,11 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			return VisitChildren(declarationExpression);
 		}
 
+		public virtual T VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression)
+		{
+			return VisitChildren(recursivePatternExpression);
+		}
+
 		public virtual T VisitOutVarDeclarationExpression(OutVarDeclarationExpression outVarDeclarationExpression)
 		{
 			return VisitChildren(outVarDeclarationExpression);
@@ -1866,6 +1876,11 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		public virtual S VisitDeclarationExpression(DeclarationExpression declarationExpression, T data)
 		{
 			return VisitChildren(declarationExpression, data);
+		}
+
+		public virtual S VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression, T data)
+		{
+			return VisitChildren(recursivePatternExpression, data);
 		}
 
 		public virtual S VisitOutVarDeclarationExpression(OutVarDeclarationExpression outVarDeclarationExpression, T data)

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/RecursivePatternExpression.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/RecursivePatternExpression.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020 Siegfried Pammer
+﻿// Copyright (c) 2023 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -20,14 +20,17 @@ using ICSharpCode.Decompiler.CSharp.Syntax.PatternMatching;
 
 namespace ICSharpCode.Decompiler.CSharp.Syntax
 {
-	/// <summary>
-	/// TypeName VariableDesignation
-	/// </summary>
-	public class DeclarationExpression : Expression
+	public class RecursivePatternExpression : Expression
 	{
+		public static readonly Role<Expression> SubPatternRole = new Role<Expression>("SubPattern", Syntax.Expression.Null);
+
 		public AstType Type {
 			get { return GetChildByRole(Roles.Type); }
 			set { SetChildByRole(Roles.Type, value); }
+		}
+
+		public AstNodeCollection<Expression> SubPatterns {
+			get { return GetChildrenByRole(SubPatternRole); }
 		}
 
 		public VariableDesignation Designation {
@@ -35,25 +38,29 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			set { SetChildByRole(Roles.VariableDesignationRole, value); }
 		}
 
+		public bool IsPositional { get; set; }
+
 		public override void AcceptVisitor(IAstVisitor visitor)
 		{
-			visitor.VisitDeclarationExpression(this);
+			visitor.VisitRecursivePatternExpression(this);
 		}
 
 		public override T AcceptVisitor<T>(IAstVisitor<T> visitor)
 		{
-			return visitor.VisitDeclarationExpression(this);
+			return visitor.VisitRecursivePatternExpression(this);
 		}
 
 		public override S AcceptVisitor<T, S>(IAstVisitor<T, S> visitor, T data)
 		{
-			return visitor.VisitDeclarationExpression(this, data);
+			return visitor.VisitRecursivePatternExpression(this, data);
 		}
 
 		protected internal override bool DoMatch(AstNode other, Match match)
 		{
-			return other is DeclarationExpression o
+			return other is RecursivePatternExpression o
 				&& Type.DoMatch(o.Type, match)
+				&& IsPositional == o.IsPositional
+				&& SubPatterns.DoMatch(o.SubPatterns, match)
 				&& Designation.DoMatch(o.Designation, match);
 		}
 	}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/UnaryOperatorExpression.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/UnaryOperatorExpression.cs
@@ -46,6 +46,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		public readonly static TokenRole NullConditionalRole = new TokenRole("?");
 		public readonly static TokenRole SuppressNullableWarningRole = new TokenRole("!");
 		public readonly static TokenRole IndexFromEndRole = new TokenRole("^");
+		public readonly static TokenRole PatternNotRole = new TokenRole("not");
 
 		public UnaryOperatorExpression()
 		{
@@ -126,6 +127,16 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 					return SuppressNullableWarningRole;
 				case UnaryOperatorType.IndexFromEnd:
 					return IndexFromEndRole;
+				case UnaryOperatorType.PatternNot:
+					return PatternNotRole;
+				case UnaryOperatorType.PatternRelationalLessThan:
+					return BinaryOperatorExpression.LessThanRole;
+				case UnaryOperatorType.PatternRelationalLessThanOrEqual:
+					return BinaryOperatorExpression.LessThanOrEqualRole;
+				case UnaryOperatorType.PatternRelationalGreaterThan:
+					return BinaryOperatorExpression.GreaterThanRole;
+				case UnaryOperatorType.PatternRelationalGreaterThanOrEqual:
+					return BinaryOperatorExpression.GreaterThanOrEqualRole;
 				default:
 					throw new NotSupportedException("Invalid value for UnaryOperatorType");
 			}
@@ -156,6 +167,11 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				case UnaryOperatorType.Await:
 				case UnaryOperatorType.SuppressNullableWarning:
 				case UnaryOperatorType.IndexFromEnd:
+				case UnaryOperatorType.PatternNot:
+				case UnaryOperatorType.PatternRelationalLessThan:
+				case UnaryOperatorType.PatternRelationalLessThanOrEqual:
+				case UnaryOperatorType.PatternRelationalGreaterThan:
+				case UnaryOperatorType.PatternRelationalGreaterThanOrEqual:
 					return ExpressionType.Extension;
 				default:
 					throw new NotSupportedException("Invalid value for UnaryOperatorType");
@@ -216,5 +232,25 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		/// C# 8 prefix ^ operator
 		/// </summary>
 		IndexFromEnd,
+		/// <summary>
+		/// C# 9 not pattern
+		/// </summary>
+		PatternNot,
+		/// <summary>
+		/// C# 9 relational pattern
+		/// </summary>
+		PatternRelationalLessThan,
+		/// <summary>
+		/// C# 9 relational pattern
+		/// </summary>
+		PatternRelationalLessThanOrEqual,
+		/// <summary>
+		/// C# 9 relational pattern
+		/// </summary>
+		PatternRelationalGreaterThan,
+		/// <summary>
+		/// C# 9 relational pattern
+		/// </summary>
+		PatternRelationalGreaterThanOrEqual,
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Syntax/IAstVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/IAstVisitor.cs
@@ -36,6 +36,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		void VisitCheckedExpression(CheckedExpression checkedExpression);
 		void VisitConditionalExpression(ConditionalExpression conditionalExpression);
 		void VisitDeclarationExpression(DeclarationExpression declarationExpression);
+		void VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression);
 		void VisitDefaultValueExpression(DefaultValueExpression defaultValueExpression);
 		void VisitDirectionExpression(DirectionExpression directionExpression);
 		void VisitIdentifierExpression(IdentifierExpression identifierExpression);
@@ -184,6 +185,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		S VisitCheckedExpression(CheckedExpression checkedExpression);
 		S VisitConditionalExpression(ConditionalExpression conditionalExpression);
 		S VisitDeclarationExpression(DeclarationExpression declarationExpression);
+		S VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression);
 		S VisitDefaultValueExpression(DefaultValueExpression defaultValueExpression);
 		S VisitDirectionExpression(DirectionExpression directionExpression);
 		S VisitIdentifierExpression(IdentifierExpression identifierExpression);
@@ -332,6 +334,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		S VisitCheckedExpression(CheckedExpression checkedExpression, T data);
 		S VisitConditionalExpression(ConditionalExpression conditionalExpression, T data);
 		S VisitDeclarationExpression(DeclarationExpression declarationExpression, T data);
+		S VisitRecursivePatternExpression(RecursivePatternExpression recursivePatternExpression, T data);
 		S VisitDefaultValueExpression(DefaultValueExpression defaultValueExpression, T data);
 		S VisitDirectionExpression(DirectionExpression directionExpression, T data);
 		S VisitIdentifierExpression(IdentifierExpression identifierExpression, T data);

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -130,6 +130,7 @@ namespace ICSharpCode.Decompiler
 				staticLocalFunctions = false;
 				ranges = false;
 				switchExpressions = false;
+				recursivePatternMatching = false;
 			}
 			if (languageVersion < CSharp.LanguageVersion.CSharp9_0)
 			{
@@ -141,6 +142,8 @@ namespace ICSharpCode.Decompiler
 				withExpressions = false;
 				usePrimaryConstructorSyntax = false;
 				covariantReturns = false;
+				relationalPatterns = false;
+				patternCombinators = false;
 			}
 			if (languageVersion < CSharp.LanguageVersion.CSharp10_0)
 			{
@@ -166,10 +169,11 @@ namespace ICSharpCode.Decompiler
 			if (fileScopedNamespaces || recordStructs)
 				return CSharp.LanguageVersion.CSharp10_0;
 			if (nativeIntegers || initAccessors || functionPointers || forEachWithGetEnumeratorExtension
-				|| recordClasses || withExpressions || usePrimaryConstructorSyntax || covariantReturns)
+				|| recordClasses || withExpressions || usePrimaryConstructorSyntax || covariantReturns
+				|| relationalPatterns || patternCombinators)
 				return CSharp.LanguageVersion.CSharp9_0;
 			if (nullableReferenceTypes || readOnlyMethods || asyncEnumerator || asyncUsingAndForEachStatement
-				|| staticLocalFunctions || ranges || switchExpressions)
+				|| staticLocalFunctions || ranges || switchExpressions || recursivePatternMatching)
 				return CSharp.LanguageVersion.CSharp8_0;
 			if (introduceUnmanagedConstraint || tupleComparisons || stackAllocInitializers
 				|| patternBasedFixedStatement)
@@ -1673,6 +1677,60 @@ namespace ICSharpCode.Decompiler
 				if (patternMatching != value)
 				{
 					patternMatching = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool recursivePatternMatching = true;
+
+		/// <summary>
+		/// Gets/Sets whether C# 8.0 recursive patterns should be detected.
+		/// </summary>
+		[Category("C# 8.0 / VS 2019")]
+		[Description("DecompilerSettings.RecursivePatternMatching")]
+		public bool RecursivePatternMatching {
+			get { return recursivePatternMatching; }
+			set {
+				if (recursivePatternMatching != value)
+				{
+					recursivePatternMatching = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool patternCombinators = true;
+
+		/// <summary>
+		/// Gets/Sets whether C# 9.0 and, or, not patterns should be detected.
+		/// </summary>
+		[Category("C# 9.0 / VS 2019.8")]
+		[Description("DecompilerSettings.PatternCombinators")]
+		public bool PatternCombinators {
+			get { return patternCombinators; }
+			set {
+				if (patternCombinators != value)
+				{
+					patternCombinators = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool relationalPatterns = true;
+
+		/// <summary>
+		/// Gets/Sets whether C# 9.0 relational patterns should be detected.
+		/// </summary>
+		[Category("C# 9.0 / VS 2019.8")]
+		[Description("DecompilerSettings.RelationalPatterns")]
+		public bool RelationalPatterns {
+			get { return relationalPatterns; }
+			set {
+				if (relationalPatterns != value)
+				{
+					relationalPatterns = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -27,7 +27,7 @@
     <GenerateAssemblyInformationalVersionAttribute>False</GenerateAssemblyInformationalVersionAttribute>
 
     <EnableDefaultItems>false</EnableDefaultItems>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>ICSharpCode.Decompiler.snk</AssemblyOriginatorKeyFile>
@@ -91,6 +91,7 @@
     <Compile Include="CSharp\Annotations.cs" />
     <Compile Include="CSharp\CallBuilder.cs" />
     <Compile Include="CSharp\CSharpLanguageVersion.cs" />
+    <Compile Include="CSharp\Syntax\Expressions\RecursivePatternExpression.cs" />
     <Compile Include="DecompilationProgress.cs" />
     <Compile Include="Disassembler\IEntityProcessor.cs" />
     <Compile Include="Disassembler\SortByNameProcessor.cs" />
@@ -139,6 +140,7 @@
     <Compile Include="Metadata\ReferenceLoadInfo.cs" />
     <Compile Include="Properties\DecompilerVersionInfo.cs" />
     <Compile Include="TypeSystem\ITypeDefinitionOrUnknown.cs" />
+    <Compile Include="Util\Index.cs" />
     <None Include="Properties\DecompilerVersionInfo.template.cs" />
     <Compile Include="Semantics\OutVarResolveResult.cs" />
     <Compile Include="SingleFileBundle.cs" />

--- a/ICSharpCode.Decompiler/IL/Instructions/Comp.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/Comp.cs
@@ -130,7 +130,7 @@ namespace ICSharpCode.Decompiler.IL
 			}
 		}
 
-		public readonly ComparisonLiftingKind LiftingKind;
+		public ComparisonLiftingKind LiftingKind;
 
 		/// <summary>
 		/// Gets the stack type of the comparison inputs.

--- a/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 using ICSharpCode.Decompiler.TypeSystem;
+
 namespace ICSharpCode.Decompiler.IL
 {
 	partial class MatchInstruction : ILInstruction
@@ -211,12 +212,12 @@ namespace ICSharpCode.Decompiler.IL
 				}
 				else if (operand.MatchLdFld(out var target, out _))
 				{
-					Debug.Assert(target.MatchLdLoc(variable));
+					Debug.Assert(target.MatchLdLocRef(variable));
 				}
 				else if (operand is CallInstruction call)
 				{
 					Debug.Assert(call.Method.AccessorKind == System.Reflection.MethodSemanticsAttributes.Getter);
-					Debug.Assert(call.Arguments[0].MatchLdLoc(variable));
+					Debug.Assert(call.Arguments[0].MatchLdLocRef(variable));
 				}
 				else
 				{

--- a/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
@@ -152,7 +152,7 @@ namespace ICSharpCode.Decompiler.IL
 				&& call.Arguments.Count == 2;
 		}
 
-		private static bool IsConstant(ILInstruction inst)
+		internal static bool IsConstant(ILInstruction inst)
 		{
 			return inst.OpCode switch {
 				OpCode.LdcDecimal => true,

--- a/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
@@ -127,9 +127,9 @@ namespace ICSharpCode.Decompiler.IL
 					testedOperand = m.testedOperand;
 					return true;
 				case Comp comp:
-					if (comp.MatchLogicNot(out var operand))
+					if (comp.MatchLogicNot(out var operand) && IsPatternMatch(operand, out testedOperand))
 					{
-						return IsPatternMatch(operand, out testedOperand);
+						return true;
 					}
 					else
 					{

--- a/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
@@ -146,19 +146,22 @@ namespace ICSharpCode.Decompiler.IL
 						}
 						return IsConstant(comp.Right);
 					}
-				case Call call when IsCallToString_op_Equality(call):
+				case Call call when IsCallToOpEquality(call, KnownTypeCode.String):
 					testedOperand = call.Arguments[0];
 					return call.Arguments[1].OpCode == OpCode.LdStr;
+				case Call call when IsCallToOpEquality(call, KnownTypeCode.Decimal):
+					testedOperand = call.Arguments[0];
+					return call.Arguments[1].OpCode == OpCode.LdcDecimal;
 				default:
 					testedOperand = null;
 					return false;
 			}
 		}
 
-		internal static bool IsCallToString_op_Equality(Call call)
+		internal static bool IsCallToOpEquality(Call call, KnownTypeCode knownType)
 		{
 			return call.Method.IsOperator && call.Method.Name == "op_Equality"
-				&& call.Method.DeclaringType.IsKnownType(KnownTypeCode.String)
+				&& call.Method.DeclaringType.IsKnownType(knownType)
 				&& call.Arguments.Count == 2;
 		}
 

--- a/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/MatchInstruction.cs
@@ -135,10 +135,20 @@ namespace ICSharpCode.Decompiler.IL
 						testedOperand = comp.Left;
 						return IsConstant(comp.Right);
 					}
+				case Call call when IsCallToString_op_Equality(call):
+					testedOperand = call.Arguments[0];
+					return call.Arguments[1].OpCode == OpCode.LdStr;
 				default:
 					testedOperand = null;
 					return false;
 			}
+		}
+
+		internal static bool IsCallToString_op_Equality(Call call)
+		{
+			return call.Method.IsOperator && call.Method.Name == "op_Equality"
+				&& call.Method.DeclaringType.IsKnownType(KnownTypeCode.String)
+				&& call.Arguments.Count == 2;
 		}
 
 		private static bool IsConstant(ILInstruction inst)
@@ -150,7 +160,6 @@ namespace ICSharpCode.Decompiler.IL
 				OpCode.LdcI4 => true,
 				OpCode.LdcI8 => true,
 				OpCode.LdNull => true,
-				OpCode.LdStr => true,
 				_ => false
 			};
 		}

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -432,12 +432,25 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 			if (string.IsNullOrEmpty(proposedName))
 			{
-				var proposedNameForStores = variable.StoreInstructions.OfType<StLoc>()
-					.Select(expr => GetNameFromInstruction(expr.Value))
-					.Except(currentLowerCaseTypeOrMemberNames).ToList();
+				var proposedNameForStores = new HashSet<string>();
+				foreach (var store in variable.StoreInstructions)
+				{
+					if (store is StLoc stloc)
+					{
+						var name = GetNameFromInstruction(stloc.Value);
+						if (!currentLowerCaseTypeOrMemberNames.Contains(name))
+							proposedNameForStores.Add(name);
+					}
+					else if (store is MatchInstruction match && match.SlotInfo == MatchInstruction.SubPatternsSlot)
+					{
+						var name = GetNameFromInstruction(match.TestedOperand);
+						if (!currentLowerCaseTypeOrMemberNames.Contains(name))
+							proposedNameForStores.Add(name);
+					}
+				}
 				if (proposedNameForStores.Count == 1)
 				{
-					proposedName = proposedNameForStores[0];
+					proposedName = proposedNameForStores.Single();
 				}
 			}
 			if (string.IsNullOrEmpty(proposedName))

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -286,12 +286,6 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		protected internal override void VisitNewObj(NewObj inst)
 		{
-			if (TransformDecimalCtorToConstant(inst, out LdcDecimal decimalConstant))
-			{
-				context.Step("TransformDecimalCtorToConstant", inst);
-				inst.ReplaceWith(decimalConstant);
-				return;
-			}
 			Block block;
 			if (TransformSpanTCtorContainingStackAlloc(inst, out ILInstruction locallocSpan))
 			{
@@ -417,43 +411,6 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (elementCountInstr == null || !elementCountInstr.UnwrapConv(ConversionKind.ZeroExtend).Match(elementCountInstr2).Success)
 				return false;
 			return true;
-		}
-
-		bool TransformDecimalCtorToConstant(NewObj inst, out LdcDecimal result)
-		{
-			IType t = inst.Method.DeclaringType;
-			result = null;
-			if (!t.IsKnownType(KnownTypeCode.Decimal))
-				return false;
-			var args = inst.Arguments;
-			if (args.Count == 1)
-			{
-				long val;
-				if (args[0].MatchLdcI(out val))
-				{
-					var paramType = inst.Method.Parameters[0].Type.GetDefinition()?.KnownTypeCode;
-					result = paramType switch {
-						KnownTypeCode.Int32 => new LdcDecimal(new decimal(unchecked((int)val))),
-						KnownTypeCode.UInt32 => new LdcDecimal(new decimal(unchecked((uint)val))),
-						KnownTypeCode.Int64 => new LdcDecimal(new decimal(val)),
-						KnownTypeCode.UInt64 => new LdcDecimal(new decimal(unchecked((ulong)val))),
-						_ => null
-					};
-					return result is not null;
-				}
-			}
-			else if (args.Count == 5)
-			{
-				int lo, mid, hi, isNegative, scale;
-				if (args[0].MatchLdcI4(out lo) && args[1].MatchLdcI4(out mid) &&
-					args[2].MatchLdcI4(out hi) && args[3].MatchLdcI4(out isNegative) &&
-					args[4].MatchLdcI4(out scale))
-				{
-					result = new LdcDecimal(new decimal(lo, mid, hi, isNegative != 0, (byte)scale));
-					return true;
-				}
-			}
-			return false;
 		}
 
 		bool TransformDecimalFieldToConstant(LdObj inst, out LdcDecimal result)

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -557,7 +557,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					return;
 				}
 			}
-			if (MatchInstruction.IsPatternMatch(inst.Condition, out _)
+			if (MatchInstruction.IsPatternMatch(inst.Condition, out _, context.Settings)
 				&& inst.TrueInst.MatchLdcI4(1) && inst.FalseInst.MatchLdcI4(0))
 			{
 				context.Step("match(x) ? true : false -> match(x)", inst);

--- a/ICSharpCode.Decompiler/IL/Transforms/PatternMatchingTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/PatternMatchingTransform.cs
@@ -268,6 +268,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				targetVariable.Kind = VariableKind.PatternLocal;
 				if (!MatchNullCheckPattern(block, varPattern, parentFalseInst, context, ref cfg))
 				{
+					if (targetVariable.Type.IsReferenceType == false)
+					{
+						DetectPropertySubPatterns(varPattern, block, parentFalseInst, context, ref cfg);
+					}
 					DetectPropertySubPatterns(parentPattern, block, parentFalseInst, context, ref cfg);
 				}
 			}

--- a/ICSharpCode.Decompiler/Util/Index.cs
+++ b/ICSharpCode.Decompiler/Util/Index.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#nullable enable
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+	/// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
+	/// <remarks>
+	/// Index is used by the C# compiler to support the new index syntax
+	/// <code>
+	/// int[] someArray = new int[5] { 1, 2, 3, 4, 5 } ;
+	/// int lastElement = someArray[^1]; // lastElement = 5
+	/// </code>
+	/// </remarks>
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+	internal
+#endif
+	readonly struct Index : IEquatable<Index>
+	{
+		private readonly int _value;
+
+		/// <summary>Construct an Index using a value and indicating if the index is from the start or from the end.</summary>
+		/// <param name="value">The index value. it has to be zero or positive number.</param>
+		/// <param name="fromEnd">Indicating if the index is from the start or from the end.</param>
+		/// <remarks>
+		/// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Index(int value, bool fromEnd = false)
+		{
+			if (value < 0)
+			{
+				ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+			}
+
+			if (fromEnd)
+				_value = ~value;
+			else
+				_value = value;
+		}
+
+		// The following private constructors mainly created for perf reason to avoid the checks
+		private Index(int value)
+		{
+			_value = value;
+		}
+
+		/// <summary>Create an Index pointing at first element.</summary>
+		public static Index Start => new Index(0);
+
+		/// <summary>Create an Index pointing at beyond last element.</summary>
+		public static Index End => new Index(~0);
+
+		/// <summary>Create an Index from the start at the position indicated by the value.</summary>
+		/// <param name="value">The index value from the start.</param>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Index FromStart(int value)
+		{
+			if (value < 0)
+			{
+				ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+			}
+
+			return new Index(value);
+		}
+
+		/// <summary>Create an Index from the end at the position indicated by the value.</summary>
+		/// <param name="value">The index value from the end.</param>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Index FromEnd(int value)
+		{
+			if (value < 0)
+			{
+				ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+			}
+
+			return new Index(~value);
+		}
+
+		/// <summary>Returns the index value.</summary>
+		public int Value {
+			get {
+				if (_value < 0)
+					return ~_value;
+				else
+					return _value;
+			}
+		}
+
+		/// <summary>Indicates whether the index is from the start or the end.</summary>
+		public bool IsFromEnd => _value < 0;
+
+		/// <summary>Calculate the offset from the start using the giving collection length.</summary>
+		/// <param name="length">The length of the collection that the Index will be used with. length has to be a positive value</param>
+		/// <remarks>
+		/// For performance reason, we don't validate the input length parameter and the returned offset value against negative values.
+		/// we don't validate either the returned offset is greater than the input length.
+		/// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
+		/// then used to index a collection will get out of range exception which will be same affect as the validation.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public int GetOffset(int length)
+		{
+			int offset = _value;
+			if (IsFromEnd)
+			{
+				// offset = length - (~value)
+				// offset = length + (~(~value) + 1)
+				// offset = length + value + 1
+
+				offset += length + 1;
+			}
+			return offset;
+		}
+
+		/// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
+		/// <param name="value">An object to compare with this object</param>
+		public override bool Equals([NotNullWhen(true)] object? value) => value is Index && _value == ((Index)value)._value;
+
+		/// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
+		/// <param name="other">An object to compare with this object</param>
+		public bool Equals(Index other) => _value == other._value;
+
+		/// <summary>Returns the hash code for this instance.</summary>
+		public override int GetHashCode() => _value;
+
+		/// <summary>Converts integer number to an Index.</summary>
+		public static implicit operator Index(int value) => FromStart(value);
+
+		/// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
+		public override string ToString()
+		{
+			if (IsFromEnd)
+				return ToStringFromEnd();
+
+			return ((uint)Value).ToString();
+		}
+
+		private static void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
+		{
+#if SYSTEM_PRIVATE_CORELIB
+            throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_NeedNonNegNum);
+#else
+			throw new ArgumentOutOfRangeException("value", "value must be non-negative");
+#endif
+		}
+
+		private string ToStringFromEnd()
+		{
+#if (!NETSTANDARD2_0 && !NETFRAMEWORK)
+            Span<char> span = stackalloc char[11]; // 1 for ^ and 10 for longest possible uint value
+            bool formatted = ((uint)Value).TryFormat(span.Slice(1), out int charsWritten);
+            Debug.Assert(formatted);
+            span[0] = '^';
+            return new string(span.Slice(0, charsWritten + 1));
+#else
+			return '^' + Value.ToString();
+#endif
+		}
+	}
+}

--- a/ILSpy.Installer/ILSpy.Installer.csproj
+++ b/ILSpy.Installer/ILSpy.Installer.csproj
@@ -1,9 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <StartupObject>ILSpy.Installer.Builder</StartupObject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);$(PlatformForInstaller)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1146,6 +1146,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pattern combinators (and, or, not).
+        /// </summary>
+        public static string DecompilerSettings_PatternCombinators {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.PatternCombinators", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use pattern matching expressions.
         /// </summary>
         public static string DecompilerSettings_PatternMatching {
@@ -1196,6 +1205,24 @@ namespace ICSharpCode.ILSpy.Properties {
         public static string DecompilerSettings_RecordStructs {
             get {
                 return ResourceManager.GetString("DecompilerSettings.RecordStructs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recursive pattern matching.
+        /// </summary>
+        public static string DecompilerSettings_RecursivePatternMatching {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.RecursivePatternMatching", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Relational patterns.
+        /// </summary>
+        public static string DecompilerSettings_RelationalPatterns {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.RelationalPatterns", resourceCulture);
             }
         }
         

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -405,6 +405,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.ParameterNullCheck" xml:space="preserve">
     <value>Use parameter null checking</value>
   </data>
+  <data name="DecompilerSettings.PatternCombinators" xml:space="preserve">
+    <value>Pattern combinators (and, or, not)</value>
+  </data>
   <data name="DecompilerSettings.PatternMatching" xml:space="preserve">
     <value>Use pattern matching expressions</value>
   </data>
@@ -422,6 +425,12 @@ Are you sure you want to continue?</value>
   </data>
   <data name="DecompilerSettings.RecordStructs" xml:space="preserve">
     <value>Record structs</value>
+  </data>
+  <data name="DecompilerSettings.RecursivePatternMatching" xml:space="preserve">
+    <value>Recursive pattern matching</value>
+  </data>
+  <data name="DecompilerSettings.RelationalPatterns" xml:space="preserve">
+    <value>Relational patterns</value>
   </data>
   <data name="DecompilerSettings.RemoveDeadAndSideEffectFreeCodeUseWithCaution" xml:space="preserve">
     <value>Remove dead and side effect free code (use with caution!)</value>


### PR DESCRIPTION
Currently not supported are:

- top-level patterns without type-checking (eg. is null, is not null, is {}, ...)
- positional pattern tuple/deconstruct
- discards in positional patterns
- not patterns (C# 9)
- relational patterns (C# 9)
- and/or pattern (C# 9)