### PR TITLE
Fix incorrect method match for static methods with instance signature

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -96,6 +96,7 @@
     <None Include="TestCases\ILPretty\Issue2260SwitchString.il" />
     <None Include="TestCases\ILPretty\Issue3442.il" />
     <None Include="TestCases\ILPretty\Issue3466.il" />
+    <None Include="testcases\ilpretty\Issue3504.il" />
     <None Include="TestCases\ILPretty\MonoFixed.il" />
     <None Include="TestCases\Correctness\NonGenericConstrainedCallVirt.il" />
     <None Include="TestCases\ILPretty\UnknownTypes.cs" />
@@ -138,6 +139,7 @@
     <Compile Include="TestCases\ILPretty\Issue3421.cs" />
     <Compile Include="TestCases\ILPretty\Issue3442.cs" />
     <Compile Include="TestCases\ILPretty\Issue3466.cs" />
+    <None Include="TestCases\ILPretty\Issue3504.cs" />
     <Compile Include="TestCases\ILPretty\MonoFixed.cs" />
     <Compile Include="TestCases\Pretty\Comparisons.cs" />
     <Compile Include="TestCases\Pretty\GloballyQualifiedTypeInStringInterpolation.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -226,6 +226,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task Issue3504()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task Issue2260SwitchString()
 		{
 			await Run();

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3504.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3504.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+internal class Issue3504
+{
+	private void Method(Console console)
+	{
+		console.WriteLine("Hello.");
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3504.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3504.il
@@ -1,0 +1,36 @@
+.class private auto ansi beforefieldinit Issue3504
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method private hidebysig 
+		instance void Method (class [System.Console]System.Console console) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 13 (0xd)
+		.maxstack 8
+
+		IL_0000: nop
+		IL_0001: ldarg.1
+        IL_0002: ldstr "Hello."
+		IL_0007: call instance void [System.Console]System.Console::WriteLine(string)
+		IL_000b: nop
+		IL_000c: ret
+	} // end of method Issue3504::Method
+
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x205e
+		// Header size: 1
+		// Code size: 8 (0x8)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+		IL_0006: nop
+		IL_0007: ret
+	} // end of method Issue3504::.ctor
+
+} // end of class Issue3504
+

--- a/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
@@ -535,6 +535,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 					{
 						if (m.TypeParameters.Count != signature.GenericParameterCount)
 							continue;
+						if (signature.Header.IsInstance != !m.IsStatic)
+							continue;
 						if (CompareSignatures(m.Parameters, parameterTypes) && CompareTypes(m.ReturnType, signature.ReturnType))
 						{
 							method = m;


### PR DESCRIPTION
### Problem
ILSpy could match an instance method call with a static method reference. This can happen when resolving a method whose *current* definition is `static` but the IL actually calls an instance method. I.e. the method was originally an instance method but was changed to `static`.
This results in the decompiled code to silently drop the instance argument on the evaluation stack. While this produces valid/compilible C# code, it does not accurately decompile the given code.

Example:

the reference code was changed from
```cs
class A {
    static A instance;
    void Ref() {}
}
```
to
```cs
class A {
    static A instance;
    static void Ref() {}
}
```

the original code is
```cs
A.instance.Ref();
```
but gets wrongly decompiled to
```cs
A.Ref(); // should still be A.instance.Ref();
```

### Solution
* The given code searches for a matching reference method. Since static and non-static are not matching, we are excluding those as potential matches. In our case this means we don't match the `Ref` method, so ILSpy decompiles the code without a reference and produces `A.instance.Ref()`
* I am not sure how to write a test because the compile and decompile step require different reference assemblies
