### PR TITLE
Decompile base & derived types in place

### DIFF
--- a/ILSpy/TreeNodes/BaseTypesEntryNode.cs
+++ b/ILSpy/TreeNodes/BaseTypesEntryNode.cs
@@ -59,7 +59,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override void Decompile(Language language, ITextOutput output, DecompilationOptions options)
 		{
-			language.WriteCommentLine(output, language.TypeToString(type, includeNamespace: true));
+			language.DecompileType(type, output, options);
 		}
 
 		IEntity IMemberTreeNode.Member => type;

--- a/ILSpy/TreeNodes/BaseTypesTreeNode.cs
+++ b/ILSpy/TreeNodes/BaseTypesTreeNode.cs
@@ -71,7 +71,8 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			App.Current.Dispatcher.Invoke(DispatcherPriority.Normal, new Action(EnsureLazyChildren));
 			foreach (ILSpyTreeNode child in this.Children)
 			{
-				child.Decompile(language, output, options);
+				if (child is IMemberTreeNode { Member: ITypeDefinition childType })
+					language.WriteCommentLine(output, language.TypeToString(childType, includeNamespace: true));
 			}
 		}
 	}

--- a/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
+++ b/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
@@ -96,7 +96,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override void Decompile(Language language, ITextOutput output, DecompilationOptions options)
 		{
-			language.WriteCommentLine(output, language.TypeToString(type, includeNamespace: true));
+			language.DecompileType(type, output, options);
 		}
 
 		IEntity IMemberTreeNode.Member => type;

--- a/ILSpy/TreeNodes/DerivedTypesTreeNode.cs
+++ b/ILSpy/TreeNodes/DerivedTypesTreeNode.cs
@@ -16,8 +16,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Windows.Threading;
 
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.TypeSystem;
@@ -104,7 +106,13 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override void Decompile(Language language, ITextOutput output, DecompilationOptions options)
 		{
-			threading.Decompile(language, output, options, EnsureLazyChildren);
+			App.Current.Dispatcher.Invoke(DispatcherPriority.Normal, new Action(EnsureLazyChildren));
+			for (int i = 0; i < Children.Count; i++)
+			{
+				// LazyChildren are async and will not be ready on first call, avoid foreach.
+				if (Children[i] is IMemberTreeNode { Member: ITypeDefinition childType })
+					language.WriteCommentLine(output, language.TypeToString(childType, includeNamespace: true));
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Problem
The list of base and derived types in ILSpy does not show anything useful in the output. At least assembly name and list of base types would be helpful, but I don't see any reason why the whole type, which already provides this information, cannot be decompiled in place - it is a simple change in the code and users do not have to jump back and forth when going through and comparing the implementations.

### Solution
* This PR makes the base and derived type nodes decompile the respective types.
* The parent nodes (`BaseTypesTreeNode` and `DerivedTypesTreeNode`) were calling all children to decompile. However, with increasing information in child nodes, it is not sustainable. They now explicitly list the children type names only, like they did before.
* While trivial in base types, the derived types are loaded asynchronously and children are not available on first decompilation. I don't see any easy way to await/add continuation to the loading, but I did not deem the output of _Derived Types_ node to be critical enough, so the output will be empty the first time. Open to ideas if that is not satisfactory.
