### PR TITLE
Fix `in` erroneously being applied to `this`

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
@@ -320,6 +320,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(ElementAtOrDefault(-5));
 		}
 
+		public void CallWithTemplatedInParameterOnSelf()
+		{
+			M2<RefLocalsAndReturns>(this);
+		}
+
 #if CS120
 		public ref readonly int M(in int x)
 		{

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4376,7 +4376,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		{
 			if (!(input.Expression is DirectionExpression dirExpr && input.ResolveResult is ByReferenceResolveResult brrr))
 				return input;
-			if (isAddressOf && kind is ReferenceKind.In or ReferenceKind.RefReadOnly)
+			if ((isAddressOf || dirExpr.Expression is ThisReferenceExpression) && kind is ReferenceKind.In or ReferenceKind.RefReadOnly)
 			{
 				return input.UnwrapChild(dirExpr.Expression);
 			}


### PR DESCRIPTION
### Problem
Fixes https://github.com/icsharpcode/ILSpy/issues/3578

### Solution
* Fairly simple: in `ChangeDirectionExpressionTo()`, we just check if the parameter is a `this` expression and if the direction is `in` or `ref readonly`; if so, we don't change it.
* [x] At least one test covering the code changed

