### PR TITLE
Add support for MCS 2.6.4 pinned region with array variable

### DIFF
--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -336,10 +336,6 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task UnsafeCode([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
-			if (options.HasFlag(CompilerOptions.UseMcs2_6_4))
-			{
-				Assert.Ignore("Decompiler bug with mono!");
-			}
 			await RunCS(options: options);
 		}
 

--- a/ICSharpCode.Decompiler/IL/ControlFlow/DetectPinnedRegions.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/DetectPinnedRegions.cs
@@ -621,7 +621,8 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 						{
 							unpinBlock = br.TargetBlock;
 						}
-						else if (innerBlock.Instructions[0].MatchIfInstruction(out _, out var trueInstr) &&
+						else if (innerBlock.Instructions.Count == 2 &&
+								innerBlock.Instructions[0].MatchIfInstruction(out _, out var trueInstr) &&
 								trueInstr is Branch trueBr && trueBr.TargetContainer == sourceContainer &&
 								reachedEdgesPerBlock[trueBr.TargetBlock.ChildIndex] == 0)
 						{


### PR DESCRIPTION
Link to issue(s) this covers:
N/A

### Problem
The decompiler did not support decompiling pinned regions with array variables when the compiler used was MCS 2.6.4.

Before:
```csharp
public unsafe int MultipleExitsOutOfFixedBlock(int[] arr)
{
	fixed (int* ptr = &System.Runtime.CompilerServices.Unsafe.AsRef<int>((int*)System.Runtime.CompilerServices.Unsafe.AsPointer(ref arr[0])))
	{
		if (*ptr < 0)
		{
			return *ptr;
		}
		if (*ptr == 21)
		{
			return 42;
		}
		if (*ptr == 42)
		{
			Console.WriteLine("outside");
			return 2;
		}
	}
	ptr = null;
	return 1;
}
```

After:
```csharp
public unsafe int MultipleExitsOutOfFixedBlock(int[] arr)
{
	fixed (int* ptr = &arr[0])
	{
		if (*ptr < 0)
		{
			return *ptr;
		}
		if (*ptr == 21)
		{
			return 42;
		}
		if (*ptr == 42)
		{
			Console.WriteLine("outside");
			return 2;
		}
	}
	return 1;
}
```
### Solution
* Added additional code to remove the `conv` instruction present in the initialization part of the pinned region.
* Extended the code responsible for removing the unpin `stloc` to correctly match the inverted condition found in MCS 2.6.4 compiled code.
* Enabled already present correctness test to run for MCS 2.6.4.

