### PR TITLE
log full instruction on onsupported OpCode

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4815,7 +4815,7 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		protected override TranslatedExpression Default(ILInstruction inst, TranslationContext context)
 		{
-			return ErrorExpression("OpCode not supported: " + inst.OpCode);
+			return ErrorExpression("OpCode not supported: " + inst);
 		}
 
 		static TranslatedExpression ErrorExpression(string message)


### PR DESCRIPTION
provides more context on analyzing obfuscated binaries for instance:
before:
```
((delegate*<Array, RuntimeFieldHandle, void>)Class195.methods[1])(array, (RuntimeFieldHandle)
/*OpCode not supported: LdMemberToken*/);
```

after:
```
((delegate*<Array, RuntimeFieldHandle, void>)Class195.methods[1])(array, (RuntimeFieldHandle)
/*OpCode not supported: ldmembertoken method_5678 at IL_000d*/);
```

PS sorry I don't have VS to run tests `ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoArrayInitializers.Expected.cs` should be fixed too.


Link to issue(s) this covers

### Problem
Link to, or brief information about the issue

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
* Which part of this PR is most in need of attention/improvement?
* [ ] At least one test covering the code changed

