### PR TITLE
Add option to turn off smooth scrolling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,10 +45,10 @@
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.1" />
     <PackageVersion Include="System.Resources.Extensions" Version="9.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageVersion Include="TomsToolbox.Composition.MicrosoftExtensions" Version="2.21.0" />
+    <PackageVersion Include="TomsToolbox.Composition.MicrosoftExtensions" Version="2.22.0" />
     <PackageVersion Include="TomsToolbox.Wpf.Composition" Version="2.20.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Composition.AttributedModel" Version="2.21.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.21.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Composition.AttributedModel" Version="2.22.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.22.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/ILSpy/App.xaml
+++ b/ILSpy/App.xaml
@@ -3,7 +3,8 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:styles="urn:TomsToolbox.Wpf.Styles"
 			 xmlns:toms="urn:TomsToolbox"
-			 xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes">
+			 xmlns:themes="clr-namespace:ICSharpCode.ILSpy.Themes"
+			 xmlns:ilSpy="clr-namespace:ICSharpCode.ILSpy">
 	<Application.Resources>
 		<Style x:Key="DialogWindow" TargetType="{x:Type Window}">
 			<Setter Property="ShowInTaskbar" Value="False" />
@@ -25,6 +26,12 @@
 
 		<Style TargetType="ScrollViewer">
 			<Setter Property="toms:AdvancedScrollWheelBehavior.Attach" Value="WithAnimation" />
+			<Style.Triggers>
+				<!-- Allow for disabling smooth scrolling -->
+				<DataTrigger Binding="{Binding Path=DisplaySettings.EnableSmoothScrolling, Source={x:Static ilSpy:App.SettingsService}}" Value="False">
+					<Setter Property="toms:AdvancedScrollWheelBehavior.Attach" Value="None"/>
+				</DataTrigger>
+			</Style.Triggers>
 		</Style>
 
 	</Application.Resources>

--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -59,6 +59,10 @@ namespace ICSharpCode.ILSpy
 
 		public static IExportProvider ExportProvider { get; private set; }
 
+		private readonly SettingsService settingsService;
+		
+		public static SettingsService SettingsService => Current.settingsService;
+
 		internal record ExceptionData(Exception Exception)
 		{
 			public string PluginName { get; init; }
@@ -69,7 +73,7 @@ namespace ICSharpCode.ILSpy
 			var cmdArgs = Environment.GetCommandLineArgs().Skip(1);
 			CommandLineArguments = CommandLineArguments.Create(cmdArgs);
 
-			var settingsService = new SettingsService();
+			settingsService = new SettingsService();
 
 			bool forceSingleInstance = (CommandLineArguments.SingleInstance ?? true)
 									   && !settingsService.MiscSettings.AllowMultipleInstances;

--- a/ILSpy/Controls/ZoomScrollViewer.xaml
+++ b/ILSpy/Controls/ZoomScrollViewer.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:Controls="clr-namespace:ICSharpCode.ILSpy.Controls"
-	xmlns:toms="urn:TomsToolbox">
+	xmlns:toms="urn:TomsToolbox"
+	xmlns:ilSpy="clr-namespace:ICSharpCode.ILSpy">
 	
 	<Style TargetType="{x:Type Controls:ZoomScrollViewer}">
 		<Setter Property="toms:AdvancedScrollWheelBehavior.Attach" Value="WithAnimation" />
@@ -33,6 +34,12 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
+		<Style.Triggers>
+			<!-- Allow for disabling smooth scrolling -->
+			<DataTrigger Binding="{Binding Path=DisplaySettings.EnableSmoothScrolling, Source={x:Static ilSpy:App.SettingsService}}" Value="False">
+				<Setter Property="toms:AdvancedScrollWheelBehavior.Attach" Value="WithoutAnimation" />
+			</DataTrigger>
+		</Style.Triggers>
 	</Style>
 
 	<!-- Template for CollapsiblePanel -->

--- a/ILSpy/Options/DisplaySettings.cs
+++ b/ILSpy/Options/DisplaySettings.cs
@@ -148,6 +148,12 @@ namespace ICSharpCode.ILSpy.Options
 			set => SetProperty(ref showRawOffsetsAndBytesBeforeInstruction, value);
 		}
 
+		private bool enableSmoothScrolling;
+		public bool EnableSmoothScrolling {
+			get => enableSmoothScrolling;
+			set => SetProperty(ref enableSmoothScrolling, value);
+		}
+
 		public XName SectionName => "DisplaySettings";
 
 		public void LoadFromXml(XElement section)
@@ -172,6 +178,7 @@ namespace ICSharpCode.ILSpy.Options
 			UseNestedNamespaceNodes = (bool?)section.Attribute("UseNestedNamespaceNodes") ?? false;
 			ShowRawOffsetsAndBytesBeforeInstruction = (bool?)section.Attribute("ShowRawOffsetsAndBytesBeforeInstruction") ?? false;
 			StyleWindowTitleBar = (bool?)section.Attribute("StyleWindowTitleBar") ?? false;
+			EnableSmoothScrolling = (bool?)section.Attribute("EnableSmoothScrolling") ?? true;
 		}
 
 		public XElement SaveToXml()
@@ -198,6 +205,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("UseNestedNamespaceNodes", UseNestedNamespaceNodes);
 			section.SetAttributeValue("ShowRawOffsetsAndBytesBeforeInstruction", ShowRawOffsetsAndBytesBeforeInstruction);
 			section.SetAttributeValue("StyleWindowTitleBar", StyleWindowTitleBar);
+			section.SetAttributeValue("EnableSmoothScrolling", EnableSmoothScrolling);
 
 			return section;
 		}

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -78,6 +78,7 @@
 				<StackPanel Margin="3">
 					<CheckBox IsChecked="{Binding Settings.SortResults}" Content="{x:Static properties:Resources.SortResultsFitness}"></CheckBox>
 					<CheckBox IsChecked="{Binding Settings.StyleWindowTitleBar}" Content="{x:Static properties:Resources.StyleTheWindowTitleBar}"></CheckBox>
+					<CheckBox IsChecked="{Binding Settings.EnableSmoothScrolling}" Content="{x:Static properties:Resources.EnableSmoothScrolling}"></CheckBox>
 				</StackPanel>
 			</GroupBox>
 		</StackPanel>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1723,6 +1723,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable smooth scrolling.
+        /// </summary>
+        public static string EnableSmoothScrolling {
+            get {
+                return ResourceManager.GetString("EnableSmoothScrolling", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable word wrap.
         /// </summary>
         public static string EnableWordWrap {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -591,6 +591,9 @@ Are you sure you want to continue?</value>
   <data name="EnableFoldingBlocksBraces" xml:space="preserve">
     <value>Enable folding on all blocks in braces</value>
   </data>
+  <data name="EnableSmoothScrolling" xml:space="preserve">
+	  <value>Enable smooth scrolling</value>
+  </data>
   <data name="EnableWordWrap" xml:space="preserve">
     <value>Enable word wrap</value>
   </data>


### PR DESCRIPTION
Fixes #3393

### Problem
Smooth scrolling was recently added and not everyone enjoys that.

### Solution
Add an option to toggle smooth scrolling. I added it under Display -> Other options
![Smooth scrolling option](https://github.com/user-attachments/assets/5e835f6b-cac4-41e8-a0ca-d7b04712cc92)

The option applies to everywhere ScrollViewer is used and ZoomScrollView, which seems to just be the options dialog and the main text editor.

~~This PR is currently blocked due to needing a bug fix in TomsToolbox https://github.com/tom-englert/TomsToolbox/pull/20, hence the draft~~


