### PR TITLE
Correctly handle use of `cgt` and others for object refs (fixes #3465)

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2017 Daniel Grunwald
+// Copyright (c) 2017 Daniel Grunwald
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -52,29 +52,16 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			{
 				return;
 			}
-			if (inst.Right.MatchLdNull())
+			if (inst.Left.ResultType == StackType.O && inst.Right.ResultType == StackType.O)
 			{
-				if (inst.Kind == ComparisonKind.GreaterThan)
+				if (inst.Kind == ComparisonKind.GreaterThan || inst.Kind == ComparisonKind.LessThan)
 				{
-					context.Step("comp(left > ldnull)  => comp(left != ldnull)", inst);
+					context.Step($"comp(left {inst.Kind.GetToken()} right) => comp(left != right)", inst);
 					inst.Kind = ComparisonKind.Inequality;
 				}
-				else if (inst.Kind == ComparisonKind.LessThanOrEqual)
+				else if (inst.Kind == ComparisonKind.GreaterThanOrEqual || inst.Kind == ComparisonKind.LessThanOrEqual)
 				{
-					context.Step("comp(left <= ldnull) => comp(left == ldnull)", inst);
-					inst.Kind = ComparisonKind.Equality;
-				}
-			}
-			else if (inst.Left.MatchLdNull())
-			{
-				if (inst.Kind == ComparisonKind.LessThan)
-				{
-					context.Step("comp(ldnull < right)  => comp(ldnull != right)", inst);
-					inst.Kind = ComparisonKind.Inequality;
-				}
-				else if (inst.Kind == ComparisonKind.GreaterThanOrEqual)
-				{
-					context.Step("comp(ldnull >= right) => comp(ldnull == right)", inst);
+					context.Step($"comp(left {inst.Kind.GetToken()} right) => comp(left == right)", inst);
 					inst.Kind = ComparisonKind.Equality;
 				}
 			}


### PR DESCRIPTION
Link to issue(s) this covers
https://github.com/icsharpcode/ILSpy/issues/3465

### Problem
ILSpy did not handle use of `cgt` for object reference comparison where neither side was `ldnull`.

This is allowed as stated in ECMA:
"cgt.un is allowed and verifiable on ObjectRefs (O). This is commonly used when comparing an ObjectRef with null (there is no “compare-not-equal” instruction, which would otherwise be a more obvious solution)" - ECMA III.1.5 - Operand type table, Table III.4: Binary Comparison or Branch Operations, Note 2

Code checks for other comparison types just like it did before for `ldnull` but now for all object refs.

### Solution
* No test currently as I'm yet to see a file using this.

@greenozon Could you verify if this changes fixes your issue on your file?

