### PR TITLE
Render operating system name as well as architecture if present

### DIFF
--- a/ILSpy/Languages/Language.cs
+++ b/ILSpy/Languages/Language.cs
@@ -387,7 +387,7 @@ namespace ICSharpCode.ILSpy
 
 			if (!Enum.IsDefined(architecture))
 			{
-				foreach ((var osEnum, var osText) in osMachineLookup)
+				foreach (var (osEnum, osText) in osMachineLookup)
 				{
 					var candidate = architecture ^ osEnum;
 					if (Enum.IsDefined(candidate))


### PR DESCRIPTION
I was diagnosing an issue with our ReadyToRun assemblies and when I loaded them in ILSpy I noticed that instead of indicating which platform they were built for it was just a number.

Digging into it, I found [this comment](https://github.com/dotnet/runtime/issues/36364#issuecomment-628232472) that indicates that if the binaries are machine specific then the value is xor'd with a constant (like flags).

This Pull Request displays the OS (if present).

I'm happy for the format of the text output to be changed, or any other changes for that matter!