### PR TITLE
Make TargetFramework and TargetServices public

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetFramework.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetFramework.cs
@@ -24,7 +24,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 	/// <summary>
 	/// A class describing the target framework of a module.
 	/// </summary>
-	sealed class TargetFramework
+	public class TargetFramework
 	{
 		const string DotNetPortableIdentifier = ".NETPortable";
 

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetServices.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetServices.cs
@@ -28,7 +28,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 	/// <summary>
 	/// Helper services for determining the target framework and platform of a module.
 	/// </summary>
-	static class TargetServices
+	public static class TargetServices
 	{
 		const string VersionToken = "Version=";
 		const string ProfileToken = "Profile=";


### PR DESCRIPTION
### Problem

Custom project writers cannot currently make use of TargetFramework and TargetServices because they're not public.

My specific use case is: I am using ILSpy in my Godot decompiler to add support for decompiling games with C# scripts. One of the quirks about building a C# project for Godot is that the SDK in the `csproj` is labelled as `Godot.NET.Sdk`, and there are custom assemblies that are automatically included without references, so I had to make a custom project writer for this and pass it into `WholeProjectDecompiler`.

I currently have to copy a bunch of files, including these, because they're not public; since we explicitly provide the ability to pass in a custom project writer to the decompiler, I think that they should be made public so that others can make use of them.

### Solution
* What it says on the tin
