### PR TITLE
Fix null reference exception when writing resource files

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -337,6 +337,9 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 			foreach (var r in module.Resources.Where(r => r.ResourceType == ResourceType.Embedded))
 			{
 				Stream stream = r.TryOpenStream();
+				if (stream == null)
+					continue;
+
 				stream.Position = 0;
 
 				if (r.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
### Problem

`TryOpenStream` can return null, and we previously didn't check for that.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
  * It's similar to the null checks for miscellaneous files.
* Which part of this PR is most in need of attention/improvement?
* [ ] At least one test covering the code changed

