### PR TITLE
Fix nested namespace directories

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Helpers\TestsAssemblyOutput.cs" />
     <Compile Include="Output\InsertParenthesesVisitorTests.cs" />
     <Compile Include="ProjectDecompiler\TargetFrameworkTests.cs" />
+    <Compile Include="ProjectDecompiler\WholeProjectDecompilerTests.cs" />
     <Compile Include="TestAssemblyResolver.cs" />
     <Compile Include="TestCases\ILPretty\Issue3421.cs" />
     <Compile Include="TestCases\ILPretty\Issue3442.cs" />

--- a/ICSharpCode.Decompiler.Tests/ProjectDecompiler/TargetFrameworkTests.cs
+++ b/ICSharpCode.Decompiler.Tests/ProjectDecompiler/TargetFrameworkTests.cs
@@ -23,7 +23,7 @@ using ICSharpCode.Decompiler.Metadata;
 
 using NUnit.Framework;
 
-namespace ICSharpCode.Decompiler.Tests
+namespace ICSharpCode.Decompiler.Tests.ProjectDecompiler
 {
 	[TestFixture]
 	public sealed class TargetFrameworkTests

--- a/ICSharpCode.Decompiler.Tests/ProjectDecompiler/WholeProjectDecompilerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/ProjectDecompiler/WholeProjectDecompilerTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) 2025 Daniel Grunwald
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using ICSharpCode.Decompiler.CSharp.ProjectDecompiler;
+using ICSharpCode.Decompiler.Metadata;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.Decompiler.Tests.ProjectDecompiler;
+
+[TestFixture]
+public sealed class WholeProjectDecompilerTests
+{
+	[Test]
+	public void UseNestedDirectoriesForNamespacesTrueWorks()
+	{
+		string targetDirectory = Path.Combine(Environment.CurrentDirectory, Path.GetRandomFileName());
+		TestFriendlyProjectDecompiler decompiler = new(new UniversalAssemblyResolver(null, false, null));
+		decompiler.Settings.UseNestedDirectoriesForNamespaces = true;
+		decompiler.DecompileProject(new PEFile("ICSharpCode.Decompiler.dll"), targetDirectory);
+		AssertDirectoryDoesntExist(targetDirectory);
+
+		string projectDecompilerDirectory = Path.Combine(targetDirectory, "ICSharpCode", "Decompiler", "CSharp", "ProjectDecompiler");
+		string projectDecompilerFile = Path.Combine(projectDecompilerDirectory, $"{nameof(WholeProjectDecompiler)}.cs");
+
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(decompiler.Files.ContainsKey(projectDecompilerFile), Is.True);
+			Assert.That(decompiler.Directories.Contains(projectDecompilerDirectory), Is.True);
+		}
+	}
+
+	[Test]
+	public void UseNestedDirectoriesForNamespacesFalseWorks()
+	{
+		string targetDirectory = Path.Combine(Environment.CurrentDirectory, Path.GetRandomFileName());
+		TestFriendlyProjectDecompiler decompiler = new(new UniversalAssemblyResolver(null, false, null));
+		decompiler.Settings.UseNestedDirectoriesForNamespaces = false;
+		decompiler.DecompileProject(new PEFile("ICSharpCode.Decompiler.dll"), targetDirectory);
+		AssertDirectoryDoesntExist(targetDirectory);
+
+		string projectDecompilerDirectory = Path.Combine(targetDirectory, "ICSharpCode.Decompiler.CSharp.ProjectDecompiler");
+		string projectDecompilerFile = Path.Combine(projectDecompilerDirectory, $"{nameof(WholeProjectDecompiler)}.cs");
+
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(decompiler.Files.ContainsKey(projectDecompilerFile), Is.True);
+			Assert.That(decompiler.Directories.Contains(projectDecompilerDirectory), Is.True);
+		}
+	}
+
+	static void AssertDirectoryDoesntExist(string directory)
+	{
+		if (Directory.Exists(directory))
+		{
+			Directory.Delete(directory, recursive: true);
+			Assert.Fail("Directory should not have been created.");
+		}
+	}
+
+	sealed class TestFriendlyProjectDecompiler(IAssemblyResolver assemblyResolver) : WholeProjectDecompiler(assemblyResolver)
+	{
+		public Dictionary<string, StringWriter> Files { get; } = [];
+		public HashSet<string> Directories { get; } = [];
+
+		protected override TextWriter CreateFile(string path)
+		{
+			StringWriter writer = new();
+			Files[path] = writer;
+			return writer;
+		}
+
+		protected override void CreateDirectory(string path)
+		{
+			Directories.Add(path);
+		}
+
+		protected override IEnumerable<ProjectItemInfo> WriteMiscellaneousFilesInProject(PEFile module) => [];
+
+		protected override IEnumerable<ProjectItemInfo> WriteResourceFilesInProject(MetadataFile module) => [];
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -743,7 +743,8 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 		public static string CleanUpPath(string text)
 		{
-			return CleanUpName(text, separateAtDots: true, treatAsFileName: true, treatAsPath: true);
+			return CleanUpName(text, separateAtDots: true, treatAsFileName: false, treatAsPath: true)
+				.Replace('.', Path.DirectorySeparatorChar);
 		}
 
 		static bool IsReservedFileSystemName(string name)

--- a/ILSpy.BamlDecompiler/BamlResourceNodeFactory.cs
+++ b/ILSpy.BamlDecompiler/BamlResourceNodeFactory.cs
@@ -62,7 +62,7 @@ namespace ILSpy.BamlDecompiler
 			var typeDefinition = result.TypeName.HasValue ? typeSystem.MainModule.GetTypeDefinition(result.TypeName.Value.TopLevelTypeName) : null;
 			if (typeDefinition != null)
 			{
-				fileName = WholeProjectDecompiler.CleanUpPath(typeDefinition.ReflectionName + ".xaml");
+				fileName = WholeProjectDecompiler.SanitizeFileName(typeDefinition.ReflectionName + ".xaml");
 				var partialTypeInfo = new PartialTypeInfo(typeDefinition);
 				foreach (var member in result.GeneratedMembers)
 				{


### PR DESCRIPTION
Resolves #3448 

### Problem

31bbcf41bcb0dcd0b3e019bc56fa158d8ac37f70 introduced a regression, preventing the `UseNestedDirectoriesForNamespaces` from functioning as intended.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
  * As part of my testing, I added two API methods to `WholeProjectDecompiler`.
* Which part of this PR is most in need of attention/improvement?
  * ~~`BamlResourceNodeFactory::WriteResourceToFile` also uses this method, which I think is incorrect, but I'm not sure what to change it to.~~
* [x] At least one test covering the code changed

