### PR TITLE
.NET 11 for Tests

### DIFF
--- a/.github/workflows/build-frontends.yml
+++ b/.github/workflows/build-frontends.yml
@@ -21,7 +21,7 @@ jobs:
         
     - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        dotnet-version: '11.0.x'
         dotnet-quality: 'preview'
 
     - name: Install dependencies

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -40,9 +40,6 @@ jobs:
         DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet
         DOTNET_ROOT: ${{ runner.temp }}/.dotnet
 
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v3
-
     - name: Install dotnet-format
       env:
         DOTNET_FORMAT_VERSION: 10.0.100-rtm.25531.102
@@ -63,10 +60,10 @@ jobs:
         Get-ChildItem Env: | Where-Object {$_.Name -Match "^ILSPY_"} | %{ echo "$($_.Name)=$($_.Value)" } | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
     - name: Restore the application
-      run: msbuild ILSpy.sln /t:Restore /p:RestoreEnablePackagePruning=false /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform
+      run: dotnet restore ILSpy.sln /p:RestoreEnablePackagePruning=false /p:Configuration=${{ matrix.configuration }} /p:Platform="$env:BuildPlatform"
 
     - name: Build
-      run: msbuild ILSpy.sln /p:Configuration=${{ matrix.configuration }} /p:Platform=$env:BuildPlatform /m
+      run: dotnet build ILSpy.sln --no-restore -c ${{ matrix.configuration }} /p:Platform="$env:BuildPlatform" /m
 
     - name: Format check
       run: dotnet-format whitespace --verify-no-changes --verbosity detailed ILSpy.sln
@@ -120,15 +117,15 @@ jobs:
     - name: Build Installer (x64 and arm64, framework-dependent)
       if: matrix.configuration == 'release'  
       run: |
-        msbuild ILSpy.Installer.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
-        msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU"
-        msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU" /p:PlatformForInstaller="ARM64"
+        dotnet msbuild ILSpy.Installer.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
+        dotnet msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU"
+        dotnet msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU" /p:PlatformForInstaller="ARM64"
 
     - name: Build VS Extensions (for 2017-2019 and 2022)
       if: matrix.configuration == 'release'  
       run: |
-        msbuild ILSpy.VSExtensions.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
-        msbuild ILSpy.VSExtensions.sln /p:Configuration="Release" /p:Platform="Any CPU"
+        dotnet msbuild ILSpy.VSExtensions.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
+        dotnet msbuild ILSpy.VSExtensions.sln /p:Configuration="Release" /p:Platform="Any CPU"
 
     # https://github.com/actions/upload-artifact
     - name: Upload VSIX (VS 2019) release build artifacts

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -35,10 +35,6 @@ jobs:
 
     - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
-
-    - uses: actions/setup-dotnet@v5
-      with:
         dotnet-version: '11.0.x'
         dotnet-quality: 'preview'
       env:

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -35,6 +35,10 @@ jobs:
 
     - uses: actions/setup-dotnet@v5
       with:
+        dotnet-version: '10.0.x'
+
+    - uses: actions/setup-dotnet@v5
+      with:
         dotnet-version: '11.0.x'
         dotnet-quality: 'preview'
       env:

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       BuildPlatform: Any CPU
       StagingDirectory: buildartifacts
-      BuildAndPublishVsix: false  # temp disable due to usage of transport feed for net11
+      BuildAndPublishVsix: true  # temp disable due to usage of transport feed for net11
 
     steps:
     - run: mkdir -p $env:StagingDirectory

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -128,8 +128,8 @@ jobs:
     - name: Build VS Extensions (for 2017-2019 and 2022)
       if: matrix.configuration == 'release' && env.BuildAndPublishVsix == 'true'
       run: |
-        dotnet msbuild ILSpy.VSExtensions.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
-        dotnet msbuild ILSpy.VSExtensions.sln /p:Configuration="Release" /p:Platform="Any CPU"
+        msbuild ILSpy.VSExtensions.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
+        msbuild ILSpy.VSExtensions.sln /p:Configuration="Release" /p:Platform="Any CPU"
 
     # https://github.com/actions/upload-artifact
     - name: Upload VSIX (VS 2019) release build artifacts

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       BuildPlatform: Any CPU
       StagingDirectory: buildartifacts
-      BuildAndPublishVsix: true  # temp disable due to usage of transport feed for net11
+      BuildAndPublishVsix: true
 
     steps:
     - run: mkdir -p $env:StagingDirectory

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -13,7 +13,7 @@ jobs:
   Build:
     permissions:
       packages: write  # for dotnet nuget push
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +40,9 @@ jobs:
       env:
         DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet
         DOTNET_ROOT: ${{ runner.temp }}/.dotnet
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v3
 
     - name: Install dotnet-format
       env:

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        dotnet-version: '11.0.x'
         dotnet-quality: 'preview'
       env:
         DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet

--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -20,7 +20,8 @@ jobs:
         Configuration: [ Debug, Release ]
     env:
       BuildPlatform: Any CPU
-      StagingDirectory: buildartifacts 
+      StagingDirectory: buildartifacts
+      BuildAndPublishVsix: false  # temp disable due to usage of transport feed for net11
 
     steps:
     - run: mkdir -p $env:StagingDirectory
@@ -122,14 +123,14 @@ jobs:
         dotnet msbuild ILSpy.Installer.sln /p:Configuration="Release" /p:Platform="Any CPU" /p:PlatformForInstaller="ARM64"
 
     - name: Build VS Extensions (for 2017-2019 and 2022)
-      if: matrix.configuration == 'release'  
+      if: matrix.configuration == 'release' && env.BuildAndPublishVsix == 'true'
       run: |
         dotnet msbuild ILSpy.VSExtensions.sln /t:Restore /p:Configuration="Release" /p:Platform="Any CPU"
         dotnet msbuild ILSpy.VSExtensions.sln /p:Configuration="Release" /p:Platform="Any CPU"
 
     # https://github.com/actions/upload-artifact
     - name: Upload VSIX (VS 2019) release build artifacts
-      if: matrix.configuration == 'release'
+      if: matrix.configuration == 'release' && env.BuildAndPublishVsix == 'true'
       uses: actions/upload-artifact@v7
       with:
         name: ILSpy VS Addin for VS 2017-2019 ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }} (${{ matrix.configuration }})
@@ -137,7 +138,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload VSIX (VS 2022) release build artifacts
-      if: matrix.configuration == 'release'
+      if: matrix.configuration == 'release' && env.BuildAndPublishVsix == 'true'
       uses: actions/upload-artifact@v7
       with:
         name: ILSpy VS Addin for VS 2022 ${{ steps.version.outputs.ILSPY_VERSION_NUMBER }} (${{ matrix.configuration }})

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.x'
+        dotnet-version: '11.0.x'
         dotnet-quality: 'preview'
 
     - name: Build

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="5.0.1" />
     <PackageVersion Include="McMaster.Extensions.Hosting.CommandLine" Version="5.0.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0-2.26177.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="5.6.0-2.26177.1" />
     <PackageVersion Include="Microsoft.DiaSymReader.Converter.Xml" Version="1.1.0-beta2-22171-02" />
     <PackageVersion Include="Microsoft.DiaSymReader" Version="1.4.0" />
     <PackageVersion Include="Microsoft.DiaSymReader.Native" Version="17.0.0-beta1.21524.1" />

--- a/ICSharpCode.Decompiler.TestRunner/ICSharpCode.Decompiler.TestRunner.csproj
+++ b/ICSharpCode.Decompiler.TestRunner/ICSharpCode.Decompiler.TestRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
@@ -41,8 +41,8 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 	abstract class AbstractToolset
 	{
 		readonly SourceCacheContext cache;
-		readonly SourceRepository repository, transportFeedRepository;
-		readonly FindPackageByIdResource resource, transportFeedResource;
+		readonly SourceRepository repository, dotnetToolsFeed;
+		readonly FindPackageByIdResource resource, dotnetToolsResource;
 		protected readonly string baseDir;
 
 		public AbstractToolset(string baseDir)
@@ -50,8 +50,8 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			this.cache = new SourceCacheContext();
 			this.repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
 			this.resource = repository.GetResource<FindPackageByIdResource>();
-			this.transportFeedRepository = Repository.Factory.GetCoreV3("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json");
-			this.transportFeedResource = transportFeedRepository.GetResource<FindPackageByIdResource>();
+			this.dotnetToolsFeed = Repository.Factory.GetCoreV3("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json");
+			this.dotnetToolsResource = dotnetToolsFeed.GetResource<FindPackageByIdResource>();
 			this.baseDir = baseDir;
 		}
 
@@ -95,7 +95,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 				NuGetVersion parsedVersion = NuGetVersion.Parse(version);
 				PackageVersionKind versionKind = ClassifyVersion(parsedVersion);
 				FindPackageByIdResource selectedResource = versionKind == PackageVersionKind.TransportFeed
-					? transportFeedResource
+					? dotnetToolsResource
 					: resource;
 
 				await selectedResource.CopyNupkgToStreamAsync(

--- a/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
@@ -41,8 +41,8 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 	abstract class AbstractToolset
 	{
 		readonly SourceCacheContext cache;
-		readonly SourceRepository repository;
-		readonly FindPackageByIdResource resource;
+		readonly SourceRepository repository, transportFeedRepository;
+		readonly FindPackageByIdResource resource, transportFeedResource;
 		protected readonly string baseDir;
 
 		public AbstractToolset(string baseDir)
@@ -50,7 +50,29 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			this.cache = new SourceCacheContext();
 			this.repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
 			this.resource = repository.GetResource<FindPackageByIdResource>();
+			this.transportFeedRepository = Repository.Factory.GetCoreV3("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json");
+			this.transportFeedResource = transportFeedRepository.GetResource<FindPackageByIdResource>();
 			this.baseDir = baseDir;
+		}
+
+		enum PackageVersionKind
+		{
+			Rtm,
+			Preview,
+			TransportFeed,
+		}
+
+		// RTM versions look like 5.3.0, and preview ones like 4.12.0-3.final. Transport feed ones eg 5.6.0-2.26177.1
+		static PackageVersionKind ClassifyVersion(NuGetVersion version)
+		{
+			if (!version.IsPrerelease)
+				return PackageVersionKind.Rtm;
+
+			var labels = version.ReleaseLabels.ToList();
+			bool looksLikeTransportFeed = labels.Count >= 3
+				&& labels.All(static label => int.TryParse(label, out _));
+
+			return looksLikeTransportFeed ? PackageVersionKind.TransportFeed : PackageVersionKind.Preview;
 		}
 
 		protected async Task FetchPackage(string packageName, string version, string sourcePath, string outputPath)
@@ -70,9 +92,15 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			{
 				packageStream = new MemoryStream();
 
-				await resource.CopyNupkgToStreamAsync(
+				NuGetVersion parsedVersion = NuGetVersion.Parse(version);
+				PackageVersionKind versionKind = ClassifyVersion(parsedVersion);
+				FindPackageByIdResource selectedResource = versionKind == PackageVersionKind.TransportFeed
+					? transportFeedResource
+					: resource;
+
+				await selectedResource.CopyNupkgToStreamAsync(
 					packageName,
-					NuGetVersion.Parse(version),
+					parsedVersion,
 					packageStream,
 					cache,
 					logger,

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
@@ -53,7 +53,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 					CompilerOptions.UseRoslyn1_3_2 => ("1.3.2", "14", null),
 					CompilerOptions.UseRoslyn2_10_0 => ("2.10.0", "latest", targetNet40 ? null : ".NETCoreApp,Version=v2.2"),
 					CompilerOptions.UseRoslyn3_11_0 => ("3.11.0", "latest", targetNet40 ? null : ".NETCoreApp,Version=v5.0"),
-					_ => (roslynLatestVersion, flags.HasFlag(CompilerOptions.Preview) ? "preview" : "latest", targetNet40 ? null : ".NETCoreApp,Version=v10.0")
+					_ => (roslynLatestVersion, flags.HasFlag(CompilerOptions.Preview) ? "preview" : "latest", targetNet40 ? null : CurrentNetCoreAppVersion)
 				};
 
 				var vbcPath = roslynToolset.GetVBCompiler(roslynVersion);

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -114,7 +114,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 #if DEBUG
 			testRunnerBasePath = Path.Combine(TesterPath, $"../../../../../ICSharpCode.Decompiler.TestRunner/bin/Debug/net{CurrentNetCoreVersion}");
 #else
-			testRunnerBasePath = Path.Combine(TesterPath, $"../../../../../ICSharpCode.Decompiler.TestRunner/bin/Release/net{CurrentNetCoreVersion});
+			testRunnerBasePath = Path.Combine(TesterPath, $"../../../../../ICSharpCode.Decompiler.TestRunner/bin/Release/net{CurrentNetCoreVersion}");
 #endif
 			// To parse: <Project><ItemGroup><PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-3.final" />
 			packagesPropsFile = Path.Combine(TesterPath, "../../../../../Directory.Packages.props");

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -93,6 +93,10 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 	public static partial class Tester
 	{
+		public const string CurrentNetCoreVersion = "11.0";
+		public const string CurrentNetCoreAppVersion = ".NETCoreApp,Version=v11.0";
+		public const string CurrentNetCoreRefAsmVersion = "11.0.0-preview.2.26159.112";
+
 		public static readonly string TesterPath;
 		public static readonly string TestCasePath;
 
@@ -108,9 +112,9 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			TesterPath = Path.GetDirectoryName(typeof(Tester).Assembly.Location);
 			TestCasePath = Path.Combine(TesterPath, "../../../../TestCases");
 #if DEBUG
-			testRunnerBasePath = Path.Combine(TesterPath, "../../../../../ICSharpCode.Decompiler.TestRunner/bin/Debug/net11.0");
+			testRunnerBasePath = Path.Combine(TesterPath, $"../../../../../ICSharpCode.Decompiler.TestRunner/bin/Debug/net{CurrentNetCoreVersion}");
 #else
-			testRunnerBasePath = Path.Combine(TesterPath, "../../../../../ICSharpCode.Decompiler.TestRunner/bin/Release/net11.0");
+			testRunnerBasePath = Path.Combine(TesterPath, $"../../../../../ICSharpCode.Decompiler.TestRunner/bin/Release/net{CurrentNetCoreVersion});
 #endif
 			// To parse: <Project><ItemGroup><PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-3.final" />
 			packagesPropsFile = Path.Combine(TesterPath, "../../../../../Directory.Packages.props");
@@ -136,7 +140,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			await vswhereToolset.Fetch().ConfigureAwait(false);
 			await RefAssembliesToolset.Fetch("5.0.0", sourcePath: "ref/net5.0").ConfigureAwait(false);
 			await RefAssembliesToolset.Fetch("10.0.0", sourcePath: "ref/net10.0").ConfigureAwait(false);
-			await RefAssembliesToolset.Fetch("11.0.0-preview.2.26159.112", sourcePath: "ref/net11.0").ConfigureAwait(false);
+			await RefAssembliesToolset.Fetch(CurrentNetCoreRefAsmVersion, sourcePath: $"ref/net{CurrentNetCoreVersion}").ConfigureAwait(false);
 
 #if DEBUG
 			await BuildTestRunner("win-x86", "Debug").ConfigureAwait(false);
@@ -342,7 +346,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			};
 
 		static readonly Dictionary<string, Lazy<string>> targetFrameworkAttributeSnippetFiles = new() {
-			{ ".NETCoreApp,Version=v11.0", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v11.0")) },
+			{ CurrentNetCoreAppVersion, new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(CurrentNetCoreAppVersion)) },
 			{ ".NETCoreApp,Version=v5.0", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v5.0")) },
 			{ ".NETCoreApp,Version=v2.2", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v2.2")) },
 		};
@@ -524,7 +528,7 @@ namespace System.Runtime.CompilerServices
 					CompilerOptions.UseRoslyn1_3_2 => ("1.3.2", "6", null),
 					CompilerOptions.UseRoslyn2_10_0 => ("2.10.0", "latest", targetNet40 ? null : ".NETCoreApp,Version=v2.2"),
 					CompilerOptions.UseRoslyn3_11_0 => ("3.11.0", "latest", targetNet40 ? null : ".NETCoreApp,Version=v5.0"),
-					_ => (roslynLatestVersion, flags.HasFlag(CompilerOptions.Preview) ? "preview" : "latest", targetNet40 ? null : ".NETCoreApp,Version=v11.0")
+					_ => (roslynLatestVersion, flags.HasFlag(CompilerOptions.Preview) ? "preview" : "latest", targetNet40 ? null : CurrentNetCoreAppVersion)
 				};
 
 				var cscPath = roslynToolset.GetCSharpCompiler(roslynVersion);
@@ -774,7 +778,7 @@ namespace System.Runtime.CompilerServices
 			}
 
 			var compilation = CSharpCompilation.Create(Path.GetFileNameWithoutExtension(assemblyName),
-				syntaxTrees, coreDefaultReferences.Select(r => MetadataReference.CreateFromFile(Path.Combine(RefAssembliesToolset.GetPath(".NETCoreApp,Version=v11.0"), r))),
+				syntaxTrees, coreDefaultReferences.Select(r => MetadataReference.CreateFromFile(Path.Combine(RefAssembliesToolset.GetPath(CurrentNetCoreAppVersion), r))),
 				new CSharpCompilationOptions(
 					OutputKind.DynamicallyLinkedLibrary,
 					platform: Platform.AnyCpu,

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -108,9 +108,9 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			TesterPath = Path.GetDirectoryName(typeof(Tester).Assembly.Location);
 			TestCasePath = Path.Combine(TesterPath, "../../../../TestCases");
 #if DEBUG
-			testRunnerBasePath = Path.Combine(TesterPath, "../../../../../ICSharpCode.Decompiler.TestRunner/bin/Debug/net10.0");
+			testRunnerBasePath = Path.Combine(TesterPath, "../../../../../ICSharpCode.Decompiler.TestRunner/bin/Debug/net11.0");
 #else
-			testRunnerBasePath = Path.Combine(TesterPath, "../../../../../ICSharpCode.Decompiler.TestRunner/bin/Release/net10.0");
+			testRunnerBasePath = Path.Combine(TesterPath, "../../../../../ICSharpCode.Decompiler.TestRunner/bin/Release/net11.0");
 #endif
 			// To parse: <Project><ItemGroup><PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0-3.final" />
 			packagesPropsFile = Path.Combine(TesterPath, "../../../../../Directory.Packages.props");
@@ -135,7 +135,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 			await vswhereToolset.Fetch().ConfigureAwait(false);
 			await RefAssembliesToolset.Fetch("5.0.0", sourcePath: "ref/net5.0").ConfigureAwait(false);
-			await RefAssembliesToolset.Fetch("10.0.0-rc.2.25502.107", sourcePath: "ref/net10.0").ConfigureAwait(false);
+			await RefAssembliesToolset.Fetch("11.0.0-preview.2.26159.112", sourcePath: "ref/net11.0").ConfigureAwait(false);
 
 #if DEBUG
 			await BuildTestRunner("win-x86", "Debug").ConfigureAwait(false);
@@ -341,7 +341,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 			};
 
 		static readonly Dictionary<string, Lazy<string>> targetFrameworkAttributeSnippetFiles = new() {
-			{ ".NETCoreApp,Version=v10.0", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v10.0")) },
+			{ ".NETCoreApp,Version=v11.0", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v11.0")) },
 			{ ".NETCoreApp,Version=v5.0", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v5.0")) },
 			{ ".NETCoreApp,Version=v2.2", new Lazy<string>(() => GetTargetFrameworkAttributeSnippetFile(".NETCoreApp,Version=v2.2")) },
 		};
@@ -454,12 +454,15 @@ namespace System.Runtime.CompilerServices
 						preprocessorSymbols.Add("NET80");
 						preprocessorSymbols.Add("NET90");
 						preprocessorSymbols.Add("NET100");
+						preprocessorSymbols.Add("NET110");
 					}
 					preprocessorSymbols.Add("ROSLYN4");
 					preprocessorSymbols.Add("CS100");
 					preprocessorSymbols.Add("CS110");
 					preprocessorSymbols.Add("CS120");
 					preprocessorSymbols.Add("CS130");
+					preprocessorSymbols.Add("CS140");
+					preprocessorSymbols.Add("CS150");
 				}
 			}
 			else if ((flags & CompilerOptions.UseMcsMask) != 0)
@@ -520,7 +523,7 @@ namespace System.Runtime.CompilerServices
 					CompilerOptions.UseRoslyn1_3_2 => ("1.3.2", "6", null),
 					CompilerOptions.UseRoslyn2_10_0 => ("2.10.0", "latest", targetNet40 ? null : ".NETCoreApp,Version=v2.2"),
 					CompilerOptions.UseRoslyn3_11_0 => ("3.11.0", "latest", targetNet40 ? null : ".NETCoreApp,Version=v5.0"),
-					_ => (roslynLatestVersion, flags.HasFlag(CompilerOptions.Preview) ? "preview" : "latest", targetNet40 ? null : ".NETCoreApp,Version=v10.0")
+					_ => (roslynLatestVersion, flags.HasFlag(CompilerOptions.Preview) ? "preview" : "latest", targetNet40 ? null : ".NETCoreApp,Version=v11.0")
 				};
 
 				var cscPath = roslynToolset.GetCSharpCompiler(roslynVersion);
@@ -770,7 +773,7 @@ namespace System.Runtime.CompilerServices
 			}
 
 			var compilation = CSharpCompilation.Create(Path.GetFileNameWithoutExtension(assemblyName),
-				syntaxTrees, coreDefaultReferences.Select(r => MetadataReference.CreateFromFile(Path.Combine(RefAssembliesToolset.GetPath(".NETCoreApp,Version=v10.0"), r))),
+				syntaxTrees, coreDefaultReferences.Select(r => MetadataReference.CreateFromFile(Path.Combine(RefAssembliesToolset.GetPath(".NETCoreApp,Version=v11.0"), r))),
 				new CSharpCompilationOptions(
 					OutputKind.DynamicallyLinkedLibrary,
 					platform: Platform.AnyCpu,

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -135,6 +135,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 			await vswhereToolset.Fetch().ConfigureAwait(false);
 			await RefAssembliesToolset.Fetch("5.0.0", sourcePath: "ref/net5.0").ConfigureAwait(false);
+			await RefAssembliesToolset.Fetch("10.0.0", sourcePath: "ref/net10.0").ConfigureAwait(false);
 			await RefAssembliesToolset.Fetch("11.0.0-preview.2.26159.112", sourcePath: "ref/net11.0").ConfigureAwait(false);
 
 #if DEBUG

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net11.0-windows</TargetFramework>
     <LangVersion>preview</LangVersion>
     <RuntimeIdentifier Condition="$(IsWindowsX64) == true">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(IsWindowsARM64) == true">win-arm64</RuntimeIdentifier>

--- a/ILSpy.AddIn.VS2022/NuGet.config
+++ b/ILSpy.AddIn.VS2022/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/ILSpy.AddIn.VS2022/NuGet.config
+++ b/ILSpy.AddIn.VS2022/NuGet.config
@@ -5,6 +5,7 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <clear />
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>

--- a/ILSpy.AddIn.VS2022/NuGet.config
+++ b/ILSpy.AddIn.VS2022/NuGet.config
@@ -4,4 +4,9 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>  
 </configuration>

--- a/ILSpy.AddIn/NuGet.config
+++ b/ILSpy.AddIn/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/ILSpy.AddIn/NuGet.config
+++ b/ILSpy.AddIn/NuGet.config
@@ -4,4 +4,9 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>  
 </configuration>

--- a/ILSpy.AddIn/NuGet.config
+++ b/ILSpy.AddIn/NuGet.config
@@ -5,8 +5,9 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
+    <clear />
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
-  </packageSourceMapping>  
+  </packageSourceMapping>
 </configuration>

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net11.0-windows</TargetFramework>
     <RuntimeIdentifier Condition="$(IsWindowsX64) == true">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(IsWindowsARM64) == true">win-arm64</RuntimeIdentifier>
 

--- a/ILSpy.Tests/ILSpy.Tests.csproj
+++ b/ILSpy.Tests/ILSpy.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net11.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <RuntimeIdentifier Condition="$(IsWindowsX64) == true">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(IsWindowsARM64) == true">win-arm64</RuntimeIdentifier>

--- a/ILSpy.sln
+++ b/ILSpy.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32014.148
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11620.152 stable
 MinimumVisualStudioVersion = 15.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{F45DB999-7E72-4000-B5AD-3A7B485A0896}"
 	ProjectSection(SolutionItems) = preProject
@@ -42,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Global

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,8 +4,8 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
+    <add key="dotnet11-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="nuget.org">
@@ -19,6 +19,7 @@
     <packageSource key="dotnet-tools">
       <package pattern="Microsoft.DiaSymReader.Converter.Xml" />
       <package pattern="Microsoft.DiaSymReader.PortablePdb" />
+      <package pattern="Microsoft.CodeAnalysis.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,6 +12,7 @@
       <package pattern="*" />
       <package pattern="Microsoft.DiaSymReader.Native" />
       <package pattern="Microsoft.DiaSymReader" />
+      <package pattern="Microsoft.CodeAnalysis.NetAnalyzers" />
     </packageSource>
     <packageSource key="dotnet10-transport">
       <package pattern="ILCompiler.Reflection.ReadyToRun.Experimental" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "11.0.0",
     "rollForward": "major",
     "allowPrerelease": true
   },


### PR DESCRIPTION
* Switch TestRunner and test projects to net11
* Enable getting Roslyn from transport feed (easily)
* Disabling VSIX build when using transport feed (RTM deps are not on a transport feed)

Built with preview 2 https://dotnet.microsoft.com/en-us/download/dotnet/11.0

To use the transport feed:

* ~~in build-ilspy.yml disable VSIX builds~~ no longer necessary with custom nuget.configs
* in nuget.config, add `<package pattern="Microsoft.CodeAnalysis.*" />` to dotnet-tools

Problem: MTP for UseWpf directly/indirectly tests. Solution: switch all test projects to net11.

```
D:\a\ILSpy\ILSpy\ILSpy.Tests\bin\Release\net10.0-windows\win-x64\ILSpy.Tests.dll (net10.0-windows) Zero tests ran
Exit code: -2147450730
  Error output: You must install or update .NET to run this application.
  
  App: D:\a\ILSpy\ILSpy\ILSpy.Tests\bin\Release\net10.0-windows\win-x64\ILSpy.Tests.exe
  Architecture: x64
  Framework: 'Microsoft.WindowsDesktop.App', version '10.0.0' (x64)
  .NET location: D:\a\_temp\.dotnet
  
  The following frameworks were found:
    11.0.0-preview.2.26159.112 at [D:\a\_temp\.dotnet\shared\Microsoft.WindowsDesktop.App]
  ```


Problem: msbuild-related test failures. Solution: switch to runner image with VS2026 (Same issue as the usage of msbuild in the pipeline).

```
"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe" /nologo /v:minimal /restore /p:OutputPath="D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-output" "D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-decompiled\Mono.Cecil.csproj"

D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-decompiled\Mono.Cecil.csproj : error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-decompiled\Mono.Cecil.csproj : error :   Version 11.0.100-preview.2.26159.112 of the .NET SDK requires at least version 18.0.0 of MSBuild. The current available version of MSBuild is 17.14.40.60911. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-decompiled\Mono.Cecil.csproj : error :   The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-decompiled\Mono.Cecil.csproj : error :   MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
D:\a\ILSpy\ILSpy\ILSpy-tests\Mono.Cecil-net45-decompiled\Mono.Cecil.csproj : error MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found.
```

Problem: msbuild in the Windows pipeline was acting up, so I had to replace it with dotnet build. Action error for documentation:

```
Run msbuild ILSpy.sln /p:Configuration=Release /p:Platform=$env:BuildPlatform /m
MSBuild version 17.14.40+3e7442088 for .NET Framework
Build started 3/27/2026 3:07:36 PM.

     1>Project "D:\a\ILSpy\ILSpy\ILSpy.sln" on node 1 (default targets).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Release|Any CPU".
     0>D:\a\ILSpy\ILSpy\ILSpy\ILSpy.csproj : error : Could not resolve SDK "Microsoft.NET.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
D:\a\ILSpy\ILSpy\ILSpy\ILSpy.csproj : error :   Version 11.0.100-preview.2.26159.112 of the .NET SDK requires at least version 18.0.0 of MSBuild. The current available version of MSBuild is 17.14.40.60911. Change the .NET SDK specified in global.json to an older version that requires the MSBuild version currently available.
D:\a\ILSpy\ILSpy\ILSpy\ILSpy.csproj : error :   The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
D:\a\ILSpy\ILSpy\ILSpy\ILSpy.csproj : error :   MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.NET.Sdk" because directory "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk" did not exist.
```