### PR TITLE
Fix changes due to eval order fix

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -60,7 +60,7 @@ jobs:
       run: msbuild ILSpy.sln /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /m
 
     - name: Execute unit tests
-      run: dotnet test --logger "junit;LogFileName=${{ matrix.configuration }}.xml" --results-directory test-results $env:Tests1 $env:Tests2 $env:Tests3
+      run: dotnet test --logger "trx;LogFileName=${{ matrix.configuration }}.trx" --results-directory test-results $env:Tests1 $env:Tests2 $env:Tests3
       env:
         Tests1: ICSharpCode.Decompiler.Tests\bin\${{ matrix.configuration }}\net8.0-windows\win-x64\ICSharpCode.Decompiler.Tests.dll
         Tests2: ILSpy.Tests\bin\${{ matrix.configuration }}\net8.0-windows\ILSpy.Tests.dll
@@ -71,13 +71,14 @@ jobs:
       if: success() || failure()
       with:
         name: test-results-${{ matrix.configuration }}
-        path: 'test-results/${{ matrix.configuration }}.xml'
+        path: 'test-results/${{ matrix.configuration }}.trx'
 
     - name: Create Test Report
-      uses: test-summary/action@v2
+      uses: icsharpcode/test-summary-action@dist
       if: always()
       with:
-        paths: "test-results/${{ matrix.configuration }}.xml"
+        paths: "test-results/${{ matrix.configuration }}.trx"
+        folded: true
 
     - name: Format check
       run: dotnet-format whitespace --verify-no-changes --verbosity detailed ILSpy.sln

--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -16,8 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
-using System.CodeDom.Compiler;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -311,6 +309,12 @@ namespace ICSharpCode.Decompiler.Tests
 		public async Task Jmp()
 		{
 			await RunIL("Jmp.il");
+		}
+
+		[Test]
+		public async Task NonGenericConstrainedCallVirt()
+		{
+			await RunIL("NonGenericConstrainedCallVirt.il", CompilerOptions.UseRoslynLatest);
 		}
 
 		[Test]

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -17,7 +17,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 
     <NoWarn>1701;1702;1705,67,169,1058,728,1720,649,168,251,660,661,675;1998;162;8632;626;8618;8714;8602;8981</NoWarn>
-    <DefineConstants>ROSLYN;NET60;CS60;CS70;CS71;CS72;CS73;CS80;CS90;CS100;CS110;CS120</DefineConstants>
+    <DefineConstants>ROSLYN;ROSLYN2;ROSLYN3;ROSLYN4;NET60;CS60;CS70;CS71;CS72;CS73;CS80;CS90;CS100;CS110;CS120</DefineConstants>
 
     <GenerateAssemblyVersionAttribute>False</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>False</GenerateAssemblyFileVersionAttribute>

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -95,6 +95,7 @@
     <None Include="TestCases\ILPretty\Issue2260SwitchString.il" />
     <None Include="TestCases\ILPretty\Issue3442.il" />
     <None Include="TestCases\ILPretty\MonoFixed.il" />
+    <None Include="TestCases\Correctness\NonGenericConstrainedCallVirt.il" />
     <None Include="TestCases\ILPretty\UnknownTypes.cs" />
     <None Include="TestCases\ILPretty\UnknownTypes.il" />
     <None Include="TestCases\ILPretty\EvalOrder.cs" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/NonGenericConstrainedCallVirt.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/NonGenericConstrainedCallVirt.il
@@ -1,0 +1,143 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+
+.assembly _
+{
+    .hash algorithm 0x00008004 // SHA1
+    .ver 0:0:0:0
+}
+
+.class public auto ansi beforefieldinit NonGenericConstrainedCallVirt
+    extends [mscorlib]System.Object
+{
+    // Methods
+    .method public hidebysig static 
+        void Main () cil managed 
+    {
+        // Method begins at RVA 0x2050
+        // Code size 16 (0x10)
+        .entrypoint
+        .maxstack 8
+
+        IL_0000: ldstr "A"
+        IL_0005: newobj instance void C::.ctor(string)
+        IL_000a: call void NonGenericConstrainedCallVirt::Foo(class C)
+        IL_000f: ret
+    } // end of method NonGenericConstrainedCallVirt::Main
+
+    .method private hidebysig static 
+        void Foo (
+            class C arg
+        ) cil managed 
+    {
+        // Method begins at RVA 0x2064
+        // Code size 25 (0x19)
+        .maxstack 8
+
+        IL_0000: ldarga arg
+        IL_0004: ldarga arg
+        IL_0008: call int32 NonGenericConstrainedCallVirt::Bar(class C&)
+        IL_000d: constrained. C
+        IL_0013: callvirt instance void C::Baz(int32)
+        IL_0018: ret
+    } // end of method NonGenericConstrainedCallVirt::Foo
+
+    .method private hidebysig static 
+        int32 Bar (
+            class C& o
+        ) cil managed 
+    {
+        // Method begins at RVA 0x2080
+        // Code size 14 (0xe)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: ldstr "B"
+        IL_0006: newobj instance void C::.ctor(string)
+        IL_000b: stind.ref
+        IL_000c: ldc.i4.0
+        IL_000d: ret
+    } // end of method NonGenericConstrainedCallVirt::Bar
+
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor () cil managed 
+    {
+        // Method begins at RVA 0x2090
+        // Code size 7 (0x7)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [mscorlib]System.Object::.ctor()
+        IL_0006: ret
+    } // end of method NonGenericConstrainedCallVirt::.ctor
+
+} // end of class NonGenericConstrainedCallVirt
+
+.class public auto ansi beforefieldinit C
+    extends [mscorlib]System.Object
+{
+    // Fields
+    .field private initonly string '<Name>k__BackingField'
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+        01 00 00 00
+    )
+
+    // Methods
+    .method public hidebysig specialname rtspecialname 
+        instance void .ctor (
+            string n
+        ) cil managed 
+    {
+        // Method begins at RVA 0x2098
+        // Code size 14 (0xe)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [mscorlib]System.Object::.ctor()
+        IL_0006: ldarg.0
+        IL_0007: ldarg.1
+        IL_0008: stfld string C::'<Name>k__BackingField'
+        IL_000d: ret
+    } // end of method C::.ctor
+
+    .method public hidebysig 
+        instance void Baz (
+            int32 arg
+        ) cil managed 
+    {
+        // Method begins at RVA 0x20a8
+        // Code size 12 (0xc)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance string C::get_Name()
+        IL_0006: call void [mscorlib]System.Console::WriteLine(string)
+        IL_000b: ret
+    } // end of method C::Baz
+
+    .method public hidebysig specialname 
+        instance string get_Name () cil managed 
+    {
+        .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = (
+            01 00 00 00
+        )
+        // Method begins at RVA 0x20b8
+        // Code size 7 (0x7)
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: ldfld string C::'<Name>k__BackingField'
+        IL_0006: ret
+    } // end of method C::get_Name
+
+    // Properties
+    .property instance string Name()
+    {
+        .get instance string C::get_Name()
+    }
+
+} // end of class C
+

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Generics.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Generics.cs
@@ -296,5 +296,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return default(T).ToString();
 		}
+
+		public static void ConstrainedCall<T>(T x, ref T y) where T : IDisposable
+		{
+			x.Dispose();
+			y.Dispose();
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -149,6 +149,7 @@ namespace ICSharpCode.Decompiler.CSharp
 							new IndexRangeTransform(),
 							new DeconstructionTransform(),
 							new NamedArgumentTransform(),
+							new RemoveUnconstrainedGenericReferenceTypeCheck(),
 							new UserDefinedLogicTransform(),
 							new InterpolatedStringTransform()
 						),
@@ -1717,6 +1718,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				var ilReader = new ILReader(typeSystem.MainModule) {
 					UseDebugSymbols = settings.UseDebugSymbols,
+					UseRefLocalsForAccurateOrderOfEvaluation = settings.UseRefLocalsForAccurateOrderOfEvaluation,
 					DebugInfo = DebugInfoProvider
 				};
 				var methodDef = metadata.GetMethodDefinition((MethodDefinitionHandle)method.MetadataToken);

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -356,11 +356,18 @@ namespace ICSharpCode.Decompiler.CSharp
 			}
 			else
 			{
+				var thisArg = callArguments.FirstOrDefault();
+				if (thisArg is LdObjIfRef ldObjIfRef)
+				{
+					Debug.Assert(constrainedTo != null);
+					thisArg = ldObjIfRef.Target;
+				}
 				target = expressionBuilder.TranslateTarget(
-					callArguments.FirstOrDefault(),
+					thisArg,
 					nonVirtualInvocation: callOpCode == OpCode.Call || method.IsConstructor,
 					memberStatic: method.IsStatic,
-					memberDeclaringType: constrainedTo ?? method.DeclaringType);
+					memberDeclaringType: method.DeclaringType,
+					constrainedTo: constrainedTo);
 				if (constrainedTo == null
 					&& target.Expression is CastExpression cast
 					&& target.ResolveResult is ConversionResolveResult conversion

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -92,7 +92,6 @@ namespace ICSharpCode.Decompiler
 				stringInterpolation = false;
 				dictionaryInitializers = false;
 				extensionMethodsInCollectionInitializers = false;
-				useRefLocalsForAccurateOrderOfEvaluation = false;
 				getterOnlyAutomaticProperties = false;
 			}
 			if (languageVersion < CSharp.LanguageVersion.CSharp7)
@@ -105,6 +104,7 @@ namespace ICSharpCode.Decompiler
 				localFunctions = false;
 				deconstruction = false;
 				patternMatching = false;
+				useRefLocalsForAccurateOrderOfEvaluation = false;
 			}
 			if (languageVersion < CSharp.LanguageVersion.CSharp7_2)
 			{
@@ -190,11 +190,11 @@ namespace ICSharpCode.Decompiler
 				return CSharp.LanguageVersion.CSharp7_2;
 			// C# 7.1 missing
 			if (outVariables || throwExpressions || tupleTypes || tupleConversions
-				|| discards || localFunctions || deconstruction || patternMatching)
+				|| discards || localFunctions || deconstruction || patternMatching || useRefLocalsForAccurateOrderOfEvaluation)
 				return CSharp.LanguageVersion.CSharp7;
 			if (awaitInCatchFinally || useExpressionBodyForCalculatedGetterOnlyProperties || nullPropagation
 				|| stringInterpolation || dictionaryInitializers || extensionMethodsInCollectionInitializers
-				|| useRefLocalsForAccurateOrderOfEvaluation || getterOnlyAutomaticProperties)
+				|| getterOnlyAutomaticProperties)
 				return CSharp.LanguageVersion.CSharp6;
 			if (asyncAwait)
 				return CSharp.LanguageVersion.CSharp5;
@@ -1126,7 +1126,7 @@ namespace ICSharpCode.Decompiler
 		/// order of evaluation.
 		/// See https://github.com/icsharpcode/ILSpy/issues/2050
 		/// </summary>
-		[Category("C# 6.0 / VS 2015")]
+		[Category("C# 7.0 / VS 2017")]
 		[Description("DecompilerSettings.UseRefLocalsForAccurateOrderOfEvaluation")]
 		public bool UseRefLocalsForAccurateOrderOfEvaluation {
 			get { return useRefLocalsForAccurateOrderOfEvaluation; }

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -107,6 +107,7 @@
     <Compile Include="DecompilationProgress.cs" />
     <Compile Include="Disassembler\IEntityProcessor.cs" />
     <Compile Include="Disassembler\SortByNameProcessor.cs" />
+    <Compile Include="IL\Transforms\RemoveUnconstrainedGenericReferenceTypeCheck.cs" />
     <Compile Include="Metadata\MetadataFile.cs" />
     <Compile Include="Metadata\ModuleReferenceMetadata.cs" />
     <Compile Include="NRTAttributes.cs" />

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -122,6 +122,7 @@ namespace ICSharpCode.Decompiler.IL
 		readonly MetadataReader metadata;
 
 		public bool UseDebugSymbols { get; set; }
+		public bool UseRefLocalsForAccurateOrderOfEvaluation { get; set; }
 		public DebugInfo.IDebugInfoProvider? DebugInfo { get; set; }
 		public List<string> Warnings { get; } = new List<string>();
 
@@ -1770,6 +1771,7 @@ namespace ICSharpCode.Decompiler.IL
 				StackType expectedStackType = CallInstruction.ExpectedTypeForThisPointer(method.DeclaringType, constrainedPrefix);
 				bool requiresLdObjIfRef = firstArgument == 1
 					&& !firstArgumentIsStObjTarget
+					&& UseRefLocalsForAccurateOrderOfEvaluation
 					&& expectedStackType == StackType.Ref && typeOfThis.IsReferenceType != false;
 				for (int i = method.Parameters.Count - 1; i >= 0; i--)
 				{

--- a/ICSharpCode.Decompiler/IL/Instructions.tt
+++ b/ICSharpCode.Decompiler/IL/Instructions.tt
@@ -255,6 +255,9 @@
 		new OpCode("ldobj", "Indirect load (ref/pointer dereference).",
 			CustomClassName("LdObj"), CustomArguments(("target", new[] { "Ref", "I" })), HasTypeOperand, MemoryAccess, CustomWriteToButKeepOriginal,
 			SupportsVolatilePrefix, SupportsUnalignedPrefix, MayThrow, ResultType("type.GetStackType()")),
+		new OpCode("ldobj.if.ref", "If argument is a ref to a reference type, loads the object reference, stores it in a temporary, and evaluates to the address of that temporary (address.of(ldobj(arg))). Otherwise, returns the argument ref as-is.<para>This instruction represents the memory-load semantics of callvirt with a generic type as receiver (where the IL always takes a ref, but only methods on value types expect one, for method on reference types there's an implicit ldobj, which this instruction makes explicit in order to preserve the order-of-evaluation).</para>",
+			CustomClassName("LdObjIfRef"), CustomArguments(("target", new[] { "Ref", "I" })), HasTypeOperand, MemoryAccess,
+			MayThrow, ResultType("Ref")),
 		new OpCode("stobj", "Indirect store (store to ref/pointer)." + Environment.NewLine
 				+ "Evaluates to the value that was stored (when using type byte/short: evaluates to the truncated value, sign/zero extended back to I4 based on type.GetSign())",
 			CustomClassName("StObj"), CustomArguments(("target", new[] { "Ref", "I" }), ("value", new[] { "type.GetStackType()" })), HasTypeOperand, MemoryAccess, CustomWriteToButKeepOriginal,
@@ -916,7 +919,8 @@ namespace ICSharpCode.Decompiler.IL
 			b = new StringBuilder();
 			b.AppendLine("protected sealed override ILInstruction GetChild(int index)");
 			b.AppendLine("{");
-			b.AppendLine("\tswitch (index) {");
+			b.AppendLine("\tswitch (index)");
+			b.AppendLine("\t{");
 			for (int i = 0; i < childCount; i++) {
 				b.AppendLine("\t\tcase " + i + ":");
 				b.AppendLine("\t\t\treturn this." + children[i].Name + ";");
@@ -933,7 +937,8 @@ namespace ICSharpCode.Decompiler.IL
 			b = new StringBuilder();
 			b.AppendLine("protected sealed override void SetChild(int index, ILInstruction value)");
 			b.AppendLine("{");
-			b.AppendLine("\tswitch (index) {");
+			b.AppendLine("\tswitch (index)");
+			b.AppendLine("\t{");
 			for (int i = 0; i < childCount; i++) {
 				b.AppendLine("\t\tcase " + i + ":");
 				b.AppendLine("\t\t\tthis." + children[i].PropertyName + " = value;");
@@ -953,7 +958,8 @@ namespace ICSharpCode.Decompiler.IL
 			b = new StringBuilder();
 			b.AppendLine("protected sealed override SlotInfo GetChildSlot(int index)");
 			b.AppendLine("{");
-			b.AppendLine("\tswitch (index) {");
+			b.AppendLine("\tswitch (index)");
+			b.AppendLine("\t{");
 			for (int i = 0; i < childCount; i++) {
 				b.AppendLine("\t\tcase " + i + ":");
 				b.AppendLine("\t\t\treturn " + children[i].SlotName + ";");
@@ -1113,7 +1119,8 @@ protected override void Disconnected()
 			opCode.Members.Add("/// <summary>Returns the method operand.</summary>" + Environment.NewLine
 							+ $"public IMethod{n} Method => method;");
 			opCode.GenerateWriteTo = true;
-			opCode.WriteOperand.Add("if (method != null) {");
+			opCode.WriteOperand.Add("if (method != null)");
+			opCode.WriteOperand.Add("{");
 			opCode.WriteOperand.Add("\toutput.Write(' ');");
 			opCode.WriteOperand.Add("\tmethod.WriteTo(output);");
 			opCode.WriteOperand.Add("}");

--- a/ICSharpCode.Decompiler/IL/Instructions/CallInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/CallInstruction.cs
@@ -98,16 +98,19 @@ namespace ICSharpCode.Decompiler.IL
 
 		/// <summary>
 		/// Gets the expected stack type for passing the this pointer in a method call.
-		/// Returns StackType.O for reference types (this pointer passed as object reference),
+		/// Returns StackType.Ref if constrainedTo is not null,
+		/// StackType.O for reference types (this pointer passed as object reference),
 		/// and StackType.Ref for type parameters and value types (this pointer passed as managed reference).
 		/// 
 		/// Returns StackType.Unknown if the input type is unknown.
 		/// </summary>
-		internal static StackType ExpectedTypeForThisPointer(IType type)
+		internal static StackType ExpectedTypeForThisPointer(IType declaringType, IType? constrainedTo)
 		{
-			if (type.Kind == TypeKind.TypeParameter)
+			if (constrainedTo != null)
 				return StackType.Ref;
-			switch (type.IsReferenceType)
+			if (declaringType.Kind == TypeKind.TypeParameter)
+				return StackType.Ref;
+			switch (declaringType.IsReferenceType)
 			{
 				case true:
 					return StackType.O;
@@ -125,7 +128,7 @@ namespace ICSharpCode.Decompiler.IL
 			Debug.Assert(Method.Parameters.Count + firstArgument == Arguments.Count);
 			if (firstArgument == 1)
 			{
-				if (!(Arguments[0].ResultType == ExpectedTypeForThisPointer(ConstrainedTo ?? Method.DeclaringType)))
+				if (!(Arguments[0].ResultType == ExpectedTypeForThisPointer(Method.DeclaringType, ConstrainedTo)))
 					Debug.Fail($"Stack type mismatch in 'this' argument in call to {Method.Name}()");
 			}
 			for (int i = 0; i < Method.Parameters.Count; ++i)

--- a/ICSharpCode.Decompiler/IL/Instructions/PatternMatching.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/PatternMatching.cs
@@ -581,5 +581,17 @@ namespace ICSharpCode.Decompiler.IL
 		{
 			return this;
 		}
+
+		public bool MatchLdObj([NotNullWhen(true)] out ILInstruction? target, IType type)
+		{
+			var inst = this as LdObj;
+			if (inst != null && inst.Type.Equals(type))
+			{
+				target = inst.Target;
+				return true;
+			}
+			target = default(ILInstruction);
+			return false;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -475,6 +475,18 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 		}
 
+		protected internal override void VisitLdObjIfRef(LdObjIfRef inst)
+		{
+			base.VisitLdObjIfRef(inst);
+			if (inst.Target is AddressOf)
+			{
+				context.Step("ldobj.if.ref(addressof(...)) -> addressof(...)", inst);
+				// there already is a temporary, so the ldobj.if.ref is a no-op in both cases
+				inst.ReplaceWith(inst.Target);
+				return;
+			}
+		}
+
 		protected internal override void VisitStObj(StObj inst)
 		{
 			base.VisitStObj(inst);

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -485,6 +485,16 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				inst.ReplaceWith(inst.Target);
 				return;
 			}
+			if (inst.Target.MatchLdLoc(out var s) && s.IsSingleDefinition && s.LoadCount == 1
+				&& s.StoreInstructions.SingleOrDefault() is StLoc {
+					Value: LdLoca { Variable: { AddressCount: 1, StoreCount: 1 } }
+				})
+			{
+				context.Step("Single use of ldobj.if.ref(ldloc v) -> ldloc v", inst);
+				// there already is a temporary, so the ldobj.if.ref is a no-op in both cases
+				inst.ReplaceWith(inst.Target);
+				return;
+			}
 		}
 
 		protected internal override void VisitStObj(StObj inst)

--- a/ICSharpCode.Decompiler/IL/Transforms/IILTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/IILTransform.cs
@@ -79,6 +79,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		{
 			return new ILReader(TypeSystem.MainModule) {
 				UseDebugSymbols = Settings.UseDebugSymbols,
+				UseRefLocalsForAccurateOrderOfEvaluation = Settings.UseRefLocalsForAccurateOrderOfEvaluation,
 				DebugInfo = DebugInfo
 			};
 		}

--- a/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
@@ -394,6 +394,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (ldloca.Variable.Type.IsReferenceType ?? false)
 				return false;
 			ILInstruction inst = ldloca;
+			if (inst.Parent is LdObjIfRef)
+			{
+				inst = inst.Parent;
+			}
 			while (inst.Parent is LdFlda ldflda)
 			{
 				inst = ldflda;

--- a/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
@@ -170,20 +170,27 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		public static bool InlineOneIfPossible(Block block, int pos, InliningOptions options, ILTransformContext context)
 		{
 			context.CancellationToken.ThrowIfCancellationRequested();
-			StLoc stloc = block.Instructions[pos] as StLoc;
-			if (stloc == null || stloc.Variable.Kind == VariableKind.PinnedLocal)
+			if (block.Instructions[pos] is not StLoc stloc)
 				return false;
-			ILVariable v = stloc.Variable;
-			// ensure the variable is accessed only a single time
-			if (v.StoreCount != 1)
-				return false;
-			if (v.LoadCount > 1 || v.LoadCount + v.AddressCount != 1)
+			if (!VariableCanBeUsedForInlining(stloc.Variable))
 				return false;
 			// TODO: inlining of small integer types might be semantically incorrect,
 			// but we can't avoid it this easily without breaking lots of tests.
 			//if (v.Type.IsSmallIntegerType())
 			//	return false; // stloc might perform implicit truncation
 			return InlineOne(stloc, options, context);
+		}
+
+		public static bool VariableCanBeUsedForInlining(ILVariable v)
+		{
+			if (v.Kind == VariableKind.PinnedLocal)
+				return false;
+			// ensure the variable is accessed only a single time
+			if (v.StoreCount != 1)
+				return false;
+			if (v.LoadCount + v.AddressCount != 1)
+				return false;
+			return true;
 		}
 
 		/// <summary>
@@ -902,6 +909,30 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				{
 					ILInstruction predecessor = inst.Parent.Children[i];
 					if (!IsSafeForInlineOver(predecessor, expressionBeingMoved))
+						return false;
+				}
+			}
+			return true;
+		}
+
+		/// <summary>
+		/// Gets whether 'expressionBeingMoved' can be moved from somewhere before 'stmt' to become the replacement of 'targetLoad'.
+		/// </summary>
+		public static bool CanMoveIntoCallVirt(ILInstruction expressionBeingMoved, ILInstruction stmt, CallVirt nestedCallVirt, ILInstruction targetLoad)
+		{
+			Debug.Assert(targetLoad.IsDescendantOf(stmt) && nestedCallVirt.IsDescendantOf(stmt));
+			ILInstruction thisArg = nestedCallVirt.Arguments[0];
+			Debug.Assert(thisArg is LdObjIfRef);
+			for (ILInstruction inst = targetLoad; inst != stmt; inst = inst.Parent)
+			{
+				if (!inst.Parent.CanInlineIntoSlot(inst.ChildIndex, expressionBeingMoved))
+					return false;
+				// Check whether re-ordering with predecessors is valid:
+				int childIndex = inst.ChildIndex;
+				for (int i = 0; i < childIndex; ++i)
+				{
+					ILInstruction predecessor = inst.Parent.Children[i];
+					if (predecessor != thisArg && !IsSafeForInlineOver(predecessor, expressionBeingMoved))
 						return false;
 				}
 			}

--- a/ICSharpCode.Decompiler/IL/Transforms/NamedArgumentTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/NamedArgumentTransform.cs
@@ -99,7 +99,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				if (call.IsInstanceCall)
 				{
 					IType thisVarType = call.ConstrainedTo ?? call.Method.DeclaringType;
-					if (CallInstruction.ExpectedTypeForThisPointer(thisVarType) == StackType.Ref)
+					if (CallInstruction.ExpectedTypeForThisPointer(call.Method.DeclaringType, call.ConstrainedTo) == StackType.Ref)
 					{
 						thisVarType = new ByReferenceType(thisVarType);
 					}

--- a/ICSharpCode.Decompiler/IL/Transforms/NullPropagationTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/NullPropagationTransform.cs
@@ -283,6 +283,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					{
 						inst = arg;
 					}
+					else if (inst is LdObjIfRef ldObjIfRef)
+					{
+						inst = ldObjIfRef.Target;
+					}
 					// ensure the access chain does not contain any 'nullable.unwrap' that aren't directly part of the chain
 					if (ArgumentsAfterFirstMayUnwrapNull(call.Arguments))
 						return false;
@@ -362,7 +366,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 							&& arg.MatchLdLoc(testedVar);
 					case Mode.UnconstrainedType:
 						// unconstrained generic type (expect: ldloc(testedVar))
-						return inst.MatchLdLoc(testedVar);
+						return inst.MatchLdLoc(testedVar) || (inst.MatchLdObjIfRef(out var testedVarLoad, out _) && testedVarLoad.MatchLdLoc(testedVar));
 					default:
 						throw new ArgumentOutOfRangeException(nameof(mode));
 				}

--- a/ICSharpCode.Decompiler/IL/Transforms/RemoveInfeasiblePathTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/RemoveInfeasiblePathTransform.cs
@@ -54,8 +54,6 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				}
 			}
 		}
-
-
 		private bool DoTransform(Block block, ILTransformContext context)
 		{
 			if (!MatchBlock1(block, out var s, out int value, out var br))

--- a/ICSharpCode.Decompiler/IL/Transforms/RemoveUnconstrainedGenericReferenceTypeCheck.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/RemoveUnconstrainedGenericReferenceTypeCheck.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) 2025 Siegfried Pammer
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ICSharpCode.Decompiler.IL.Transforms
+{
+	/// <summary>
+	///	[stloc address(...)]
+	///	stloc temp(default.value ``0)
+	///	if (comp.o(ldloc temp == ldnull)) Block IL_002a {
+	///		stloc temp(ldobj ``0(ldloc address))
+	///		stloc address(ldloca temp)
+	///	}
+	///	stloc V_i(expr_i)
+	///	...(constrained[``0].callvirt Method(ldobj.if.ref ``0(ldloc address), ldloc V_i ...))...
+	///	
+	///=>
+	///
+	///	[stloc address(...)]
+	/// stloc address(ldobj.if.ref(ldloc address))
+	///	stloc V_i(expr_i)
+	///	...(constrained[``0].callvirt Method(ldobj.if.ref ``0(ldloc address), ldloc V_i ...))...
+	///	
+	/// Then ldobj.if.ref in the call is redundant because any object reference was already loaded into an immutable temporary.
+	/// So we can removed and inlining of the arguments (V_i) becomes possible.
+	/// 
+	/// Finally the newly created ldobj.if.ref is inlined into the place where the old ldobj.if.ref was.
+	/// 
+	/// =>
+	/// 
+	///	[stloc address(...)]
+	///	...(constrained[``0].callvirt Method(ldobj.if.ref ``0(ldloc address), expr_i ...))...
+	/// 
+	/// </summary>
+	class RemoveUnconstrainedGenericReferenceTypeCheck : IStatementTransform
+	{
+		void IStatementTransform.Run(Block block, int pos, StatementTransformContext context)
+		{
+			int startPos = pos;
+			// stloc temp(default.value ``0)
+			if (!block.Instructions[pos].MatchStLoc(out var temp, out var defaultValue))
+				return;
+			if (!defaultValue.MatchDefaultValue(out var type))
+				return;
+			if (temp.StoreCount != 2 || temp.LoadCount != 1 || temp.AddressCount != 1)
+				return;
+			pos++;
+			// if (comp.o(ldloc temp == ldnull)) Block IL_002a {
+			// 	stloc temp(ldobj ``0(ldloc address))
+			// 	stloc address(ldloca temp)
+			// }
+			if (block.Instructions.ElementAtOrDefault(pos) is not IfInstruction ifInst)
+				return;
+			if (!ifInst.Condition.MatchCompEqualsNull(out var tempLoadForNullCheck))
+				return;
+			if (!tempLoadForNullCheck.MatchLdLoc(temp))
+				return;
+			if (ifInst.TrueInst is not Block dereferenceBlock)
+				return;
+			if (ifInst.FalseInst is not Nop)
+				return;
+			if (dereferenceBlock.Instructions is not [StLoc tempStore, StLoc addressReassign])
+				return;
+			if (tempStore.Variable != temp)
+				return;
+			if (!tempStore.Value.MatchLdObj(out var addressLoadForLdObj, type))
+				return;
+			if (!addressLoadForLdObj.MatchLdLoc(addressReassign.Variable))
+				return;
+			if (!addressReassign.Value.MatchLdLoca(temp))
+				return;
+			var address = addressReassign.Variable;
+			if (address.StoreCount != 2 || address.LoadCount != 2 || address.AddressCount != 0)
+				return;
+			pos++;
+			// pos now is the first store to V_i
+			// ...(constrained[``0].callvirt Method(ldobj.if.ref ``0(ldloc address), ldloc V_i ...))...
+			var callTarget = address.LoadInstructions.Single(l => addressLoadForLdObj != l);
+			if (callTarget.Parent is not LdObjIfRef { Parent: CallVirt call } ldobjIfRef)
+				return;
+			if (call.Arguments.Count == 0 || call.Arguments[0] != ldobjIfRef || !type.Equals(call.ConstrainedTo))
+				return;
+			ILInstruction containingStmt = call;
+			while (containingStmt.Parent != block)
+			{
+				if (containingStmt.Parent == null)
+					return;
+				containingStmt = containingStmt.Parent;
+			}
+			if (containingStmt.ChildIndex < pos)
+				return;
+			// check if we can inline all temporaries used in the call:
+			int temporaryInitIndex = containingStmt.ChildIndex - 1;
+			List<(ILInstruction, ILInstruction)> replacements = new();
+			for (int argIndex = call.Arguments.Count - 1; argIndex > 0 && temporaryInitIndex >= pos; argIndex--)
+			{
+				var argument = call.Arguments[argIndex];
+				switch (argument)
+				{
+					case LdLoc load:
+						if (block.Instructions[temporaryInitIndex].MatchStLoc(load.Variable, out var expr) && ILInlining.VariableCanBeUsedForInlining(load.Variable))
+						{
+							if (!ILInlining.CanMoveIntoCallVirt(expr, containingStmt, call, argument))
+							{
+								return;
+							}
+							replacements.Add((argument, expr));
+							temporaryInitIndex--;
+						}
+						break;
+				}
+			}
+			// all stores to V_i processed?
+			if (temporaryInitIndex != pos - 1)
+			{
+				return;
+			}
+			context.Step("RemoveUnconstrainedGenericReferenceTypeCheck", block.Instructions[startPos]);
+			foreach (var (argument, expr) in replacements)
+			{
+				argument.ReplaceWith(expr);
+			}
+			block.Instructions.RemoveRange(startPos, containingStmt.ChildIndex - startPos);
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/SplitVariables.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/SplitVariables.cs
@@ -107,6 +107,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				case LdObj _:
 				case StObj stobj when stobj.Target == addressLoadingInstruction:
 					return AddressUse.Immediate;
+				case LdObjIfRef:
+					// This is either an immediate use, or we need to check how the parent uses the address.
+					return DetermineAddressUse(addressLoadingInstruction.Parent, targetVar);
 				case LdFlda ldflda:
 					return DetermineAddressUse(ldflda, targetVar);
 				case Await await:

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
@@ -318,6 +318,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						if (resolveContext != null && !IsMethodApplicable(method, call.Arguments, rootType, resolveContext, settings))
 							goto default;
 						inst = call.Arguments[0];
+						if (inst is LdObjIfRef ldObjIfRef)
+						{
+							inst = ldObjIfRef.Target;
+						}
 						if (method.IsAccessor)
 						{
 							if (method.AccessorOwner is IProperty property &&
@@ -367,6 +371,22 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						{
 							path.Insert(0, new AccessPathElement(ldobj.OpCode, ldflda.Field));
 							inst = ldflda.Target;
+							break;
+						}
+						goto default;
+					}
+					case LdObjIfRef ldobj:
+					{
+						if (ldobj.Target is LdFlda ldflda && (kind != AccessPathKind.Setter || !ldflda.Field.IsReadOnly))
+						{
+							path.Insert(0, new AccessPathElement(ldobj.OpCode, ldflda.Field));
+							inst = ldflda.Target;
+							break;
+						}
+						if (ldobj.Target is LdLoca ldloca)
+						{
+							target = ldloca.Variable;
+							inst = null;
 							break;
 						}
 						goto default;

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformExpressionTrees.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformExpressionTrees.cs
@@ -643,7 +643,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		ILInstruction PrepareCallTarget(IType expectedType, ILInstruction target, IType targetType)
 		{
 			ILInstruction result;
-			switch (CallInstruction.ExpectedTypeForThisPointer(expectedType))
+			switch (CallInstruction.ExpectedTypeForThisPointer(expectedType, null))
 			{
 				case StackType.Ref:
 					if (target.ResultType == StackType.Ref)

--- a/ICSharpCode.Decompiler/IL/Transforms/UsingTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/UsingTransform.cs
@@ -316,7 +316,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					// the null check of reference types might have been transformed into "objVar?.Dispose();"
 					if (!(rewrap.Argument is CallVirt cv))
 						return false;
-					if (!(cv.Arguments.FirstOrDefault() is NullableUnwrap unwrap))
+					target = cv.Arguments.FirstOrDefault();
+					if (target is LdObjIfRef ldObjIfRef)
+						target = ldObjIfRef.Target;
+					if (!(target is NullableUnwrap unwrap))
 						return false;
 					numObjVarLoadsInCheck = 1;
 					disposeCall = cv;
@@ -342,6 +345,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					target = cv.Arguments.FirstOrDefault();
 					if (target == null)
 						return false;
+					if (target is LdObjIfRef ldObjIfRef)
+						target = ldObjIfRef.Target;
 					if (target.MatchBox(out var newTarget, out var type) && type.Equals(objVar.Type))
 						target = newTarget;
 					else if (isInlinedIsInst && target.MatchIsInst(out newTarget, out type) && type.IsKnownType(disposeTypeCode))

--- a/ILSpy/Languages/ILAstLanguage.cs
+++ b/ILSpy/Languages/ILAstLanguage.cs
@@ -109,6 +109,7 @@ namespace ICSharpCode.ILSpy
 				var typeSystem = new DecompilerTypeSystem(module, assemblyResolver);
 				var reader = new ILReader(typeSystem.MainModule);
 				reader.UseDebugSymbols = options.DecompilerSettings.UseDebugSymbols;
+				reader.UseRefLocalsForAccurateOrderOfEvaluation = options.DecompilerSettings.UseRefLocalsForAccurateOrderOfEvaluation;
 				var methodBody = module.GetMethodBody(methodDef.RelativeVirtualAddress);
 				ILFunction il = reader.ReadIL((SRM.MethodDefinitionHandle)method.MetadataToken, methodBody, kind: ILFunctionKind.TopLevelFunction, cancellationToken: options.CancellationToken);
 				var decompiler = new CSharpDecompiler(typeSystem, options.DecompilerSettings) { CancellationToken = options.CancellationToken };


### PR DESCRIPTION
Reason: Recent changes in the runtime as well as Roslyn fixing an eval order bug of constrained calls.

Link to issue(s) this covers
#3438 
#3419

I will clean up the PR before merge.