### PR TITLE
Select first assembly from list after assembly list change

### DIFF
--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -392,7 +392,9 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 
 			AvalonEditTextOutput output = new();
 			if (FormatExceptions(App.StartupExceptions.ToArray(), output))
+			{
 				DockWorkspace.Instance.ShowText(output);
+			}
 		}
 
 		private static bool FormatExceptions(App.ExceptionData[] exceptions, ITextOutput output)
@@ -413,7 +415,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			if (list.ListName != AssemblyList.ListName)
 			{
 				ShowAssemblyList(list);
-				SelectNode(Root);
+				SelectNode(Root?.Children.FirstOrDefault());
 			}
 		}
 


### PR DESCRIPTION
... instead of the root node.

as discussed in https://github.com/icsharpcode/ILSpy/pull/3298#issuecomment-2395407799

That really looks much better
