### PR TITLE
Enable `<RollForward>major</RollForward>` for `ILSpy.exe`

### DIFF
--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
+    <RollForward>major</RollForward>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Allow `ILSpy.exe` to launch when .NET 8 (the version it currently targets) is not installed, but some later major version (e.g. .NET 9) is available instead.

ref. https://learn.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior

### Problem

https://github.com/icsharpcode/ILSpy/issues/3390


