### PR TITLE
Fix SDK-style (modern) inter-project references

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetServices.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/TargetServices.cs
@@ -76,11 +76,11 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 				targetFrameworkIdentifier = frameworkParts.FirstOrDefault(a => !a.StartsWith(VersionToken, StringComparison.OrdinalIgnoreCase) && !a.StartsWith(ProfileToken, StringComparison.OrdinalIgnoreCase));
 				string frameworkVersion = frameworkParts.FirstOrDefault(a => a.StartsWith(VersionToken, StringComparison.OrdinalIgnoreCase));
 
-				if (frameworkVersion != null)
+				if (frameworkVersion != null && Version.TryParse(frameworkVersion.Substring(VersionToken.Length).Replace("v", ""), out var version))
 				{
-					versionNumber = int.Parse(frameworkVersion.Substring(VersionToken.Length).Replace("v", "").Replace(".", ""));
-					if (versionNumber < 100)
-						versionNumber *= 10;
+					versionNumber = version.Major * 100 + version.Minor * 10;
+					if (version.Build > 0)
+						versionNumber += version.Build;
 				}
 
 				string frameworkProfile = frameworkParts.FirstOrDefault(a => a.StartsWith(ProfileToken, StringComparison.OrdinalIgnoreCase));

--- a/ICSharpCode.Decompiler/Solution/SolutionCreator.cs
+++ b/ICSharpCode.Decompiler/Solution/SolutionCreator.cs
@@ -193,7 +193,12 @@ namespace ICSharpCode.Decompiler.Solution
 		static void FixProjectReferences(string projectFilePath, XElement itemGroup,
 			Dictionary<string, ProjectItem> projects, bool sdkStyle)
 		{
-			var referenceTagName = sdkStyle ? "Reference" : ProjectFileNamespace + "Reference";
+			XName GetElementName(string localName) => sdkStyle ? localName : ProjectFileNamespace + localName;
+
+			var referenceTagName = GetElementName("Reference");
+			var projectReferenceTagName = GetElementName("ProjectReference");
+			var projectTagName = GetElementName("Project");
+			var nameTagName = GetElementName("Name");
 
 			foreach (var item in itemGroup.Elements(referenceTagName).ToList())
 			{
@@ -202,9 +207,9 @@ namespace ICSharpCode.Decompiler.Solution
 				{
 					item.Remove();
 
-					var projectReference = new XElement(ProjectFileNamespace + "ProjectReference",
-						new XElement(ProjectFileNamespace + "Project", referencedProject.Guid.ToString("B").ToLowerInvariant()),
-						new XElement(ProjectFileNamespace + "Name", referencedProject.ProjectName));
+					var projectReference = new XElement(projectReferenceTagName,
+						new XElement(projectTagName, referencedProject.Guid.ToString("B").ToLowerInvariant()),
+						new XElement(nameTagName, referencedProject.ProjectName));
 					projectReference.SetAttributeValue("Include", GetRelativePath(projectFilePath, referencedProject.FilePath));
 
 					itemGroup.Add(projectReference);

--- a/ICSharpCode.Decompiler/Solution/SolutionCreator.cs
+++ b/ICSharpCode.Decompiler/Solution/SolutionCreator.cs
@@ -41,7 +41,7 @@ namespace ICSharpCode.Decompiler.Solution
 		/// <exception cref="ArgumentException">Thrown when <paramref name="targetFile"/> is null or empty.</exception>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="projects"/> is null.</exception>
 		/// <exception cref="InvalidOperationException">Thrown when <paramref name="projects"/> contains no items.</exception>
-		public static void WriteSolutionFile(string targetFile, IEnumerable<ProjectItem> projects)
+		public static void WriteSolutionFile(string targetFile, List<ProjectItem> projects)
 		{
 			if (string.IsNullOrWhiteSpace(targetFile))
 			{
@@ -53,19 +53,17 @@ namespace ICSharpCode.Decompiler.Solution
 				throw new ArgumentNullException(nameof(projects));
 			}
 
-			var projectList = projects.ToList();
-
-			if (!projectList.Any())
+			if (!projects.Any())
 			{
 				throw new InvalidOperationException("At least one project is expected.");
 			}
 
 			using (var writer = new StreamWriter(targetFile))
 			{
-				WriteSolutionFile(writer, projectList, targetFile);
+				WriteSolutionFile(writer, projects, targetFile);
 			}
 
-			FixProjectReferences(projectList);
+			FixProjectReferences(projects);
 		}
 
 		static void WriteSolutionFile(TextWriter writer, List<ProjectItem> projects, string solutionFilePath)

--- a/ICSharpCode.Decompiler/Solution/SolutionCreator.cs
+++ b/ICSharpCode.Decompiler/Solution/SolutionCreator.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.Decompiler.Solution
 	/// </summary>
 	public static class SolutionCreator
 	{
-		private static readonly XNamespace ProjectFileNamespace = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
+		static readonly XNamespace ProjectFileNamespace = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
 
 		/// <summary>
 		/// Writes a solution file to the specified <paramref name="targetFile"/>.
@@ -52,20 +52,22 @@ namespace ICSharpCode.Decompiler.Solution
 				throw new ArgumentNullException(nameof(projects));
 			}
 
-			if (!projects.Any())
+			var projectList = projects.ToList();
+
+			if (!projectList.Any())
 			{
 				throw new InvalidOperationException("At least one project is expected.");
 			}
 
 			using (var writer = new StreamWriter(targetFile))
 			{
-				WriteSolutionFile(writer, projects, targetFile);
+				WriteSolutionFile(writer, projectList, targetFile);
 			}
 
-			FixProjectReferences(projects);
+			FixProjectReferences(projectList);
 		}
 
-		private static void WriteSolutionFile(TextWriter writer, IEnumerable<ProjectItem> projects, string solutionFilePath)
+		static void WriteSolutionFile(TextWriter writer, List<ProjectItem> projects, string solutionFilePath)
 		{
 			WriteHeader(writer);
 			WriteProjects(writer, projects, solutionFilePath);
@@ -90,7 +92,7 @@ namespace ICSharpCode.Decompiler.Solution
 			writer.WriteLine("MinimumVisualStudioVersion = 10.0.40219.1");
 		}
 
-		private static void WriteProjects(TextWriter writer, IEnumerable<ProjectItem> projects, string solutionFilePath)
+		static void WriteProjects(TextWriter writer, List<ProjectItem> projects, string solutionFilePath)
 		{
 			foreach (var project in projects)
 			{
@@ -103,7 +105,7 @@ namespace ICSharpCode.Decompiler.Solution
 			}
 		}
 
-		private static IEnumerable<string> WriteSolutionConfigurations(TextWriter writer, IEnumerable<ProjectItem> projects)
+		static List<string> WriteSolutionConfigurations(TextWriter writer, List<ProjectItem> projects)
 		{
 			var platforms = projects.GroupBy(p => p.PlatformName).Select(g => g.Key).ToList();
 
@@ -125,10 +127,10 @@ namespace ICSharpCode.Decompiler.Solution
 			return platforms;
 		}
 
-		private static void WriteProjectConfigurations(
+		static void WriteProjectConfigurations(
 			TextWriter writer,
-			IEnumerable<ProjectItem> projects,
-			IEnumerable<string> solutionPlatforms)
+			List<ProjectItem> projects,
+			List<string> solutionPlatforms)
 		{
 			writer.WriteLine("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
 
@@ -152,9 +154,11 @@ namespace ICSharpCode.Decompiler.Solution
 			writer.WriteLine("\tEndGlobalSection");
 		}
 
-		private static void FixProjectReferences(IEnumerable<ProjectItem> projects)
+		static void FixProjectReferences(List<ProjectItem> projects)
 		{
-			var projectsMap = projects.ToDictionary(p => p.ProjectName, p => p);
+			var projectsMap = projects.ToDictionary(
+				p => p.ProjectName,
+				p => p);
 
 			foreach (var project in projects)
 			{
@@ -192,7 +196,7 @@ namespace ICSharpCode.Decompiler.Solution
 			}
 		}
 
-		private static string GetRelativePath(string fromFilePath, string toFilePath)
+		static string GetRelativePath(string fromFilePath, string toFilePath)
 		{
 			Uri fromUri = new Uri(fromFilePath);
 			Uri toUri = new Uri(toFilePath);

--- a/ILSpy/Commands/SaveCodeContextMenuEntry.cs
+++ b/ILSpy/Commands/SaveCodeContextMenuEntry.cs
@@ -78,7 +78,7 @@ namespace ICSharpCode.ILSpy.TextView
 					{
 						var assemblies = selectedNodes.OfType<AssemblyTreeNode>()
 							.Select(n => n.LoadedAssembly)
-							.Where(a => a.IsLoadedAsValidAssembly).ToArray();
+							.Where(a => a.IsLoadedAsValidAssembly).ToList();
 						SolutionWriter.CreateSolution(tabPage, textView, selectedPath, currentLanguage, assemblies);
 					}
 					return;

--- a/ILSpy/SolutionWriter.cs
+++ b/ILSpy/SolutionWriter.cs
@@ -153,8 +153,8 @@ namespace ICSharpCode.ILSpy
 				}
 				else
 				{
-					await Task.Run(() => SolutionCreator.WriteSolutionFile(solutionFilePath, projects))
-						.ConfigureAwait(false);
+					await Task.Run(() => SolutionCreator.WriteSolutionFile(solutionFilePath, projects.ToList()))
+							.ConfigureAwait(false);
 				}
 			}
 			catch (AggregateException ae)

--- a/ILSpy/SolutionWriter.cs
+++ b/ILSpy/SolutionWriter.cs
@@ -56,7 +56,7 @@ namespace ICSharpCode.ILSpy
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="textView"/>> or
 		/// <paramref name="assemblies"/> is null.</exception>
 		public static void CreateSolution(TabPageModel tabPage, DecompilerTextView textView, string solutionFilePath,
-			Language language, IEnumerable<LoadedAssembly> assemblies)
+			Language language, List<LoadedAssembly> assemblies)
 		{
 			if (textView == null)
 			{
@@ -77,7 +77,7 @@ namespace ICSharpCode.ILSpy
 
 			textView
 				.RunWithCancellation(ct => writer.CreateSolution(tabPage, assemblies, language, ct))
-				.Then(output => textView.ShowText(output))
+				.Then(textView.ShowText)
 				.HandleExceptions();
 		}
 
@@ -94,41 +94,29 @@ namespace ICSharpCode.ILSpy
 			projects = new ConcurrentBag<ProjectItem>();
 		}
 
-		async Task<AvalonEditTextOutput> CreateSolution(TabPageModel tabPage, IEnumerable<LoadedAssembly> assemblies, Language language, CancellationToken ct)
+		async Task<AvalonEditTextOutput> CreateSolution(TabPageModel tabPage, List<LoadedAssembly> allAssemblies, Language language, CancellationToken ct)
 		{
 			var result = new AvalonEditTextOutput();
 
-			var assembliesByShortName = assemblies.ToLookup(_ => _.ShortName);
+			var assembliesByShortName = allAssemblies.GroupBy(_ => _.ShortName).ToDictionary(_ => _.Key, _ => _.ToList());
 			bool first = true;
 			bool abort = false;
 
-			foreach (var item in assembliesByShortName)
+			foreach (var (shortName, assemblies) in assembliesByShortName)
 			{
-				var enumerator = item.GetEnumerator();
-				if (!enumerator.MoveNext())
+				if (assemblies.Count == 1)
+				{
 					continue;
-				var firstAssembly = enumerator.Current;
-				if (!enumerator.MoveNext())
-					continue;
+				}
+
 				if (first)
 				{
 					result.WriteLine("Duplicate assembly names selected, cannot generate a solution:");
 					abort = true;
+					first = false;
 				}
 
-				result.Write("- " + firstAssembly.Text + " conflicts with ");
-
-				first = true;
-				do
-				{
-					var asm = enumerator.Current;
-					if (!first)
-						result.Write(", ");
-					result.Write(asm.Text);
-					first = false;
-				} while (enumerator.MoveNext());
-				result.WriteLine();
-				first = false;
+				result.WriteLine("- " + assemblies[0].Text + " conflicts with " + string.Join(", ", assemblies.Skip(1)));
 			}
 
 			if (abort)
@@ -141,7 +129,7 @@ namespace ICSharpCode.ILSpy
 				// Explicitly create an enumerable partitioner here to avoid Parallel.ForEach's special cases for lists,
 				// as those seem to use static partitioning which is inefficient if assemblies take differently
 				// long to decompile.
-				await Task.Run(() => Parallel.ForEach(Partitioner.Create(assemblies),
+				await Task.Run(() => Parallel.ForEach(Partitioner.Create(allAssemblies),
 					new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount, CancellationToken = ct },
 					item => WriteProject(tabPage, item, language, solutionDirectory, ct)))
 					.ConfigureAwait(false);
@@ -153,7 +141,7 @@ namespace ICSharpCode.ILSpy
 				}
 				else
 				{
-					await Task.Run(() => SolutionCreator.WriteSolutionFile(solutionFilePath, projects.ToList()))
+					await Task.Run(() => SolutionCreator.WriteSolutionFile(solutionFilePath, projects.ToList()), ct)
 							.ConfigureAwait(false);
 				}
 			}
@@ -184,14 +172,14 @@ namespace ICSharpCode.ILSpy
 			if (statusOutput.Count == 0)
 			{
 				result.WriteLine("Successfully decompiled the following assemblies into Visual Studio projects:");
-				foreach (var item in assemblies.Select(n => n.Text.ToString()))
+				foreach (var n in allAssemblies)
 				{
-					result.WriteLine(item);
+					result.WriteLine(n.Text.ToString());
 				}
 
 				result.WriteLine();
 
-				if (assemblies.Count() == projects.Count)
+				if (allAssemblies.Count == projects.Count)
 				{
 					result.WriteLine("Created the Visual Studio Solution file.");
 				}


### PR DESCRIPTION
[Link to issue(s) this covers](https://github.com/icsharpcode/ILSpy/issues/2875)

### Problem
The XML namespace isn't correctly configured when using new-style solution files.

### Solution

There are three changes in this PR; I bundled them here as they are near in code and I didn't think anyone would object to the cleanup. (Please let me know if you'd rather I split up the changes.)

* Cleanup use of repeated enumeration of an IEnumerable<T> in a public API
* Change project guids to be written in lower-case (this fixes compatibility with some old Microsoft tools, I believe no other common tools care either way, and the uuid RFC specifies lower-case)
* Detects whether the solution is an SDK-style by examining its xml and chooses the XML namespace appropriately (this is the fix for issue 2875)

