### PR TITLE
Remove NaturalSort.Extension for net10 in-built CompareOptions.NumericOrdering

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,6 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
-    <PackageVersion Include="NaturalSort.Extension" Version="4.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NUnit" Version="4.3.2" />

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="DataGridExtensions" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
-    <PackageReference Include="NaturalSort.Extension" />
     <PackageReference Include="TomsToolbox.Composition.MicrosoftExtensions" />
     <PackageReference Include="TomsToolbox.Wpf.Composition.AttributedModel" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" />

--- a/ILSpy/TreeNodes/NaturalStringComparer.cs
+++ b/ILSpy/TreeNodes/NaturalStringComparer.cs
@@ -18,8 +18,7 @@
 
 using System;
 using System.Collections.Generic;
-
-using NaturalSort.Extension;
+using System.Globalization;
 
 namespace ICSharpCode.ILSpy.TreeNodes
 {
@@ -28,6 +27,6 @@ namespace ICSharpCode.ILSpy.TreeNodes
 	/// </summary>
 	public sealed class NaturalStringComparer
 	{
-		public static readonly IComparer<string> Instance = StringComparison.CurrentCultureIgnoreCase.WithNaturalSort();
+		public static readonly IComparer<string> Instance = StringComparer.Create(CultureInfo.CurrentCulture, CompareOptions.NumericOrdering);
 	}
 }

--- a/doc/third-party-notices.txt
+++ b/doc/third-party-notices.txt
@@ -499,33 +499,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-License Notice for NaturalSort.Extension (part of ILSpy)
----------------------------
-
-https://github.com/tompazourek/NaturalSort.Extension/blob/master/LICENSE
-
-The MIT License (MIT)
-
-Copyright (c) 2022 Tomáš Pažourek
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
 License Notice for Tom's Toolbox (part of ILSpy)
 ---------------------------
 


### PR DESCRIPTION
In .NET 10 since preview1, see https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview1/libraries.md#numeric-ordering-for-string-comparison

@tompazourek thanks for https://github.com/tompazourek/NaturalSort.Extension/ - it was great to have that available pre-net10!

Tested in https://github.com/christophwille/poc-oh/commit/f8e4ebf26c480f22212d78a4868921abb374d871