### PR TITLE
Update ready to run

### DIFF
--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Iced" Version="1.18.0" />
-    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.0-preview.5.23260.1" />
+    <PackageReference Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.0-rc.2.23471.30" />
     <!-- ILCompiler.Reflection.ReadyToRun has dependencies on System.Reflection.Metadata and
          System.Runtime.CompilerServices.Unsafe. Because the AddIn compiles into ILSpy's output
          directory, we're at risk of overwriting our dependencies with different versions.

--- a/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunDisassembler.cs
@@ -114,10 +114,13 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			ulong baseInstrIP = instructions[0].IP;
 
 			var boundsMap = new Dictionary<uint, uint>();
-			foreach (var bound in runtimeFunction.DebugInfo.BoundsList)
+			if (runtimeFunction.DebugInfo != null)
 			{
-				// ignoring the return value assuming the same key is always mapped to the same value in runtimeFunction.DebugInfo.BoundsList
-				boundsMap.TryAdd(bound.NativeOffset, bound.ILOffset);
+				foreach (var bound in runtimeFunction.DebugInfo.BoundsList)
+				{
+					// ignoring the return value assuming the same key is always mapped to the same value in runtimeFunction.DebugInfo.BoundsList
+					boundsMap.TryAdd(bound.NativeOffset, bound.ILOffset);
+				}
 			}
 
 			foreach (var instr in instructions)
@@ -141,7 +144,10 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 						}
 					}
 				}
-				DecorateGCInfo(instr, baseInstrIP, readyToRunMethod.GcInfo);
+				if (ReadyToRunOptions.GetIsShowGCInfo(null))
+				{
+					DecorateGCInfo(instr, baseInstrIP, readyToRunMethod.GcInfo);
+				}
 				formatter.Format(instr, tempOutput);
 				output.Write(instr.IP.ToString("X16"));
 				output.Write(" ");


### PR DESCRIPTION
This change updated the ready-to-run package to the latest version.

The major contribution of this PR is testing. With the latest package, I made sure all the scenarios listed below passed the [stress](https://github.com/icsharpcode/ILSpy/blob/6d8647bb338c2afd802bfed078e3615ef36fb802/ILSpy.ReadyToRun/ReadyToRunLanguage.cs#L19) test without any exceptions. Found and fixed a couple of bugs along the way.

Here are the test scenarios: 

- [x] Disassembling `System.Private.CoreLib.dll`, 
- [x] Disassembling a HelloWorld application as in the [wiki](https://github.com/icsharpcode/ILSpy/wiki/ILSpy.ReadyToRun), 
- [x] Disassembling an application compiled using the [CompositeMode](https://github.com/icsharpcode/ILSpy/pull/2944), and 
- [x] Disassembling an application compiled using [hot-cold splitting](https://github.com/dotnet/runtimelab/issues/1910), an experimental crossgen2 mode that is not made public yet. 

All these are targetting the latest .net 8 binaries.