### PR TITLE
Always move initializer decompilation setting

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Transforms/TransformFieldAndConstructorInitializers.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/TransformFieldAndConstructorInitializers.cs
@@ -350,7 +350,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						if (!(fieldOrProperty is IField || fieldOrProperty is IProperty) || !fieldOrProperty.IsStatic)
 							break;
 						// Only move fields that are constants, if the declaring type is not marked beforefieldinit.
-						if (!declaringTypeIsBeforeFieldInit && fieldOrProperty is not IField { IsConst: true })
+						if (!context.Settings.AlwaysMoveInitializer && !declaringTypeIsBeforeFieldInit && fieldOrProperty is not IField { IsConst: true })
 						{
 							pos++;
 							continue;

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -2274,6 +2274,27 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		bool alwaysMoveInitializer = false;
+
+		/// <summary>
+		/// If set to false (the default), the decompiler will move field initializers at the start of constructors
+		/// to their respective field declrations (TransformFieldAndConstructorInitializers) only when the declaring
+		/// type has BeforeFieldInit or the member IsConst.
+		/// If set true, the decompiler will always move them regardless of the flags.
+		/// </summary>
+		[Category("DecompilerSettings.Other")]
+		[Description("DecompilerSettings.AlwaysMoveInitializer")]
+		public bool AlwaysMoveInitializer {
+			get { return alwaysMoveInitializer; }
+			set {
+				if (alwaysMoveInitializer != value)
+				{
+					alwaysMoveInitializer = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		bool sortCustomAttributes = false;
 
 		/// <summary>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -730,6 +730,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always move field initializers from constructors to declarations.
+        /// </summary>
+        public static string DecompilerSettings_AlwaysMoveInitializer {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.AlwaysMoveInitializer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always qualify member references.
         /// </summary>
         public static string DecompilerSettings_AlwaysQualifyMemberReferences {
@@ -1838,20 +1847,20 @@ namespace ICSharpCode.ILSpy.Properties {
                 return ResourceManager.GetString("ExpandUsingDeclarationsAfterDecompilation", resourceCulture);
             }
         }
-
-		/// <summary>
-		///   Looks up a localized string similar to Extract all package entries.
-		/// </summary>
-		public static string ExtractAllPackageEntries {
-			get {
-				return ResourceManager.GetString("ExtractAllPackageEntries", resourceCulture);
-			}
-		}
-
-		/// <summary>
-		///   Looks up a localized string similar to Extract package entry.
-		/// </summary>
-		public static string ExtractPackageEntry {
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extract all package entries.
+        /// </summary>
+        public static string ExtractAllPackageEntries {
+            get {
+                return ResourceManager.GetString("ExtractAllPackageEntries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extract package entry.
+        /// </summary>
+        public static string ExtractPackageEntry {
             get {
                 return ResourceManager.GetString("ExtractPackageEntry", resourceCulture);
             }

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -264,6 +264,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.AlwaysCastTargetsOfExplicitInterfaceImplementationCalls" xml:space="preserve">
     <value>Always cast targets of explicit interface implementation calls</value>
   </data>
+  <data name="DecompilerSettings.AlwaysMoveInitializer" xml:space="preserve">
+    <value>Always move field initializers from constructors to declarations</value>
+  </data>
   <data name="DecompilerSettings.AlwaysQualifyMemberReferences" xml:space="preserve">
     <value>Always qualify member references</value>
   </data>
@@ -361,7 +364,7 @@ Are you sure you want to continue?</value>
     <value>Transform to do-while, if possible</value>
   </data>
   <data name="DecompilerSettings.ExpandParamsArguments" xml:space="preserve">
-	  <value>Expand params arguments by removing explicit array creation</value>
+    <value>Expand params arguments by removing explicit array creation</value>
   </data>
   <data name="DecompilerSettings.FSpecificOptions" xml:space="preserve">
     <value>F#-specific options</value>

--- a/ILSpy/Properties/Resources.zh-Hans.resx
+++ b/ILSpy/Properties/Resources.zh-Hans.resx
@@ -258,6 +258,9 @@
   <data name="DecompilerSettings.AlwaysCastTargetsOfExplicitInterfaceImplementationCalls" xml:space="preserve">
     <value>始终强制转换显式接口实现调用的目标</value>
   </data>
+  <data name="DecompilerSettings.AlwaysMoveInitializer" xml:space="preserve">
+    <value />
+  </data>
   <data name="DecompilerSettings.AlwaysQualifyMemberReferences" xml:space="preserve">
     <value>始终限定成员引用</value>
   </data>


### PR DESCRIPTION
### Problem
Sometimes one needs to find out which options a dependency property has, what the coercion or changed methods are, or which types registers it. More often than not, DPs are initialized in a type with static constructor. In such case, the declaring type is not eligible for `beforeFieldInit` and the decompiler cannot tell whether the static members have been initialized inline or in the constructor. However, It is non-trivial effort to manually find the constructor and the relevant initialization in it.

### Solution
This PR adds an option to always move initializers from static constructors to the declaration.

<img src="https://github.com/user-attachments/assets/818f46e0-e288-44ad-89d1-4dded8a09db8" />

#### Before

<img width="1191" height="687" alt="image" src="https://github.com/user-attachments/assets/844a9553-c2d4-464e-9f45-3be98089face" />

#### After

<img width="1458" height="676" alt="image" src="https://github.com/user-attachments/assets/ad9ece5a-78d9-49c8-9a12-af19fb74da05" />

