### PR TITLE
Show base members

### DIFF
--- a/ILSpy/FilterSettings.cs
+++ b/ILSpy/FilterSettings.cs
@@ -47,6 +47,7 @@ namespace ICSharpCode.ILSpy
 		public FilterSettings(XElement element)
 		{
 			this.ShowApiLevel = (ApiVisibility?)(int?)element.Element("ShowAPILevel") ?? ApiVisibility.PublicAndInternal;
+			this.ShowApiInherited = (bool?)element.Element("ShowAPIInherited") ?? false;
 			this.Language = Languages.GetLanguage((string)element.Element("Language"));
 			this.LanguageVersion = Language.LanguageVersions.FirstOrDefault(v => v.Version == (string)element.Element("LanguageVersion"));
 			if (this.LanguageVersion == default(LanguageVersion))
@@ -58,6 +59,7 @@ namespace ICSharpCode.ILSpy
 			return new XElement(
 				"FilterSettings",
 				new XElement("ShowAPILevel", (int)this.ShowApiLevel),
+				new XElement("ShowAPIInherited", this.ShowApiInherited),
 				new XElement("Language", this.Language.Name),
 				new XElement("LanguageVersion", this.LanguageVersion?.Version)
 			);
@@ -139,6 +141,19 @@ namespace ICSharpCode.ILSpy
 				OnPropertyChanged(nameof(ApiVisPublicOnly));
 				OnPropertyChanged(nameof(ApiVisPublicAndInternal));
 				OnPropertyChanged(nameof(ApiVisAll));
+			}
+		}
+
+		bool showApiInherited;
+
+		public bool ShowApiInherited {
+			get { return showApiInherited; }
+			set {
+				if (showApiInherited != value)
+				{
+					showApiInherited = value;
+					OnPropertyChanged(nameof(ShowApiInherited));
+				}
 			}
 		}
 

--- a/ILSpy/FilterSettings.cs
+++ b/ILSpy/FilterSettings.cs
@@ -47,7 +47,7 @@ namespace ICSharpCode.ILSpy
 		public FilterSettings(XElement element)
 		{
 			this.ShowApiLevel = (ApiVisibility?)(int?)element.Element("ShowAPILevel") ?? ApiVisibility.PublicAndInternal;
-			this.ShowApiInherited = (bool?)element.Element("ShowAPIInherited") ?? false;
+			this.ShowBaseApi = (bool?)element.Element("ShowBaseAPI") ?? false;
 			this.Language = Languages.GetLanguage((string)element.Element("Language"));
 			this.LanguageVersion = Language.LanguageVersions.FirstOrDefault(v => v.Version == (string)element.Element("LanguageVersion"));
 			if (this.LanguageVersion == default(LanguageVersion))
@@ -59,7 +59,7 @@ namespace ICSharpCode.ILSpy
 			return new XElement(
 				"FilterSettings",
 				new XElement("ShowAPILevel", (int)this.ShowApiLevel),
-				new XElement("ShowAPIInherited", this.ShowApiInherited),
+				new XElement("ShowBaseAPI", this.ShowBaseApi),
 				new XElement("Language", this.Language.Name),
 				new XElement("LanguageVersion", this.LanguageVersion?.Version)
 			);
@@ -144,15 +144,15 @@ namespace ICSharpCode.ILSpy
 			}
 		}
 
-		bool showApiInherited;
+		bool showBaseApi;
 
-		public bool ShowApiInherited {
-			get { return showApiInherited; }
+		public bool ShowBaseApi {
+			get { return showBaseApi; }
 			set {
-				if (showApiInherited != value)
+				if (showBaseApi != value)
 				{
-					showApiInherited = value;
-					OnPropertyChanged(nameof(ShowApiInherited));
+					showBaseApi = value;
+					OnPropertyChanged(nameof(ShowBaseApi));
 				}
 			}
 		}

--- a/ILSpy/MainWindow.xaml
+++ b/ILSpy/MainWindow.xaml
@@ -138,6 +138,7 @@
 				<MenuItem Header="{x:Static properties:Resources.Show_publiconlyTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicOnly}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_internalTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicAndInternal}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_allTypesAndMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisAll}" />
+				<MenuItem Header="{x:Static properties:Resources.Show_inheritedMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ShowApiInherited}" />
 				<Separator/>
 				<MenuItem Header="{x:Static properties:Resources.Theme}" ItemsSource="{x:Static themes:ThemeManager.AllThemes}">
 					<MenuItem.ItemContainerStyle>

--- a/ILSpy/MainWindow.xaml
+++ b/ILSpy/MainWindow.xaml
@@ -138,7 +138,7 @@
 				<MenuItem Header="{x:Static properties:Resources.Show_publiconlyTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicOnly}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_internalTypesMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisPublicAndInternal}" />
 				<MenuItem Header="{x:Static properties:Resources.Show_allTypesAndMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ApiVisAll}" />
-				<MenuItem Header="{x:Static properties:Resources.Show_inheritedMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ShowApiInherited}" />
+				<MenuItem Header="{x:Static properties:Resources.Show_baseMembers}" IsCheckable="True" IsChecked="{Binding Workspace.ActiveTabPage.FilterSettings.ShowBaseApi}" />
 				<Separator/>
 				<MenuItem Header="{x:Static properties:Resources.Theme}" ItemsSource="{x:Static themes:ThemeManager.AllThemes}">
 					<MenuItem.ItemContainerStyle>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -2503,7 +2503,16 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show public, private and internal.
+        ///   Looks up a localized string similar to Show in_herited members.
+        /// </summary>
+        public static string Show_inheritedMembers {
+            get {
+                return ResourceManager.GetString("Show_inheritedMembers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show public, private and _internal.
         /// </summary>
         public static string Show_internalTypesMembers {
             get {

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -2503,11 +2503,11 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show in_herited members.
+        ///   Looks up a localized string similar to Show _base members.
         /// </summary>
-        public static string Show_inheritedMembers {
+        public static string Show_baseMembers {
             get {
-                return ResourceManager.GetString("Show_inheritedMembers", resourceCulture);
+                return ResourceManager.GetString("Show_baseMembers", resourceCulture);
             }
         }
         

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -901,8 +901,11 @@ Do you want to continue?</value>
   <data name="Show_allTypesAndMembers" xml:space="preserve">
     <value>Show _all types and members</value>
   </data>
+  <data name="Show_inheritedMembers" xml:space="preserve">
+    <value>Show in_herited members</value>
+  </data>
   <data name="Show_internalTypesMembers" xml:space="preserve">
-    <value>Show public, private and internal</value>
+    <value>Show public, private and _internal</value>
   </data>
   <data name="Show_publiconlyTypesMembers" xml:space="preserve">
     <value>Show only _public types and members</value>

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -901,8 +901,8 @@ Do you want to continue?</value>
   <data name="Show_allTypesAndMembers" xml:space="preserve">
     <value>Show _all types and members</value>
   </data>
-  <data name="Show_inheritedMembers" xml:space="preserve">
-    <value>Show in_herited members</value>
+  <data name="Show_baseMembers" xml:space="preserve">
+    <value>Show _base members</value>
   </data>
   <data name="Show_internalTypesMembers" xml:space="preserve">
     <value>Show public, private and _internal</value>

--- a/ILSpy/Properties/Resources.zh-Hans.resx
+++ b/ILSpy/Properties/Resources.zh-Hans.resx
@@ -872,6 +872,9 @@
   <data name="Show_allTypesAndMembers" xml:space="preserve">
     <value>显示所有类型和成员(_A)</value>
   </data>
+  <data name="Show_inheritedMembers" xml:space="preserve">
+    <value>显示继承成员(_H)</value>
+  </data>
   <data name="Show_internalTypesMembers" xml:space="preserve">
     <value>显示内部类型和成员(_I)</value>
   </data>

--- a/ILSpy/Properties/Resources.zh-Hans.resx
+++ b/ILSpy/Properties/Resources.zh-Hans.resx
@@ -872,8 +872,8 @@
   <data name="Show_allTypesAndMembers" xml:space="preserve">
     <value>显示所有类型和成员(_A)</value>
   </data>
-  <data name="Show_inheritedMembers" xml:space="preserve">
-    <value>显示继承成员(_H)</value>
+  <data name="Show_baseMembers" xml:space="preserve">
+    <value>显示基成员(_B)</value>
   </data>
   <data name="Show_internalTypesMembers" xml:space="preserve">
     <value>显示内部类型和成员(_I)</value>

--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -90,7 +90,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		protected override void OnFilterSettingsChanged()
 		{
 			base.OnFilterSettingsChanged();
-			if (loadedInheritedMembers != null && loadedInheritedMembers != FilterSettings.ShowApiInherited)
+			if (loadedInheritedMembers != null && loadedInheritedMembers != FilterSettings.ShowBaseApi)
 			{
 				this.Children.Clear();
 				if (IsVisible)
@@ -106,12 +106,12 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				this.Children.Add(new BaseTypesTreeNode(ParentAssemblyNode.LoadedAssembly.GetPEFileOrNull(), TypeDefinition));
 			if (!TypeDefinition.IsSealed)
 				this.Children.Add(new DerivedTypesTreeNode(ParentAssemblyNode.AssemblyList, TypeDefinition));
-			loadedInheritedMembers = FilterSettings.ShowApiInherited;
-			IEnumerable<ITypeDefinition> nestedTypes = GetMembers(TypeDefinition, t => t.NestedTypes, FilterSettings.ShowApiInherited);
-			IEnumerable<IField> fields = GetMembers(TypeDefinition, t => t.Fields, FilterSettings.ShowApiInherited);
-			IEnumerable<IProperty> properties = GetMembers(TypeDefinition, t => t.Properties, FilterSettings.ShowApiInherited);
-			IEnumerable<IEvent> events = GetMembers(TypeDefinition, t => t.Events, FilterSettings.ShowApiInherited);
-			IEnumerable<IMethod> methods = GetMembers(TypeDefinition, t => t.Methods, FilterSettings.ShowApiInherited);
+			loadedInheritedMembers = FilterSettings.ShowBaseApi;
+			IEnumerable<ITypeDefinition> nestedTypes = GetMembers(TypeDefinition, t => t.NestedTypes, FilterSettings.ShowBaseApi);
+			IEnumerable<IField> fields = GetMembers(TypeDefinition, t => t.Fields, FilterSettings.ShowBaseApi);
+			IEnumerable<IProperty> properties = GetMembers(TypeDefinition, t => t.Properties, FilterSettings.ShowBaseApi);
+			IEnumerable<IEvent> events = GetMembers(TypeDefinition, t => t.Events, FilterSettings.ShowBaseApi);
+			IEnumerable<IMethod> methods = GetMembers(TypeDefinition, t => t.Methods, FilterSettings.ShowBaseApi);
 			foreach (var nestedType in nestedTypes.OrderBy(t => t.Name, NaturalStringComparer.Instance))
 			{
 				this.Children.Add(new TypeTreeNode(nestedType, ParentAssemblyNode));

--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -106,12 +106,12 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				this.Children.Add(new BaseTypesTreeNode(ParentAssemblyNode.LoadedAssembly.GetPEFileOrNull(), TypeDefinition));
 			if (!TypeDefinition.IsSealed)
 				this.Children.Add(new DerivedTypesTreeNode(ParentAssemblyNode.AssemblyList, TypeDefinition));
-			loadedInheritedMembers = FilterSettings.ShowBaseApi;
-			IEnumerable<ITypeDefinition> nestedTypes = GetMembers(TypeDefinition, t => t.NestedTypes, FilterSettings.ShowBaseApi);
-			IEnumerable<IField> fields = GetMembers(TypeDefinition, t => t.Fields, FilterSettings.ShowBaseApi);
-			IEnumerable<IProperty> properties = GetMembers(TypeDefinition, t => t.Properties, FilterSettings.ShowBaseApi);
-			IEnumerable<IEvent> events = GetMembers(TypeDefinition, t => t.Events, FilterSettings.ShowBaseApi);
-			IEnumerable<IMethod> methods = GetMembers(TypeDefinition, t => t.Methods, FilterSettings.ShowBaseApi);
+			loadedInheritedMembers = FilterSettings?.ShowBaseApi;
+			IEnumerable<ITypeDefinition> nestedTypes = GetMembers(TypeDefinition, t => t.NestedTypes, FilterSettings?.ShowBaseApi);
+			IEnumerable<IField> fields = GetMembers(TypeDefinition, t => t.Fields, FilterSettings?.ShowBaseApi);
+			IEnumerable<IProperty> properties = GetMembers(TypeDefinition, t => t.Properties, FilterSettings?.ShowBaseApi);
+			IEnumerable<IEvent> events = GetMembers(TypeDefinition, t => t.Events, FilterSettings?.ShowBaseApi);
+			IEnumerable<IMethod> methods = GetMembers(TypeDefinition, t => t.Methods, FilterSettings?.ShowBaseApi);
 			foreach (var nestedType in nestedTypes.OrderBy(t => t.Name, NaturalStringComparer.Instance))
 			{
 				this.Children.Add(new TypeTreeNode(nestedType, ParentAssemblyNode));
@@ -147,10 +147,10 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			}
 		}
 
-		private IEnumerable<TMember> GetMembers<TMember>(ITypeDefinition type, Func<ITypeDefinition, IEnumerable<TMember>> selector, bool includeInherited)
+		private IEnumerable<TMember> GetMembers<TMember>(ITypeDefinition type, Func<ITypeDefinition, IEnumerable<TMember>> selector, bool? includeInherited)
 		{
 			IEnumerable<TMember> allMembers = selector(type);
-			if (includeInherited)
+			if (includeInherited == true)
 				foreach (var baseType in type.GetNonInterfaceBaseTypes().Reverse().Select(t => t.GetDefinition()))
 					if (baseType != null && baseType != type)
 						allMembers = allMembers.Concat(selector(baseType));


### PR DESCRIPTION
<img height="500" src="https://github.com/icsharpcode/ILSpy/assets/10546952/ce4c0e5a-20de-4b49-8773-23609ea5944d" />

<img height="500" src="https://github.com/icsharpcode/ILSpy/assets/10546952/2f083c35-c0eb-4e67-893b-78e79f40e036" />

### Problem
There isn't any way to show all members, including inherited, available on a type. This, for example, makes it slightly challenging to find out where a member that user knows about comes from.

### Solution
* Added _View > Show base members_ setting stored in filter settings.
* When the setting is on, the node concatenates `NestedTypes`, `Fields`, `Properties`, `Events` and `Methods` from the list of non-interface base types on the `ITypeDefinition`.
* Searching is not affected, i.e. searching for "button.fontstyle" will not yield any results even when the setting is on. This could be added in the future if needed.
* If expanded, a type node will reload children when the setting changes.

An alternative approach would be for the inheritance check to be part of the standard filtering. That might, however, slow down enumareting children considerably, as all inherited members would have to be checked each time.

Having a global setting is not necessary. If preferrable, we could only have explicit _Show base members_ in context menu on individual type nodes that would only affect them on by one. The current approach felt simpler (and possibly allowing for the search to take the setting into account in the future).