### PR TITLE
Minor Dev Environment Fixes (.editorconfig cleanup, typo fix, .gitignore tweak)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -106,7 +106,7 @@ csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_after_semicolon_in_for_statement = true
 csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_around_declaration_statements = false
 csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_before_comma = false
 csharp_space_before_dot = false
@@ -179,16 +179,11 @@ csharp_style_prefer_not_pattern = true:suggestion
 csharp_style_prefer_extended_property_pattern = true:suggestion
 
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
@@ -196,8 +191,6 @@ dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_readonly_field = true:suggestion
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_predefined_type_for_member_access = true:silent
 dotnet_style_require_accessibility_modifiers = omit_if_default:suggestion
 dotnet_style_allow_multiple_blank_lines_experimental = false:warning
 dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
@@ -206,10 +199,7 @@ dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:sil
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_property = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_event = false:silent
+
 
 # Errors and warnings
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,6 @@ multitargeting.props
 ILSpy.Installer/wix/
 /VERSION
 /ICSharpCode.Decompiler/Properties/DecompilerVersionInfo.cs
-*/.vscode/
+**/.vscode/
 DecompilerTests.config.json
 *.trx

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -149,7 +149,7 @@ Examples:
 		[Option(generateDiagrammerCmd + "-report-excluded", "Outputs a report of types excluded from the generated diagrammer" +
 			$" - whether by default because compiler-generated, explicitly by '{exclude}' or implicitly by '{include}'." +
 			" You may find this useful to develop and debug your regular expressions.", CommandOptionType.NoValue)]
-		public bool ReportExludedTypes { get; set; }
+		public bool ReportExcludedTypes { get; set; }
 
 		[Option(generateDiagrammerCmd + "-docs", "The path or file:// URI of the XML file containing the target assembly's documentation comments." +
 			" You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the assmbly." +
@@ -221,7 +221,7 @@ Examples:
 							OutputFolder = OutputDirectory,
 							Include = Include,
 							Exclude = Exclude,
-							ReportExludedTypes = ReportExludedTypes,
+							ReportExcludedTypes = ReportExcludedTypes,
 							JsonOnly = JsonOnly,
 							XmlDocs = XmlDocs,
 							StrippedNamespaces = StrippedNamespaces

--- a/ICSharpCode.ILSpyX/MermaidDiagrammer/GenerateHtmlDiagrammer.cs
+++ b/ICSharpCode.ILSpyX/MermaidDiagrammer/GenerateHtmlDiagrammer.cs
@@ -32,7 +32,7 @@ namespace ICSharpCode.ILSpyX.MermaidDiagrammer
 		public string? Include { get; set; }
 		public string? Exclude { get; set; }
 		public bool JsonOnly { get; set; }
-		public bool ReportExludedTypes { get; set; }
+		public bool ReportExcludedTypes { get; set; }
 		public string? XmlDocs { get; set; }
 
 		/// <summary>Namespaces to strip from <see cref="XmlDocs"/>.

--- a/ICSharpCode.ILSpyX/MermaidDiagrammer/Generator.Run.cs
+++ b/ICSharpCode.ILSpyX/MermaidDiagrammer/Generator.Run.cs
@@ -127,7 +127,7 @@ namespace ICSharpCode.ILSpyX.MermaidDiagrammer
 				Debug.WriteLine("Successfully generated HTML diagrammer.");
 			}
 
-			if (ReportExludedTypes)
+			if (ReportExcludedTypes)
 			{
 				string excludedTypes = model.Excluded.Join(Environment.NewLine);
 				File.WriteAllText(Path.Combine(outputFolder, "excluded types.txt"), excludedTypes);


### PR DESCRIPTION
Minor fixes that seemed like they're small enough to bundle together for review (there should be no run-time change in behavior):

* Removed duplicate settings in .editorconfig.
* Fix invalid .editorconfig value (valid values for csharp_space_around_declaration_statements seem to be "false" and "ignore"; "do_not_ignore" currently is equivalent to false based on https://github.com/dotnet/roslyn/issues/28022).
* Change .gitignore to ignore all .vscode folders, not just a top-level one.
* Typo fix (ReportExludedTypes -> ReportExcludedTypes)