### PR TITLE
Fix exception when writing resx files without adding any resources

### DIFF
--- a/ICSharpCode.Decompiler/Util/ResXResourceWriter.cs
+++ b/ICSharpCode.Decompiler/Util/ResXResourceWriter.cs
@@ -312,6 +312,9 @@ namespace ICSharpCode.Decompiler.Util
 
 		public void Generate()
 		{
+			if (writer == null)
+				InitWriter();
+
 			if (written)
 				throw new InvalidOperationException("The resource is already generated.");
 


### PR DESCRIPTION
### Problem

Version [9.0.0.7889](https://www.nuget.org/packages/ICSharpCode.Decompiler/9.0.0.7889) throws a NullReferenceException when trying to write a resx file without calling AddResource() due to the uninitialized writer.

### Solution
Initialize the writer during Generate, in case it was not initialized yet.
