### PR TITLE
Read and use tuple element names and dynamic type information from PDBs

### DIFF
--- a/ICSharpCode.Decompiler/DebugInfo/IDebugInfoProvider.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/IDebugInfoProvider.cs
@@ -23,6 +23,7 @@ namespace ICSharpCode.Decompiler.DebugInfo
 		IList<SequencePoint> GetSequencePoints(MethodDefinitionHandle method);
 		IList<Variable> GetVariables(MethodDefinitionHandle method);
 		bool TryGetName(MethodDefinitionHandle method, int index, out string name);
+		bool TryGetExtraTypeInfo(MethodDefinitionHandle method, int index, out string[] tupleElementNames, out bool[] dynamicFlags);
 		string SourceFileName { get; }
 	}
 }

--- a/ICSharpCode.Decompiler/DebugInfo/IDebugInfoProvider.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/IDebugInfoProvider.cs
@@ -17,13 +17,19 @@ namespace ICSharpCode.Decompiler.DebugInfo
 		public string Name { get; }
 	}
 
+	public struct PdbExtraTypeInfo
+	{
+		public string[] TupleElementNames;
+		public bool[] DynamicFlags;
+	}
+
 	public interface IDebugInfoProvider
 	{
 		string Description { get; }
 		IList<SequencePoint> GetSequencePoints(MethodDefinitionHandle method);
 		IList<Variable> GetVariables(MethodDefinitionHandle method);
 		bool TryGetName(MethodDefinitionHandle method, int index, out string name);
-		bool TryGetExtraTypeInfo(MethodDefinitionHandle method, int index, out string[] tupleElementNames, out bool[] dynamicFlags);
+		bool TryGetExtraTypeInfo(MethodDefinitionHandle method, int index, out PdbExtraTypeInfo extraTypeInfo);
 		string SourceFileName { get; }
 	}
 }

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -95,6 +95,7 @@
     <Compile Include="DecompilationProgress.cs" />
     <Compile Include="Disassembler\IEntityProcessor.cs" />
     <Compile Include="Disassembler\SortByNameProcessor.cs" />
+    <Compile Include="IL\ApplyPdbLocalTypeInfoTypeVisitor.cs" />
     <Compile Include="NRTAttributes.cs" />
     <Compile Include="PartialTypeInfo.cs" />
     <Compile Include="CSharp\ProjectDecompiler\IProjectFileWriter.cs" />

--- a/ICSharpCode.Decompiler/IL/ApplyPdbLocalTypeInfoTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/IL/ApplyPdbLocalTypeInfoTypeVisitor.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Immutable;
+
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.Decompiler.TypeSystem.Implementation;
+
+namespace ICSharpCode.Decompiler.IL
+{
+	/// <summary>
+	/// Heavily based on <see cref="ApplyAttributeTypeVisitor"/>
+	/// </summary>
+	sealed class ApplyPdbLocalTypeInfoTypeVisitor : TypeVisitor
+	{
+		private readonly bool[] dynamicData;
+		private readonly string[] tupleElementNames;
+		private int dynamicTypeIndex = 0;
+		private int tupleTypeIndex = 0;
+
+		public ApplyPdbLocalTypeInfoTypeVisitor(bool[] dynamicData, string[] tupleElementNames)
+		{
+			this.dynamicData = dynamicData;
+			this.tupleElementNames = tupleElementNames;
+		}
+
+		public override IType VisitModOpt(ModifiedType type)
+		{
+			dynamicTypeIndex++;
+			return base.VisitModOpt(type);
+		}
+
+		public override IType VisitModReq(ModifiedType type)
+		{
+			dynamicTypeIndex++;
+			return base.VisitModReq(type);
+		}
+
+		public override IType VisitPointerType(PointerType type)
+		{
+			dynamicTypeIndex++;
+			return base.VisitPointerType(type);
+		}
+
+		public override IType VisitArrayType(ArrayType type)
+		{
+			dynamicTypeIndex++;
+			return base.VisitArrayType(type);
+		}
+
+		public override IType VisitByReferenceType(ByReferenceType type)
+		{
+			dynamicTypeIndex++;
+			return base.VisitByReferenceType(type);
+		}
+
+		public override IType VisitTupleType(TupleType type)
+		{
+			if (tupleElementNames != null && tupleTypeIndex < tupleElementNames.Length)
+			{
+				int tupleCardinality = type.Cardinality;
+				string[] extractedValues = new string[tupleCardinality];
+				Array.Copy(tupleElementNames, tupleTypeIndex, extractedValues, 0,
+					Math.Min(tupleCardinality, tupleElementNames.Length - tupleTypeIndex));
+				var elementNames = ImmutableArray.CreateRange(extractedValues);
+				tupleTypeIndex += tupleCardinality;
+
+				int level = 0;
+				var elementTypes = new IType[type.ElementTypes.Length];
+				for (int i = 0; i < type.ElementTypes.Length; i++)
+				{
+					dynamicTypeIndex++;
+					IType elementType = type.ElementTypes[i];
+					if (i != 0 && (i - level) % TupleType.RestPosition == 0 && elementType is TupleType tuple)
+					{
+						tupleTypeIndex += tuple.Cardinality;
+						level++;
+					}
+					elementTypes[i] = elementType.AcceptVisitor(this);
+				}
+
+				return new TupleType(
+					type.Compilation,
+					elementTypes.ToImmutableArray(),
+					elementNames,
+					type.GetDefinition()?.ParentModule
+				);
+			}
+			return base.VisitTupleType(type);
+		}
+
+		public override IType VisitParameterizedType(ParameterizedType type)
+		{
+			if (TupleType.IsTupleCompatible(type, out var tupleCardinality))
+				tupleTypeIndex += tupleCardinality;
+			// Visit generic type and type arguments.
+			// Like base implementation, except that it increments dynamicTypeIndex.
+			var genericType = type.GenericType.AcceptVisitor(this);
+			bool changed = type.GenericType != genericType;
+			var arguments = new IType[type.TypeArguments.Count];
+			for (int i = 0; i < type.TypeArguments.Count; i++)
+			{
+				dynamicTypeIndex++;
+				arguments[i] = type.TypeArguments[i].AcceptVisitor(this);
+				changed = changed || arguments[i] != type.TypeArguments[i];
+			}
+			if (!changed)
+				return type;
+			return new ParameterizedType(genericType, arguments);
+		}
+
+		public override IType VisitFunctionPointerType(FunctionPointerType type)
+		{
+			dynamicTypeIndex++;
+			if (type.ReturnIsRefReadOnly)
+			{
+				dynamicTypeIndex++;
+			}
+			var returnType = type.ReturnType.AcceptVisitor(this);
+			bool changed = type.ReturnType != returnType;
+			var parameters = new IType[type.ParameterTypes.Length];
+			for (int i = 0; i < parameters.Length; i++)
+			{
+				dynamicTypeIndex += type.ParameterReferenceKinds[i] switch {
+					ReferenceKind.None => 1,
+					ReferenceKind.Ref => 1,
+					ReferenceKind.Out => 2, // in/out also count the modreq
+					ReferenceKind.In => 2,
+					_ => throw new NotSupportedException()
+				};
+				parameters[i] = type.ParameterTypes[i].AcceptVisitor(this);
+				changed = changed || parameters[i] != type.ParameterTypes[i];
+			}
+			if (!changed)
+				return type;
+			return type.WithSignature(returnType, parameters.ToImmutableArray());
+		}
+
+		public override IType VisitTypeDefinition(ITypeDefinition type)
+		{
+			IType newType = type;
+			var ktc = type.KnownTypeCode;
+			if (ktc == KnownTypeCode.Object && dynamicData is not null)
+			{
+				if (dynamicTypeIndex >= dynamicData.Length)
+					newType = SpecialType.Dynamic;
+				else if (dynamicData[dynamicTypeIndex])
+					newType = SpecialType.Dynamic;
+			}
+			return newType;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/IL/ApplyPdbLocalTypeInfoTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/IL/ApplyPdbLocalTypeInfoTypeVisitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 
+using ICSharpCode.Decompiler.DebugInfo;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.Decompiler.TypeSystem.Implementation;
 
@@ -16,10 +17,17 @@ namespace ICSharpCode.Decompiler.IL
 		private int dynamicTypeIndex = 0;
 		private int tupleTypeIndex = 0;
 
-		public ApplyPdbLocalTypeInfoTypeVisitor(bool[] dynamicData, string[] tupleElementNames)
+		private ApplyPdbLocalTypeInfoTypeVisitor(bool[] dynamicData, string[] tupleElementNames)
 		{
 			this.dynamicData = dynamicData;
 			this.tupleElementNames = tupleElementNames;
+		}
+
+		public static IType Apply(IType type, PdbExtraTypeInfo pdbExtraTypeInfo)
+		{
+			if (pdbExtraTypeInfo.DynamicFlags is null && pdbExtraTypeInfo.TupleElementNames is null)
+				return type;
+			return type.AcceptVisitor(new ApplyPdbLocalTypeInfoTypeVisitor(pdbExtraTypeInfo.DynamicFlags, pdbExtraTypeInfo.TupleElementNames));
 		}
 
 		public override IType VisitModOpt(ModifiedType type)

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 Daniel Grunwald
+// Copyright (c) 2014 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -304,6 +304,14 @@ namespace ICSharpCode.Decompiler.IL
 			{
 				kind = VariableKind.Local;
 			}
+
+			if (UseDebugSymbols && DebugInfo is not null &&
+				DebugInfo.TryGetExtraTypeInfo((MethodDefinitionHandle)method.MetadataToken, index,
+					out string[] tupleElementNames, out bool[] dynamicFlags))
+			{
+				type = type.AcceptVisitor(new ApplyPdbLocalTypeInfoTypeVisitor(dynamicFlags, tupleElementNames));
+			}
+
 			ILVariable ilVar = new ILVariable(kind, type, index);
 			if (!UseDebugSymbols || DebugInfo == null || !DebugInfo.TryGetName((MethodDefinitionHandle)method.MetadataToken, index, out string name))
 			{

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -306,10 +306,9 @@ namespace ICSharpCode.Decompiler.IL
 			}
 
 			if (UseDebugSymbols && DebugInfo is not null &&
-				DebugInfo.TryGetExtraTypeInfo((MethodDefinitionHandle)method.MetadataToken, index,
-					out string[] tupleElementNames, out bool[] dynamicFlags))
+				DebugInfo.TryGetExtraTypeInfo((MethodDefinitionHandle)method.MetadataToken, index, out var pdbExtraTypeInfo))
 			{
-				type = type.AcceptVisitor(new ApplyPdbLocalTypeInfoTypeVisitor(dynamicFlags, tupleElementNames));
+				type = ApplyPdbLocalTypeInfoTypeVisitor.Apply(type, pdbExtraTypeInfo);
 			}
 
 			ILVariable ilVar = new ILVariable(kind, type, index);

--- a/ICSharpCode.ILSpyX/PdbProvider/MonoCecilDebugInfoProvider.cs
+++ b/ICSharpCode.ILSpyX/PdbProvider/MonoCecilDebugInfoProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018 Siegfried Pammer
+// Copyright (c) 2018 Siegfried Pammer
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -134,6 +134,16 @@ namespace ICSharpCode.ILSpyX.PdbProvider
 			var variable = info.Variables.FirstOrDefault(v => v.Index == index);
 			name = variable.Name;
 			return name != null;
+		}
+
+		public bool TryGetExtraTypeInfo(SRM.MethodDefinitionHandle method, int index,
+			[NotNullWhen(true)] out string[]? tupleElementNames, [NotNullWhen(true)] out bool[]? dynamicFlags)
+		{
+			// Mono.Cecil's WindowsPDB reader is unable to read tuple element names
+			// and dynamic flags custom debug information.
+			tupleElementNames = null;
+			dynamicFlags = null;
+			return false;
 		}
 	}
 }

--- a/ICSharpCode.ILSpyX/PdbProvider/MonoCecilDebugInfoProvider.cs
+++ b/ICSharpCode.ILSpyX/PdbProvider/MonoCecilDebugInfoProvider.cs
@@ -136,13 +136,11 @@ namespace ICSharpCode.ILSpyX.PdbProvider
 			return name != null;
 		}
 
-		public bool TryGetExtraTypeInfo(SRM.MethodDefinitionHandle method, int index,
-			[NotNullWhen(true)] out string[]? tupleElementNames, [NotNullWhen(true)] out bool[]? dynamicFlags)
+		public bool TryGetExtraTypeInfo(SRM.MethodDefinitionHandle method, int index, out PdbExtraTypeInfo extraTypeInfo)
 		{
 			// Mono.Cecil's WindowsPDB reader is unable to read tuple element names
 			// and dynamic flags custom debug information.
-			tupleElementNames = null;
-			dynamicFlags = null;
+			extraTypeInfo = default;
 			return false;
 		}
 	}

--- a/ICSharpCode.ILSpyX/PdbProvider/PortableDebugInfoProvider.cs
+++ b/ICSharpCode.ILSpyX/PdbProvider/PortableDebugInfoProvider.cs
@@ -218,7 +218,7 @@ namespace ICSharpCode.ILSpyX.PdbProvider
 				{
 					dynamicFlags = new bool[reader.Length * 8];
 					int j = 0;
-					while (reader.Offset < reader.Length)
+					while (reader.RemainingBytes > 0)
 					{
 						int b = reader.ReadByte();
 						for (int i = 1; i < 0x100; i <<= 1)

--- a/ICSharpCode.ILSpyX/PdbProvider/PortableDebugInfoProvider.cs
+++ b/ICSharpCode.ILSpyX/PdbProvider/PortableDebugInfoProvider.cs
@@ -199,10 +199,10 @@ namespace ICSharpCode.ILSpyX.PdbProvider
 					continue;
 				if (cdi.Value.IsNil || cdi.Kind.IsNil)
 					continue;
-				var reader = metadata.GetBlobReader(cdi.Value);
 				var kind = metadata.GetGuid(cdi.Kind);
 				if (kind == KnownGuids.TupleElementNames && tupleElementNames is null)
 				{
+					var reader = metadata.GetBlobReader(cdi.Value);
 					var list = new List<string?>();
 					while (reader.RemainingBytes > 0)
 					{
@@ -216,7 +216,7 @@ namespace ICSharpCode.ILSpyX.PdbProvider
 				}
 				else if (kind == KnownGuids.DynamicLocalVariables && dynamicFlags is null)
 				{
-					dynamicFlags = new bool[reader.Length * 8];
+					var reader = metadata.GetBlobReader(cdi.Value);
 					int j = 0;
 					while (reader.RemainingBytes > 0)
 					{

--- a/ICSharpCode.ILSpyX/PdbProvider/PortableDebugInfoProvider.cs
+++ b/ICSharpCode.ILSpyX/PdbProvider/PortableDebugInfoProvider.cs
@@ -204,8 +204,10 @@ namespace ICSharpCode.ILSpyX.PdbProvider
 					var list = new List<string?>();
 					while (reader.RemainingBytes > 0)
 					{
+						// Read a UTF8 null-terminated string
 						int length = reader.IndexOf(0);
 						string s = reader.ReadUTF8(length);
+						// Skip null terminator
 						reader.ReadByte();
 						list.Add(string.IsNullOrWhiteSpace(s) ? null : s);
 					}


### PR DESCRIPTION
Link to issue(s) this covers:
fixes https://github.com/icsharpcode/ILSpy/issues/3112

### Problem
ILSpy did not utilize helpful type information from PDB files when determining the type of local variables.

### Solution
* Implementation as mentioned in the original issue.
* Added additional code to extract the necessary information from the PDB file and added a new `TypeVisitor` to apply this information to the type system.

