### PR TITLE
ilspycmd: list/extract embedded resources, decompile BAML to XAML

### DIFF
--- a/ICSharpCode.ILSpyCmd/BamlAwareWholeProjectDecompiler.cs
+++ b/ICSharpCode.ILSpyCmd/BamlAwareWholeProjectDecompiler.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+using ICSharpCode.BamlDecompiler;
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp.ProjectDecompiler;
+using ICSharpCode.Decompiler.DebugInfo;
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.ILSpyCmd
+{
+	sealed class BamlAwareWholeProjectDecompiler : WholeProjectDecompiler
+	{
+		readonly BamlDecompilerTypeSystem bamlTypeSystem;
+		readonly BamlDecompilerSettings bamlSettings;
+
+		public BamlAwareWholeProjectDecompiler(
+			DecompilerSettings settings,
+			IAssemblyResolver assemblyResolver,
+			AssemblyReferenceClassifier assemblyReferenceClassifier,
+			IDebugInfoProvider debugInfoProvider,
+			BamlDecompilerTypeSystem bamlTypeSystem,
+			BamlDecompilerSettings bamlSettings)
+			: base(settings, assemblyResolver, projectWriter: null, assemblyReferenceClassifier, debugInfoProvider)
+		{
+			this.bamlTypeSystem = bamlTypeSystem ?? throw new ArgumentNullException(nameof(bamlTypeSystem));
+			this.bamlSettings = bamlSettings ?? throw new ArgumentNullException(nameof(bamlSettings));
+		}
+
+		public CancellationToken CancellationToken { get; set; }
+
+		protected override IEnumerable<ProjectItemInfo> WriteResourceToFile(string fileName, string resourceName, Stream entryStream)
+		{
+			if (!fileName.EndsWith(".baml", StringComparison.OrdinalIgnoreCase))
+				return base.WriteResourceToFile(fileName, resourceName, entryStream);
+
+			var decompiler = new XamlDecompiler(bamlTypeSystem, bamlSettings) {
+				CancellationToken = CancellationToken
+			};
+			var result = decompiler.Decompile(entryStream);
+
+			string xamlFileName;
+			PartialTypeInfo partialTypeInfo = null;
+
+			var typeDefinition = result.TypeName.HasValue
+				? bamlTypeSystem.MainModule.GetTypeDefinition(result.TypeName.Value.TopLevelTypeName)
+				: null;
+			if (typeDefinition != null)
+			{
+				xamlFileName = SanitizeFileName(typeDefinition.ReflectionName + ".xaml");
+				partialTypeInfo = new PartialTypeInfo(typeDefinition);
+				foreach (var member in result.GeneratedMembers)
+					partialTypeInfo.AddDeclaredMember(member);
+			}
+			else
+			{
+				xamlFileName = Path.ChangeExtension(fileName, ".xaml");
+			}
+
+			string fullPath = Path.Combine(TargetDirectory, xamlFileName);
+			string directory = Path.GetDirectoryName(fullPath);
+			if (!string.IsNullOrEmpty(directory))
+				Directory.CreateDirectory(directory);
+			result.Xaml.Save(fullPath);
+
+			var item = new ProjectItemInfo("Page", xamlFileName)
+				.With("Generator", "MSBuild:Compile")
+				.With("SubType", "Designer");
+			if (partialTypeInfo != null)
+				item.PartialTypes = new List<PartialTypeInfo> { partialTypeInfo };
+
+			return new[] { item };
+		}
+	}
+}

--- a/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
+++ b/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.ILSpyX\ICSharpCode.ILSpyX.csproj" />
     <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.BamlDecompiler\ICSharpCode.BamlDecompiler.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -10,6 +10,7 @@ using System.Reflection.PortableExecutable;
 using System.Threading;
 using System.Threading.Tasks;
 
+using ICSharpCode.BamlDecompiler;
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.ProjectDecompiler;
@@ -52,6 +53,15 @@ Examples:
     Generate a HTML diagrammer containing filtered type info into a custom output folder
     (including types in the LightJson namespace while excluding types in nested LightJson.Serialization namespace)
         ilspycmd sample.dll --generate-diagrammer -o c:\diagrammer --generate-diagrammer-include LightJson\\..+ --generate-diagrammer-exclude LightJson\\.Serialization\\..+
+
+    List all embedded resources in a WPF assembly (including BAML entries inside .g.resources containers).
+        ilspycmd sample.dll --list-resources
+
+    Extract a single resource. If the name ends with .baml, the output is decompiled XAML; otherwise raw bytes.
+        ilspycmd sample.dll --resource sample.g.resources/mainwindow.baml -o c:\decompiled
+
+    Decompile assembly as a compilable project and convert all BAML resources to XAML Page items.
+        ilspycmd sample.dll -p -o c:\decompiled --decompile-baml
 ")]
 	[HelpOption("-h|--help")]
 	[ProjectOptionRequiresOutputDirectoryValidation]
@@ -92,6 +102,15 @@ Examples:
 
 		[Option("-l|--list <entity-type(s)>", "Lists all entities of the specified type(s). Valid types: c(lass), i(nterface), s(truct), d(elegate), e(num)", CommandOptionType.MultipleValue)]
 		public string[] EntityTypes { get; } = Array.Empty<string>();
+
+		[Option("--list-resources", "Lists all embedded resources in the assembly. Entries inside .resources containers are listed individually as '<container>/<entry>'.", CommandOptionType.NoValue)]
+		public bool ListResourcesFlag { get; }
+
+		[Option("--resource <name>", "Extract a single resource by name (as printed by --list-resources). Resources whose name ends with '.baml' are decompiled to XAML.", CommandOptionType.SingleValue)]
+		public string ResourceName { get; }
+
+		[Option("--decompile-baml", "When used with -p, decompile BAML resources to XAML files (Page items) instead of leaving them as raw byte streams.", CommandOptionType.NoValue)]
+		public bool DecompileBamlFlag { get; }
 
 		public string DecompilerVersion => "ilspycmd: " + typeof(ILSpyCmdProgram).Assembly.GetName().Version.ToString() +
 				Environment.NewLine
@@ -306,6 +325,20 @@ Examples:
 				{
 					return DumpPackageAssemblies(fileName, outputDirectory, app);
 				}
+				else if (ListResourcesFlag)
+				{
+					if (outputDirectory != null)
+					{
+						string outputName = Path.GetFileNameWithoutExtension(fileName);
+						output = File.CreateText(Path.Combine(outputDirectory, outputName) + ".resources.txt");
+					}
+
+					return ListResources(fileName, output);
+				}
+				else if (ResourceName != null)
+				{
+					return ExtractResource(fileName, ResourceName, output, outputDirectory, app);
+				}
 				else
 				{
 					if (outputDirectory != null)
@@ -430,6 +463,85 @@ Examples:
 			return 0;
 		}
 
+		int ListResources(string assemblyFileName, TextWriter output)
+		{
+			var module = new PEFile(assemblyFileName);
+			foreach (var path in ResourceExtensions.EnumerateResourcePaths(module))
+			{
+				output.WriteLine(path);
+			}
+			return 0;
+		}
+
+		int ExtractResource(string assemblyFileName, string resourceName, TextWriter output, string outputDirectory, CommandLineApplication app)
+		{
+			var module = new PEFile(assemblyFileName);
+			if (!ResourceExtensions.TryGetResource(module, resourceName, out object value))
+			{
+				app.Error.WriteLine($"Resource '{resourceName}' not found.");
+				app.Error.WriteLine("Available resources:");
+				foreach (var p in ResourceExtensions.EnumerateResourcePaths(module))
+					app.Error.WriteLine("  " + p);
+				return ProgramExitCodes.EX_DATAERR;
+			}
+
+			bool isBaml = resourceName.EndsWith(".baml", StringComparison.OrdinalIgnoreCase);
+			if (isBaml && value is byte[] bamlBytes)
+			{
+				var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Metadata.DetectTargetFrameworkId());
+				foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
+					resolver.AddSearchDirectory(path);
+				var bamlSettings = new BamlDecompilerSettings {
+					ThrowOnAssemblyResolveErrors = GetSettings(module).ThrowOnAssemblyResolveErrors
+				};
+
+				using var bamlStream = new MemoryStream(bamlBytes);
+				var xaml = ResourceExtensions.DecompileBaml(module, resolver, bamlStream, bamlSettings, CancellationToken.None);
+				if (outputDirectory != null)
+				{
+					string xamlFile = WholeProjectDecompiler.SanitizeFileName(Path.GetFileNameWithoutExtension(resourceName) + ".xaml");
+					string fullPath = Path.Combine(outputDirectory, xamlFile);
+					xaml.Save(fullPath);
+				}
+				else
+				{
+					output.Write(xaml.ToString());
+				}
+				return 0;
+			}
+
+			if (value is byte[] binary)
+			{
+				if (outputDirectory != null)
+				{
+					string fileName = WholeProjectDecompiler.SanitizeFileName(Path.GetFileName(resourceName));
+					string fullPath = Path.Combine(outputDirectory, fileName);
+					File.WriteAllBytes(fullPath, binary);
+				}
+				else
+				{
+					var stdout = Console.OpenStandardOutput();
+					stdout.Write(binary, 0, binary.Length);
+					stdout.Flush();
+				}
+			}
+			else
+			{
+				string text = value as string ?? value?.ToString() ?? string.Empty;
+				if (outputDirectory != null)
+				{
+					string fileName = WholeProjectDecompiler.SanitizeFileName(Path.GetFileName(resourceName));
+					string fullPath = Path.Combine(outputDirectory, fileName);
+					File.WriteAllText(fullPath, text);
+				}
+				else
+				{
+					output.Write(text);
+				}
+			}
+			return 0;
+		}
+
 		int ShowIL(string assemblyFileName, TextWriter output)
 		{
 			var module = new PEFile(assemblyFileName);
@@ -450,7 +562,21 @@ Examples:
 			{
 				resolver.AddSearchDirectory(path);
 			}
-			var decompiler = new WholeProjectDecompiler(GetSettings(module), resolver, null, resolver, TryLoadPDB(module));
+			var settings = GetSettings(module);
+			var debugInfo = TryLoadPDB(module);
+			WholeProjectDecompiler decompiler;
+			if (DecompileBamlFlag)
+			{
+				var bamlTypeSystem = new BamlDecompilerTypeSystem(module, resolver);
+				var bamlSettings = new BamlDecompilerSettings {
+					ThrowOnAssemblyResolveErrors = settings.ThrowOnAssemblyResolveErrors
+				};
+				decompiler = new BamlAwareWholeProjectDecompiler(settings, resolver, resolver, debugInfo, bamlTypeSystem, bamlSettings);
+			}
+			else
+			{
+				decompiler = new WholeProjectDecompiler(settings, resolver, null, resolver, debugInfo);
+			}
 			using (var projectFileWriter = new StreamWriter(File.OpenWrite(projectFileName)))
 				return decompiler.DecompileProject(module, Path.GetDirectoryName(projectFileName), projectFileWriter);
 		}

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -276,8 +276,8 @@ Examples:
 					var checkResult = await updateCheckTask;
 					if (null != checkResult && checkResult.UpdateRecommendation)
 					{
-						Console.WriteLine("You are not using the latest version of the tool, please update.");
-						Console.WriteLine($"Latest version is '{checkResult.LatestVersion}' (yours is '{checkResult.RunningVersion}')");
+						app.Error.WriteLine("You are not using the latest version of the tool, please update.");
+						app.Error.WriteLine($"Latest version is '{checkResult.LatestVersion}' (yours is '{checkResult.RunningVersion}')");
 					}
 				}
 			}

--- a/ICSharpCode.ILSpyCmd/ResourceExtensions.cs
+++ b/ICSharpCode.ILSpyCmd/ResourceExtensions.cs
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Xml.Linq;
+
+using ICSharpCode.BamlDecompiler;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.Util;
+
+namespace ICSharpCode.ILSpyCmd
+{
+	static class ResourceExtensions
+	{
+		public static IEnumerable<string> EnumerateResourcePaths(MetadataFile module)
+		{
+			foreach (var r in module.Resources.Where(r => r.ResourceType == ResourceType.Embedded))
+			{
+				IReadOnlyList<string> entries;
+				if (r.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase)
+					&& TryReadResourcesEntryNames(r, out entries))
+				{
+					foreach (var name in entries)
+						yield return r.Name + "/" + name;
+				}
+				else
+				{
+					yield return r.Name;
+				}
+			}
+		}
+
+		public static bool TryGetResource(MetadataFile module, string resourcePath, out object value)
+		{
+			foreach (var r in module.Resources.Where(r => r.ResourceType == ResourceType.Embedded))
+			{
+				if (string.Equals(resourcePath, r.Name, StringComparison.OrdinalIgnoreCase))
+				{
+					using Stream stream = r.TryOpenStream();
+					if (stream == null)
+					{
+						value = null;
+						return false;
+					}
+					stream.Position = 0;
+					var ms = new MemoryStream();
+					stream.CopyTo(ms);
+					value = ms.ToArray();
+					return true;
+				}
+
+				string prefix = r.Name + "/";
+				if (r.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase)
+					&& resourcePath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+				{
+					string entryName = resourcePath.Substring(prefix.Length);
+					if (TryReadResourcesEntry(r, entryName, out value))
+						return true;
+				}
+			}
+
+			value = null;
+			return false;
+		}
+
+		public static XDocument DecompileBaml(MetadataFile module, IAssemblyResolver resolver, Stream bamlStream, BamlDecompilerSettings settings, CancellationToken cancellationToken)
+		{
+			var typeSystem = new BamlDecompilerTypeSystem(module, resolver);
+			var decompiler = new XamlDecompiler(typeSystem, settings) {
+				CancellationToken = cancellationToken
+			};
+			return decompiler.Decompile(bamlStream).Xaml;
+		}
+
+		static bool TryReadResourcesEntryNames(Resource r, out IReadOnlyList<string> names)
+		{
+			using Stream stream = r.TryOpenStream();
+			if (stream == null)
+			{
+				names = Array.Empty<string>();
+				return false;
+			}
+			stream.Position = 0;
+
+			ResourcesFile resourcesFile;
+			try
+			{
+				resourcesFile = new ResourcesFile(stream);
+			}
+			catch (Exception ex) when (ex is BadImageFormatException || ex is EndOfStreamException)
+			{
+				names = null;
+				return false;
+			}
+
+			using (resourcesFile)
+			{
+				var list = new List<string>(resourcesFile.ResourceCount);
+				for (int i = 0; i < resourcesFile.ResourceCount; i++)
+					list.Add(resourcesFile.GetResourceName(i));
+				names = list;
+				return true;
+			}
+		}
+
+		static bool TryReadResourcesEntry(Resource r, string entryName, out object value)
+		{
+			using Stream stream = r.TryOpenStream();
+			if (stream == null)
+			{
+				value = null;
+				return false;
+			}
+			stream.Position = 0;
+
+			ResourcesFile resourcesFile;
+			try
+			{
+				resourcesFile = new ResourcesFile(stream);
+			}
+			catch (Exception ex) when (ex is BadImageFormatException || ex is EndOfStreamException)
+			{
+				value = null;
+				return false;
+			}
+
+			using (resourcesFile)
+			{
+				for (int i = 0; i < resourcesFile.ResourceCount; i++)
+				{
+					if (!string.Equals(resourcesFile.GetResourceName(i), entryName, StringComparison.OrdinalIgnoreCase))
+						continue;
+
+					object entryValue = resourcesFile.GetResourceValue(i);
+					if (entryValue is ResourceSerializedObject serialized)
+					{
+						value = serialized.GetBytes();
+					}
+					else if (entryValue is Stream s)
+					{
+						var ms = new MemoryStream();
+						s.Position = 0;
+						s.CopyTo(ms);
+						value = ms.ToArray();
+					}
+					else
+					{
+						value = entryValue;
+					}
+					return true;
+				}
+			}
+
+			value = null;
+			return false;
+		}
+	}
+}

--- a/ICSharpCode.ILSpyCmd/packages.lock.json
+++ b/ICSharpCode.ILSpyCmd/packages.lock.json
@@ -342,6 +342,12 @@
         "resolved": "8.0.0",
         "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
       },
+      "icsharpcode.bamldecompiler": {
+        "type": "Project",
+        "dependencies": {
+          "ICSharpCode.Decompiler": "[8.0.0-noversion, )"
+        }
+      },
       "icsharpcode.decompiler": {
         "type": "Project",
         "dependencies": {


### PR DESCRIPTION
## Summary

Adds three new options to `ilspycmd` so that resources — including BAML — can be inspected and extracted from the command line. The BAML decompilation reuses the existing `ICSharpCode.BamlDecompiler` library, mirroring the GUI's `BamlResourceFileHandler` pattern (no GUI dependencies pulled in).

- `--list-resources` — prints every embedded-resource leaf in the assembly, including individual entries inside `.resources` containers (e.g. `MyApp.g.resources/views/mainwindow.baml`).
- `--resource <name>` — extracts a single leaf by name. Names ending in `.baml` are decompiled to XAML; everything else is emitted as raw bytes (text to stdout, binary to the binary stdout stream, or written to `-o`). Unknown names exit with `EX_DATAERR` and print the available leaves to stderr.
- `--decompile-baml` — modifier for `-p`. Swaps in a `BamlAwareWholeProjectDecompiler` so `.baml` entries become `.xaml` `Page` items in the generated project. `PartialTypeInfo` flows through, so the C# decompiler suppresses the duplicate `IComponentConnector.Connect` overrides. Default `-p` behaviour is unchanged.

## Test plan

Verified end-to-end against `ILSpy.BamlDecompiler.Tests.dll` (23 BAML resources):

- [x] `--list-resources` lists all 23 `.baml` entries under `…g.resources/cases/*.baml`
- [x] `--resource …simple.baml` writes XAML to stdout — byte-identical to the source `.xaml`
- [x] `--resource …simple.baml -o <dir>` writes `simple.xaml` to disk
- [x] `--resource does-not-exist` exits 65 (`EX_DATAERR`) and lists available names on stderr
- [x] `-p -o <dir> --decompile-baml` produces 23 `.xaml` files; the generated project keeps `<UseWPF>True</UseWPF>` so SDK-style implicit `Page` discovery picks them up; `Simple.cs` no longer contains the duplicate `Connect()` method
- [x] `-p` without `--decompile-baml` is unchanged (raw `.baml` stays in the embedded resources)