### PR TITLE
Add scopes to AssignVariableName

### DIFF
--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -233,22 +233,21 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task ExceptionHandling([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
-			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings {
-				NullPropagation = false,
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => {
+				settings.NullPropagation = false;
 				// legacy csc generates a dead store in debug builds
-				RemoveDeadStores = (cscOptions == CompilerOptions.None),
-				FileScopedNamespaces = false,
+				settings.RemoveDeadStores = (cscOptions == CompilerOptions.None);
+				settings.FileScopedNamespaces = false;
 			});
 		}
 
 		[Test]
 		public async Task Switch([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
-			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings {
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => {
 				// legacy csc generates a dead store in debug builds
-				RemoveDeadStores = (cscOptions == CompilerOptions.None),
-				SwitchExpressions = false,
-				FileScopedNamespaces = false,
+				settings.RemoveDeadStores = (cscOptions == CompilerOptions.None);
+				settings.SwitchExpressions = false;
 			});
 		}
 
@@ -267,7 +266,10 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task DelegateConstruction([ValueSource(nameof(defaultOptionsWithMcs))] CompilerOptions cscOptions)
 		{
-			await RunForLibrary(cscOptions: cscOptions);
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => {
+				settings.QueryExpressions = false;
+				settings.NullableReferenceTypes = false;
+			});
 		}
 
 		[Test]
@@ -293,9 +295,9 @@ namespace ICSharpCode.Decompiler.Tests
 		{
 			await RunForLibrary(
 				cscOptions: cscOptions,
-				decompilerSettings: new DecompilerSettings {
-					UseEnhancedUsing = false,
-					FileScopedNamespaces = false,
+				configureDecompiler: settings => {
+					settings.UseEnhancedUsing = false;
+					settings.FileScopedNamespaces = false;
 				}
 			);
 		}
@@ -327,11 +329,11 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task Loops([ValueSource(nameof(defaultOptionsWithMcs))] CompilerOptions cscOptions)
 		{
-			DecompilerSettings settings = Tester.GetSettings(cscOptions);
-			// legacy csc generates a dead store in debug builds
-			settings.RemoveDeadStores = (cscOptions == CompilerOptions.None);
-			settings.UseExpressionBodyForCalculatedGetterOnlyProperties = false;
-			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: settings);
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => {
+				// legacy csc generates a dead store in debug builds
+				settings.RemoveDeadStores = (cscOptions == CompilerOptions.None);
+				settings.UseExpressionBodyForCalculatedGetterOnlyProperties = false;
+			});
 		}
 
 		[Test]
@@ -440,9 +442,7 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task VariableNamingWithoutSymbols([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
-			var settings = Tester.GetSettings(cscOptions);
-			settings.UseDebugSymbols = false;
-			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: settings);
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.UseDebugSymbols = false);
 		}
 
 		[Test]
@@ -474,7 +474,7 @@ namespace ICSharpCode.Decompiler.Tests
 		{
 			await RunForLibrary(
 				cscOptions: cscOptions,
-				decompilerSettings: new DecompilerSettings { UseEnhancedUsing = false, FileScopedNamespaces = false }
+				configureDecompiler: settings => { settings.UseEnhancedUsing = false; }
 			);
 		}
 
@@ -499,7 +499,7 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task FileScopedNamespaces([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
 		{
-			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings());
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.FileScopedNamespaces = true);
 		}
 
 		[Test]
@@ -601,7 +601,7 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task Issue1080([ValueSource(nameof(roslynOnlyOptions))] CompilerOptions cscOptions)
 		{
-			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings(CSharp.LanguageVersion.CSharp6));
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.SetLanguageVersion(CSharp.LanguageVersion.CSharp6));
 		}
 
 		[Test]
@@ -712,12 +712,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await RunForLibrary(cscOptions: cscOptions);
 		}
 
-		async Task RunForLibrary([CallerMemberName] string testName = null, AssemblerOptions asmOptions = AssemblerOptions.None, CompilerOptions cscOptions = CompilerOptions.None, DecompilerSettings decompilerSettings = null)
+		async Task RunForLibrary([CallerMemberName] string testName = null, AssemblerOptions asmOptions = AssemblerOptions.None, CompilerOptions cscOptions = CompilerOptions.None, Action<DecompilerSettings> configureDecompiler = null)
 		{
-			await Run(testName, asmOptions | AssemblerOptions.Library, cscOptions | CompilerOptions.Library, decompilerSettings);
+			await Run(testName, asmOptions | AssemblerOptions.Library, cscOptions | CompilerOptions.Library, configureDecompiler);
 		}
 
-		async Task Run([CallerMemberName] string testName = null, AssemblerOptions asmOptions = AssemblerOptions.None, CompilerOptions cscOptions = CompilerOptions.None, DecompilerSettings decompilerSettings = null)
+		async Task Run([CallerMemberName] string testName = null, AssemblerOptions asmOptions = AssemblerOptions.None, CompilerOptions cscOptions = CompilerOptions.None, Action<DecompilerSettings> configureDecompiler = null)
 		{
 			var csFile = Path.Combine(TestCasePath, testName + ".cs");
 			var exeFile = TestsAssemblyOutput.GetFilePath(TestCasePath, testName, Tester.GetSuffix(cscOptions) + ".exe");
@@ -739,7 +739,9 @@ namespace ICSharpCode.Decompiler.Tests
 			}
 
 			// 2. Decompile
-			var decompiled = await Tester.DecompileCSharp(exeFile, decompilerSettings ?? Tester.GetSettings(cscOptions)).ConfigureAwait(false);
+			var settings = Tester.GetSettings(cscOptions);
+			configureDecompiler?.Invoke(settings);
+			var decompiled = await Tester.DecompileCSharp(exeFile, settings).ConfigureAwait(false);
 
 			// 3. Compile
 			CodeAssert.FilesAreEqual(csFile, decompiled, Tester.GetPreprocessorSymbols(cscOptions).Append("EXPECTED_OUTPUT").ToArray());

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
@@ -50,9 +50,9 @@ namespace ClassLibrary1
 			//IL_00e1: Expected O, but got Unknown
 			//IL_00e1: Expected O, but got Unknown
 			UnknownGenericClass<UnknownEventArgs> val = new UnknownGenericClass<UnknownEventArgs>();
-			UnknownEventArgs val2 = (val.UnknownProperty = val.UnknownProperty);
+			UnknownEventArgs e = (val.UnknownProperty = val.UnknownProperty);
 			List<object> list = new List<object> {
-				val[((object)val2).GetHashCode()] ?? "",
+				val[((object)e).GetHashCode()] ?? "",
 				val.NotProperty,
 				val.get_NotPropertyWithGeneric<string>(42),
 				val[42],
@@ -61,10 +61,10 @@ namespace ClassLibrary1
 			};
 			val.OnEvent += Instance_OnEvent;
 			val.OnEvent -= Instance_OnEvent;
-			UnknownEventArgs val3 = val[(UnknownEventArgs)null];
-			val[new UnknownEventArgs()] = val3;
-			UnknownEventArgs val4 = val[new UnknownEventArgs(), new UnknownEventArgs()];
-			val[new UnknownEventArgs(), new UnknownEventArgs()] = val4;
+			UnknownEventArgs e2 = val[(UnknownEventArgs)null];
+			val[new UnknownEventArgs()] = e2;
+			UnknownEventArgs e3 = val[new UnknownEventArgs(), new UnknownEventArgs()];
+			val[new UnknownEventArgs(), new UnknownEventArgs()] = e3;
 		}
 
 		public void MethodUnknownStatic()

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/GuessAccessors.cs
@@ -15,8 +15,8 @@ namespace ClassLibrary1
 			//IL_0007: Expected O, but got Unknown
 			UnknownClass val = new UnknownClass();
 			int? unknownProperty = val.UnknownProperty;
-			int? num2 = (val.UnknownProperty = unknownProperty.GetValueOrDefault());
-			int? num3 = num2;
+			int? num = (val.UnknownProperty = unknownProperty.GetValueOrDefault());
+			int? num3 = num;
 			List<object> list = new List<object> {
 			val[unknownProperty.Value] ?? "",
 			val.NotProperty,

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
@@ -4943,8 +4943,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void Issue1779(int value)
 		{
-			CustomStruct2 @struct = GetStruct();
-			@struct.IntProp += value;
+			CustomStruct2 customStruct = GetStruct();
+			customStruct.IntProp += value;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -377,10 +377,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 		public static void NameConflict2(int j)
 		{
 			List<Action<int>> list = new List<Action<int>>();
-			for (int k = 0; k < 10; k++)
+			for (int i = 0; i < 10; i++)
 			{
-				list.Add(delegate (int i) {
-					Console.WriteLine(i);
+				list.Add(delegate (int k) {
+					Console.WriteLine(k);
 				});
 			}
 		}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -19,15 +19,33 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 #if CS100
 using System.Threading.Tasks;
+
 #endif
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 {
 	public static class DelegateConstruction
 	{
+		internal class Dummy
+		{
+			public int baz;
+
+			public List<Dummy> more;
+		}
+
+		[CompilerGenerated]
+		internal class Helper
+		{
+			internal bool HelpMe(Dummy dum)
+			{
+				return true;
+			}
+		}
+
 		private class InstanceTests
 		{
 			public struct SomeData
@@ -642,6 +660,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 		private void Run(ParameterizedThreadStart del, object x)
 		{
 			del(x);
+		}
+
+		public void Issue1572(DelegateConstruction.Dummy dum)
+		{
+#if EXPECTED_OUTPUT
+			DelegateConstruction.Helper CS_0024_003C_003E8__locals0 = new DelegateConstruction.Helper();
+			DelegateConstruction.Dummy dummy = dum.more.Where((DelegateConstruction.Dummy dummy2) => true).Where((DelegateConstruction.Dummy dummy2) => true).FirstOrDefault();
+			Console.WriteLine();
+			dummy.baz++;
+#else
+			DelegateConstruction.Helper h = new DelegateConstruction.Helper();
+			DelegateConstruction.Dummy localDummy = dum.more.Where(h.HelpMe).Where(h.HelpMe).FirstOrDefault();
+			Console.WriteLine();
+			localDummy.baz++;
+#endif
 		}
 	}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExceptionHandling.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExceptionHandling.cs
@@ -418,9 +418,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			{
 				Console.WriteLine(input);
 			}
-			catch (TException val)
+			catch (TException ex)
 			{
-				Console.WriteLine(val.Message);
+				Console.WriteLine(ex.Message);
 				throw;
 			}
 		}
@@ -452,9 +452,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			{
 				Console.WriteLine(input);
 			}
-			catch (TException val) when (val.Message.Contains("Test"))
+			catch (TException ex) when (ex.Message.Contains("Test"))
 			{
-				Console.WriteLine(val.Message);
+				Console.WriteLine(ex.Message);
 				throw;
 			}
 		}
@@ -465,9 +465,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			{
 				Console.WriteLine(input);
 			}
-			catch (TException val) when (val.Message.Contains("Test"))
+			catch (TException ex) when (ex.Message.Contains("Test"))
 			{
-				Console.WriteLine("{0} {1}", val, val.ToString());
+				Console.WriteLine("{0} {1}", ex, ex.ToString());
 			}
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
@@ -182,11 +182,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			GetRef<ReadOnlyStruct>().Method();
 
 			// call on a copy, not the original ref:
-			NormalStruct @ref = GetRef<NormalStruct>();
-			@ref.Method();
+			NormalStruct normalStruct = GetRef<NormalStruct>();
+			normalStruct.Method();
 
-			ReadOnlyStruct ref2 = GetRef<ReadOnlyStruct>();
-			ref2.Method();
+			ReadOnlyStruct readOnlyStruct = GetRef<ReadOnlyStruct>();
+			readOnlyStruct.Method();
 		}
 
 		public void CallOnReadOnlyRefReturn()
@@ -293,13 +293,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public void RefReassignment(ref NormalStruct s)
 		{
-			ref NormalStruct @ref = ref GetRef<NormalStruct>();
-			RefReassignment(ref @ref);
+			ref NormalStruct reference = ref GetRef<NormalStruct>();
+			RefReassignment(ref reference);
 			if (s.GetHashCode() == 0)
 			{
-				@ref = ref GetRef<NormalStruct>();
+				reference = ref GetRef<NormalStruct>();
 			}
-			RefReassignment(ref @ref.GetHashCode() == 4 ? ref @ref : ref s);
+			RefReassignment(ref reference.GetHashCode() == 4 ? ref reference : ref s);
 		}
 
 		public static void Main(string[] args)

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/Async.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/Async.cs
@@ -40,9 +40,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.VBPretty
 		public async void AwaitDefaultYieldAwaitable()
 		{
 #if LEGACY_VBC || (OPTIMIZE && !ROSLYN4)
-			YieldAwaitable yieldAwaitable = default(YieldAwaitable);
-			YieldAwaitable yieldAwaitable2 = yieldAwaitable;
-			await yieldAwaitable2;
+			YieldAwaitable yieldAwaitable2 = default(YieldAwaitable);
+			YieldAwaitable yieldAwaitable = yieldAwaitable2;
+			await yieldAwaitable;
 #else
 			await default(YieldAwaitable);
 #endif
@@ -51,9 +51,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.VBPretty
 		public async void AwaitDefaultHopToThreadPool()
 		{
 #if LEGACY_VBC || (OPTIMIZE && !ROSLYN4)
-			HopToThreadPoolAwaitable hopToThreadPoolAwaitable = default(HopToThreadPoolAwaitable);
-			HopToThreadPoolAwaitable hopToThreadPoolAwaitable2 = hopToThreadPoolAwaitable;
-			await hopToThreadPoolAwaitable2;
+			HopToThreadPoolAwaitable hopToThreadPoolAwaitable2 = default(HopToThreadPoolAwaitable);
+			HopToThreadPoolAwaitable hopToThreadPoolAwaitable = hopToThreadPoolAwaitable2;
+			await hopToThreadPoolAwaitable;
 #else
 			await default(HopToThreadPoolAwaitable);
 #endif

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1282,7 +1282,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				if (string.IsNullOrWhiteSpace(parameter.Name) && !parameter.Type.IsArgList())
 				{
-					// needs to be consistent with logic in ILReader.CreateILVarable
+					// needs to be consistent with logic in ILReader.CreateILVariable
 					parameter.Name = "P_" + i;
 				}
 				i++;

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2554,7 +2554,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 				if (string.IsNullOrEmpty(pd.Name) && !pd.Type.IsArgList())
 				{
-					// needs to be consistent with logic in ILReader.CreateILVarable(ParameterDefinition)
+					// needs to be consistent with logic in ILReader.CreateILVariable
 					pd.Name = "P_" + i;
 				}
 				if (settings.AnonymousTypes && parameter.Type.ContainsAnonymousType())

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2547,6 +2547,11 @@ namespace ICSharpCode.Decompiler.CSharp
 			foreach (var parameter in parameters)
 			{
 				var pd = astBuilder.ConvertParameter(parameter);
+				if (variables.TryGetValue(i, out var v))
+				{
+					pd.AddAnnotation(new ILVariableResolveResult(v, parameters[i].Type));
+					pd.Name = v.Name;
+				}
 				if (string.IsNullOrEmpty(pd.Name) && !pd.Type.IsArgList())
 				{
 					// needs to be consistent with logic in ILReader.CreateILVarable(ParameterDefinition)
@@ -2554,8 +2559,6 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 				if (settings.AnonymousTypes && parameter.Type.ContainsAnonymousType())
 					pd.Type = null;
-				if (variables.TryGetValue(i, out var v))
-					pd.AddAnnotation(new ILVariableResolveResult(v, parameters[i].Type));
 				yield return pd;
 				i++;
 			}

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2020 AlphaSierraPapa for the SharpDevelop Team
+// Copyright (c) 2010-2020 AlphaSierraPapa for the SharpDevelop Team
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -426,8 +426,9 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 
 		/// <summary>
 		/// Determines whether the specified identifier is a keyword in the given context.
+		/// If <paramref name="context"/> is <see langword="null" /> all keywords are treated as unconditional.
 		/// </summary>
-		public static bool IsKeyword(string identifier, AstNode context)
+		public static bool IsKeyword(string identifier, AstNode context = null)
 		{
 			// only 2-10 char lower-case identifiers can be keywords
 			if (identifier.Length > maxKeywordLength || identifier.Length < 2 || identifier[0] < 'a')
@@ -440,10 +441,12 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			}
 			if (queryKeywords.Contains(identifier))
 			{
-				return context.Ancestors.Any(ancestor => ancestor is QueryExpression);
+				return context == null || context.Ancestors.Any(ancestor => ancestor is QueryExpression);
 			}
 			if (identifier == "await")
 			{
+				if (context == null)
+					return true;
 				foreach (AstNode ancestor in context.Ancestors)
 				{
 					// with lambdas/anonymous methods,

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -1389,6 +1389,16 @@ namespace ICSharpCode.Decompiler.CSharp
 				var astBuilder = exprBuilder.astBuilder;
 				var method = (MethodDeclaration)astBuilder.ConvertEntity(function.ReducedMethod);
 
+				var variables = function.Variables.Where(v => v.Kind == VariableKind.Parameter).ToDictionary(v => v.Index);
+
+				foreach (var (i, p) in method.Parameters.WithIndex())
+				{
+					if (variables.TryGetValue(i, out var v))
+					{
+						p.Name = v.Name;
+					}
+				}
+
 				if (function.Method.HasBody)
 				{
 					var nestedBuilder = new StatementBuilder(

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -1165,6 +1165,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			function.MoveNextMethod = moveNextFunction.Method;
 			function.SequencePointCandidates = moveNextFunction.SequencePointCandidates;
 			function.CodeSize = moveNextFunction.CodeSize;
+			function.LocalVariableSignatureLength = moveNextFunction.LocalVariableSignatureLength;
 			function.IsIterator = IsAsyncEnumerator;
 			moveNextFunction.Variables.Clear();
 			moveNextFunction.ReleaseRef();

--- a/ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs
@@ -656,6 +656,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			function.MoveNextMethod = moveNextFunction.Method;
 			function.SequencePointCandidates = moveNextFunction.SequencePointCandidates;
 			function.CodeSize = moveNextFunction.CodeSize;
+			function.LocalVariableSignatureLength = moveNextFunction.LocalVariableSignatureLength;
 
 			// Copy-propagate temporaries holding a copy of 'this'.
 			// This is necessary because the old (pre-Roslyn) C# compiler likes to store 'this' in temporary variables.

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -342,7 +342,10 @@ namespace ICSharpCode.Decompiler.IL
 			if (index < 0)
 				ilVar.Name = "this";
 			else if (string.IsNullOrWhiteSpace(name))
+			{
 				ilVar.Name = "P_" + index;
+				ilVar.HasGeneratedName = true;
+			}
 			else
 				ilVar.Name = name;
 			return ilVar;
@@ -706,6 +709,7 @@ namespace ICSharpCode.Decompiler.IL
 			var function = new ILFunction(this.method, body.GetCodeSize(), this.genericContext, mainContainer, kind);
 			function.Variables.AddRange(parameterVariables);
 			function.Variables.AddRange(localVariables);
+			function.LocalVariableSignatureLength = localVariables.Length;
 			Debug.Assert(stackVariables != null);
 			function.Variables.AddRange(stackVariables);
 			function.Variables.AddRange(variableByExceptionHandler.Values);

--- a/ICSharpCode.Decompiler/IL/Instructions/ILFunction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/ILFunction.cs
@@ -68,6 +68,11 @@ namespace ICSharpCode.Decompiler.IL
 		public readonly ILVariableCollection Variables;
 
 		/// <summary>
+		/// Gets 
+		/// </summary>
+		public int LocalVariableSignatureLength;
+
+		/// <summary>
 		/// Gets the scope in which the local function is declared.
 		/// Returns null, if this is not a local function.
 		/// </summary>

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -215,7 +215,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 							if (variables.TryGetValue(i, out var v))
 								variableMapping[v] = p.Name;
 						}
-						if (!parentScope.IsReservedVariableName(p.Name, out _))
+						string nameWithoutNumber = SplitName(p.Name, out int newIndex);
+						if (!parentScope.IsReservedVariableName(nameWithoutNumber, out _))
 						{
 							AddExistingName(reservedVariableNames, p.Name);
 							if (variables.TryGetValue(i, out var v))

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -729,22 +729,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				type = NullableType.GetUnderlyingType(((TypeWithElementType)type).ElementType);
 			}
 
-			string name = type.Kind switch {
-				TypeKind.Array => "array",
-				TypeKind.Pointer => "ptr",
-				TypeKind.TypeParameter => "val",
-				TypeKind.Unknown => "val",
-				TypeKind.Dynamic => "val",
-				TypeKind.ByReference => "reference",
-				TypeKind.Tuple => "tuple",
-				TypeKind.NInt => "num",
-				TypeKind.NUInt => "num",
-				_ => null
-			};
-			if (name != null)
-			{
-				return name;
-			}
+			string name;
 			if (type.IsAnonymousType())
 			{
 				name = "anon";
@@ -753,13 +738,28 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			{
 				name = "ex";
 			}
+			else if (type.Name.EndsWith("EventArgs", StringComparison.Ordinal))
+			{
+				name = "e";
+			}
 			else if (type.IsCSharpNativeIntegerType())
 			{
 				name = "num";
 			}
 			else if (!typeNameToVariableNameDict.TryGetValue(type.FullName, out name))
 			{
-				name = type.Name;
+				name = type.Kind switch {
+					TypeKind.Array => "array",
+					TypeKind.Pointer => "ptr",
+					TypeKind.TypeParameter => "val",
+					TypeKind.Unknown => "val",
+					TypeKind.Dynamic => "val",
+					TypeKind.ByReference => "reference",
+					TypeKind.Tuple => "tuple",
+					TypeKind.NInt => "num",
+					TypeKind.NUInt => "num",
+					_ => type.Name
+				};
 				// remove the 'I' for interfaces
 				if (name.Length >= 3 && name[0] == 'I' && char.IsUpper(name[1]) && char.IsLower(name[2]))
 					name = name.Substring(1);

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -657,8 +657,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 			if (name.Length == 0)
 				return "obj";
-			else
-				return char.ToLower(name[0]) + name.Substring(1);
+			string lowerCaseName = char.ToLower(name[0]) + name.Substring(1);
+			if (CSharp.OutputVisitor.CSharpOutputVisitor.IsKeyword(lowerCaseName))
+				return null;
+			return lowerCaseName;
 		}
 
 		internal static IType GuessType(IType variableType, ILInstruction inst, ILTransformContext context)

--- a/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
+++ b/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
@@ -225,7 +225,7 @@ namespace ICSharpCode.Decompiler.Util
 				yield return func(index++, element);
 		}
 
-		public static IEnumerable<(int, T)> WithIndex<T>(this ICollection<T> source)
+		public static IEnumerable<(int, T)> WithIndex<T>(this IEnumerable<T> source)
 		{
 			int index = 0;
 			foreach (var item in source)


### PR DESCRIPTION
Link to issue(s) this covers: #1572, #1956, #2439, #2694 

Needs more thorough testing on larger code bases, but it will be hard to verify the results.

@tamlin-mike @yyjdelete @greenozon

@dgrunwald I suspect that the "allow shadowing of names in local functions / lambdas" language feature could be implemented in ILSpy by making sure that no variables in the ILFunction.CapturedVariables list have the same name as any local variable or parameter? The changes in this PR only introduce the concept of a scope per ILFunction, so parameters of "independent" lambdas such as `list.Where(x => x > 5).Select(x => x * 2)` are allowed even without the setting, but nested lambdas that "shadow" a lambda parameter, but don't use any variable from a parent scope are not allowed right now.