### PR TITLE
`@file` support with breaking changes to command line options

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Iced" Version="1.21.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="3.1.12" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
+    <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="McMaster.Extensions.Hosting.CommandLine" Version="4.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />

--- a/ILSpy.AddIn.Shared/Commands/OpenCodeItemCommand.cs
+++ b/ILSpy.AddIn.Shared/Commands/OpenCodeItemCommand.cs
@@ -140,7 +140,7 @@ namespace ICSharpCode.ILSpy.AddIn.Commands
 				return;
 			}
 
-			OpenAssembliesInILSpy(new ILSpyParameters(validRefs.Select(r => r.AssemblyFile), "/navigateTo:" +
+			OpenAssembliesInILSpy(new ILSpyParameters(validRefs.Select(r => r.AssemblyFile), "--navigateto:" +
 				(symbol.OriginalDefinition ?? symbol).GetDocumentationCommentId()));
 		}
 

--- a/ILSpy.AddIn.Shared/ILSpyAddInPackage.cs
+++ b/ILSpy.AddIn.Shared/ILSpyAddInPackage.cs
@@ -97,6 +97,24 @@ namespace ICSharpCode.ILSpy.AddIn
 			OpenReferenceCommand.Register(this);
 			OpenCodeItemCommand.Register(this);
 		}
+
+		protected override int QueryClose(out bool canClose)
+		{
+			var tempFiles = ILSpyInstance.TempFiles;
+			while (tempFiles.TryPop(out var filename))
+			{
+				try
+				{
+					System.IO.File.Delete(filename);
+				}
+				catch (Exception)
+				{
+				}
+			}
+
+			return base.QueryClose(out canClose);
+		}
+
 		#endregion
 
 		public void ShowMessage(string format, params object[] items)

--- a/ILSpy.AddIn.Shared/ILSpyInstance.cs
+++ b/ILSpy.AddIn.Shared/ILSpyInstance.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ICSharpCode.ILSpy.AddIn
 {
@@ -47,85 +44,28 @@ namespace ICSharpCode.ILSpy.AddIn
 		{
 			var commandLineArguments = parameters?.AssemblyFileNames?.Concat(parameters.Arguments);
 			string ilSpyExe = GetILSpyPath();
+
+			const string defaultOptions = "--navigateto:none";
+			string argumentsToPass = defaultOptions;
+
+			if ((commandLineArguments != null) && commandLineArguments.Any())
+			{
+				string assemblyArguments = string.Join(" ", commandLineArguments);
+
+				string filepath = Path.GetTempFileName();
+				File.WriteAllText(filepath, assemblyArguments);
+
+				argumentsToPass = $"@\"{filepath}\"";
+			}
+
 			var process = new Process() {
 				StartInfo = new ProcessStartInfo() {
 					FileName = ilSpyExe,
 					UseShellExecute = false,
-					Arguments = "/navigateTo:none"
+					Arguments = argumentsToPass
 				}
 			};
 			process.Start();
-
-			if ((commandLineArguments != null) && commandLineArguments.Any())
-			{
-				// Only need a message to started process if there are any parameters to pass
-				SendMessage(ilSpyExe, "ILSpy:\r\n" + string.Join(Environment.NewLine, commandLineArguments), true);
-			}
-		}
-
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD110:Observe result of async calls", Justification = "<Pending>")]
-		void SendMessage(string ilSpyExe, string message, bool activate)
-		{
-			string expectedProcessName = Path.GetFileNameWithoutExtension(ilSpyExe);
-			// We wait asynchronously until target window can be found and try to find it multiple times
-			Task.Run(async () => {
-				bool success = false;
-				int remainingAttempts = 20;
-				do
-				{
-					NativeMethods.EnumWindows(
-						(hWnd, lParam) => {
-							string windowTitle = NativeMethods.GetWindowText(hWnd, 100);
-							if (windowTitle.StartsWith("ILSpy", StringComparison.Ordinal))
-							{
-								string processName = NativeMethods.GetProcessNameFromWindow(hWnd);
-								Debug.WriteLine("Found {0:x4}: '{1}' in '{2}'", hWnd, windowTitle, processName);
-								if (string.Equals(processName, expectedProcessName, StringComparison.OrdinalIgnoreCase))
-								{
-									IntPtr result = Send(hWnd, message);
-									Debug.WriteLine("WM_COPYDATA result: {0:x8}", result);
-									if (result == (IntPtr)1)
-									{
-										if (activate)
-											NativeMethods.SetForegroundWindow(hWnd);
-										success = true;
-										return false; // stop enumeration
-									}
-								}
-							}
-							return true; // continue enumeration
-						}, IntPtr.Zero);
-
-					// Wait some time before next attempt
-					await Task.Delay(500);
-					remainingAttempts--;
-				} while (!success && (remainingAttempts > 0));
-			});
-		}
-
-		unsafe static IntPtr Send(IntPtr hWnd, string message)
-		{
-			const uint SMTO_NORMAL = 0;
-
-			CopyDataStruct lParam;
-			lParam.Padding = IntPtr.Zero;
-			lParam.Size = message.Length * 2;
-			fixed (char* buffer = message)
-			{
-				lParam.Buffer = (IntPtr)buffer;
-				IntPtr result;
-				// SendMessage with 3s timeout (e.g. when the target process is stopped in the debugger)
-				if (NativeMethods.SendMessageTimeout(
-					hWnd, NativeMethods.WM_COPYDATA, IntPtr.Zero, ref lParam,
-					SMTO_NORMAL, 3000, out result) != IntPtr.Zero)
-				{
-					return result;
-				}
-				else
-				{
-					return IntPtr.Zero;
-				}
-			}
 		}
 	}
 }

--- a/ILSpy.AddIn.Shared/ILSpyInstance.cs
+++ b/ILSpy.AddIn.Shared/ILSpyInstance.cs
@@ -52,7 +52,7 @@ namespace ICSharpCode.ILSpy.AddIn
 
 			if ((commandLineArguments != null) && commandLineArguments.Any())
 			{
-				string assemblyArguments = string.Join(" ", commandLineArguments);
+				string assemblyArguments = string.Join("\r\n", commandLineArguments);
 
 				string filepath = Path.GetTempFileName();
 				File.WriteAllText(filepath, assemblyArguments);

--- a/ILSpy.AddIn.Shared/ILSpyInstance.cs
+++ b/ILSpy.AddIn.Shared/ILSpyInstance.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -20,8 +21,9 @@ namespace ICSharpCode.ILSpy.AddIn
 
 	class ILSpyInstance
 	{
-		readonly ILSpyParameters parameters;
+		internal static readonly ConcurrentStack<string> TempFiles = new ConcurrentStack<string>();
 
+		readonly ILSpyParameters parameters;
 		public ILSpyInstance(ILSpyParameters parameters = null)
 		{
 			this.parameters = parameters;
@@ -54,6 +56,8 @@ namespace ICSharpCode.ILSpy.AddIn
 
 				string filepath = Path.GetTempFileName();
 				File.WriteAllText(filepath, assemblyArguments);
+
+				TempFiles.Push(filepath);
 
 				argumentsToPass = $"@\"{filepath}\"";
 			}

--- a/ILSpy.AddIn.VS2022/ILSpy.AddIn.VS2022.csproj
+++ b/ILSpy.AddIn.VS2022/ILSpy.AddIn.VS2022.csproj
@@ -70,7 +70,6 @@
     <Compile Include="..\ICSharpCode.Decompiler\Metadata\LightJson\Serialization\TextScanner.cs" Link="Decompiler\LightJson\Serialization\TextScanner.cs" />
     <Compile Include="..\ICSharpCode.Decompiler\Metadata\UniversalAssemblyResolver.cs" Link="UniversalAssemblyResolver.cs" />
     <Compile Include="..\ICSharpCode.Decompiler\Util\EmptyList.cs" Link="Decompiler\EmptyList.cs" />
-    <Compile Include="..\ILSpy\NativeMethods.cs" Link="NativeMethods.cs" />
     <Compile Include="Decompiler\Dummy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/ILSpy.AddIn/ILSpy.AddIn.csproj
+++ b/ILSpy.AddIn/ILSpy.AddIn.csproj
@@ -76,7 +76,6 @@
     <Compile Include="..\ICSharpCode.Decompiler\Metadata\LightJson\Serialization\TextScanner.cs" Link="Decompiler\LightJson\Serialization\TextScanner.cs" />
     <Compile Include="..\ICSharpCode.Decompiler\Metadata\UniversalAssemblyResolver.cs" Link="UniversalAssemblyResolver.cs" />
     <Compile Include="..\ICSharpCode.Decompiler\Util\EmptyList.cs" Link="Decompiler\EmptyList.cs" />
-    <Compile Include="..\ILSpy\NativeMethods.cs" Link="NativeMethods.cs" />
     <Compile Include="Decompiler\Dummy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -53,12 +53,11 @@ namespace ICSharpCode.ILSpy.Tests
 		}
 
 		[Test]
-		public void VerifyCaseSensitivityOfOptionsThrows()
+		public void VerifyCaseSensitivityOfOptionsDoesntThrow()
 		{
-			Action act = () => new CommandLineArguments(new string[] { "--navigateTo:none" });
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--navigateTo:none" });
 
-			act.Should().Throw<McMaster.Extensions.CommandLineUtils.UnrecognizedCommandParsingException>()
-				.WithMessage("Unrecognized option '--navigateTo:none'");
+			cmdLineArgs.ArgumentsParser.RemainingArguments.Should().HaveCount(1);
 		}
 
 		[Test]

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+
+using FluentAssertions;
 
 using NUnit.Framework;
 
@@ -34,6 +36,22 @@ namespace ICSharpCode.ILSpy.Tests
 			const string navigateTo = "MyNamespace.MyClass";
 			var cmdLineArgs = new CommandLineArguments(new string[] { "--navigateto", navigateTo });
 			cmdLineArgs.NavigateTo.Should().BeEquivalentTo(navigateTo);
+		}
+
+		[Test]
+		public void VerifyNavigateToOption_NoneTest_Matching_VSAddin()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--navigateto:none" });
+			cmdLineArgs.NavigateTo.Should().BeEquivalentTo("none");
+		}
+
+		[Test]
+		public void VerifyCaseSensitivityOfOptionsThrows()
+		{
+			Action act = () => new CommandLineArguments(new string[] { "--navigateTo:none" });
+
+			act.Should().Throw<McMaster.Extensions.CommandLineUtils.UnrecognizedCommandParsingException>()
+				.WithMessage("Unrecognized option '--navigateTo:none'");
 		}
 
 		[Test]

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -24,25 +24,75 @@ namespace ICSharpCode.ILSpy.Tests
 		[Test]
 		public void VerifySeparateOption()
 		{
-			var cmdLineArgs = new CommandLineArguments(new string[] { "/separate" });
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--instancing", "Multi" });
 			cmdLineArgs.SingleInstance.Should().BeFalse();
 		}
 
 		[Test]
 		public void VerifySingleInstanceOption()
 		{
-			var cmdLineArgs = new CommandLineArguments(new string[] { "/singleInstance" });
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--instancing", "Single" });
 			cmdLineArgs.SingleInstance.Should().BeTrue();
 		}
 
 		[Test]
-		public void VerifySeparateSingleInstanceOptionOrdering()
+		public void VerifyNavigateToOption()
 		{
-			var cmdLineArgsCase1 = new CommandLineArguments(new string[] { "/singleInstance", "/separate" });
-			cmdLineArgsCase1.SingleInstance.Should().BeFalse();
+			const string navigateTo = "MyNamespace.MyClass";
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--navigateto", navigateTo });
+			cmdLineArgs.NavigateTo.Should().BeEquivalentTo(navigateTo);
+		}
 
-			var cmdLineArgsCase2 = new CommandLineArguments(new string[] { "/separate", "/singleInstance" });
-			cmdLineArgsCase2.SingleInstance.Should().BeTrue();
+		[Test]
+		public void VerifySearchOption()
+		{
+			const string searchWord = "TestContainers";
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--search", searchWord });
+			cmdLineArgs.Search.Should().BeEquivalentTo(searchWord);
+		}
+
+		[Test]
+		public void VerifyLanguageOption()
+		{
+			const string language = "csharp";
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--language", language });
+			cmdLineArgs.Language.Should().BeEquivalentTo(language);
+		}
+
+		[Test]
+		public void VerifyConfigOption()
+		{
+			const string configFile = "myilspyoptions.xml";
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--config", configFile });
+			cmdLineArgs.ConfigFile.Should().BeEquivalentTo(configFile);
+		}
+
+		[Test]
+		public void VerifyNoActivateOption()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--noactivate" });
+			cmdLineArgs.NoActivate.Should().BeTrue();
+		}
+
+		[Test]
+		public void MultipleAssembliesAsArguments()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { "assembly1", "assembly2", "assembly3" });
+			cmdLineArgs.AssembliesToLoad.Should().HaveCount(3);
+		}
+
+		[Test]
+		public void PassAtFileArgumentsSpaceSeparated()
+		{
+			string filepath = System.IO.Path.GetTempFileName();
+
+			System.IO.File.WriteAllText(filepath, "assembly1 assembly2 assembly3 --instancing multi --noactivate");
+
+			var cmdLineArgs = new CommandLineArguments(new string[] { $"@{filepath}" });
+
+			cmdLineArgs.SingleInstance.Should().BeFalse();
+			cmdLineArgs.NoActivate.Should().BeTrue();
+			cmdLineArgs.AssembliesToLoad.Should().HaveCount(3);
 		}
 	}
 }

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -100,13 +100,21 @@ namespace ICSharpCode.ILSpy.Tests
 		}
 
 		[Test]
-		public void PassAtFileArgumentsSpaceSeparated()
+		public void PassAtFileArguments()
 		{
 			string filepath = System.IO.Path.GetTempFileName();
 
-			System.IO.File.WriteAllText(filepath, "assembly1 assembly2 assembly3 --newinstance --noactivate");
+			System.IO.File.WriteAllText(filepath, "assembly1\r\nassembly2\r\nassembly3\r\n--newinstance\r\n--noactivate");
 
 			var cmdLineArgs = new CommandLineArguments(new string[] { $"@{filepath}" });
+
+			try
+			{
+				System.IO.File.Delete(filepath);
+			}
+			catch (Exception)
+			{
+			}
 
 			cmdLineArgs.SingleInstance.Should().BeFalse();
 			cmdLineArgs.NoActivate.Should().BeTrue();

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -1,0 +1,48 @@
+﻿using FluentAssertions;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests
+{
+	[TestFixture]
+	public class CommandLineArgumentsTests
+	{
+		[Test]
+		public void VerifyEmptyArgumentsArray()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { });
+
+			cmdLineArgs.AssembliesToLoad.Should().BeEmpty();
+			cmdLineArgs.SingleInstance.Should().BeNull();
+			cmdLineArgs.NavigateTo.Should().BeNull();
+			cmdLineArgs.Search.Should().BeNull();
+			cmdLineArgs.Language.Should().BeNull();
+			cmdLineArgs.NoActivate.Should().BeFalse();
+			cmdLineArgs.ConfigFile.Should().BeNull();
+		}
+
+		[Test]
+		public void VerifySeparateOption()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { "/separate" });
+			cmdLineArgs.SingleInstance.Should().BeFalse();
+		}
+
+		[Test]
+		public void VerifySingleInstanceOption()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { "/singleInstance" });
+			cmdLineArgs.SingleInstance.Should().BeTrue();
+		}
+
+		[Test]
+		public void VerifySeparateSingleInstanceOptionOrdering()
+		{
+			var cmdLineArgsCase1 = new CommandLineArguments(new string[] { "/singleInstance", "/separate" });
+			cmdLineArgsCase1.SingleInstance.Should().BeFalse();
+
+			var cmdLineArgsCase2 = new CommandLineArguments(new string[] { "/separate", "/singleInstance" });
+			cmdLineArgsCase2.SingleInstance.Should().BeTrue();
+		}
+	}
+}

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -24,6 +24,13 @@ namespace ICSharpCode.ILSpy.Tests
 		}
 
 		[Test]
+		public void VerifyHelpOption()
+		{
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--help" });
+			cmdLineArgs.ArgumentsParser.IsShowingInformation.Should().BeTrue();
+		}
+
+		[Test]
 		public void VerifyForceNewInstanceOption()
 		{
 			var cmdLineArgs = new CommandLineArguments(new string[] { "--newinstance" });

--- a/ILSpy.Tests/CommandLineArgumentsTests.cs
+++ b/ILSpy.Tests/CommandLineArgumentsTests.cs
@@ -22,17 +22,10 @@ namespace ICSharpCode.ILSpy.Tests
 		}
 
 		[Test]
-		public void VerifySeparateOption()
+		public void VerifyForceNewInstanceOption()
 		{
-			var cmdLineArgs = new CommandLineArguments(new string[] { "--instancing", "Multi" });
+			var cmdLineArgs = new CommandLineArguments(new string[] { "--newinstance" });
 			cmdLineArgs.SingleInstance.Should().BeFalse();
-		}
-
-		[Test]
-		public void VerifySingleInstanceOption()
-		{
-			var cmdLineArgs = new CommandLineArguments(new string[] { "--instancing", "Single" });
-			cmdLineArgs.SingleInstance.Should().BeTrue();
 		}
 
 		[Test]
@@ -86,7 +79,7 @@ namespace ICSharpCode.ILSpy.Tests
 		{
 			string filepath = System.IO.Path.GetTempFileName();
 
-			System.IO.File.WriteAllText(filepath, "assembly1 assembly2 assembly3 --instancing multi --noactivate");
+			System.IO.File.WriteAllText(filepath, "assembly1 assembly2 assembly3 --newinstance --noactivate");
 
 			var cmdLineArgs = new CommandLineArguments(new string[] { $"@{filepath}" });
 

--- a/ILSpy.Tests/ILSpy.Tests.csproj
+++ b/ILSpy.Tests/ILSpy.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Analyzers\MethodUsesAnalyzerTests.cs" />
     <Compile Include="Analyzers\TestCases\MainAssembly.cs" />
     <Compile Include="Analyzers\TypeUsedByAnalyzerTests.cs" />
+    <Compile Include="CommandLineArgumentsTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -87,6 +87,11 @@ namespace ICSharpCode.ILSpy
 											  Hyperlink.RequestNavigateEvent,
 											  new RequestNavigateEventHandler(Window_RequestNavigate));
 			ILSpyTraceListener.Install();
+
+			if (App.CommandLineArguments.ArgumentsParser.IsShowingInformation)
+			{
+				MessageBox.Show(App.CommandLineArguments.ArgumentsParser.GetHelpText(), "ILSpy Command Line Arguments");
+			}
 		}
 
 		static Assembly ResolvePluginDependencies(AssemblyLoadContext context, AssemblyName assemblyName)

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -92,6 +92,12 @@ namespace ICSharpCode.ILSpy
 			{
 				MessageBox.Show(App.CommandLineArguments.ArgumentsParser.GetHelpText(), "ILSpy Command Line Arguments");
 			}
+
+			if (App.CommandLineArguments.ArgumentsParser.RemainingArguments.Any())
+			{
+				string unknownArguments = string.Join(", ", App.CommandLineArguments.ArgumentsParser.RemainingArguments);
+				MessageBox.Show(unknownArguments, "ILSpy Unknown Command Line Arguments Passed");
+			}
 		}
 
 		static Assembly ResolvePluginDependencies(AssemblyLoadContext context, AssemblyName assemblyName)

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -54,7 +54,7 @@ namespace ICSharpCode.ILSpy
 				CommandOptionType.NoValue);
 
 			var oNavigateTo = app.Option<string>("-n|--navigateto <TYPENAME>",
-				"Navigates to the member specified by the given ID string.\r\nThe member is searched for only in the assemblies specified on the command line.\r\nExample: 'ILSpy ILSpy.exe --navigateTo:T:ICSharpCode.ILSpy.CommandLineArguments'",
+				"Navigates to the member specified by the given ID string.\r\nThe member is searched for only in the assemblies specified on the command line.\r\nExample: 'ILSpy ILSpy.exe --navigateto:T:ICSharpCode.ILSpy.CommandLineArguments'",
 				CommandOptionType.SingleValue);
 			oNavigateTo.DefaultValue = null;
 

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -23,7 +23,7 @@ using System.Linq;
 
 namespace ICSharpCode.ILSpy
 {
-	sealed class CommandLineArguments
+	public sealed class CommandLineArguments
 	{
 		// see /doc/Command Line.txt for details
 		public List<string> AssembliesToLoad = new List<string>();
@@ -34,6 +34,8 @@ namespace ICSharpCode.ILSpy
 		public bool NoActivate;
 		public string ConfigFile;
 
+		public CommandLineApplication ArgumentsParser { get; }
+
 		public CommandLineArguments(IEnumerable<string> arguments)
 		{
 			var app = new CommandLineApplication() {
@@ -43,6 +45,9 @@ namespace ICSharpCode.ILSpy
 				// Note: options are case-sensitive (!), and, default behavior would be UnrecognizedArgumentHandling.Throw on Parse()
 				// UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue
 			};
+
+			app.HelpOption();
+			ArgumentsParser = app;
 
 			var oForceNewInstance = app.Option("--newinstance",
 				"Start a new instance of ILSpy even if the user configuration is set to single-instance",
@@ -76,7 +81,6 @@ namespace ICSharpCode.ILSpy
 			// To enable this, MultipleValues must be set to true, and the argument must be the last one specified.
 			var files = app.Argument("Assemblies", "Assemblies to load", multipleValues: true);
 
-			// string helptext = app.GetHelpText();
 			app.Parse(arguments.ToArray());
 
 			if (oForceNewInstance.HasValue())

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -47,16 +47,40 @@ namespace ICSharpCode.ILSpy
 				ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
 			};
 
-			var oInstancing = app.Option("-i|--instancing <single/multi>", "Single or multi instance", CommandOptionType.SingleValue);
-			var oNavigateTo = app.Option("-n|--navigateto <TYPENAME>", "Navigates to the member specified by the given ID string", CommandOptionType.SingleValue);
-			var oSearch = app.Option("-s|--search <STRING>", "Search for", CommandOptionType.SingleValue);
-			var oLanguage = app.Option("-l|--language <STRING>", "Selects the specified language", CommandOptionType.SingleValue);
-			var oConfig = app.Option("-c|--config <STRING>", "Search for", CommandOptionType.SingleValue);
-			var oNoActivate = app.Option("--noactivate", "Search for", CommandOptionType.NoValue);
+			var oInstancing = app.Option("-i|--instancing <single/multi>",
+				"Single or multi instance",
+				CommandOptionType.SingleValue);
+
+			var oNavigateTo = app.Option<string>("-n|--navigateto <TYPENAME>",
+				"Navigates to the member specified by the given ID string.\r\nThe member is searched for only in the assemblies specified on the command line.\r\nExample: 'ILSpy ILSpy.exe --navigateTo:T:ICSharpCode.ILSpy.CommandLineArguments'",
+				CommandOptionType.SingleValue);
+			oNavigateTo.DefaultValue = null;
+
+			var oSearch = app.Option<string>("-s|--search <SEARCHTERM>",
+				"Search for t:TypeName, m:Member or c:Constant; use exact match (=term), 'should not contain' (-term) or 'must contain' (+term); use /reg(ular)?Ex(pressions)?/ or both - t:/Type(Name)?/...",
+				CommandOptionType.SingleValue);
+			oSearch.DefaultValue = null;
+
+			var oLanguage = app.Option<string>("-l|--language <LANGUAGEIDENTIFIER>",
+				"Selects the specified language.\r\nExample: 'ILSpy --language:C#' or 'ILSpy --language:IL'",
+				CommandOptionType.SingleValue);
+			oLanguage.DefaultValue = null;
+
+			var oConfig = app.Option<string>("-c|--config <CONFIGFILENAME>",
+				"Provide a specific configuration file.\r\nExample: 'ILSpy --config:myconfig.xml'",
+				CommandOptionType.SingleValue);
+			oConfig.DefaultValue = null;
+
+			var oNoActivate = app.Option("--noactivate",
+				"Do not activate the existing ILSpy instance. This option has no effect if a new ILSpy instance is being started.",
+				CommandOptionType.NoValue);
 
 			// https://natemcmaster.github.io/CommandLineUtils/docs/arguments.html#variable-numbers-of-arguments
 			// To enable this, MultipleValues must be set to true, and the argument must be the last one specified.
 			var files = app.Argument("Assemblies", "Assemblies to load", multipleValues: true);
+
+
+			// string helptext = app.GetHelpText();
 
 			app.Parse(arguments.ToArray());
 
@@ -76,17 +100,10 @@ namespace ICSharpCode.ILSpy
 				}
 			}
 
-			if (oNavigateTo.Value != null)
-				NavigateTo = oNavigateTo.Value();
-
-			if (oSearch.Value != null)
-				Search = oSearch.Value();
-
-			if (oLanguage.Value != null)
-				Language = oLanguage.Value();
-
-			if (oConfig.Value != null)
-				ConfigFile = oConfig.Value();
+			NavigateTo = oNavigateTo.ParsedValue;
+			Search = oSearch.ParsedValue;
+			Language = oLanguage.ParsedValue;
+			ConfigFile = oConfig.ParsedValue;
 
 			if (oNoActivate.HasValue())
 				NoActivate = true;

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -18,9 +18,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+
+using McMaster.Extensions.CommandLineUtils;
+
+using TomsToolbox.Essentials;
 
 namespace ICSharpCode.ILSpy
 {
+	internal enum InstancingMode
+	{
+		Single,
+		Multi
+	}
+
 	sealed class CommandLineArguments
 	{
 		// see /doc/Command Line.txt for details
@@ -34,31 +45,58 @@ namespace ICSharpCode.ILSpy
 
 		public CommandLineArguments(IEnumerable<string> arguments)
 		{
-			foreach (string arg in arguments)
+			var app = new CommandLineApplication() {
+				ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
+			};
+
+			var oInstancing = app.Option("-i|--instancing <single/multi>", "Single or multi instance", CommandOptionType.SingleValue);
+			var oNavigateTo = app.Option("-n|--navigateto <TYPENAME>", "Navigates to the member specified by the given ID string", CommandOptionType.SingleValue);
+			var oSearch = app.Option("-s|--search <STRING>", "Search for", CommandOptionType.SingleValue);
+			var oLanguage = app.Option("-l|--language <STRING>", "Selects the specified language", CommandOptionType.SingleValue);
+			var oConfig = app.Option("-c|--config <STRING>", "Search for", CommandOptionType.SingleValue);
+			var oNoActivate = app.Option("--noactivate", "Search for", CommandOptionType.NoValue);
+
+			// https://natemcmaster.github.io/CommandLineUtils/docs/arguments.html#variable-numbers-of-arguments
+			// To enable this, MultipleValues must be set to true, and the argument must be the last one specified.
+			var files = app.Argument("Assemblies", "Assemblies to load", multipleValues: true);
+
+			app.Parse(arguments.ToArray());
+
+			if (oInstancing.Value != null)
 			{
-				if (arg.Length == 0)
-					continue;
-				if (arg[0] == '/')
+				if (Enum.TryParse<InstancingMode>(oInstancing.Value(), true, out var mode))
 				{
-					if (arg.Equals("/singleInstance", StringComparison.OrdinalIgnoreCase))
-						this.SingleInstance = true;
-					else if (arg.Equals("/separate", StringComparison.OrdinalIgnoreCase))
-						this.SingleInstance = false;
-					else if (arg.StartsWith("/navigateTo:", StringComparison.OrdinalIgnoreCase))
-						this.NavigateTo = arg.Substring("/navigateTo:".Length);
-					else if (arg.StartsWith("/search:", StringComparison.OrdinalIgnoreCase))
-						this.Search = arg.Substring("/search:".Length);
-					else if (arg.StartsWith("/language:", StringComparison.OrdinalIgnoreCase))
-						this.Language = arg.Substring("/language:".Length);
-					else if (arg.Equals("/noActivate", StringComparison.OrdinalIgnoreCase))
-						this.NoActivate = true;
-					else if (arg.StartsWith("/config:", StringComparison.OrdinalIgnoreCase))
-						this.ConfigFile = arg.Substring("/config:".Length);
+					switch (mode)
+					{
+						case InstancingMode.Single:
+							SingleInstance = true;
+							break;
+						case InstancingMode.Multi:
+							SingleInstance = false;
+							break;
+					}
 				}
-				else
-				{
-					this.AssembliesToLoad.Add(arg);
-				}
+			}
+
+			if (oNavigateTo.Value != null)
+				NavigateTo = oNavigateTo.Value();
+
+			if (oSearch.Value != null)
+				Search = oSearch.Value();
+
+			if (oLanguage.Value != null)
+				Language = oLanguage.Value();
+
+			if (oConfig.Value != null)
+				ConfigFile = oConfig.Value();
+
+			if (oNoActivate.HasValue())
+				NoActivate = true;
+
+			foreach (var assembly in files.Values)
+			{
+				if (!string.IsNullOrWhiteSpace(assembly))
+					AssembliesToLoad.Add(assembly);
 			}
 		}
 	}

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.ILSpy
 		{
 			var app = new CommandLineApplication() {
 				// https://natemcmaster.github.io/CommandLineUtils/docs/response-file-parsing.html?tabs=using-attributes
-				ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
+				ResponseFileHandling = ResponseFileHandling.ParseArgsAsLineSeparated,
 
 				// Note: options are case-sensitive (!), and, default behavior would be UnrecognizedArgumentHandling.Throw on Parse()
 				// UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -43,7 +43,7 @@ namespace ICSharpCode.ILSpy
 				ResponseFileHandling = ResponseFileHandling.ParseArgsAsLineSeparated,
 
 				// Note: options are case-sensitive (!), and, default behavior would be UnrecognizedArgumentHandling.Throw on Parse()
-				// UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue
+				UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue
 			};
 
 			app.HelpOption();

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -39,6 +39,9 @@ namespace ICSharpCode.ILSpy
 			var app = new CommandLineApplication() {
 				// https://natemcmaster.github.io/CommandLineUtils/docs/response-file-parsing.html?tabs=using-attributes
 				ResponseFileHandling = ResponseFileHandling.ParseArgsAsSpaceSeparated,
+
+				// Note: options are case-sensitive (!), and, default behavior would be UnrecognizedArgumentHandling.Throw on Parse()
+				// UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue
 			};
 
 			var oForceNewInstance = app.Option("--newinstance",

--- a/ILSpy/CommandLineArguments.cs
+++ b/ILSpy/CommandLineArguments.cs
@@ -16,13 +16,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using McMaster.Extensions.CommandLineUtils;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
-using McMaster.Extensions.CommandLineUtils;
-
-using TomsToolbox.Essentials;
 
 namespace ICSharpCode.ILSpy
 {

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -66,7 +66,6 @@
     <EmbeddedResource Include="TextView\ILAsm-Mode.xshd" />
     <EmbeddedResource Include="TextView\Asm-Mode.xshd" />
     <EmbeddedResource Include="TextView\XML-Mode.xshd" />
-    <None Remove="Properties\launchSettings.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
     <PackageReference Include="DataGridExtensions" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />

--- a/ILSpy/Properties/launchSettings.json
+++ b/ILSpy/Properties/launchSettings.json
@@ -2,12 +2,12 @@
 	"profiles": {
 		"ILSpy": {
 			"commandName": "Executable",
-			"executablePath": ".\\ILSpy.exe",
+			"executablePath": "./ilspy.exe",
 			"commandLineArgs": "--newinstance"
 		},
 		"ILSpy single-instance": {
 			"commandName": "Executable",
-			"executablePath": ".\\ILSpy.exe"
+			"executablePath": "./ilspy.exe"
 		}
 	}
 }

--- a/ILSpy/Properties/launchSettings.json
+++ b/ILSpy/Properties/launchSettings.json
@@ -1,13 +1,13 @@
 {
-  "profiles": {
-    "ILSpy": {
-      "commandName": "Executable",
-      "executablePath": ".\\ILSpy.exe",
-      "commandLineArgs": "/separate"
-    },
-    "ILSpy single-instance": {
-      "commandName": "Executable",
-      "executablePath": ".\\ILSpy.exe"
-    }
-  }
+	"profiles": {
+		"ILSpy": {
+			"commandName": "Executable",
+			"executablePath": ".\\ILSpy.exe",
+			"commandLineArgs": "--newinstance"
+		},
+		"ILSpy single-instance": {
+			"commandName": "Executable",
+			"executablePath": ".\\ILSpy.exe"
+		}
+	}
 }

--- a/ILSpy/SingleInstanceHandling.cs
+++ b/ILSpy/SingleInstanceHandling.cs
@@ -64,10 +64,14 @@ namespace ICSharpCode.ILSpy
 		{
 			// Fully qualify the paths before passing them to another process,
 			// because that process might use a different current directory.
-			if (string.IsNullOrEmpty(argument) || argument[0] == '/')
+			if (string.IsNullOrEmpty(argument) || argument[0] == '-')
 				return argument;
 			try
 			{
+				if (argument.StartsWith("@"))
+				{
+					return "@" + FullyQualifyPath(argument.Substring(1));
+				}
 				return Path.Combine(Environment.CurrentDirectory, argument);
 			}
 			catch (ArgumentException)

--- a/doc/Command Line.txt
+++ b/doc/Command Line.txt
@@ -1,54 +1,27 @@
 ﻿ILSpy Command Line Arguments
 
-Command line arguments can be either options or file names.
-If an argument is a file name, the file will be opened as assembly and added to the current assembly list.
+Usage:  <Assemblies> [options]
+        @ResponseFile.rsp
 
-Available options:
-    /singleInstance    If ILSpy is already running, activates the existing instance
-                       and passes command line arguments to that instance.
-                       This is the default value if /list is not used.
-    
-    /separate          Start up a separate ILSpy instance even if it is already running.
-    
-    /noActivate        Do not activate the existing ILSpy instance. This option has no effect
-                       if a new ILSpy instance is being started.
-    
-    /list:listname     Specifies the name of the assembly list that is loaded initially.
-                       When this option is not specified, ILSpy loads the previously opened list.
-                       Specify "/list" (without value) to open the default list.
-                       
-                       When this option is used, ILSpy will activate an existing instance
-                       only if it uses the same list as specified.
-                       
-                       [Note: Assembly Lists are not yet implemented]
-    
-    /clearList         Clears the assembly list before loading the specified assemblies.
-                       [Note: Assembly Lists are not yet implemented]
-    
-    /navigateTo:tag    Navigates to the member specified by the given ID string.
-                       The member is searched for only in the assemblies specified on the command line.
-                       Example: 'ILSpy ILSpy.exe /navigateTo:T:ICSharpCode.ILSpy.CommandLineArguments'
-                       
-                       The syntax of ID strings is described in appendix A of the C# language specification.
-    
-    /language:name     Selects the specified language.
-                       Example: 'ILSpy /language:C#' or 'ILSpy /language:IL'
+Arguments:
+  Assemblies                          Assemblies to load
 
-WM_COPYDATA (SendMessage API):
-    ILSpy can be controlled by other programs that send a WM_COPYDATA message to its main window.
-    The message data must be an Unicode (UTF-16) string starting with "ILSpy:\r\n".
-    All lines except the first ("ILSpy:") in that string are handled as command-line arguments.
-    There must be exactly one argument per line.
-    
-    That is, by sending this message:
-        ILSpy:
-        C:\Assembly.dll
-        /navigateTo:T:Type
-    The target ILSpy instance will open C:\Assembly.dll and navigate to the specified type.
-    
-    ILSpy will return TRUE (1) if it handles the message, and FALSE (0) otherwise.
-    The /separate option will be ignored; WM_COPYDATA will never start up a new instance.
-    The /noActivate option has no effect, sending WM_COPYDATA will never activate the window.
-    Instead, the calling process should use SetForegroundWindow().
-    If you use /list with WM_COPYDATA, you need to specify /singleInstance as well, otherwise
-    ILSpy will not handle the message if it has opened a different assembly list.
+Options:
+  --newinstance                       Start a new instance of ILSpy even if the user configuration is set to single-instance
+  -n|--navigateto <TYPENAME>          Navigates to the member specified by the given ID string.
+                                      The member is searched for only in the assemblies specified on the command line.
+                                      Example: 'ILSpy ILSpy.exe --navigateTo:T:ICSharpCode.ILSpy.CommandLineArguments'
+  -s|--search <SEARCHTERM>            Search for t:TypeName, m:Member or c:Constant; use exact match (=term),
+                                      'should not contain' (-term) or 'must contain' (+term); use
+                                      /reg(ular)?Ex(pressions)?/ or both - t:/Type(Name)?/...
+  -l|--language <LANGUAGEIDENTIFIER>  Selects the specified language.
+                                      Example: 'ILSpy --language:C#' or 'ILSpy --language:IL'
+  -c|--config <CONFIGFILENAME>        Provide a specific configuration file.
+                                      Example: 'ILSpy --config:myconfig.xml'
+  --noactivate                        Do not activate the existing ILSpy instance. 
+                                      This option has no effect if a new ILSpy instance is being started.
+
+Note on @ResponseFile.rsp: 
+
+* The response file should contain the arguments as if they were passed on the command line (space-separated).
+* Use it when the list of assemblies is too long to fit on the command line.

--- a/doc/Command Line.txt
+++ b/doc/Command Line.txt
@@ -23,5 +23,5 @@ Options:
 
 Note on @ResponseFile.rsp: 
 
-* The response file should contain the arguments as if they were passed on the command line (space-separated).
+* The response file should contain the arguments, one argument per line (not space-separated!).
 * Use it when the list of assemblies is too long to fit on the command line.

--- a/publishlocaldev.ps1
+++ b/publishlocaldev.ps1
@@ -1,7 +1,13 @@
-# For local development of the VSIX package - build and publish the x64 build only
+# For local development of the VSIX package - build and publish (VS2022 also needs arm64)
 
 $output_x64 = "./ILSpy/bin/Debug/net8.0-windows/win-x64/publish/fwdependent"
 
 dotnet publish ./ILSpy/ILSpy.csproj -c Debug --no-restore --no-self-contained -r win-x64 -o $output_x64
 dotnet publish ./ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj -c Debug --no-restore --no-self-contained -r win-x64 -o $output_x64
 dotnet publish ./ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj -c Debug --no-restore --no-self-contained -r win-x64 -o $output_x64
+
+$output_arm64 = "./ILSpy/bin/Debug/net8.0-windows/win-arm64/publish/fwdependent"
+
+dotnet publish ./ILSpy/ILSpy.csproj -c Debug --no-restore --no-self-contained -r win-arm64 -o $output_arm64
+dotnet publish ./ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj -c Debug --no-restore --no-self-contained -r win-arm64 -o $output_arm64
+dotnet publish ./ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj -c Debug --no-restore --no-self-contained -r win-arm64 -o $output_arm64

--- a/publishlocaldev.ps1
+++ b/publishlocaldev.ps1
@@ -1,0 +1,7 @@
+# For local development of the VSIX package - build and publish the x64 build only
+
+$output_x64 = "./ILSpy/bin/Debug/net8.0-windows/win-x64/publish/fwdependent"
+
+dotnet publish ./ILSpy/ILSpy.csproj -c Debug --no-restore --no-self-contained -r win-x64 -o $output_x64
+dotnet publish ./ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj -c Debug --no-restore --no-self-contained -r win-x64 -o $output_x64
+dotnet publish ./ILSpy.BamlDecompiler/ILSpy.BamlDecompiler.csproj -c Debug --no-restore --no-self-contained -r win-x64 -o $output_x64


### PR DESCRIPTION
See the amended "Command Line.txt".

Notes:
* `singleInstance` is removed. Reason: if the user has a configuration for allowing multiple instances of ILSpy and there are already multiple instances actually running, we cannot enforce that parameter anyways.
* `separate` has been replaced with `newinstance`. This will always open a new instance of ILSpy irrespective of what the user has configured.
* we no longer use `/` but standard `--` for options
* we now support `@file` for passing command line parameters
* VS Addin uses the new `@file` approach