### PR TITLE
fixes: Decompile Package (.nuget;.vsix; ecc...)

### DIFF
--- a/ICSharpCode.ILSpyX/FileLoaders/ArchiveFileLoader.cs
+++ b/ICSharpCode.ILSpyX/FileLoaders/ArchiveFileLoader.cs
@@ -25,6 +25,11 @@ namespace ICSharpCode.ILSpyX.FileLoaders
 	{
 		public Task<LoadResult?> Load(string fileName, Stream stream, FileLoadSettings settings)
 		{
+			if (!File.Exists(fileName))
+			{
+				return Task.FromResult<LoadResult?>(null);
+			}
+
 			try
 			{
 				var zip = LoadedPackage.FromZipFile(fileName);

--- a/ICSharpCode.ILSpyX/FileLoaders/BundleFileLoader.cs
+++ b/ICSharpCode.ILSpyX/FileLoaders/BundleFileLoader.cs
@@ -25,6 +25,10 @@ namespace ICSharpCode.ILSpyX.FileLoaders
 	{
 		public Task<LoadResult?> Load(string fileName, Stream stream, FileLoadSettings settings)
 		{
+			if (!File.Exists(fileName))
+			{
+				return Task.FromResult(default(LoadResult?));
+			}
 			var bundle = LoadedPackage.FromBundle(fileName);
 			var result = bundle != null ? new LoadResult { Package = bundle } : null;
 			return Task.FromResult(result);

--- a/ICSharpCode.ILSpyX/FileLoaders/WebCilFileLoader.cs
+++ b/ICSharpCode.ILSpyX/FileLoaders/WebCilFileLoader.cs
@@ -28,6 +28,12 @@ namespace ICSharpCode.ILSpyX.FileLoaders
 	{
 		public Task<LoadResult?> Load(string fileName, Stream stream, FileLoadSettings settings)
 		{
+
+			if (!File.Exists(fileName))
+			{
+				return Task.FromResult<LoadResult?>(null);
+			}
+
 			MetadataReaderOptions options = settings.ApplyWinRTProjections
 						? MetadataReaderOptions.ApplyWindowsRuntimeProjections
 						: MetadataReaderOptions.None;

--- a/ILSpy/TreeNodes/PackageFolderTreeNode.cs
+++ b/ILSpy/TreeNodes/PackageFolderTreeNode.cs
@@ -67,7 +67,8 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			}
 			foreach (var entry in root.Entries.OrderBy(e => e.Name))
 			{
-				if (entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+				if (entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+					|| entry.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
 				{
 					var asm = root.ResolveFileName(entry.Name);
 					if (asm != null)


### PR DESCRIPTION
- Avoid exception on ArchiveFileLoader, BundleFileLoader and WebCilFileLoader
- Try Resolve .exe file

Link to issue(s) this covers

### Problem
in the last master d7771486d20206d94481f0a0f49275a101dc60c3, if you try to load the nuget or vsix package, when you select a library in the decompiler tab a FileLoadException is reported

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
* Which part of this PR is most in need of attention/improvement?
* [ ] At least one test covering the code changed

