### PR TITLE
Fix null check in MatchLegacySwitchOnStringWithDict

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/SwitchOnStringTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/SwitchOnStringTransform.cs
@@ -668,7 +668,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (!FixCasesWithoutValue(sections, stringValues))
 				return false;
 			// switch contains case null:
-			if (nullValueCaseBlock != defaultBlock)
+			if (nullValueCaseBlock != null && nullValueCaseBlock != defaultBlock)
 			{
 				if (!AddNullSection(sections, stringValues, nullValueCaseBlock))
 				{


### PR DESCRIPTION
Updated the condition for `nullValueCaseBlock` to ensure it is not null and not equal to `defaultBlock`.

### Problem

Resolves #3421 

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
* Which part of this PR is most in need of attention/improvement?
* [ ] At least one test covering the code changed
  * Is a test necessary for this? If so, I'm not sure what the best way to write that test is.

