### PR TITLE
WPF refactoring

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,12 +45,12 @@
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Composition" Version="2.18.1" />
-    <PackageVersion Include="TomsToolbox.Wpf.Composition.Mef" Version="2.18.1" />
-    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.18.1" />
+    <PackageVersion Include="TomsToolbox.Wpf.Composition" Version="2.20.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Composition.Mef" Version="2.20.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.20.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="TomsToolbox.Composition.Analyzer" Version="2.18.1" />
+    <GlobalPackageReference Include="TomsToolbox.Composition.Analyzer" Version="2.20.0" />
   </ItemGroup>
 </Project>

--- a/ICSharpCode.ILSpyX/AssemblyListManager.cs
+++ b/ICSharpCode.ILSpyX/AssemblyListManager.cs
@@ -113,14 +113,16 @@ namespace ICSharpCode.ILSpyX
 		public void SaveList(AssemblyList list)
 		{
 			this.settingsProvider.Update(
-				delegate (XElement root) {
+				root => {
 					XElement? doc = root.Element("AssemblyLists");
 					if (doc == null)
 					{
 						doc = new XElement("AssemblyLists");
 						root.Add(doc);
 					}
-					XElement? listElement = doc.Elements("List").FirstOrDefault(e => (string?)e.Attribute("name") == list.ListName);
+
+					XElement? listElement = doc.Elements("List")
+						.FirstOrDefault(e => (string?)e.Attribute("name") == list.ListName);
 					if (listElement != null)
 						listElement.ReplaceWith(list.SaveAsXml());
 					else
@@ -163,13 +165,9 @@ namespace ICSharpCode.ILSpyX
 		{
 			AssemblyLists.Clear();
 			this.settingsProvider.Update(
-				delegate (XElement root) {
+				root => {
 					XElement? doc = root.Element("AssemblyLists");
-					if (doc == null)
-					{
-						return;
-					}
-					doc.Remove();
+					doc?.Remove();
 				});
 		}
 

--- a/ILSpy/Analyzers/AnalyzerTreeView.xaml
+++ b/ILSpy/Analyzers/AnalyzerTreeView.xaml
@@ -12,8 +12,7 @@
 	ShowRoot="False"
 	BorderThickness="0"
 	Root="{Binding Root}"
-	toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedItems}"
-	SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+	toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedItems, Mode=TwoWay}"
 	SelectionChanged="AnalyzerTreeView_OnSelectionChanged">
 
 	<UIElement.InputBindings>

--- a/ILSpy/Analyzers/AnalyzerTreeViewModel.cs
+++ b/ILSpy/Analyzers/AnalyzerTreeViewModel.cs
@@ -17,8 +17,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Windows;
@@ -38,8 +36,6 @@ namespace ICSharpCode.ILSpy.Analyzers
 	[Export]
 	public class AnalyzerTreeViewModel : ToolPaneModel
 	{
-		private AnalyzerTreeNode selectedItem;
-
 		public const string PaneContentId = "analyzerPane";
 
 		public AnalyzerTreeViewModel()
@@ -52,14 +48,20 @@ namespace ICSharpCode.ILSpy.Analyzers
 
 		public AnalyzerRootNode Root { get; } = new();
 
-		public AnalyzerTreeNode SelectedItem {
-			get => selectedItem;
-			set => SetProperty(ref selectedItem, value);
-		}
-
 		public ICommand AnalyzeCommand => new DelegateCommand(AnalyzeSelected);
 
-		public ObservableCollection<AnalyzerTreeNode> SelectedItems { get; } = [];
+		private AnalyzerTreeNode[] selectedItems = [];
+
+		public AnalyzerTreeNode[] SelectedItems {
+			get => selectedItems ?? [];
+			set {
+				if (SelectedItems.SequenceEqual(value))
+					return;
+
+				selectedItems = value;
+				OnPropertyChanged();
+			}
+		}
 
 		private void AnalyzeSelected()
 		{
@@ -87,7 +89,7 @@ namespace ICSharpCode.ILSpy.Analyzers
 			}
 
 			target.IsExpanded = true;
-			this.SelectedItem = target;
+			this.SelectedItems = [target];
 		}
 
 		public void Analyze(IEntity entity)

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -216,9 +216,6 @@ namespace ICSharpCode.ILSpy
 			}
 
 			MainWindow = new MainWindow();
-			MainWindow.Loaded += (sender, args) => {
-				ExportProvider.GetExportedValue<AssemblyTreeModel>().Initialize();
-			};
 			MainWindow.Show();
 		}
 

--- a/ILSpy/AssemblyTree/AssemblyListPane.xaml
+++ b/ILSpy/AssemblyTree/AssemblyListPane.xaml
@@ -15,8 +15,7 @@
 						AllowDrop="True"
 						BorderThickness="0" Visibility="Visible"
 						Root="{Binding Root}"
-						SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
-						toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedItems}">
+						toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedItems, Mode=TwoWay}">
 	<treeView:SharpTreeView.ItemContainerStyle>
 		<Style TargetType="treeView:SharpTreeViewItem">
 			<Setter Property="Template">

--- a/ILSpy/AssemblyTree/AssemblyListPane.xaml
+++ b/ILSpy/AssemblyTree/AssemblyListPane.xaml
@@ -7,6 +7,7 @@
 						xmlns:treeNodes="clr-namespace:ICSharpCode.ILSpy.TreeNodes"
 						xmlns:assemblyTree="clr-namespace:ICSharpCode.ILSpy.AssemblyTree"
 						xmlns:toms="urn:TomsToolbox"
+						xmlns:viewModels="clr-namespace:ICSharpCode.ILSpy.ViewModels"
 						mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="800"
 						d:DataContext="{d:DesignInstance assemblyTree:AssemblyTreeModel}"
 						AutomationProperties.Name="Assemblies and Classes"
@@ -15,7 +16,8 @@
 						AllowDrop="True"
 						BorderThickness="0" Visibility="Visible"
 						Root="{Binding Root}"
-						toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedItems, Mode=TwoWay}">
+						toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedItems, Mode=TwoWay}"
+						viewModels:Pane.IsActive="{Binding IsActive}">
 	<treeView:SharpTreeView.ItemContainerStyle>
 		<Style TargetType="treeView:SharpTreeViewItem">
 			<Setter Property="Template">

--- a/ILSpy/AssemblyTree/AssemblyListPane.xaml.cs
+++ b/ILSpy/AssemblyTree/AssemblyListPane.xaml.cs
@@ -20,6 +20,9 @@ using System.ComponentModel.Composition;
 using System.Windows;
 using System.Windows.Threading;
 
+using ICSharpCode.ILSpy.ViewModels;
+using ICSharpCode.ILSpyX.TreeView;
+
 using TomsToolbox.Wpf.Composition.Mef;
 
 namespace ICSharpCode.ILSpy.AssemblyTree
@@ -57,6 +60,20 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 						ScrollIntoView(selected);
 						this.SelectedItem = selected;
 					});
+				}
+			}
+			else if (e.Property == Pane.IsActiveProperty)
+			{
+				if (!true.Equals(e.NewValue))
+					return;
+
+				if (SelectedItem is SharpTreeNode selectedItem)
+				{
+					FocusNode(selectedItem);
+				}
+				else
+				{
+					Focus();
 				}
 			}
 		}

--- a/ILSpy/Commands/RemoveAssembliesWithLoadErrors.cs
+++ b/ILSpy/Commands/RemoveAssembliesWithLoadErrors.cs
@@ -19,6 +19,7 @@
 using System.ComponentModel.Composition;
 using System.Linq;
 
+using ICSharpCode.ILSpy.AssemblyTree;
 using ICSharpCode.ILSpy.Properties;
 
 namespace ICSharpCode.ILSpy
@@ -27,18 +28,26 @@ namespace ICSharpCode.ILSpy
 	[PartCreationPolicy(CreationPolicy.Shared)]
 	class RemoveAssembliesWithLoadErrors : SimpleCommand
 	{
+		private readonly AssemblyTreeModel assemblyTreeModel;
+
+		[ImportingConstructor]
+		public RemoveAssembliesWithLoadErrors(AssemblyTreeModel assemblyTreeModel)
+		{
+			this.assemblyTreeModel = assemblyTreeModel;
+		}
+
 		public override bool CanExecute(object parameter)
 		{
-			return MainWindow.Instance.AssemblyTreeModel.AssemblyList?.GetAssemblies().Any(l => l.HasLoadError) == true;
+			return assemblyTreeModel.AssemblyList.GetAssemblies().Any(l => l.HasLoadError);
 		}
 
 		public override void Execute(object parameter)
 		{
-			foreach (var asm in MainWindow.Instance.AssemblyTreeModel.AssemblyList.GetAssemblies())
+			foreach (var assembly in assemblyTreeModel.AssemblyList.GetAssemblies())
 			{
-				if (!asm.HasLoadError)
+				if (!assembly.HasLoadError)
 					continue;
-				var node = MainWindow.Instance.AssemblyTreeModel.FindAssemblyNode(asm);
+				var node = MainWindow.Instance.AssemblyTreeModel.FindAssemblyNode(assembly);
 				if (node != null && node.CanDelete())
 					node.Delete();
 			}
@@ -49,14 +58,22 @@ namespace ICSharpCode.ILSpy
 	[PartCreationPolicy(CreationPolicy.Shared)]
 	class ClearAssemblyList : SimpleCommand
 	{
+		private readonly AssemblyTreeModel assemblyTreeModel;
+
+		[ImportingConstructor]
+		public ClearAssemblyList(AssemblyTreeModel assemblyTreeModel)
+		{
+			this.assemblyTreeModel = assemblyTreeModel;
+		}
+
 		public override bool CanExecute(object parameter)
 		{
-			return MainWindow.Instance.AssemblyTreeModel.AssemblyList?.Count > 0;
+			return assemblyTreeModel.AssemblyList.Count > 0;
 		}
 
 		public override void Execute(object parameter)
 		{
-			MainWindow.Instance.AssemblyTreeModel.AssemblyList?.Clear();
+			assemblyTreeModel.AssemblyList.Clear();
 		}
 	}
 }

--- a/ILSpy/Commands/ShowPane.cs
+++ b/ILSpy/Commands/ShowPane.cs
@@ -1,5 +1,4 @@
 ﻿using ICSharpCode.ILSpy.Docking;
-using ICSharpCode.ILSpy.Properties;
 using ICSharpCode.ILSpy.ViewModels;
 
 namespace ICSharpCode.ILSpy.Commands
@@ -30,7 +29,13 @@ namespace ICSharpCode.ILSpy.Commands
 
 		public override void Execute(object parameter)
 		{
-			DockWorkspace.Instance.ActiveTabPage = model;
+			var workspace = DockWorkspace.Instance;
+
+			// ensure the tab control is focused before setting the active tab page, else the tab will not be focused
+			workspace.ActiveTabPage?.Focus();
+			// reset first, else clicking on the already active tab will not focus the tab and the menu checkmark will not be updated
+			workspace.ActiveTabPage = null;
+			workspace.ActiveTabPage = model;
 		}
 	}
 }

--- a/ILSpy/Controls/TreeView/SharpTreeView.cs
+++ b/ILSpy/Controls/TreeView/SharpTreeView.cs
@@ -416,7 +416,9 @@ namespace ICSharpCode.ILSpy.Controls.TreeView
 				throw new ArgumentNullException("node");
 			doNotScrollOnExpanding = true;
 			foreach (SharpTreeNode ancestor in node.Ancestors())
+			{
 				ancestor.IsExpanded = true;
+			}
 			doNotScrollOnExpanding = false;
 			base.ScrollIntoView(node);
 		}

--- a/ILSpy/Docking/CloseAllDocumentsCommand.cs
+++ b/ILSpy/Docking/CloseAllDocumentsCommand.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.Composition;
 
 using ICSharpCode.ILSpy.Properties;
 

--- a/ILSpy/Docking/DockWorkspace.cs
+++ b/ILSpy/Docking/DockWorkspace.cs
@@ -35,7 +35,6 @@ using ICSharpCode.ILSpy.Analyzers;
 using ICSharpCode.ILSpy.Search;
 using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.ViewModels;
-using ICSharpCode.ILSpyX.Extensions;
 
 using TomsToolbox.Composition;
 using TomsToolbox.Essentials;
@@ -52,6 +51,8 @@ namespace ICSharpCode.ILSpy.Docking
 		public static readonly DockWorkspace Instance = new();
 
 		private readonly ObservableCollection<TabPageModel> tabPages = [];
+
+		private DockingManager dockingManager;
 
 		private DockWorkspace()
 		{
@@ -179,8 +180,17 @@ namespace ICSharpCode.ILSpy.Docking
 			}
 		}
 
+		public PaneModel ActivePane {
+			get => dockingManager?.ActiveContent as PaneModel;
+			set {
+				if (dockingManager is not null)
+					dockingManager.ActiveContent = value;
+			}
+		}
+
 		public void InitializeLayout(DockingManager manager)
 		{
+			this.dockingManager = manager;
 			manager.LayoutUpdateStrategy = this;
 			XmlLayoutSerializer serializer = new XmlLayoutSerializer(manager);
 			serializer.LayoutSerializationCallback += LayoutSerializationCallback;

--- a/ILSpy/Docking/DockWorkspace.cs
+++ b/ILSpy/Docking/DockWorkspace.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
@@ -51,13 +52,17 @@ namespace ICSharpCode.ILSpy.Docking
 		public static readonly DockWorkspace Instance = new();
 
 		private readonly ObservableCollection<TabPageModel> tabPages = [];
-		private readonly ObservableCollection<ToolPaneModel> toolPanes = [];
 
 		private DockWorkspace()
 		{
 			this.tabPages.CollectionChanged += TabPages_CollectionChanged;
 			TabPages = new(tabPages);
-			ToolPanes = new(toolPanes);
+
+			ToolPanes = exportProvider
+				.GetExportedValues<ToolPaneModel>("ToolPane")
+				.OrderBy(item => item.Title)
+				.ToArray()
+				.AsReadOnly();
 
 			// Make sure there is at least one tab open
 			AddTabPage();
@@ -83,10 +88,15 @@ namespace ICSharpCode.ILSpy.Docking
 					.ExceptNullItems()
 					.Any(assemblyNode => !e.OldItems.Contains(assemblyNode.LoadedAssembly));
 
-				if (!found && tabPages.Count > 1)
+				if (!found)
 				{
 					tabPages.Remove(tab);
 				}
+			}
+
+			if (tabPages.Count == 0)
+			{
+				AddTabPage();
 			}
 		}
 
@@ -117,11 +127,11 @@ namespace ICSharpCode.ILSpy.Docking
 
 		public ReadOnlyObservableCollection<TabPageModel> TabPages { get; }
 
-		public ReadOnlyObservableCollection<ToolPaneModel> ToolPanes { get; }
+		public ReadOnlyCollection<ToolPaneModel> ToolPanes { get; }
 
 		public bool ShowToolPane(string contentId)
 		{
-			var pane = toolPanes.FirstOrDefault(p => p.ContentId == contentId);
+			var pane = ToolPanes.FirstOrDefault(p => p.ContentId == contentId);
 			if (pane != null)
 			{
 				pane.Show();
@@ -132,10 +142,15 @@ namespace ICSharpCode.ILSpy.Docking
 
 		public void Remove(PaneModel model)
 		{
-			if (model is TabPageModel document)
-				tabPages.Remove(document);
-			if (model is ToolPaneModel tool)
-				tool.IsVisible = false;
+			switch (model)
+			{
+				case TabPageModel document:
+					tabPages.Remove(document);
+					break;
+				case ToolPaneModel tool:
+					tool.IsVisible = false;
+					break;
+			}
 		}
 
 		private TabPageModel activeTabPage = null;
@@ -166,10 +181,6 @@ namespace ICSharpCode.ILSpy.Docking
 
 		public void InitializeLayout(DockingManager manager)
 		{
-			var panes = exportProvider.GetExportedValues<ToolPaneModel>("ToolPane").OrderBy(item => item.Title);
-
-			this.toolPanes.AddRange(panes);
-
 			manager.LayoutUpdateStrategy = this;
 			XmlLayoutSerializer serializer = new XmlLayoutSerializer(manager);
 			serializer.LayoutSerializationCallback += LayoutSerializationCallback;
@@ -188,13 +199,13 @@ namespace ICSharpCode.ILSpy.Docking
 			switch (e.Model)
 			{
 				case LayoutAnchorable la:
-					e.Content = this.toolPanes.FirstOrDefault(p => p.ContentId == la.ContentId);
+					e.Content = this.ToolPanes.FirstOrDefault(p => p.ContentId == la.ContentId);
 					e.Cancel = e.Content == null;
 					la.CanDockAsTabbedDocument = false;
-					if (!e.Cancel)
+					if (e.Content is ToolPaneModel toolPaneModel)
 					{
-						e.Cancel = ((ToolPaneModel)e.Content).IsVisible;
-						((ToolPaneModel)e.Content).IsVisible = true;
+						e.Cancel = toolPaneModel.IsVisible;
+						toolPaneModel.IsVisible = true;
 					}
 					break;
 				default:
@@ -220,16 +231,14 @@ namespace ICSharpCode.ILSpy.Docking
 
 		internal void CloseAllTabs()
 		{
-			foreach (var doc in tabPages.ToArray())
-			{
-				if (doc.IsCloseable)
-					tabPages.Remove(doc);
-			}
+			var activePage = ActiveTabPage;
+
+			tabPages.RemoveWhere(page => page != activePage);
 		}
 
 		internal void ResetLayout()
 		{
-			foreach (var pane in toolPanes)
+			foreach (var pane in ToolPanes)
 			{
 				pane.IsVisible = false;
 			}

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 
 using AvalonDock.Layout.Serialization;
 
@@ -70,11 +71,14 @@ namespace ICSharpCode.ILSpy
 
 			InitializeComponent();
 
-			mainWindowViewModel.Workspace.InitializeLayout(dockManager);
-
-			MenuService.Instance.Init(mainMenu, toolBar, InputBindings);
-
 			InitFileLoaders();
+
+			Dispatcher.BeginInvoke(DispatcherPriority.Background, () => {
+				mainWindowViewModel.Workspace.InitializeLayout(dockManager);
+				MenuService.Instance.Init(mainMenu, toolBar, InputBindings);
+
+				Dispatcher.BeginInvoke(DispatcherPriority.Background, AssemblyTreeModel.Initialize);
+			});
 		}
 
 		void SetWindowBounds(Rect bounds)

--- a/ILSpy/MainWindow.xaml.cs
+++ b/ILSpy/MainWindow.xaml.cs
@@ -77,7 +77,10 @@ namespace ICSharpCode.ILSpy
 				mainWindowViewModel.Workspace.InitializeLayout(dockManager);
 				MenuService.Instance.Init(mainMenu, toolBar, InputBindings);
 
-				Dispatcher.BeginInvoke(DispatcherPriority.Background, AssemblyTreeModel.Initialize);
+				Dispatcher.BeginInvoke(DispatcherPriority.Background, () => {
+					AssemblyTreeModel.Initialize();
+					AssemblyTreeModel.Show();
+				});
 			});
 		}
 

--- a/ILSpy/Util/MenuService.cs
+++ b/ILSpy/Util/MenuService.cs
@@ -142,7 +142,7 @@ namespace ICSharpCode.ILSpy.Util
 
 			windowMenuItem.Items.Clear();
 
-			var toolItems = dockWorkspace.ToolPanes.ObservableSelect(toolPane => CreateMenuItem(toolPane, inputBindings));
+			var toolItems = dockWorkspace.ToolPanes.Select(toolPane => CreateMenuItem(toolPane, inputBindings)).ToArray();
 			var tabItems = dockWorkspace.TabPages.ObservableSelect(tabPage => CreateMenuItem(tabPage, dockWorkspace));
 
 			var allItems = new ObservableCompositeCollection<Control>(defaultItems, [new Separator()], toolItems, [new Separator()], tabItems);

--- a/ILSpy/Util/MenuService.cs
+++ b/ILSpy/Util/MenuService.cs
@@ -207,7 +207,8 @@ namespace ICSharpCode.ILSpy.Util
 			menuItem.SetBinding(MenuItem.IsCheckedProperty, new Binding(nameof(dock.ActiveTabPage)) {
 				Source = dock,
 				ConverterParameter = pane,
-				Converter = BinaryOperationConverter.Equality
+				Converter = BinaryOperationConverter.Equality,
+				Mode = BindingMode.OneWay
 			});
 
 			return menuItem;

--- a/ILSpy/Util/SettingsService.cs
+++ b/ILSpy/Util/SettingsService.cs
@@ -152,6 +152,11 @@ namespace ICSharpCode.ILSpy.Util
 			}
 		}
 
+		public AssemblyList CreateEmptyAssemblyList()
+		{
+			return AssemblyListManager.CreateList(string.Empty);
+		}
+
 		private bool reloading;
 
 		public void Reload()

--- a/ILSpy/ViewModels/TabPageModel.cs
+++ b/ILSpy/ViewModels/TabPageModel.cs
@@ -17,9 +17,13 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
 
 using ICSharpCode.ILSpy.TextView;
+
+using TomsToolbox.Wpf;
 
 namespace ICSharpCode.ILSpy.ViewModels
 {
@@ -95,6 +99,19 @@ namespace ICSharpCode.ILSpy.ViewModels
 			}
 			tabPage.Title = Properties.Resources.Decompiling;
 			action(textView);
+		}
+
+		public static void Focus(this TabPageModel tabPage)
+		{
+			if (tabPage.Content is not FrameworkElement content)
+				return;
+
+			var focusable = content
+				.VisualDescendantsAndSelf()
+				.OfType<FrameworkElement>()
+				.FirstOrDefault(item => item.Focusable);
+
+			focusable?.Focus();
 		}
 	}
 


### PR DESCRIPTION
- Fix #3293: Right panel shows old info in case all is deleted in the left-hand tree
- Optimize selection handling