### PR TITLE
Allow creating a MetadataFile with a MetadataReader / MetadataStringDecoder

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/MetadataFile.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataFile.cs
@@ -239,23 +239,32 @@ namespace ICSharpCode.Decompiler.Metadata
 			}
 		}
 
-		public MetadataFile(MetadataFileKind kind, string fileName, MetadataReaderProvider metadata, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, int metadataOffset = 0, bool isEmbedded = false)
+		public MetadataFile(MetadataFileKind kind, string fileName, MetadataReaderProvider metadata, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, int metadataOffset = 0, bool isEmbedded = false, MetadataStringDecoder? utf8Decoder = null)
 		{
 			this.Kind = kind;
 			this.FileName = fileName;
-			this.Metadata = metadata.GetMetadataReader(metadataOptions);
+			this.Metadata = metadata.GetMetadataReader(metadataOptions, utf8Decoder);
 			this.MetadataOffset = metadataOffset;
 			this.IsEmbedded = isEmbedded;
 		}
 
-		private protected MetadataFile(MetadataFileKind kind, string fileName, PEReader reader, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default)
+		public MetadataFile(MetadataFileKind kind, string fileName, MetadataReader metadataReader, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, int metadataOffset = 0, bool isEmbedded = false)
+		{
+			this.Kind = kind;
+			this.FileName = fileName;
+			this.Metadata = metadataReader;
+			this.MetadataOffset = metadataOffset;
+			this.IsEmbedded = isEmbedded;
+		}
+
+		private protected MetadataFile(MetadataFileKind kind, string fileName, PEReader reader, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, MetadataStringDecoder? utf8Decoder = null)
 		{
 			this.Kind = kind;
 			this.FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
 			_ = reader ?? throw new ArgumentNullException(nameof(reader));
 			if (!reader.HasMetadata)
 				throw new MetadataFileNotSupportedException("PE file does not contain any managed metadata.");
-			this.Metadata = reader.GetMetadataReader(metadataOptions);
+			this.Metadata = reader.GetMetadataReader(metadataOptions, utf8Decoder);
 		}
 
 		public virtual MethodBodyBlock GetMethodBody(int rva)

--- a/ICSharpCode.Decompiler/Metadata/MetadataFile.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataFile.cs
@@ -248,7 +248,7 @@ namespace ICSharpCode.Decompiler.Metadata
 			this.IsEmbedded = isEmbedded;
 		}
 
-		public MetadataFile(MetadataFileKind kind, string fileName, MetadataReader metadataReader, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, int metadataOffset = 0, bool isEmbedded = false)
+		public MetadataFile(MetadataFileKind kind, string fileName, MetadataReader metadataReader, int metadataOffset = 0, bool isEmbedded = false)
 		{
 			this.Kind = kind;
 			this.FileName = fileName;

--- a/ICSharpCode.Decompiler/Metadata/PEFile.cs
+++ b/ICSharpCode.Decompiler/Metadata/PEFile.cs
@@ -35,18 +35,18 @@ namespace ICSharpCode.Decompiler.Metadata
 	{
 		public PEReader Reader { get; }
 
-		public PEFile(string fileName, PEStreamOptions streamOptions = PEStreamOptions.Default, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default)
-			: this(fileName, new PEReader(new FileStream(fileName, FileMode.Open, FileAccess.Read), streamOptions), metadataOptions)
+		public PEFile(string fileName, PEStreamOptions streamOptions = PEStreamOptions.Default, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, MetadataStringDecoder? utf8Decoder = null)
+			: this(fileName, new PEReader(new FileStream(fileName, FileMode.Open, FileAccess.Read), streamOptions), metadataOptions, utf8Decoder)
 		{
 		}
 
-		public PEFile(string fileName, Stream stream, PEStreamOptions streamOptions = PEStreamOptions.Default, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default)
-			: this(fileName, new PEReader(stream, streamOptions), metadataOptions)
+		public PEFile(string fileName, Stream stream, PEStreamOptions streamOptions = PEStreamOptions.Default, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, MetadataStringDecoder? utf8Decoder = null)
+			: this(fileName, new PEReader(stream, streamOptions), metadataOptions, utf8Decoder)
 		{
 		}
 
-		public PEFile(string fileName, PEReader reader, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default)
-			: base(MetadataFileKind.PortableExecutable, fileName, reader, metadataOptions)
+		public PEFile(string fileName, PEReader reader, MetadataReaderOptions metadataOptions = MetadataReaderOptions.Default, MetadataStringDecoder? utf8Decoder = null)
+			: base(MetadataFileKind.PortableExecutable, fileName, reader, metadataOptions, utf8Decoder)
 		{
 			this.Reader = reader;
 		}


### PR DESCRIPTION
### Problem
`System.Reflection.Metadata` allows specifying a `System.Reflection.Metadata.MetadataStringDecoder` to your `MetadataReader` to cache any strings it allocates, thereby reducing allocations.

I have an existing `MetadataReader` that is using my custom `MetadataStringDecoder`, however `ICSharpCode.Decompiler.Metadata.MetadataFile` does not allow me to pass in my existing `MetadataReader`, it instead requires that I pass in a `System.Reflection.Metadata.MetadataReaderProvider`.

If `MetadataReaderProvider.GetMetadataReader` is called multiple times with the same inputs, the same `MetadataReader` will be returned each time. I thought that maybe I could create a `MetadataReaderProvider` to get the `MetadataReader` that I and `ICSharpCode.Decompiler` both need to use, however `GetMetadataReader` does not return its cached `MetadataReader` if it is called multiple times with different arguments. `GetMetadataReader` allows specifying a `MetadataStringDecoder` to it, however, `ICSharpCode.Decompiler` does not support this, which means
* it's not possible for me to have a single `MetadataReader` that is shared by `ICSharpCode.Decompiler` and code that runs outside of it
* `ICSharpCode.Decompiler` will create a lot of extra string allocations in my program that could be avoided with the use of `MetadataStringDecoder`

### Solution
There are two potential ways this can be solved
* Add an optional `MetadataStringDecoder` parameter to existing code paths that lead to the creation of a `MetadataFile`
* Add an overload to `MetadataFile` that allows specifying an existing `MetadataReader` directly

The former approach works well with the `PEReader` type, which derives from `MetadataFile`, while the latter works better when you're handling PE parsing yourself and want to interact with `MetadataFile` directly. As such, I have implemented both approaches.

`utf8Decoder` is the name that `System.Reflection.Metadata` gives to `MetadataStringDecoder` parameters, so I have used the same name