### PR TITLE
Fix #3284: Focus, Tabs and Title issues

### DIFF
--- a/ILSpy/AssemblyTree/AssemblyListPane.xaml.cs
+++ b/ILSpy/AssemblyTree/AssemblyListPane.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System.ComponentModel.Composition;
 using System.Windows;
-
-using ICSharpCode.ILSpyX.TreeView;
+using System.Windows.Threading;
 
 using TomsToolbox.Wpf.Composition.Mef;
 
@@ -31,13 +30,16 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 					return;
 
 				model.SetActiveView(this);
-			}
-			else if (e.Property == SelectedItemProperty)
-			{
-				if (e.NewValue is not SharpTreeNode treeNode)
-					return;
 
-				FocusNode(treeNode);
+				// If there is already a selected item in the model, we need to scroll it into view, so it can be selected in the UI.
+				var selected = model.SelectedItem;
+				if (selected != null)
+				{
+					this.Dispatcher.BeginInvoke(DispatcherPriority.Background, () => {
+						ScrollIntoView(selected);
+						this.SelectedItem = selected;
+					});
+				}
 			}
 		}
 	}

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -418,17 +418,22 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 
 			Root = assemblyListTreeNode;
 
+			var mainWindow = Application.Current?.MainWindow;
+
+			if (mainWindow == null)
+				return;
+
 			if (assemblyList.ListName == AssemblyListManager.DefaultListName)
 #if DEBUG
-				this.Title = $"ILSpy {DecompilerVersionInfo.FullVersion}";
+				mainWindow.Title = $"ILSpy {DecompilerVersionInfo.FullVersion}";
 #else
-				this.Title = "ILSpy";
+				mainWindow.Title = "ILSpy";
 #endif
 			else
 #if DEBUG
-				this.Title = $"ILSpy {DecompilerVersionInfo.FullVersion} - " + assemblyList.ListName;
+				mainWindow.Title = $"ILSpy {DecompilerVersionInfo.FullVersion} - " + assemblyList.ListName;
 #else
-				this.Title = "ILSpy - " + assemblyList.ListName;
+				mainWindow.Title = "ILSpy - " + assemblyList.ListName;
 #endif
 		}
 


### PR DESCRIPTION
Fix #3284: 
- Focus always moving to the assembly tree view when changing tabs
- don't decompile when just switching tabs
- AssemblyTree title is wrong
