### PR TITLE
Switch to (finally) released coverlet.MTP

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="TomsToolbox.Wpf.Composition" Version="2.22.2" />
     <PackageVersion Include="TomsToolbox.Wpf.Composition.AttributedModel" Version="2.22.2" />
     <PackageVersion Include="TomsToolbox.Wpf.Styles" Version="2.22.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.MTP" Version="8.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -67,10 +67,7 @@
     <PackageReference Include="Microsoft.DiaSymReader" />
     <PackageReference Include="Microsoft.DiaSymReader.Native" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -41,10 +41,7 @@
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
 	<PackageReference Include="Microsoft.Testing.Extensions.VSTestBridge" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy.Tests/ILSpy.Tests.csproj
+++ b/ILSpy.Tests/ILSpy.Tests.csproj
@@ -75,10 +75,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.MTP" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />


### PR DESCRIPTION
https://www.nuget.org/packages/coverlet.MTP#readme-body-tab

Run

`dotnet test --coverlet --coverlet-output-format cobertura --coverlet-include [ICSharpCode.Decompiler*]*`

in \ILSpy\ICSharpCode.Decompiler.Tests, results will be in .\bin\Debug\net10.0-windows\win-x64\TestResults

Use 

https://github.com/danielpalme/ReportGenerator

`dotnet tool install -g dotnet-reportgenerator-globaltool`

With settings generated using https://reportgenerator.io/usage

`reportgenerator -reports:coverage.cobertura.xml -targetdir:coveragereport`

Local run on Ryzen AI 9 HX 370:

Test run summary: Passed!
  total: 2714
  failed: 0
  succeeded: 2701
  skipped: 13
  duration: 25m 07s 494ms