### PR TITLE
Allow specifying an IDecompilerTypeSystem rather than a DecompilerTypeSystem to CSharpDecompiler

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -257,7 +257,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		/// <summary>
 		/// Creates a new <see cref="CSharpDecompiler"/> instance from the given <paramref name="typeSystem"/> and the given <paramref name="settings"/>.
 		/// </summary>
-		public CSharpDecompiler(DecompilerTypeSystem typeSystem, DecompilerSettings settings)
+		public CSharpDecompiler(IDecompilerTypeSystem typeSystem, DecompilerSettings settings)
 		{
 			this.typeSystem = typeSystem ?? throw new ArgumentNullException(nameof(typeSystem));
 			this.settings = settings;


### PR DESCRIPTION
I wish to provide my own custom `IDecompilerTypeSystem` to `CSharpDecompiler`. The existing constructor `CSharpDecompiler(DecompilerTypeSystem typeSystem, DecompilerSettings settings)` limits to you to specifying a value of the concrete `DecompilerTypeSystem` type, however this value is assigned to the `typeSystem` field which is of type `IDecompilerTypeSystem`. I did not see any restrictions that require that the `IDecompilerTypeSystem` that is used *must* either be of type `DecompilerTypeSystem` or `SimpleCompilation` (which `DecompilerTypeSystem` derives from) so I am proposing to modify the type of `typeSystem` constructor parameter to match the type of the field that it then assigns to