### PR TITLE
Fix dotnet-format to v8 via transport feed for dotnet8

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -35,7 +35,7 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Install dotnet-format
-      run: dotnet tool install -g dotnet-format --version "6.2.315104" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json
+      run: dotnet tool install -g dotnet-format --version "8.0.453106" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
 
     - name: Get Version
       id: version

--- a/BuildTools/pre-commit
+++ b/BuildTools/pre-commit
@@ -5,10 +5,10 @@
 
 set -eu
 
-DOTNET_FORMAT_VERSION=6.2.315104
+DOTNET_FORMAT_VERSION=8.0.453106
 DOTNET_PATH="$LOCALAPPDATA/ICSharpCode/ILSpy/dotnet-format-$DOTNET_FORMAT_VERSION"
 if [ ! -d "$DOTNET_PATH" ]; then
- dotnet tool install --tool-path "$DOTNET_PATH" dotnet-format --version "$DOTNET_FORMAT_VERSION" --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json"
+ dotnet tool install --tool-path "$DOTNET_PATH" dotnet-format --version "$DOTNET_FORMAT_VERSION" --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json"
 fi
 
 "$DOTNET_PATH/dotnet-format.exe" --version

--- a/ICSharpCode.ILSpyX/Analyzers/AnalyzerContext.cs
+++ b/ICSharpCode.ILSpyX/Analyzers/AnalyzerContext.cs
@@ -34,49 +34,49 @@ namespace ICSharpCode.ILSpyX.Analyzers
 	{
 		public required AssemblyList AssemblyList { get; init; }
 
-	/// <summary>
-	/// CancellationToken. Currently Analyzers do not support cancellation from the UI, but it should be checked nonetheless.
-	/// </summary>
-	public CancellationToken CancellationToken { get; init; }
+		/// <summary>
+		/// CancellationToken. Currently Analyzers do not support cancellation from the UI, but it should be checked nonetheless.
+		/// </summary>
+		public CancellationToken CancellationToken { get; init; }
 
-	/// <summary>
-	/// Currently used language.
-	/// </summary>
-	public required ILanguage Language { get; init; }
+		/// <summary>
+		/// Currently used language.
+		/// </summary>
+		public required ILanguage Language { get; init; }
 
-/// <summary>
-/// Allows the analyzer to control whether the tree nodes will be sorted.
-/// Must be set within <see cref="IAnalyzer.Analyze(ISymbol, AnalyzerContext)"/>
-/// before the results are enumerated.
-/// </summary>
-public bool SortResults { get; set; }
+		/// <summary>
+		/// Allows the analyzer to control whether the tree nodes will be sorted.
+		/// Must be set within <see cref="IAnalyzer.Analyze(ISymbol, AnalyzerContext)"/>
+		/// before the results are enumerated.
+		/// </summary>
+		public bool SortResults { get; set; }
 
-public MethodBodyBlock? GetMethodBody(IMethod method)
-{
-	if (!method.HasBody || method.MetadataToken.IsNil || method.ParentModule?.MetadataFile == null)
-		return null;
-	var module = method.ParentModule.MetadataFile;
-	var md = module.Metadata.GetMethodDefinition((MethodDefinitionHandle)method.MetadataToken);
-	try
-	{
-		return module.GetMethodBody(md.RelativeVirtualAddress);
-	}
-	catch (BadImageFormatException)
-	{
-		return null;
-	}
-}
+		public MethodBodyBlock? GetMethodBody(IMethod method)
+		{
+			if (!method.HasBody || method.MetadataToken.IsNil || method.ParentModule?.MetadataFile == null)
+				return null;
+			var module = method.ParentModule.MetadataFile;
+			var md = module.Metadata.GetMethodDefinition((MethodDefinitionHandle)method.MetadataToken);
+			try
+			{
+				return module.GetMethodBody(md.RelativeVirtualAddress);
+			}
+			catch (BadImageFormatException)
+			{
+				return null;
+			}
+		}
 
-public AnalyzerScope GetScopeOf(IEntity entity)
-{
-	return new AnalyzerScope(AssemblyList, entity);
-}
+		public AnalyzerScope GetScopeOf(IEntity entity)
+		{
+			return new AnalyzerScope(AssemblyList, entity);
+		}
 
-readonly ConcurrentDictionary<MetadataFile, DecompilerTypeSystem> typeSystemCache = new();
+		readonly ConcurrentDictionary<MetadataFile, DecompilerTypeSystem> typeSystemCache = new();
 
-public DecompilerTypeSystem GetOrCreateTypeSystem(MetadataFile module)
-{
-	return typeSystemCache.GetOrAdd(module, m => new DecompilerTypeSystem(m, m.GetAssemblyResolver()));
-}
+		public DecompilerTypeSystem GetOrCreateTypeSystem(MetadataFile module)
+		{
+			return typeSystemCache.GetOrAdd(module, m => new DecompilerTypeSystem(m, m.GetAssemblyResolver()));
+		}
 	}
 }


### PR DESCRIPTION
See also PR #2747 

```
You can invoke the tool using the following command: dotnet-format
Tool 'dotnet-format' (version '8.0.453106') was successfully installed.
8.0.453106+2651752953c0d41c8c7b8d661cf2237151af33d0
  The dotnet runtime version is '8.0.7'.
  Formatting code files in workspace 'Z:\GitWorkspace\ILSpy\ILSpy.sln'.
```

