### PR TITLE
Enable detection of .NET version without TargetFrameworkAttribute

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinderExtensions.cs
+++ b/ICSharpCode.Decompiler/Metadata/DotNetCorePathFinderExtensions.cs
@@ -109,8 +109,7 @@ namespace ICSharpCode.Decompiler.Metadata
 								}
 								else if (r.Version.Major == 4 && r.Version.Minor == 2)
 								{
-									version = r.Version.Build switch
-									{
+									version = r.Version.Build switch {
 										<= 0 => "2.0",
 										1 => "3.0",
 										_ => "3.1"


### PR DESCRIPTION
### Problem

Without `TargetFrameworkAttribute`, all .NET 5+ assemblies are currently assumed to be targeting .NET Core 3.1.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
* Which part of this PR is most in need of attention/improvement?
  * I have no unit test.
* [ ] At least one test covering the code changed

