### PR TITLE
Fix the issue where PDBs generated by ILSpy do not match certain asse…

### DIFF
--- a/ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs
+++ b/ICSharpCode.Decompiler/DebugInfo/PortablePdbWriter.cs
@@ -235,8 +235,9 @@ namespace ICSharpCode.Decompiler.DebugInfo
 
 			if (pdbId == null)
 			{
-				var debugDir = file.Reader.ReadDebugDirectory().FirstOrDefault(dir => dir.Type == DebugDirectoryEntryType.CodeView);
+				var debugDir = file.Reader.ReadDebugDirectory().LastOrDefault(dir => dir.Type == DebugDirectoryEntryType.CodeView);
 				var portable = file.Reader.ReadCodeViewDebugDirectoryData(debugDir);
+				Debug.Assert(!portable.Path.EndsWith(".ni.pdb"));
 				pdbId = new BlobContentId(portable.Guid, debugDir.Stamp);
 			}
 


### PR DESCRIPTION
<img width="920" height="414" alt="image" src="https://github.com/user-attachments/assets/194cac1d-f233-491e-bfd7-1fa23cf205e6" />

As shown in the image above, the file `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\Copilot\Conversations.Service\Microsoft.VisualStudio.Copilot.Service.dll` contains two sets of CodeView entries in its Debug Directory:

| Type | Age | GUID \| Timestamp | PDB Name |
| :--- | :--- | :--- | :--- |
| RSDS | 00000001 | {FD8F8A2F-2C21-C8C0-51B2-72A6D9F1736B} | Microsoft.VisualStudio.Copilot.Service.ni.pdb |
| RSDS | 00000001 | {9DD21ECB-9171-4F44-B337-CF21CA9180B7} | D:\a\_work\1\s\obj\src\Copilot.Service\x64\Release\net8.0\Microsoft.VisualStudio.Copilot.Service.pdb |

The first entry points to a non-Portable PDB filename (specifically a Native Image `.ni.pdb`). We must skip this entry; otherwise, Visual Studio will fail to load the generated PDB for debugging.

Since ILSpy has lagged significantly behind the rapid evolution of C# standards in recent years, many assemblies cannot be perfectly decompiled into source projects that can be successfully recompiled. In this situation, PDB debugging serves as a critical mitigation for these issues. Therefore, I hope that the PDB feature is at least perfectly usable.