### PR TITLE
Load resource stream outside of delegate

### DIFF
--- a/ILSpy/TextView/DecompilerTextView.cs
+++ b/ILSpy/TextView/DecompilerTextView.cs
@@ -1447,17 +1447,20 @@ namespace ICSharpCode.ILSpy.TextView
 
 			if (resourceStream != null)
 			{
+				IHighlightingDefinition highlightingDefinition;
+
+				using (resourceStream)
+				using (XmlTextReader reader = new XmlTextReader(resourceStream))
+				{
+					highlightingDefinition = HighlightingLoader.Load(reader, manager);
+				}
+
 				manager.RegisterHighlighting(
-					name, extensions,
-					delegate {
-						using (resourceStream)
-						using (XmlTextReader reader = new XmlTextReader(resourceStream))
-						{
-							var highlightingDefinition = HighlightingLoader.Load(reader, manager);
-							ThemeManager.Current.ApplyHighlightingColors(highlightingDefinition);
-							return highlightingDefinition;
-						}
-					});
+				name, extensions,
+				delegate {
+					ThemeManager.Current.ApplyHighlightingColors(highlightingDefinition);
+					return highlightingDefinition;
+				});
 			}
 		}
 	}


### PR DESCRIPTION
Fixes [Lazy loaded highlight definition failing when clear and add assemblies](https://github.com/icsharpcode/ILSpy/issues/3343).

### Problem
Reading from the Manifest Resource Stream inside of the RegisterHighlighting delegate seems to result in malformed reads (possibly due to threading issues).

### Solution
Workaround is to read the stream before registering the delegate.
