### PR TITLE
Fix Derived Types Node always being empty

### DIFF
--- a/ILSpy/TreeNodes/DerivedTypesTreeNode.cs
+++ b/ILSpy/TreeNodes/DerivedTypesTreeNode.cs
@@ -73,7 +73,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 					continue;
 				var metadata = module.Metadata;
 				var assembly = module.GetTypeSystemOrNull()?.MainModule as MetadataModule;
-				if (assembly != null)
+				if (assembly == null)
 					continue;
 				foreach (var h in metadata.TypeDefinitions)
 				{


### PR DESCRIPTION
it appears Fix #3263 added an accidental `!=` instead of `==` and broke the derived types node.

no issue exists, but i can create one if desired

### Problem
Derived type nodes where always empty with a build from latest version. Traced it to what appears to be a backwards null check `!= null` vs `== null`.

### Solution
* Corrected the comparison, derived types tab is now populated
* need someone to verify the original issue in #3263 is still fixed by the resultant code. (I would expect it to be, but don't know how to check myself)
* [ ] At least one test covering the code changed

