### PR TITLE
Decorate the disassembly with GCInfo

### DIFF
--- a/ILSpy.ReadyToRun/Properties/Resources.Designer.cs
+++ b/ILSpy.ReadyToRun/Properties/Resources.Designer.cs
@@ -95,5 +95,14 @@ namespace ILSpy.ReadyToRun.Properties {
                 return ResourceManager.GetString("ShowUnwindInfo", resourceCulture);
             }
         }
-    }
+
+		/// <summary>
+		///   Looks up a localized string similar to Show GC Info.
+		/// </summary>
+		public static string ShowGCInfo {
+			get {
+				return ResourceManager.GetString("ShowGCInfo", resourceCulture);
+			}
+		}
+	}
 }

--- a/ILSpy.ReadyToRun/Properties/Resources.resx
+++ b/ILSpy.ReadyToRun/Properties/Resources.resx
@@ -129,4 +129,7 @@
   <data name="ShowUnwindInfo" xml:space="preserve">
     <value>Show Unwind Info</value>
   </data>
+  <data name="ShowGCInfo" xml:space="preserve">
+    <value>Show GC Info</value>
+  </data>
 </root>

--- a/ILSpy.ReadyToRun/Properties/Resources.zh-Hans.resx
+++ b/ILSpy.ReadyToRun/Properties/Resources.zh-Hans.resx
@@ -129,4 +129,7 @@
   <data name="ShowUnwindInfo" xml:space="preserve">
     <value>显示展开信息</value>
   </data>
+  <data name="ShowGCInfo" xml:space="preserve">
+    <value>?</value>
+  </data>
 </root>

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -129,6 +129,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 						}
 					}
 				}
+				DecorateGCInfo(instr, baseInstrIP, readyToRunMethod.GcInfo);
 				formatter.Format(instr, tempOutput);
 				output.Write(instr.IP.ToString("X16"));
 				output.Write(" ");
@@ -150,6 +151,20 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 				output.WriteLine();
 			}
 			output.WriteLine();
+		}
+
+		private void DecorateGCInfo(Instruction instr, ulong baseInstrIP, BaseGcInfo gcInfo)
+		{
+			ulong codeOffset = instr.IP - baseInstrIP;
+			if (gcInfo != null && gcInfo.Transitions != null && gcInfo.Transitions.TryGetValue((int)codeOffset, out List<BaseGcTransition> transitionsForOffset))
+			{
+				// this value comes from a manual count of the spaces used for each instruction in Disassemble()
+				string indent = new string(' ', 36);
+				foreach (var transition in transitionsForOffset)
+				{
+					WriteCommentLine(indent + transition.ToString());
+				}
+			}
 		}
 
 		private void WriteCommentLine(string comment)

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -47,9 +47,18 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 
 		public void Disassemble(PEFile currentFile, int bitness, ulong address, bool showMetadataTokens, bool showMetadataTokensInBase10)
 		{
-			// TODO: Decorate the disassembly with GCInfo
 			ReadyToRunMethod readyToRunMethod = runtimeFunction.Method;
 			WriteCommentLine(readyToRunMethod.SignatureString);
+
+			if (readyToRunMethod.GcInfo != null)
+			{
+				string[] lines = readyToRunMethod.GcInfo.ToString().Split(Environment.NewLine);
+				WriteCommentLine("GC info:");
+				foreach (string line in lines)
+				{
+					WriteCommentLine(line);
+				}
+			}
 
 			Dictionary<ulong, UnwindCode> unwindInfo = null;
 			if (ReadyToRunOptions.GetIsShowUnwindInfo(null) && bitness == 64)

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -50,13 +50,20 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			ReadyToRunMethod readyToRunMethod = runtimeFunction.Method;
 			WriteCommentLine(readyToRunMethod.SignatureString);
 
-			if (ReadyToRunOptions.GetIsShowGCInfo(null) && readyToRunMethod.GcInfo != null)
+			if (ReadyToRunOptions.GetIsShowGCInfo(null))
 			{
-				string[] lines = readyToRunMethod.GcInfo.ToString().Split(Environment.NewLine);
-				WriteCommentLine("GC info:");
-				foreach (string line in lines)
+				if (readyToRunMethod.GcInfo != null)
 				{
-					WriteCommentLine(line);
+					string[] lines = readyToRunMethod.GcInfo.ToString().Split(Environment.NewLine);
+					WriteCommentLine("GC info:");
+					foreach (string line in lines)
+					{
+						WriteCommentLine(line);
+					}
+				}
+				else
+				{
+					WriteCommentLine("GC Info is not available for this method");
 				}
 			}
 

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -50,7 +50,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			ReadyToRunMethod readyToRunMethod = runtimeFunction.Method;
 			WriteCommentLine(readyToRunMethod.SignatureString);
 
-			if (readyToRunMethod.GcInfo != null)
+			if (ReadyToRunOptions.GetIsShowGCInfo(null) && readyToRunMethod.GcInfo != null)
 			{
 				string[] lines = readyToRunMethod.GcInfo.ToString().Split(Environment.NewLine);
 				WriteCommentLine("GC info:");

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
@@ -11,6 +11,7 @@
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<TextBlock Margin="3" Text="{x:Static properties:Resources.DisassemblyFormat}" />
 		<ComboBox Grid.Column="1" Margin="3" ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}" />
@@ -18,5 +19,7 @@
 		<CheckBox Grid.Row="1" Grid.Column="1" Margin="3" IsChecked="{Binding IsShowUnwindInfo}" />
 		<TextBlock Grid.Row="2" Margin="3" Text="{x:Static properties:Resources.ShowDebugInfo}"/>
 		<CheckBox Grid.Row="2" Grid.Column="1" Margin="3" IsChecked="{Binding IsShowDebugInfo}" />
+		<TextBlock Grid.Row="3" Margin="3" Text="{x:Static properties:Resources.ShowGCInfo}"/>
+		<CheckBox Grid.Row="3" Grid.Column="1" Margin="3" IsChecked="{Binding IsShowGCInfo}" />
 	</Grid>
 </UserControl>

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
@@ -39,6 +39,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			s.DisassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(settings);
 			s.IsShowUnwindInfo = ReadyToRunOptions.GetIsShowUnwindInfo(settings);
 			s.IsShowDebugInfo = ReadyToRunOptions.GetIsShowDebugInfo(settings);
+			s.IsShowGCInfo = ReadyToRunOptions.GetIsShowGCInfo(settings);
 
 			this.DataContext = s;
 		}
@@ -51,7 +52,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		public void Save(XElement root)
 		{
 			Options s = (Options)this.DataContext;
-			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo, s.IsShowDebugInfo);
+			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo, s.IsShowDebugInfo, s.IsShowGCInfo);
 		}
 	}
 
@@ -83,6 +84,18 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			set {
 				isShowDebugInfo = value;
 				OnPropertyChanged(nameof(IsShowDebugInfo));
+			}
+		}
+
+		private bool isShowGCInfo;
+
+		public bool IsShowGCInfo {
+			get {
+				return isShowGCInfo;
+			}
+			set {
+				isShowGCInfo = value;
+				OnPropertyChanged(nameof(IsShowGCInfo));
 			}
 		}
 

--- a/ILSpy.ReadyToRun/ReadyToRunOptions.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptions.cs
@@ -87,12 +87,32 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool isShowUnwindInfo, bool isShowDebugInfo)
+		public static bool GetIsShowGCInfo(ILSpySettings settings)
+		{
+			if (settings == null)
+			{
+				settings = ILSpySettings.Load();
+			}
+			XElement e = settings[ns + "ReadyToRunOptions"];
+			XAttribute a = e.Attribute("IsShowGCInfo");
+
+			if (a == null)
+			{
+				return false;
+			}
+			else
+			{
+				return (bool)a;
+			}
+		}
+
+		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool isShowUnwindInfo, bool isShowDebugInfo, bool isShowGCInfo)
 		{
 			XElement section = new XElement(ns + "ReadyToRunOptions");
 			section.SetAttributeValue("DisassemblyFormat", disassemblyFormat);
 			section.SetAttributeValue("IsShowUnwindInfo", isShowUnwindInfo);
 			section.SetAttributeValue("IsShowDebugInfo", isShowDebugInfo);
+			section.SetAttributeValue("IsShowGCInfo", isShowGCInfo);
 			XElement existingElement = root.Element(ns + "ReadyToRunOptions");
 			if (existingElement != null)
 			{


### PR DESCRIPTION
Fixes https://github.com/icsharpcode/ILSpy/issues/1885

Shows GC Info at the beginning and the GC transitions as well. Also it stops iterating through the whole `runtimeFunction.DebugInfo.BoundsList` for each instruction for a slight performance improvement.

![image](https://github.com/icsharpcode/ILSpy/assets/32459232/c72aa2d1-a860-43c9-896c-921a4d19e127)


