### PR TITLE
Fix #3705: Code window is empty when select a .baml and refresh

### DIFF
--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -947,11 +947,30 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 
 		private void RefreshInternal()
 		{
+			_ = RefreshInternalAsync();
+		}
+
+		private async Task RefreshInternalAsync()
+		{
 			using (Keyboard.FocusedElement.PreserveFocus())
 			{
 				var path = GetPathForNode(SelectedItem);
 
 				ShowAssemblyList(settingsService.AssemblyListManager.LoadList(AssemblyList.ListName));
+
+				// Ensure assembly loaded before FindNodeByPath to allow lazy-loaded resource nodes to be found
+				if (path?.Length > 0)
+				{
+					foreach (var asm in AssemblyList.GetAssemblies())
+					{
+						if (asm.FileName == path[0])
+						{
+							await asm.GetMetadataFileAsync().Catch<Exception>(_ => { });
+							break;
+						}
+					}
+				}
+
 				SelectNode(FindNodeByPath(path, true), inNewTabPage: false);
 
 				RefreshDecompiledView();

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -947,7 +947,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 
 		private void RefreshInternal()
 		{
-			_ = RefreshInternalAsync();
+			RefreshInternalAsync().HandleExceptions();
 		}
 
 		private async Task RefreshInternalAsync()
@@ -958,15 +958,25 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 
 				ShowAssemblyList(settingsService.AssemblyListManager.LoadList(AssemblyList.ListName));
 
-				// Ensure assembly loaded before FindNodeByPath to allow lazy-loaded resource nodes to be found
+				// Ensure the assembly is loaded before FindNodeByPath, so lazy-loaded
+				// resource nodes (e.g. .baml entries) are present in the tree.
 				if (path?.Length > 0)
 				{
-					foreach (var asm in AssemblyList.GetAssemblies())
+					var rootAssembly = AssemblyList.FindAssembly(path[0]);
+					if (rootAssembly != null)
 					{
-						if (asm.FileName == path[0])
+						// FindNodeByPath() blocks the UI if the assembly is not yet loaded,
+						// so use an async wait instead.
+						var preAwaitSelection = SelectedItem;
+						await rootAssembly.GetMetadataFileAsync().Catch<Exception>(_ => { });
+
+						// If the user navigated to a different node while the assembly
+						// was loading, respect that — don't restore the pre-refresh path.
+						// A change to null counts too (e.g. user cleared the selection).
+						if (!ReferenceEquals(SelectedItem, preAwaitSelection))
 						{
-							await asm.GetMetadataFileAsync().Catch<Exception>(_ => { });
-							break;
+							RefreshDecompiledView();
+							return;
 						}
 					}
 				}


### PR DESCRIPTION
<img width="827" height="1022" alt="image" src="https://github.com/user-attachments/assets/2de3ac8b-27bf-4435-b7ce-cb40ee2368c7" />
<img width="838" height="449" alt="image" src="https://github.com/user-attachments/assets/9899a473-9734-45d4-88fe-a687c122cbf4" />
<img width="832" height="843" alt="image" src="https://github.com/user-attachments/assets/7e3fcfcf-2c50-4f1e-b870-6dd419eec1fb" />
<img width="835" height="678" alt="image" src="https://github.com/user-attachments/assets/b6ea1b98-2c5b-44e4-b226-fa9b1d8acd48" />
<img width="840" height="1090" alt="image" src="https://github.com/user-attachments/assets/71308089-1c26-45d8-89e7-f91908602e8b" />
