### PR TITLE
Fixes #3251: Decompiler Settings: Checkbox in group header does not reflect state of the group

### DIFF
--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -7,13 +7,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:options="clr-namespace:ICSharpCode.ILSpy.Options"
              d:DataContext="{d:DesignInstance options:DecompilerSettingsViewModel}">
-	<UserControl.Resources>
-		<CollectionViewSource x:Key="SettingsCollection" Source="{Binding Settings}">
-			<CollectionViewSource.GroupDescriptions>
-				<PropertyGroupDescription PropertyName="Category" />
-			</CollectionViewSource.GroupDescriptions>
-		</CollectionViewSource>
-	</UserControl.Resources>
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
@@ -24,33 +17,26 @@
 		</Grid.ColumnDefinitions>
 		<TextBlock Margin="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Text="{x:Static properties:Resources.DecompilerSettingsPanelLongText}" />
 		<ScrollViewer Grid.Row="1">
-			<ItemsControl ItemsSource="{Binding Source={StaticResource SettingsCollection}}">
-				<ItemsControl.GroupStyle>
-					<GroupStyle>
-						<GroupStyle.ContainerStyle>
-							<Style TargetType="{x:Type GroupItem}" BasedOn="{StaticResource {x:Type GroupItem}}">
-								<Setter Property="Template">
-									<Setter.Value>
-										<ControlTemplate TargetType="GroupItem">
-											<Expander Padding="0" BorderThickness="0" IsExpanded="True">
-												<Expander.Header>
-													<CheckBox Checked="OnGroupChecked" Unchecked="OnGroupUnchecked" Loaded="OnGroupLoaded" VerticalContentAlignment="Center" 
-													          FontSize="16" FontWeight="Bold" 
-													          d:DataContext="{d:DesignInstance GroupItem}" 
-													          Content="{Binding Name}" />
-												</Expander.Header>
-												<ItemsPresenter />
-											</Expander>
-										</ControlTemplate>
-									</Setter.Value>
-								</Setter>
-							</Style>
-						</GroupStyle.ContainerStyle>
-					</GroupStyle>
-				</ItemsControl.GroupStyle>
+			<ItemsControl ItemsSource="{Binding Settings}">
 				<ItemsControl.ItemTemplate>
 					<DataTemplate>
-						<CheckBox Margin="19,0,0,0" IsChecked="{Binding IsEnabled}" Content="{Binding Description}" />
+						<Grid>
+							<Expander Padding="0" BorderThickness="0" IsExpanded="True">
+								<Expander.Header>
+									<CheckBox VerticalContentAlignment="Center" 
+									          FontSize="16" FontWeight="Bold" 
+									          Content="{Binding Category}"
+									          IsChecked="{Binding AreAllItemsChecked, Mode=TwoWay}"/>
+								</Expander.Header>
+								<ItemsControl ItemsSource="{Binding Settings}">
+									<ItemsControl.ItemTemplate>
+										<DataTemplate>
+											<CheckBox Margin="28,0,0,0" IsChecked="{Binding IsEnabled}" Content="{Binding Description}" />
+										</DataTemplate>
+									</ItemsControl.ItemTemplate>
+								</ItemsControl>
+							</Expander>
+						</Grid>
 					</DataTemplate>
 				</ItemsControl.ItemTemplate>
 			</ItemsControl>

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -7,16 +7,9 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:options="clr-namespace:ICSharpCode.ILSpy.Options"
              d:DataContext="{d:DesignInstance options:DecompilerSettingsViewModel}">
-	<Grid>
-		<Grid.RowDefinitions>
-			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
-		</Grid.RowDefinitions>
-		<Grid.ColumnDefinitions>
-			<ColumnDefinition Width="*" />
-		</Grid.ColumnDefinitions>
-		<TextBlock Margin="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Text="{x:Static properties:Resources.DecompilerSettingsPanelLongText}" />
-		<ScrollViewer Grid.Row="1">
+	<DockPanel>
+		<TextBlock Margin="3" DockPanel.Dock="Top" TextWrapping="Wrap" Text="{x:Static properties:Resources.DecompilerSettingsPanelLongText}" />
+		<ScrollViewer>
 			<ItemsControl ItemsSource="{Binding Settings}">
 				<ItemsControl.ItemTemplate>
 					<DataTemplate>
@@ -41,5 +34,5 @@
 				</ItemsControl.ItemTemplate>
 			</ItemsControl>
 		</ScrollViewer>
-	</Grid>
+	</DockPanel>
 </UserControl>

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml
@@ -1,9 +1,12 @@
 ﻿<UserControl x:Class="ICSharpCode.ILSpy.Options.DecompilerSettingsPanel"
              x:ClassModifier="internal"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:properties="clr-namespace:ICSharpCode.ILSpy.Properties"
-	xmlns:toms="urn:TomsToolbox">
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:properties="clr-namespace:ICSharpCode.ILSpy.Properties"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:options="clr-namespace:ICSharpCode.ILSpy.Options"
+             d:DataContext="{d:DesignInstance options:DecompilerSettingsViewModel}">
 	<UserControl.Resources>
 		<CollectionViewSource x:Key="SettingsCollection" Source="{Binding Settings}">
 			<CollectionViewSource.GroupDescriptions>
@@ -20,44 +23,37 @@
 			<ColumnDefinition Width="*" />
 		</Grid.ColumnDefinitions>
 		<TextBlock Margin="3" Grid.ColumnSpan="3" TextWrapping="Wrap" Text="{x:Static properties:Resources.DecompilerSettingsPanelLongText}" />
-		<ListBox Grid.Row="1" ItemsSource="{Binding Source={StaticResource SettingsCollection}}">
-			<ListBox.ItemContainerStyle>
-				<Style TargetType="ListBoxItem">
-					<Setter Property="IsTabStop" Value="False"/>
-					<Setter Property="Focusable" Value="False"/>
-				</Style>
-			</ListBox.ItemContainerStyle>
-			<ListBox.GroupStyle>
-				<GroupStyle>
-					<GroupStyle.Panel>
-						<ItemsPanelTemplate>
-							<VirtualizingStackPanel Orientation="Vertical" />
-						</ItemsPanelTemplate>
-					</GroupStyle.Panel>
-					<GroupStyle.ContainerStyle>
-						<Style TargetType="{x:Type GroupItem}" BasedOn="{StaticResource {x:Type GroupItem}}">
-							<Setter Property="Template">
-								<Setter.Value>
-									<ControlTemplate>
-										<Expander Padding="0" BorderThickness="0" IsExpanded="True">
-											<Expander.Header>
-												<CheckBox Checked="OnGroupChecked" Unchecked="OnGroupUnchecked" Loaded="OnGroupLoaded" VerticalContentAlignment="Center"
-														  FontSize="16" FontWeight="Bold" Content="{Binding Name}" />
-											</Expander.Header>
-											<ItemsPresenter/>
-										</Expander>
-									</ControlTemplate>
-								</Setter.Value>
-							</Setter>
-						</Style>
-					</GroupStyle.ContainerStyle>
-				</GroupStyle>
-			</ListBox.GroupStyle>
-			<ListBox.ItemTemplate>
-				<DataTemplate>
-					<CheckBox Margin="19,0,0,0" IsChecked="{Binding IsEnabled}" Content="{Binding Description}" />
-				</DataTemplate>
-			</ListBox.ItemTemplate>
-		</ListBox>
+		<ScrollViewer Grid.Row="1">
+			<ItemsControl ItemsSource="{Binding Source={StaticResource SettingsCollection}}">
+				<ItemsControl.GroupStyle>
+					<GroupStyle>
+						<GroupStyle.ContainerStyle>
+							<Style TargetType="{x:Type GroupItem}" BasedOn="{StaticResource {x:Type GroupItem}}">
+								<Setter Property="Template">
+									<Setter.Value>
+										<ControlTemplate TargetType="GroupItem">
+											<Expander Padding="0" BorderThickness="0" IsExpanded="True">
+												<Expander.Header>
+													<CheckBox Checked="OnGroupChecked" Unchecked="OnGroupUnchecked" Loaded="OnGroupLoaded" VerticalContentAlignment="Center" 
+													          FontSize="16" FontWeight="Bold" 
+													          d:DataContext="{d:DesignInstance GroupItem}" 
+													          Content="{Binding Name}" />
+												</Expander.Header>
+												<ItemsPresenter />
+											</Expander>
+										</ControlTemplate>
+									</Setter.Value>
+								</Setter>
+							</Style>
+						</GroupStyle.ContainerStyle>
+					</GroupStyle>
+				</ItemsControl.GroupStyle>
+				<ItemsControl.ItemTemplate>
+					<DataTemplate>
+						<CheckBox Margin="19,0,0,0" IsChecked="{Binding IsEnabled}" Content="{Binding Description}" />
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+		</ScrollViewer>
 	</Grid>
 </UserControl>

--- a/ILSpy/Options/DecompilerSettingsPanel.xaml.cs
+++ b/ILSpy/Options/DecompilerSettingsPanel.xaml.cs
@@ -16,12 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
 using System.Xml.Linq;
 
 using ICSharpCode.ILSpyX.Settings;
@@ -32,7 +26,7 @@ namespace ICSharpCode.ILSpy.Options
 	/// Interaction logic for DecompilerSettingsPanel.xaml
 	/// </summary>
 	[ExportOptionPage(Title = nameof(Properties.Resources.Decompiler), Order = 10)]
-	internal partial class DecompilerSettingsPanel : UserControl, IOptionPage
+	internal partial class DecompilerSettingsPanel : IOptionPage
 	{
 		public DecompilerSettingsPanel()
 		{
@@ -59,58 +53,9 @@ namespace ICSharpCode.ILSpy.Options
 			MainWindow.Instance.AssemblyListManager.UseDebugSymbols = newSettings.UseDebugSymbols;
 		}
 
-		private void OnGroupChecked(object sender, RoutedEventArgs e)
-		{
-			CheckGroup((CollectionViewGroup)((CheckBox)sender).DataContext, true);
-		}
-		private void OnGroupUnchecked(object sender, RoutedEventArgs e)
-		{
-			CheckGroup((CollectionViewGroup)((CheckBox)sender).DataContext, false);
-		}
-
-		void CheckGroup(CollectionViewGroup group, bool value)
-		{
-			foreach (var item in group.Items)
-			{
-				switch (item)
-				{
-					case CollectionViewGroup subGroup:
-						CheckGroup(subGroup, value);
-						break;
-					case CSharpDecompilerSetting setting:
-						setting.IsEnabled = value;
-						break;
-				}
-			}
-		}
-
-		bool IsGroupChecked(CollectionViewGroup group)
-		{
-			bool value = true;
-			foreach (var item in group.Items)
-			{
-				switch (item)
-				{
-					case CollectionViewGroup subGroup:
-						value = value && IsGroupChecked(subGroup);
-						break;
-					case CSharpDecompilerSetting setting:
-						value = value && setting.IsEnabled;
-						break;
-				}
-			}
-			return value;
-		}
-
-		private void OnGroupLoaded(object sender, RoutedEventArgs e)
-		{
-			CheckBox checkBox = (CheckBox)sender;
-			checkBox.IsChecked = IsGroupChecked((CollectionViewGroup)checkBox.DataContext);
-		}
-
 		public void LoadDefaults()
 		{
-			MainWindow.Instance.CurrentDecompilerSettings = new Decompiler.DecompilerSettings();
+			MainWindow.Instance.CurrentDecompilerSettings = new();
 			this.DataContext = new DecompilerSettingsViewModel(MainWindow.Instance.CurrentDecompilerSettings);
 		}
 	}

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -7,7 +7,6 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d"
 			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 			 xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
-			 xmlns:toms="urn:TomsToolbox"
 			 d:DataContext="{d:DesignInstance local:DisplaySettingsViewModel}">
 	<UserControl.Resources>
 		<local:FontSizeConverter x:Key="fontSizeConv" />


### PR DESCRIPTION
Fixes #3251 #3249
Supersedes #3250 

### Problem
Decompiler Settings: Checkbox in group header does not reflect state of the group

### Solution
* Move the logic from UI to ViewModel, and implement it following WPF best practices .
* [ ] At least one test covering the code changed => Xaml is not covered by tests

