### PR TITLE
Fix PowerShell PostBuild failing when solution path contains spaces

### DIFF
--- a/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj
+++ b/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell -Command &quot;Copy-Item $(ProjectDir)manifest.psd1 $(TargetDir)$(TargetName).psd1&quot;" />
-	<Exec Condition=" '$(OS)' != 'Windows_NT' " Command="pwsh -Command &quot;Copy-Item $(ProjectDir)manifest.psd1 $(TargetDir)$(TargetName).psd1&quot;" />
+    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell -Command &quot;Copy-Item '$(ProjectDir)manifest.psd1' '$(TargetDir)$(TargetName).psd1'&quot;" />
+	<Exec Condition=" '$(OS)' != 'Windows_NT' " Command="pwsh -Command &quot;Copy-Item '$(ProjectDir)manifest.psd1' '$(TargetDir)$(TargetName).psd1'&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- Quote `$(ProjectDir)` and `$(TargetDir)` MSBuild properties in the PowerShell `Copy-Item` commands in `ICSharpCode.Decompiler.PowerShell.csproj`
- Without quotes, the PostBuild target fails with `MSB3073` when the solution is cloned into a directory whose path contains spaces

## Reproduction
1. Clone the repo into a folder with a space in its name (e.g. `C:\Dev\ILSpy 10.0`)
2. Run `dotnet build ILSpy.sln --configuration Release`
3. Build fails with: `error MSB3073: The command "powershell -Command "Copy-Item ..." exited with code 1`

## Fix
Wrap the path arguments in single quotes so PowerShell treats them as literal string paths:
```xml
<Exec Command="powershell -Command &quot;Copy-Item '$(ProjectDir)manifest.psd1' '$(TargetDir)$(TargetName).psd1'&quot;" />
```

## Test plan
- [x] Verified build succeeds in a path with spaces (`C:\Dev\IlySpy 10.0`)
- [x] 0 warnings, 0 errors on full solution build