### PR TITLE
Parenthesize interpolations containing `global::`

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="TestCases\ILPretty\Issue3442.cs" />
     <Compile Include="TestCases\ILPretty\MonoFixed.cs" />
     <Compile Include="TestCases\Pretty\Comparisons.cs" />
+    <Compile Include="TestCases\Pretty\GloballyQualifiedTypeInStringInterpolation.cs" />
     <Compile Include="TestCases\Pretty\Issue3406.cs" />
     <Compile Include="TestCases\Pretty\PointerArithmetic.cs" />
     <Compile Include="TestCases\Pretty\Issue3439.cs" />

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -309,6 +309,19 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task GloballyQualifiedTypeInStringInterpolation([ValueSource(nameof(roslynOnlyWithNet40Options))] CompilerOptions cscOptions)
+		{
+			// https://github.com/icsharpcode/ILSpy/issues/3447
+			await RunForLibrary(
+				cscOptions: cscOptions,
+				configureDecompiler: settings => {
+					settings.UsingDeclarations = false;
+					settings.AlwaysUseGlobal = true;
+				}
+			);
+		}
+
+		[Test]
 		public async Task LiftedOperators([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
@@ -4,7 +4,11 @@
 	{
 		public static string Root => $"Prefix {(global::System.DateTime.Now)} suffix";
 		public static string Cast => $"Prefix {((int)global::System.DateTime.Now.Ticks)} suffix";
+#if CS100 && !NET40
+		public static string Lambda1 => $"Prefix {(() => global::System.DateTime.Now)} suffix";
+#else
 		public static string Lambda1 => $"Prefix {(global::System.Func<global::System.DateTime>)(() => global::System.DateTime.Now)} suffix";
+#endif
 		public static string Lambda2 => $"Prefix {((global::System.Func<global::System.DateTime>)(() => global::System.DateTime.Now))()} suffix";
 		public static string Method1 => $"Prefix {M(global::System.DateTime.Now)} suffix";
 		public static string Method2 => $"Prefix {(global::System.DateTime.Now.Ticks)} suffix";

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
@@ -4,7 +4,7 @@
 	{
 		public static string Root => $"Prefix {(global::System.DateTime.Now)} suffix";
 		public static string Cast => $"Prefix {((int)global::System.DateTime.Now.Ticks)} suffix";
-#if CS100 && !NET40
+#if CS100 && NET60
 		public static string Lambda1 => $"Prefix {(() => global::System.DateTime.Now)} suffix";
 #else
 		public static string Lambda1 => $"Prefix {(global::System.Func<global::System.DateTime>)(() => global::System.DateTime.Now)} suffix";

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
@@ -1,0 +1,7 @@
+﻿namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public static class GloballyQualifiedTypeInStringInterpolation
+	{
+		public static string CurrentDateTime => $"Time: {(global::System.DateTime.Now)}";
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/GloballyQualifiedTypeInStringInterpolation.cs
@@ -2,6 +2,20 @@
 {
 	public static class GloballyQualifiedTypeInStringInterpolation
 	{
-		public static string CurrentDateTime => $"Time: {(global::System.DateTime.Now)}";
+		public static string Root => $"Prefix {(global::System.DateTime.Now)} suffix";
+		public static string Cast => $"Prefix {((int)global::System.DateTime.Now.Ticks)} suffix";
+		public static string Lambda1 => $"Prefix {(global::System.Func<global::System.DateTime>)(() => global::System.DateTime.Now)} suffix";
+		public static string Lambda2 => $"Prefix {((global::System.Func<global::System.DateTime>)(() => global::System.DateTime.Now))()} suffix";
+		public static string Method1 => $"Prefix {M(global::System.DateTime.Now)} suffix";
+		public static string Method2 => $"Prefix {(global::System.DateTime.Now.Ticks)} suffix";
+		public static string Method3 => $"Prefix {(global::System.DateTime.Equals(global::System.DateTime.Now, global::System.DateTime.Now))} suffix";
+		public static string ConditionalExpression1 => $"Prefix {(Boolean ? global::System.DateTime.Now : global::System.DateTime.UtcNow)} suffix";
+		public static string ConditionalExpression2 => $"Prefix {(Boolean ? global::System.DateTime.Now : global::System.DateTime.UtcNow).Ticks} suffix";
+
+		private static bool Boolean => false;
+		private static long M(global::System.DateTime time)
+		{
+			return time.Ticks;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
@@ -17,7 +17,6 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Linq;
 
 using ICSharpCode.Decompiler.CSharp.Syntax;
 

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
@@ -389,6 +389,26 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			base.VisitAsExpression(asExpression);
 		}
 
+		public override void VisitInterpolation(Interpolation interpolation)
+		{
+			// If an interpolation contains global::, we need to parenthesize the expression.
+			if (IsThisOrChildMemberTypeWithDoubleColon(interpolation))
+				Parenthesize(interpolation.Expression);
+			base.VisitInterpolation(interpolation);
+
+			static bool IsThisOrChildMemberTypeWithDoubleColon(AstNode node)
+			{
+				if (node is MemberType { IsDoubleColon: true })
+					return true;
+				foreach (var child in node.Children)
+				{
+					if (IsThisOrChildMemberTypeWithDoubleColon(child))
+						return true;
+				}
+				return false;
+			}
+		}
+
 		// Conditional operator
 		public override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
 		{

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Linq;
 
 using ICSharpCode.Decompiler.CSharp.Syntax;
 
@@ -392,21 +393,9 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		public override void VisitInterpolation(Interpolation interpolation)
 		{
 			// If an interpolation contains global::, we need to parenthesize the expression.
-			if (IsThisOrChildMemberTypeWithDoubleColon(interpolation))
+			if (interpolation.Descendants.Any(n => n is MemberType { IsDoubleColon: true }))
 				Parenthesize(interpolation.Expression);
 			base.VisitInterpolation(interpolation);
-
-			static bool IsThisOrChildMemberTypeWithDoubleColon(AstNode node)
-			{
-				if (node is MemberType { IsDoubleColon: true })
-					return true;
-				foreach (var child in node.Children)
-				{
-					if (IsThisOrChildMemberTypeWithDoubleColon(child))
-						return true;
-				}
-				return false;
-			}
 		}
 
 		// Conditional operator


### PR DESCRIPTION
Resolves #3447 

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
  * As recommended, I implemented the fix in the `InsertParenthesesVisitor` class.
* Which part of this PR is most in need of attention/improvement?
  * I used recursion to check if any child has `global::`. Is there a better (more performant) way to check?
* [x] At least one test covering the code changed

