### PR TITLE
Add smooth scrolling behavior to settings panels and DecompilerTextView

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.15.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.16.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
 </Project>

--- a/ILSpy/Controls/ZoomScrollViewer.cs
+++ b/ILSpy/Controls/ZoomScrollViewer.cs
@@ -108,7 +108,7 @@ namespace ICSharpCode.ILSpy.Controls
 				z.ComputedZoomButtonCollapsed = (z.AlwaysShowZoomButtons == false) && (z.CurrentZoom == 1.0);
 		}
 
-		protected override void OnMouseWheel(MouseWheelEventArgs e)
+		protected override void OnPreviewMouseWheel(MouseWheelEventArgs e)
 		{
 			if (!e.Handled && Keyboard.Modifiers == ModifierKeys.Control && MouseWheelZoom)
 			{
@@ -165,7 +165,7 @@ namespace ICSharpCode.ILSpy.Controls
 
 				e.Handled = true;
 			}
-			base.OnMouseWheel(e);
+			base.OnPreviewMouseWheel(e);
 		}
 
 		internal static double RoundToOneIfClose(double val)

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -3,7 +3,7 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:properties="clr-namespace:ICSharpCode.ILSpy.Properties"
-	xmlns:options="clr-namespace:ICSharpCode.ILSpy.Options">
+	xmlns:toms="urn:TomsToolbox">
 	<UserControl.Resources>
 		<CollectionViewSource x:Key="SettingsCollection" Source="{Binding Settings}">
 			<CollectionViewSource.GroupDescriptions>
@@ -20,7 +20,7 @@
 			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<TextBlock Margin="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Text="{x:Static properties:Resources.DecompilerSettingsPanelLongText}" />
-		<ListBox Grid.Row="1" ItemsSource="{Binding Source={StaticResource SettingsCollection}}">
+		<ListBox Grid.Row="1" ItemsSource="{Binding Source={StaticResource SettingsCollection}}" toms:SmoothScrollingBehavior.Register="True">
 			<ListBox.ItemContainerStyle>
 				<Style TargetType="ListBoxItem">
 					<Setter Property="IsTabStop" Value="False"/>

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -7,11 +7,12 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
+			 xmlns:toms="urn:TomsToolbox"
 			 d:DataContext="{d:DesignInstance local:DisplaySettingsViewModel}">
 	<UserControl.Resources>
 		<local:FontSizeConverter x:Key="fontSizeConv" />
 	</UserControl.Resources>
-	<ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+	<ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" toms:SmoothScrollingBehavior.Register="True">
 		<StackPanel Orientation="Vertical">
 			<DockPanel>
 				<Label DockPanel.Dock="Left" Content="{x:Static properties:Resources.DisplaySettingsPanel_Theme}" />

--- a/ILSpy/TextView/DecompilerTextView.xaml
+++ b/ILSpy/TextView/DecompilerTextView.xaml
@@ -7,6 +7,7 @@
              xmlns:editing="clr-namespace:ICSharpCode.AvalonEdit.Editing;assembly=ICSharpCode.AvalonEdit"
              xmlns:folding="clr-namespace:ICSharpCode.AvalonEdit.Folding;assembly=ICSharpCode.AvalonEdit"
              xmlns:styles="urn:TomsToolbox.Wpf.Styles"
+             xmlns:toms="urn:TomsToolbox"
              xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes">
 	<UserControl.Resources>
 		<BooleanToVisibilityConverter x:Key="boolToVisibility" />
@@ -81,7 +82,8 @@
 								Padding="{TemplateBinding Padding}"
 								BorderBrush="{TemplateBinding BorderBrush}"
 								BorderThickness="{TemplateBinding BorderThickness}"
-								TextOptions.TextFormattingMode="{Binding CurrentZoom, ElementName=PART_ScrollViewer, Converter={x:Static local:ZoomLevelToTextFormattingModeConverter.Instance}}" />
+								TextOptions.TextFormattingMode="{Binding CurrentZoom, ElementName=PART_ScrollViewer, Converter={x:Static local:ZoomLevelToTextFormattingModeConverter.Instance}}" 
+								toms:SmoothScrollingBehavior.Register="true"/>
 							<ControlTemplate.Triggers>
 								<Trigger Property="WordWrap"
 								         Value="True">


### PR DESCRIPTION
supersedes #3234 by @SlimeNull; code has been cleaned up and moved to [TomsToolbox](https://github.com/tom-englert/TomsToolbox/blob/master/src/TomsToolbox.Wpf/Interactivity/SmoothScrollingBehavior.cs)

