### PR TITLE
Extract multiple package entries

### DIFF
--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1820,11 +1820,20 @@ namespace ICSharpCode.ILSpy.Properties {
                 return ResourceManager.GetString("ExpandUsingDeclarationsAfterDecompilation", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Extract package entry.
-        /// </summary>
-        public static string ExtractPackageEntry {
+
+		/// <summary>
+		///   Looks up a localized string similar to Extract all package entries.
+		/// </summary>
+		public static string ExtractAllPackageEntries {
+			get {
+				return ResourceManager.GetString("ExtractAllPackageEntries", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Extract package entry.
+		/// </summary>
+		public static string ExtractPackageEntry {
             get {
                 return ResourceManager.GetString("ExtractPackageEntry", resourceCulture);
             }

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -624,6 +624,9 @@ Are you sure you want to continue?</value>
   <data name="ExpandUsingDeclarationsAfterDecompilation" xml:space="preserve">
     <value>Expand using declarations after decompilation</value>
   </data>
+  <data name="ExtractAllPackageEntries" xml:space="preserve">
+    <value>Extract all package entries</value>
+  </data>
   <data name="ExtractPackageEntry" xml:space="preserve">
     <value>Extract package entry</value>
   </data>

--- a/ILSpy/Properties/Resources.zh-Hans.resx
+++ b/ILSpy/Properties/Resources.zh-Hans.resx
@@ -582,6 +582,9 @@
   <data name="ExpandUsingDeclarationsAfterDecompilation" xml:space="preserve">
     <value>反编译后展开引用和声明</value>
   </data>
+  <data name="ExtractAllPackageEntries" xml:space="preserve">
+    <value>提取所有包条目</value>
+  </data>
   <data name="ExtractPackageEntry" xml:space="preserve">
     <value>提取包条目</value>
   </data>


### PR DESCRIPTION
Close https://github.com/icsharpcode/ILSpy/issues/3498

I see this file structure:
```
runtimes/win-x64/native  // folder
    WebViewer2Loader     // file
```

I don't know if following is also possible:
```
runtimes                        // folder
    win-x64                     // folder
        native                  // folder
            WebViewer2Loader    // file
```
If it's impossible, recursion is unnecessary in GetFullPath
    