### PR TITLE
PSCmdLet to output target framework for an assembly

### DIFF
--- a/ICSharpCode.Decompiler.PowerShell/GetTargetFramework.cs
+++ b/ICSharpCode.Decompiler.PowerShell/GetTargetFramework.cs
@@ -1,0 +1,21 @@
+﻿using System.Management.Automation;
+
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.Decompiler.PowerShell
+{
+	[Cmdlet(VerbsCommon.Get, "TargetFramework")]
+	[OutputType(typeof(string))]
+	public class GetTargetFramework : PSCmdlet
+	{
+		[Parameter(Position = 0, Mandatory = true)]
+		public CSharpDecompiler Decompiler { get; set; }
+
+		protected override void ProcessRecord()
+		{
+			MetadataFile module = Decompiler.TypeSystem.MainModule.MetadataFile;
+			WriteObject(module.Metadata.DetectTargetFrameworkId());
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.PowerShell/manifest.psd1
+++ b/ICSharpCode.Decompiler.PowerShell/manifest.psd1
@@ -68,7 +68,8 @@
     'Get-DecompiledSource',
     'Get-DecompiledTypes',
     'Get-Decompiler',
-    'Get-DecompilerVersion'
+    'Get-DecompilerVersion',
+    'Get-TargetFramework'
   )
 
   # Variables to export from this module


### PR DESCRIPTION
### Problem
Sometimes it is helpful to validate that all the assemblies in a directory are targeting the expected framework(s).

### Solution
Adding a simple PS cmdlet to output the target framework for an assembly using PowerShell.

