### PR TITLE
Reduce "unsafe" by replacing byte* pointer usage with  ReadOnlySpan<byte>

### DIFF
--- a/ILSpy/Metadata/CorTables/ClassLayoutTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/ClassLayoutTableTreeNode.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -83,9 +84,9 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public ClassLayout(ReadOnlySpan<byte> ptr, int typeDefSize)
 			{
-				PackingSize = (ushort)Helpers.GetValue(ptr, 2);
-				ClassSize = (uint)Helpers.GetValue(ptr.Slice(2, 4));
-				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr.Slice(6, typeDefSize)));
+				PackingSize = BinaryPrimitives.ReadUInt16LittleEndian(ptr);
+				ClassSize = BinaryPrimitives.ReadUInt32LittleEndian(ptr.Slice(2, 4));
+				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(6, typeDefSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/ClassLayoutTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/ClassLayoutTableTreeNode.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -38,7 +39,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -49,7 +50,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			var list = new List<ClassLayoutEntry>();
 
 			var length = metadata.GetTableRowCount(TableIndex.ClassLayout);
-			byte* ptr = metadata.MetadataPointer;
+			ReadOnlySpan<byte> ptr = metadata.AsReadOnlySpan();
 			int metadataOffset = module.Reader.PEHeaders.MetadataStartOffset;
 			ClassLayoutEntry scrollTargetEntry = default;
 
@@ -80,15 +81,15 @@ namespace ICSharpCode.ILSpy.Metadata
 			public readonly EntityHandle Parent;
 			public readonly uint ClassSize;
 
-			public unsafe ClassLayout(byte* ptr, int typeDefSize)
+			public ClassLayout(ReadOnlySpan<byte> ptr, int typeDefSize)
 			{
 				PackingSize = (ushort)Helpers.GetValue(ptr, 2);
-				ClassSize = (uint)Helpers.GetValue(ptr + 2, 4);
-				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr + 6, typeDefSize));
+				ClassSize = (uint)Helpers.GetValue(ptr.Slice(2, 4));
+				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr.Slice(6, typeDefSize)));
 			}
 		}
 
-		unsafe struct ClassLayoutEntry
+		struct ClassLayoutEntry
 		{
 			readonly PEFile module;
 			readonly MetadataReader metadata;
@@ -117,7 +118,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			[ColumnInfo("X8", Kind = ColumnKind.Other)]
 			public uint ClassSize => classLayout.ClassSize;
 
-			public ClassLayoutEntry(PEFile module, byte* ptr, int metadataOffset, int row)
+			public ClassLayoutEntry(PEFile module, ReadOnlySpan<byte> ptr, int metadataOffset, int row)
 			{
 				this.module = module;
 				this.metadata = module.Metadata;
@@ -125,7 +126,7 @@ namespace ICSharpCode.ILSpy.Metadata
 				var rowOffset = metadata.GetTableMetadataOffset(TableIndex.ClassLayout)
 					+ metadata.GetTableRowSize(TableIndex.ClassLayout) * (row - 1);
 				this.Offset = metadataOffset + rowOffset;
-				this.classLayout = new ClassLayout(ptr + rowOffset, metadata.GetTableRowCount(TableIndex.TypeDef) < ushort.MaxValue ? 2 : 4);
+				this.classLayout = new ClassLayout(ptr.Slice(rowOffset), metadata.GetTableRowCount(TableIndex.TypeDef) < ushort.MaxValue ? 2 : 4);
 				this.parentTooltip = null;
 			}
 		}

--- a/ILSpy/Metadata/CorTables/EventMapTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/EventMapTableTreeNode.cs
@@ -82,8 +82,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public EventMap(ReadOnlySpan<byte> ptr, int typeDefSize, int eventDefSize)
 			{
-				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, typeDefSize));
-				EventList = MetadataTokens.EventDefinitionHandle(Helpers.GetValue(ptr.Slice(typeDefSize, eventDefSize)));
+				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(0, typeDefSize)));
+				EventList = MetadataTokens.EventDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(typeDefSize, eventDefSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/EventMapTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/EventMapTableTreeNode.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -38,7 +39,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -50,7 +51,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			EventMapEntry scrollTargetEntry = default;
 
 			var length = metadata.GetTableRowCount(TableIndex.EventMap);
-			byte* ptr = metadata.MetadataPointer;
+			ReadOnlySpan<byte> ptr = metadata.AsReadOnlySpan();
 			int metadataOffset = module.Reader.PEHeaders.MetadataStartOffset;
 			for (int rid = 1; rid <= length; rid++)
 			{
@@ -79,14 +80,14 @@ namespace ICSharpCode.ILSpy.Metadata
 			public readonly TypeDefinitionHandle Parent;
 			public readonly EventDefinitionHandle EventList;
 
-			public unsafe EventMap(byte* ptr, int typeDefSize, int eventDefSize)
+			public EventMap(ReadOnlySpan<byte> ptr, int typeDefSize, int eventDefSize)
 			{
 				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, typeDefSize));
-				EventList = MetadataTokens.EventDefinitionHandle(Helpers.GetValue(ptr + typeDefSize, eventDefSize));
+				EventList = MetadataTokens.EventDefinitionHandle(Helpers.GetValue(ptr.Slice(typeDefSize, eventDefSize)));
 			}
 		}
 
-		unsafe struct EventMapEntry
+		struct EventMapEntry
 		{
 			readonly PEFile module;
 			readonly MetadataReader metadata;
@@ -120,7 +121,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			string eventListTooltip;
 			public string EventListTooltip => GenerateTooltip(ref eventListTooltip, module, eventMap.EventList);
 
-			public EventMapEntry(PEFile module, byte* ptr, int metadataOffset, int row)
+			public EventMapEntry(PEFile module, ReadOnlySpan<byte> ptr, int metadataOffset, int row)
 			{
 				this.module = module;
 				this.metadata = module.Metadata;
@@ -130,7 +131,7 @@ namespace ICSharpCode.ILSpy.Metadata
 				this.Offset = metadataOffset + rowOffset;
 				int typeDefSize = metadata.GetTableRowCount(TableIndex.TypeDef) < ushort.MaxValue ? 2 : 4;
 				int eventDefSize = metadata.GetTableRowCount(TableIndex.Event) < ushort.MaxValue ? 2 : 4;
-				this.eventMap = new EventMap(ptr + rowOffset, typeDefSize, eventDefSize);
+				this.eventMap = new EventMap(ptr.Slice(rowOffset), typeDefSize, eventDefSize);
 				this.parentTooltip = null;
 				this.eventListTooltip = null;
 			}

--- a/ILSpy/Metadata/CorTables/FieldLayoutTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/FieldLayoutTableTreeNode.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -82,8 +83,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public FieldLayout(ReadOnlySpan<byte> ptr, int fieldDefSize)
 			{
-				Offset = Helpers.GetValue(ptr, 4);
-				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValue(ptr.Slice(4, fieldDefSize)));
+				Offset = BinaryPrimitives.ReadInt32LittleEndian(ptr);
+				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(4, fieldDefSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/FieldLayoutTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/FieldLayoutTableTreeNode.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -38,7 +39,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -50,7 +51,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			FieldLayoutEntry scrollTargetEntry = default;
 
 			var length = metadata.GetTableRowCount(TableIndex.FieldLayout);
-			byte* ptr = metadata.MetadataPointer;
+			ReadOnlySpan<byte> ptr = metadata.AsReadOnlySpan();
 			int metadataOffset = module.Reader.PEHeaders.MetadataStartOffset;
 			for (int rid = 1; rid <= length; rid++)
 			{
@@ -79,14 +80,14 @@ namespace ICSharpCode.ILSpy.Metadata
 			public readonly int Offset;
 			public readonly FieldDefinitionHandle Field;
 
-			public unsafe FieldLayout(byte* ptr, int fieldDefSize)
+			public FieldLayout(ReadOnlySpan<byte> ptr, int fieldDefSize)
 			{
 				Offset = Helpers.GetValue(ptr, 4);
-				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValue(ptr + 4, fieldDefSize));
+				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValue(ptr.Slice(4, fieldDefSize)));
 			}
 		}
 
-		unsafe struct FieldLayoutEntry
+		struct FieldLayoutEntry
 		{
 			readonly PEFile module;
 			readonly MetadataReader metadata;
@@ -112,7 +113,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			[ColumnInfo("X8", Kind = ColumnKind.Other)]
 			public int FieldOffset => fieldLayout.Offset;
 
-			public FieldLayoutEntry(PEFile module, byte* ptr, int metadataOffset, int row)
+			public FieldLayoutEntry(PEFile module, ReadOnlySpan<byte> ptr, int metadataOffset, int row)
 			{
 				this.module = module;
 				this.metadata = module.Metadata;
@@ -121,7 +122,7 @@ namespace ICSharpCode.ILSpy.Metadata
 					+ metadata.GetTableRowSize(TableIndex.FieldLayout) * (row - 1);
 				this.Offset = metadataOffset + rowOffset;
 				int fieldDefSize = metadata.GetTableRowCount(TableIndex.Field) < ushort.MaxValue ? 2 : 4;
-				this.fieldLayout = new FieldLayout(ptr + rowOffset, fieldDefSize);
+				this.fieldLayout = new FieldLayout(ptr.Slice(rowOffset), fieldDefSize);
 				this.fieldTooltip = null;
 			}
 		}

--- a/ILSpy/Metadata/CorTables/FieldMarshalTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/FieldMarshalTableTreeNode.cs
@@ -82,8 +82,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public FieldMarshal(ReadOnlySpan<byte> ptr, int blobHeapSize, int hasFieldMarshalRefSize)
 			{
-				Parent = Helpers.FromHasFieldMarshalTag((uint)Helpers.GetValue(ptr, hasFieldMarshalRefSize));
-				NativeType = MetadataTokens.BlobHandle(Helpers.GetValue(ptr.Slice(hasFieldMarshalRefSize, blobHeapSize)));
+				Parent = Helpers.FromHasFieldMarshalTag((uint)Helpers.GetValueLittleEndian(ptr, hasFieldMarshalRefSize));
+				NativeType = MetadataTokens.BlobHandle(Helpers.GetValueLittleEndian(ptr.Slice(hasFieldMarshalRefSize, blobHeapSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/FieldRVATableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/FieldRVATableTreeNode.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -38,7 +39,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -50,7 +51,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			FieldRVAEntry scrollTargetEntry = default;
 
 			var length = metadata.GetTableRowCount(TableIndex.FieldRva);
-			byte* ptr = metadata.MetadataPointer;
+			ReadOnlySpan<byte> ptr = metadata.AsReadOnlySpan();
 			int metadataOffset = module.Reader.PEHeaders.MetadataStartOffset;
 			for (int rid = 1; rid <= length; rid++)
 			{
@@ -79,14 +80,14 @@ namespace ICSharpCode.ILSpy.Metadata
 			public readonly int Offset;
 			public readonly FieldDefinitionHandle Field;
 
-			public unsafe FieldRVA(byte* ptr, int fieldDefSize)
+			public FieldRVA(ReadOnlySpan<byte> ptr, int fieldDefSize)
 			{
 				Offset = Helpers.GetValue(ptr, 4);
-				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValue(ptr + 4, fieldDefSize));
+				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValue(ptr.Slice(4, fieldDefSize)));
 			}
 		}
 
-		unsafe struct FieldRVAEntry
+		struct FieldRVAEntry
 		{
 			readonly PEFile module;
 			readonly MetadataReader metadata;
@@ -112,7 +113,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			[ColumnInfo("X8", Kind = ColumnKind.Other)]
 			public int FieldOffset => fieldRVA.Offset;
 
-			public FieldRVAEntry(PEFile module, byte* ptr, int metadataOffset, int row)
+			public FieldRVAEntry(PEFile module, ReadOnlySpan<byte> ptr, int metadataOffset, int row)
 			{
 				this.module = module;
 				this.metadata = module.Metadata;
@@ -121,7 +122,7 @@ namespace ICSharpCode.ILSpy.Metadata
 					+ metadata.GetTableRowSize(TableIndex.FieldRva) * (row - 1);
 				this.Offset = metadataOffset + rowOffset;
 				int fieldDefSize = metadata.GetTableRowCount(TableIndex.Field) < ushort.MaxValue ? 2 : 4;
-				this.fieldRVA = new FieldRVA(ptr + rowOffset, fieldDefSize);
+				this.fieldRVA = new FieldRVA(ptr.Slice(rowOffset), fieldDefSize);
 				this.fieldTooltip = null;
 			}
 		}

--- a/ILSpy/Metadata/CorTables/FieldRVATableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/FieldRVATableTreeNode.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -82,8 +83,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public FieldRVA(ReadOnlySpan<byte> ptr, int fieldDefSize)
 			{
-				Offset = Helpers.GetValue(ptr, 4);
-				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValue(ptr.Slice(4, fieldDefSize)));
+				Offset = BinaryPrimitives.ReadInt32LittleEndian(ptr);
+				Field = MetadataTokens.FieldDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(4, fieldDefSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/ImplMapTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/ImplMapTableTreeNode.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -88,10 +89,10 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public ImplMap(ReadOnlySpan<byte> span, int moduleRefSize, int memberForwardedTagRefSize, int stringHandleSize)
 			{
-				MappingFlags = (PInvokeAttributes)Helpers.GetValue(span.Slice(0, 2));
-				MemberForwarded = Helpers.FromMemberForwardedTag((uint)Helpers.GetValue(span.Slice(2, memberForwardedTagRefSize)));
-				ImportName = MetadataTokens.StringHandle(Helpers.GetValue(span.Slice(2 + memberForwardedTagRefSize, stringHandleSize)));
-				ImportScope = MetadataTokens.ModuleReferenceHandle(Helpers.GetValue(span.Slice(2 + memberForwardedTagRefSize + stringHandleSize, moduleRefSize)));
+				MappingFlags = (PInvokeAttributes)BinaryPrimitives.ReadUInt16LittleEndian(span);
+				MemberForwarded = Helpers.FromMemberForwardedTag((uint)Helpers.GetValueLittleEndian(span.Slice(2, memberForwardedTagRefSize)));
+				ImportName = MetadataTokens.StringHandle(Helpers.GetValueLittleEndian(span.Slice(2 + memberForwardedTagRefSize, stringHandleSize)));
+				ImportScope = MetadataTokens.ModuleReferenceHandle(Helpers.GetValueLittleEndian(span.Slice(2 + memberForwardedTagRefSize + stringHandleSize, moduleRefSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/InterfaceImplTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/InterfaceImplTableTreeNode.cs
@@ -82,8 +82,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public InterfaceImpl(ReadOnlySpan<byte> ptr, int classSize, int interfaceSize)
 			{
-				Class = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, classSize));
-				Interface = Helpers.FromTypeDefOrRefTag((uint)Helpers.GetValue(ptr.Slice(classSize, interfaceSize)));
+				Class = MetadataTokens.TypeDefinitionHandle(Helpers.GetValueLittleEndian(ptr, classSize));
+				Interface = Helpers.FromTypeDefOrRefTag((uint)Helpers.GetValueLittleEndian(ptr.Slice(classSize, interfaceSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/InterfaceImplTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/InterfaceImplTableTreeNode.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -38,7 +39,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -50,7 +51,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			InterfaceImplEntry scrollTargetEntry = default;
 
 			var length = metadata.GetTableRowCount(TableIndex.InterfaceImpl);
-			byte* ptr = metadata.MetadataPointer;
+			ReadOnlySpan<byte> ptr = metadata.AsReadOnlySpan();
 			int metadataOffset = module.Reader.PEHeaders.MetadataStartOffset;
 			for (int rid = 1; rid <= length; rid++)
 			{
@@ -79,14 +80,14 @@ namespace ICSharpCode.ILSpy.Metadata
 			public readonly EntityHandle Class;
 			public readonly EntityHandle Interface;
 
-			public unsafe InterfaceImpl(byte* ptr, int classSize, int interfaceSize)
+			public InterfaceImpl(ReadOnlySpan<byte> ptr, int classSize, int interfaceSize)
 			{
 				Class = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, classSize));
-				Interface = Helpers.FromTypeDefOrRefTag((uint)Helpers.GetValue(ptr + classSize, interfaceSize));
+				Interface = Helpers.FromTypeDefOrRefTag((uint)Helpers.GetValue(ptr.Slice(classSize, interfaceSize)));
 			}
 		}
 
-		unsafe struct InterfaceImplEntry
+		struct InterfaceImplEntry
 		{
 			readonly PEFile module;
 			readonly MetadataReader metadata;
@@ -120,7 +121,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			string interfaceTooltip;
 			public string InterfaceTooltip => GenerateTooltip(ref interfaceTooltip, module, interfaceImpl.Interface);
 
-			public InterfaceImplEntry(PEFile module, byte* ptr, int metadataOffset, int row)
+			public InterfaceImplEntry(PEFile module, ReadOnlySpan<byte> ptr, int metadataOffset, int row)
 			{
 				this.module = module;
 				this.metadata = module.Metadata;
@@ -128,7 +129,7 @@ namespace ICSharpCode.ILSpy.Metadata
 				var rowOffset = metadata.GetTableMetadataOffset(TableIndex.InterfaceImpl)
 					+ metadata.GetTableRowSize(TableIndex.InterfaceImpl) * (row - 1);
 				this.Offset = metadataOffset + rowOffset;
-				this.interfaceImpl = new InterfaceImpl(ptr + rowOffset, metadata.GetTableRowCount(TableIndex.TypeDef) < ushort.MaxValue ? 2 : 4, metadata.ComputeCodedTokenSize(16384, TableMask.TypeDef | TableMask.TypeRef | TableMask.TypeSpec));
+				this.interfaceImpl = new InterfaceImpl(ptr.Slice(rowOffset), metadata.GetTableRowCount(TableIndex.TypeDef) < ushort.MaxValue ? 2 : 4, metadata.ComputeCodedTokenSize(16384, TableMask.TypeDef | TableMask.TypeRef | TableMask.TypeSpec));
 				this.interfaceTooltip = null;
 				this.classTooltip = null;
 			}

--- a/ILSpy/Metadata/CorTables/NestedClassTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/NestedClassTableTreeNode.cs
@@ -82,8 +82,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public NestedClass(ReadOnlySpan<byte> ptr, int typeDefSize)
 			{
-				Nested = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, typeDefSize));
-				Enclosing = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr.Slice(typeDefSize), typeDefSize));
+				Nested = MetadataTokens.TypeDefinitionHandle(Helpers.GetValueLittleEndian(ptr, typeDefSize));
+				Enclosing = MetadataTokens.TypeDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(typeDefSize), typeDefSize));
 			}
 		}
 

--- a/ILSpy/Metadata/CorTables/PropertyMapTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/PropertyMapTableTreeNode.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -38,7 +39,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -50,7 +51,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			PropertyMapEntry scrollTargetEntry = default;
 
 			var length = metadata.GetTableRowCount(TableIndex.PropertyMap);
-			byte* ptr = metadata.MetadataPointer;
+			ReadOnlySpan<byte> ptr = metadata.AsReadOnlySpan();
 			int metadataOffset = module.Reader.PEHeaders.MetadataStartOffset;
 			for (int rid = 1; rid <= length; rid++)
 			{
@@ -79,14 +80,14 @@ namespace ICSharpCode.ILSpy.Metadata
 			public readonly TypeDefinitionHandle Parent;
 			public readonly PropertyDefinitionHandle PropertyList;
 
-			public unsafe PropertyMap(byte* ptr, int typeDefSize, int propertyDefSize)
+			public PropertyMap(ReadOnlySpan<byte> ptr, int typeDefSize, int propertyDefSize)
 			{
 				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, typeDefSize));
-				PropertyList = MetadataTokens.PropertyDefinitionHandle(Helpers.GetValue(ptr + typeDefSize, propertyDefSize));
+				PropertyList = MetadataTokens.PropertyDefinitionHandle(Helpers.GetValue(ptr.Slice(typeDefSize, propertyDefSize)));
 			}
 		}
 
-		unsafe struct PropertyMapEntry
+		struct PropertyMapEntry
 		{
 			readonly PEFile module;
 			readonly MetadataReader metadata;
@@ -120,7 +121,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			string propertyListTooltip;
 			public string PropertyListTooltip => GenerateTooltip(ref propertyListTooltip, module, propertyMap.PropertyList);
 
-			public PropertyMapEntry(PEFile module, byte* ptr, int metadataOffset, int row)
+			public PropertyMapEntry(PEFile module, ReadOnlySpan<byte> ptr, int metadataOffset, int row)
 			{
 				this.module = module;
 				this.metadata = module.Metadata;
@@ -130,7 +131,7 @@ namespace ICSharpCode.ILSpy.Metadata
 				this.Offset = metadataOffset + rowOffset;
 				int typeDefSize = metadata.GetTableRowCount(TableIndex.TypeDef) < ushort.MaxValue ? 2 : 4;
 				int propertyDefSize = metadata.GetTableRowCount(TableIndex.Property) < ushort.MaxValue ? 2 : 4;
-				this.propertyMap = new PropertyMap(ptr + rowOffset, typeDefSize, propertyDefSize);
+				this.propertyMap = new PropertyMap(ptr.Slice(rowOffset), typeDefSize, propertyDefSize);
 				this.propertyListTooltip = null;
 				this.parentTooltip = null;
 			}

--- a/ILSpy/Metadata/CorTables/PropertyMapTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/PropertyMapTableTreeNode.cs
@@ -82,8 +82,8 @@ namespace ICSharpCode.ILSpy.Metadata
 
 			public PropertyMap(ReadOnlySpan<byte> ptr, int typeDefSize, int propertyDefSize)
 			{
-				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValue(ptr, typeDefSize));
-				PropertyList = MetadataTokens.PropertyDefinitionHandle(Helpers.GetValue(ptr.Slice(typeDefSize, propertyDefSize)));
+				Parent = MetadataTokens.TypeDefinitionHandle(Helpers.GetValueLittleEndian(ptr, typeDefSize));
+				PropertyList = MetadataTokens.PropertyDefinitionHandle(Helpers.GetValueLittleEndian(ptr.Slice(typeDefSize, propertyDefSize)));
 			}
 		}
 

--- a/ILSpy/Metadata/DebugTables/StateMachineMethodTableTreeNode.cs
+++ b/ILSpy/Metadata/DebugTables/StateMachineMethodTableTreeNode.cs
@@ -44,7 +44,7 @@ namespace ICSharpCode.ILSpy.Metadata
 
 		public override object Icon => Images.Literal;
 
-		public unsafe override bool View(ViewModels.TabPageModel tabPage)
+		public override bool View(ViewModels.TabPageModel tabPage)
 		{
 			tabPage.Title = Text.ToString();
 			tabPage.SupportsLanguageSwitching = false;
@@ -53,7 +53,7 @@ namespace ICSharpCode.ILSpy.Metadata
 			var list = new List<StateMachineMethodEntry>();
 			StateMachineMethodEntry scrollTargetEntry = default;
 			var length = metadata.GetTableRowCount(TableIndex.StateMachineMethod);
-			var reader = new BlobReader(metadata.MetadataPointer, metadata.MetadataLength);
+			var reader = metadata.AsBlobReader();
 			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.StateMachineMethod);
 
 			for (int rid = 1; rid <= length; rid++)

--- a/ILSpy/Metadata/Helpers.cs
+++ b/ILSpy/Metadata/Helpers.cs
@@ -212,19 +212,18 @@ namespace ICSharpCode.ILSpy.Metadata
 			}
 		}
 
-		[Obsolete("Use ReadOnlySpan<byte> overload")]
+		[Obsolete("Use safe GetValueLittleEndian(ReadOnlySpan<byte>) or appropriate BinaryPrimitives.Read* method")]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static unsafe int GetValue(byte* ptr, int size)
-			=> GetValue(new ReadOnlySpan<byte>(ptr, size));
+			=> GetValueLittleEndian(new ReadOnlySpan<byte>(ptr, size));
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static int GetValue(ReadOnlySpan<byte> ptr, int size)
-			=> GetValue(ptr.Slice(0, size));
+		public static int GetValueLittleEndian(ReadOnlySpan<byte> ptr, int size)
+			=> GetValueLittleEndian(ptr.Slice(0, size));
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static int GetValue(ReadOnlySpan<byte> ptr)
+		public static int GetValueLittleEndian(ReadOnlySpan<byte> ptr)
 		{
-			// endianess?
 			int result = 0;
 			for (int i = 0; i < ptr.Length; i += 2)
 			{

--- a/ILSpy/Metadata/Helpers.cs
+++ b/ILSpy/Metadata/Helpers.cs
@@ -212,11 +212,21 @@ namespace ICSharpCode.ILSpy.Metadata
 			}
 		}
 
+		[Obsolete("Use ReadOnlySpan<byte> overload")]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static unsafe int GetValue(byte* ptr, int size)
+			=> GetValue(new ReadOnlySpan<byte>(ptr, size));
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static int GetValue(ReadOnlySpan<byte> ptr, int size)
+			=> GetValue(ptr.Slice(0, size));
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static int GetValue(ReadOnlySpan<byte> ptr)
 		{
+			// endianess?
 			int result = 0;
-			for (int i = 0; i < size; i += 2)
+			for (int i = 0; i < ptr.Length; i += 2)
 			{
 				result |= ptr[i] << 8 * i;
 				result |= ptr[i + 1] << 8 * (i + 1);


### PR DESCRIPTION
This replaces all the `unsafe` code involved in metadata parsing in the ILSpy project with the equivalent using `ReadOnlySpan<byte>`. There's a little bit left in ICSharpCode.Decompiler, mostly around resource handling.

Not sure if it's worth it, especially given possible performance regression when running on netfx, but since I already did it as an experiment, it might be useful to the project.

side note: I think all ECMA 335 metadata is little endian, but the code doesn't really seem to deal with that. I don't think .net runs on any big endian machines anymore anyway.
