### PR TITLE
Exclude `System.Runtime.CompilerServices.RefSafetyRulesAttribute` fro…

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Transforms/EscapeInvalidIdentifiers.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/EscapeInvalidIdentifiers.cs
@@ -136,6 +136,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						switch (trr.Type.FullName)
 						{
 							case "System.Security.UnverifiableCodeAttribute":
+							case "System.Runtime.CompilerServices.RefSafetyRulesAttribute":
 								attribute.Remove();
 								break;
 						}


### PR DESCRIPTION
…m the `module` attribute in the generated `AssemblyInfo.cs`, because including it causes the compiler error: `error CS8335: Do not use 'System.Runtime.CompilerServices.RefSafetyRulesAttribute'. This is reserved for compiler usage.`.


