### PR TITLE
Fix #3734: Search pane flickers when navigating to search result in large assembly

### DIFF
--- a/ILSpy/Search/SearchPane.xaml.cs
+++ b/ILSpy/Search/SearchPane.xaml.cs
@@ -86,6 +86,7 @@ namespace ICSharpCode.ILSpy.Search
 		{
 			// Don't restart the search when only auto-loaded (dependency) assemblies are added;
 			// this avoids flickering when navigating to a result in a large assembly.
+			// Explicit variable assignment necessary bc  implicit operator T on WrappedEventArgs<T>
 			System.Collections.Specialized.NotifyCollectionChangedEventArgs collectionChange = e;
 			if (collectionChange.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
 				&& collectionChange.NewItems?.Cast<LoadedAssembly>().All(asm => asm.IsAutoLoaded) == true)

--- a/ILSpy/Search/SearchPane.xaml.cs
+++ b/ILSpy/Search/SearchPane.xaml.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Composition;
@@ -75,14 +76,23 @@ namespace ICSharpCode.ILSpy.Search
 			InitializeComponent();
 
 			ContextMenuProvider.Add(listBox);
-			MessageBus<CurrentAssemblyListChangedEventArgs>.Subscribers += (sender, e) => CurrentAssemblyList_Changed();
+			MessageBus<CurrentAssemblyListChangedEventArgs>.Subscribers += (sender, e) => CurrentAssemblyList_Changed(e);
 			MessageBus<SettingsChangedEventArgs>.Subscribers += (sender, e) => Settings_PropertyChanged(sender, e);
 
 			CompositionTarget.Rendering += UpdateResults;
 		}
 
-		void CurrentAssemblyList_Changed()
+		void CurrentAssemblyList_Changed(CurrentAssemblyListChangedEventArgs e)
 		{
+			// Don't restart the search when only auto-loaded (dependency) assemblies are added;
+			// this avoids flickering when navigating to a result in a large assembly.
+			System.Collections.Specialized.NotifyCollectionChangedEventArgs collectionChange = e;
+			if (collectionChange.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
+				&& collectionChange.NewItems?.Cast<LoadedAssembly>().All(asm => asm.IsAutoLoaded) == true)
+			{
+				return;
+			}
+
 			if (IsVisible)
 			{
 				StartSearch(this.SearchTerm);


### PR DESCRIPTION
via Debugger Agent:

<img width="1286" height="488" alt="image" src="https://github.com/user-attachments/assets/aff41681-6b7b-4ae2-9825-0bc4260d0bf9" />
