### PR TITLE
Update ReadyToRun to use 9.0 package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="DiffLib" Version="2017.7.26.1241" />
     <PackageVersion Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.72.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="8.0.0-rc.2.23471.30" />
+    <PackageVersion Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="9.0.1-rtm.24557.9" />
     <PackageVersion Include="Iced" Version="1.21.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" />
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
@@ -39,9 +39,9 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.11.1" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="8.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.1" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="9.0.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="TomsToolbox.Composition.MicrosoftExtensions" Version="2.20.0" />

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -30,6 +30,7 @@ using System.Runtime.CompilerServices;
 
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.Disassembler;
 using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.Solution;
 using ICSharpCode.Decompiler.TypeSystem;
@@ -94,6 +95,10 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		}
 
 		public void WriteReference(IMember member, string text, bool isDefinition = false)
+		{
+		}
+
+		public void WriteReference(MetadataFile metadata, Handle handle, string text, string protocol = "decompile", bool isDefinition = false)
 		{
 		}
 	}

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,7 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
+    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
@@ -12,7 +12,7 @@
       <package pattern="Microsoft.DiaSymReader.Native" />
       <package pattern="Microsoft.DiaSymReader" />
     </packageSource>
-    <packageSource key="dotnet8-transport">
+    <packageSource key="dotnet9-transport">
       <package pattern="ILCompiler.Reflection.ReadyToRun.Experimental" />
     </packageSource>
     <packageSource key="dotnet-tools">


### PR DESCRIPTION
Link to issue(s) this covers #3337 

### Problem
This update improves the disassembly for https://github.com/dotnet/runtime/pull/98623, https://github.com/dotnet/runtime/pull/101761. These PRs added new helper calls to the runtime from ready to run native code, which could appear as opaque call to random addresses if not properly annotated.

### Solution
* The diassembly for methods having calls to these new helper functions will be properly annotated with the call target
* Updated the DummyOutput to match the updated signature so that the code compile with `STRESS` defined in `ReadyToRunLanguage.cs`, and
* Tested the diassembly functionality with the .NET 9 `System.Private.CoreLib.dll` and no error found.