### PR TITLE
Fix for "Unable to locate dotnet CLI. Ensure that it is on the PATH."

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -35,7 +35,7 @@ jobs:
       uses: microsoft/setup-msbuild@v2
 
     - name: Install dotnet-format
-      run: dotnet tool install -g dotnet-format --version "8.0.453106" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
+      run: dotnet tool install -g dotnet-format --version "8.3.546805" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
 
     - name: Get Version
       id: version

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -30,7 +30,10 @@ jobs:
       with:
         dotnet-version: '8.0.x'
         dotnet-quality: 'ga'
-    
+      env:
+        DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet
+        DOTNET_ROOT: ${{ runner.temp }}/.dotnet
+
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v2
 

--- a/BuildTools/pre-commit
+++ b/BuildTools/pre-commit
@@ -5,7 +5,7 @@
 
 set -eu
 
-DOTNET_FORMAT_VERSION=8.0.453106
+DOTNET_FORMAT_VERSION=8.3.546805
 DOTNET_PATH="$LOCALAPPDATA/ICSharpCode/ILSpy/dotnet-format-$DOTNET_FORMAT_VERSION"
 if [ ! -d "$DOTNET_PATH" ]; then
  echo "Downloading dotnet-format $DOTNET_FORMAT_VERSION..."


### PR DESCRIPTION
https://github.com/microsoft/azure-pipelines-tasks/issues/19162 with https://github.com/dotnet/format/pull/2000

Updated to latest dotnet-format in the 8 series as the fix was merged post-RTM.
