### PR TITLE
Fix syntax error in CreateBoldRun method for CROSS_PLATFORM

### DIFF
--- a/ILSpy/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyTreeNode.cs
@@ -191,7 +191,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		private static Bold CreateBoldRun(string text)
 		{
 #if CROSS_PLATFORM
-			return new Bold().Add(new Run(text)));
+			return new Bold().Add(new Run(text));
 #else
 			return new Bold(new Run(text));
 #endif


### PR DESCRIPTION
### Problem

A small break in the conditional statement

### Solution

Remove the extra `)`.

