### PR TITLE
fix #3372 empty tree for assembly

### DIFF
--- a/ICSharpCode.ILSpyX/LoadedAssembly.cs
+++ b/ICSharpCode.ILSpyX/LoadedAssembly.cs
@@ -353,7 +353,7 @@ namespace ICSharpCode.ILSpyX
 				}
 			}
 
-			if (result?.IsSuccess != true)
+			if (result?.IsSuccess != true || result.Package?.Kind == LoadedPackage.PackageKind.Zip) // workaround to check this before zip
 			{
 				stream.Position = 0;
 				try
@@ -367,7 +367,8 @@ namespace ICSharpCode.ILSpyX
 				}
 				catch (Exception ex)
 				{
-					result = new LoadResult { FileLoadException = ex };
+					if (result == null)
+						result = new LoadResult { FileLoadException = ex };
 				}
 			}
 


### PR DESCRIPTION
fix https://github.com/icsharpcode/ILSpy/issues/3372

### Problem
Loading as Zip-file works for every library and should be the last resort. The regression was in commit 65e30c0bd68924560e45d001caabe41235917057.

### Solution
* in case zip loader was successful, we have to check before proceed with `PEFile`

