### PR TITLE
Correct flag to flags

### DIFF
--- a/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
+++ b/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
@@ -1886,7 +1886,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 				}
 			}
 			if ((val & ~tested) != 0)
-				output.Write("flag({0:x4}) ", val & ~tested);
+				output.Write("flags({0:x4}) ", val & ~tested);
 		}
 
 		void WriteEnum<T>(T enumValue, EnumNameCollection<T> enumNames) where T : struct
@@ -1906,8 +1906,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			}
 			if (val != 0)
 			{
-				output.Write("flag({0:x4})", val);
-				output.Write(' ');
+				output.Write("flags({0:x4}) ", val);
 			}
 
 		}


### PR DESCRIPTION
According to the grammar of [ilasm](https://github.com/dotnet/runtime/blob/81899bbcb38ef43ae73b0eaf5dcf38234f8d875b/src/coreclr/ilasm/prebuilt/asmparse.grammar#L531), this should be `flags` instead of `flag`.