### PR TITLE
Fix #3402: System.NullReferenceException on right click on .NET 9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.NETCore.ILAsm" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NETCore.ILDAsm" Version="9.0.0" />
-	<PackageVersion Include="Microsoft.Sbom.Targets" Version="3.0.1" />
+    <PackageVersion Include="Microsoft.Sbom.Targets" Version="3.0.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
@@ -45,10 +45,10 @@
     <PackageVersion Include="System.Reflection.Metadata" Version="9.0.1" />
     <PackageVersion Include="System.Resources.Extensions" Version="9.0.1" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
-    <PackageVersion Include="TomsToolbox.Composition.MicrosoftExtensions" Version="2.21.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Composition" Version="2.20.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Composition.AttributedModel" Version="2.21.0" />
-    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.21.0" />
+    <PackageVersion Include="TomsToolbox.Composition.MicrosoftExtensions" Version="2.22.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Composition" Version="2.22.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Composition.AttributedModel" Version="2.22.0" />
+    <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.22.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -767,6 +767,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 				}
 				else
 				{
+					// ensure that we are only connected once to the event, else we might get multiple notifications
 					ContextMenuProvider.ContextMenuClosed -= ContextMenuClosed;
 					ContextMenuProvider.ContextMenuClosed += ContextMenuClosed;
 				}

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -767,6 +767,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 				}
 				else
 				{
+					ContextMenuProvider.ContextMenuClosed -= ContextMenuClosed;
 					ContextMenuProvider.ContextMenuClosed += ContextMenuClosed;
 				}
 			}


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
#3402: System.NullReferenceException on right click on .NET 9

### Solution
* Fixed in TomsToolbox

https://github.com/tom-englert/TomsToolbox/commit/31b9dd57974512ba3d27a17bc25a25f802d4cb34
