### PR TITLE
Update TransformCollectionAndObjectInitializers to check for init-only properties

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformCollectionAndObjectInitializers.cs
@@ -58,7 +58,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			{
 				case NewObj newObjInst:
 					if (newObjInst.ILStackWasEmpty && v.Kind == VariableKind.Local
-						&& !TypeContainsInitOnlyProperties(newObjInst.Method.DeclaringType.GetDefinition())
+						&& !TypeContainsInitOnlyProperties(newObjInst.Method.DeclaringTypeDefinition)
 						&& !currentMethod.IsConstructor
 						&& !currentMethod.IsCompilerGeneratedOrIsInCompilerGeneratedClass())
 					{


### PR DESCRIPTION



### Problem
Fixes #3677



### Solution
The main culprit was here:

```c#
					if (newObjInst.ILStackWasEmpty && v.Kind == VariableKind.Local
						&& !currentMethod.IsConstructor
						&& !currentMethod.IsCompilerGeneratedOrIsInCompilerGeneratedClass())
```
Adding a simple check to see if the declaring type has init-only properties fixes the issue.

I would add a test that covers this, but I do not know how to force the C# compiler to allocate an object locally instead of on the stack consistently; if you have any tips, let me know.
