### PR TITLE
Add the Entry Size Info

### DIFF
--- a/ILSpy/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyTreeNode.cs
@@ -413,7 +413,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			output.WriteLine("Entries:");
 			foreach (var entry in package.Entries)
 			{
-				output.WriteLine("  " + entry.Name);
+				output.WriteLine($" {entry.Name} ({entry.TryGetLength()} bytes)");
 			}
 		}
 


### PR DESCRIPTION


### Problem
When use a single file fomart, can not found the detal size of assmessly

### Solution
* Add the size info on the entry output 
![image](https://github.com/icsharpcode/ILSpy/assets/898009/81c52aef-27f8-4b37-9720-3294f117682e)



