### PR TITLE
Update Scorecard actions versions and apply Zizmor offline findings

### DIFF
--- a/.github/workflows/build-frontends.yml
+++ b/.github/workflows/build-frontends.yml
@@ -17,6 +17,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
+        
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+        persist-credentials: false
 
     - uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
     
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/generate-bom.yml
+++ b/.github/workflows/generate-bom.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Install CycloneDX
       run: dotnet tool install --global CycloneDX

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,5 @@
 name: Scorecard supply-chain security
+
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection (disabled)
@@ -23,19 +24,19 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        uses: ossf/scorecard-action@v2.4.0 # https://github.com/marketplace/actions/ossf-scorecard-action
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
https://github.com/woodruffw/zizmor found the following problem across the board (offline mode):

```
17 |       - uses: actions/checkout@v4
   |  _______-
18 | |       with:
19 | |         submodules: true
   | |________________________- does not set persist-credentials: false
```

Also fixed are old versions in Scorecard.yml