### PR TITLE
Ignore empty version directories of dotnet

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
+++ b/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
@@ -249,21 +249,22 @@ namespace ICSharpCode.Decompiler.Metadata
 		static string GetClosestVersionFolder(string basePath, Version version)
 		{
 			var foundVersions = new DirectoryInfo(basePath).GetDirectories()
-				.Select(d => ConvertToVersion(d.Name))
+				.Select(ConvertToVersion)
 				.Where(v => v.version != null);
 			foreach (var folder in foundVersions.OrderBy(v => v.version))
 			{
 				if (folder.version >= version)
-					return folder.directoryName;
+					if(folder.directory.EnumerateFiles().Any())
+						return folder.directory.Name;
 			}
 			return version.ToString();
 		}
 
-		internal static (Version version, string directoryName) ConvertToVersion(string name)
+		internal static (Version version, DirectoryInfo directory) ConvertToVersion(DirectoryInfo directory)
 		{
 			string RemoveTrailingVersionInfo()
 			{
-				string shortName = name;
+				string shortName = directory.Name;
 				int dashIndex = shortName.IndexOf('-');
 				if (dashIndex > 0)
 				{
@@ -274,7 +275,7 @@ namespace ICSharpCode.Decompiler.Metadata
 
 			try
 			{
-				return (new Version(RemoveTrailingVersionInfo()), name);
+				return (new Version(RemoveTrailingVersionInfo()), directory);
 			}
 			catch (Exception ex)
 			{

--- a/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
+++ b/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs
@@ -253,9 +253,11 @@ namespace ICSharpCode.Decompiler.Metadata
 				.Where(v => v.version != null);
 			foreach (var folder in foundVersions.OrderBy(v => v.version))
 			{
-				if (folder.version >= version)
-					if(folder.directory.EnumerateFiles().Any())
-						return folder.directory.Name;
+				if (folder.version >= version
+					&& folder.directory.EnumerateFiles("*.dll", SearchOption.AllDirectories).Any())
+				{
+					return folder.directory.Name;
+				}
 			}
 			return version.ToString();
 		}

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -386,11 +386,11 @@ namespace ICSharpCode.Decompiler.Metadata
 		string FindClosestVersionDirectory(string basePath, Version? version)
 		{
 			string? path = null;
-			foreach (var folder in new DirectoryInfo(basePath).GetDirectories().Select(d => DotNetCorePathFinder.ConvertToVersion(d.Name))
+			foreach (var folder in new DirectoryInfo(basePath).GetDirectories().Select(DotNetCorePathFinder.ConvertToVersion)
 				.Where(v => v.Item1 != null).OrderByDescending(v => v.Item1))
 			{
 				if (path == null || version == null || folder.Item1 >= version)
-					path = folder.Item2;
+					path = folder.Item2.Name;
 			}
 			return path ?? version?.ToString() ?? ".";
 		}


### PR DESCRIPTION
#3261 

### Problem
Dotnet core assemblies can not be resolved if empty folders of previously installed versions exist.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
Ignore empty Directories
* Which part of this PR is most in need of attention/improvement?
I changed the result of ConvertToVersion only check for empty directories where the directory is considered a fitting version. I hope that is fine.
In my case the version directories where completly empty but maybe it would make sense to look for at least one file that does have .dll or .exe extension?
* [ ] At least one test covering the code changed
I'm not sure how to test things that are environment dependend.

