### PR TITLE
List name first in ILSpy title for multiple instances

### DIFF
--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -469,9 +469,9 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 #endif
 			else
 #if DEBUG
-				mainWindow.Title = $"ILSpy {DecompilerVersionInfo.FullVersion} - " + assemblyList.ListName;
+				mainWindow.Title = string.Format(settingsService.MiscSettings.AllowMultipleInstances ? "{1} - {0}" : "{0} - {1}", $"ILSpy {DecompilerVersionInfo.FullVersion}", assemblyList.ListName);
 #else
-				mainWindow.Title = "ILSpy - " + assemblyList.ListName;
+				mainWindow.Title = string.Format(settingsService.MiscSettings.AllowMultipleInstances ? "{1} - {0}" : "{0} - {1}", "ILSpy", assemblyList.ListName);
 #endif
 		}
 


### PR DESCRIPTION
Fixes #3562

### Problem
I have multiple instances of ILSpy allowed, because I need to use see different set of assemblies at the same time. However, since the word "ILSpy" is shown first in the title, it is not easy to find out which window is the correct one, as the list name gets often cut of (especially if the title also contains the build number).

### Solution
When multiple instances are allowed, swap the main window title from "ILSpy - List name" to "List name - ILSpy"

