### PR TITLE
feat(analyzer): syntax-highlight entity signatures in Analyze panel

### DIFF
--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -171,8 +171,8 @@ Examples:
 		public bool ReportExcludedTypes { get; set; }
 
 		[Option(generateDiagrammerCmd + "-docs", "The path or file:// URI of the XML file containing the target assembly's documentation comments." +
-			" You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the assmbly." +
-			" To enable XML documentation output for your assmbly, see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#create-xml-documentation-output",
+			" You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the assembly." +
+			" To enable XML documentation output for your assembly, see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#create-xml-documentation-output",
 			CommandOptionType.SingleValue)]
 		public string XmlDocs { get; set; }
 

--- a/ICSharpCode.ILSpyCmd/README.md
+++ b/ICSharpCode.ILSpyCmd/README.md
@@ -70,8 +70,8 @@ Options:
                                           your regular expressions.
   --generate-diagrammer-docs              The path or file:// URI of the XML file containing the target assembly's
                                           documentation comments. You only need to set this if a) you want your diagrams
-                                          annotated with them and b) the file name differs from that of the assmbly. To
-                                          enable XML documentation output for your assmbly, see
+                                          annotated with them and b) the file name differs from that of the assembly. To
+                                          enable XML documentation output for your assembly, see
                                           https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#create-xml-documentation-output
   --generate-diagrammer-strip-namespaces  Optional space-separated namespace names that are removed for brevity from XML
                                           documentation comments. Note that the order matters: e.g. replace

--- a/ILSpy/Analyzers/AnalyzerEntityTreeNode.cs
+++ b/ILSpy/Analyzers/AnalyzerEntityTreeNode.cs
@@ -19,7 +19,11 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows;
+using System.Windows.Controls;
 
+using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Utils;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.TreeNodes;
 using ICSharpCode.ILSpyX;
@@ -56,6 +60,22 @@ namespace ICSharpCode.ILSpy.Analyzers
 		}
 
 		public override object? ToolTip => Member?.ParentModule?.MetadataFile?.FileName;
+
+		/// <summary>
+		/// Renders a member signature with C# syntax highlighting for the Analyze tree view.
+		/// </summary>
+		protected object CreateHighlightedSignatureText(string signature)
+		{
+			IHighlightingDefinition? highlighting = Language.SyntaxHighlighting;
+			if (highlighting == null)
+				return signature;
+
+			var document = new TextDocument(signature);
+			var richText = DocumentPrinter.ConvertTextDocumentToRichText(document, new DocumentHighlighter(document, highlighting)).ToRichTextModel();
+			var textBlock = new TextBlock();
+			textBlock.Inlines.AddRange(richText.CreateRuns(document));
+			return textBlock;
+		}
 
 		public override bool HandleAssemblyListChanged(ICollection<LoadedAssembly> removedAssemblies, ICollection<LoadedAssembly> addedAssemblies)
 		{

--- a/ILSpy/Analyzers/TreeNodes/AnalyzedEventTreeNode.cs
+++ b/ILSpy/Analyzers/TreeNodes/AnalyzedEventTreeNode.cs
@@ -46,7 +46,7 @@ namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 		public override object Icon => EventTreeNode.GetIcon(analyzedEvent);
 
 		// TODO: This way of formatting is not suitable for events which explicitly implement interfaces.
-		public override object Text => prefix + Language.EntityToString(analyzedEvent, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames);
+		public override object Text => CreateHighlightedSignatureText(prefix + Language.EntityToString(analyzedEvent, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames));
 
 		protected override void LoadChildren()
 		{

--- a/ILSpy/Analyzers/TreeNodes/AnalyzedFieldTreeNode.cs
+++ b/ILSpy/Analyzers/TreeNodes/AnalyzedFieldTreeNode.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 
 		public override object Icon => FieldTreeNode.GetIcon(analyzedField);
 
-		public override object Text => Language.EntityToString(analyzedField, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames);
+		public override object Text => CreateHighlightedSignatureText(Language.EntityToString(analyzedField, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames));
 
 		protected override void LoadChildren()
 		{

--- a/ILSpy/Analyzers/TreeNodes/AnalyzedMethodTreeNode.cs
+++ b/ILSpy/Analyzers/TreeNodes/AnalyzedMethodTreeNode.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 
 		public override object Icon => MethodTreeNode.GetIcon(analyzedMethod);
 
-		public override object Text => prefix + Language.EntityToString(analyzedMethod, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames);
+		public override object Text => CreateHighlightedSignatureText(prefix + Language.EntityToString(analyzedMethod, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames));
 
 		protected override void LoadChildren()
 		{

--- a/ILSpy/Analyzers/TreeNodes/AnalyzedPropertyTreeNode.cs
+++ b/ILSpy/Analyzers/TreeNodes/AnalyzedPropertyTreeNode.cs
@@ -43,7 +43,7 @@ namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 		public override object Icon => PropertyTreeNode.GetIcon(analyzedProperty);
 
 		// TODO: This way of formatting is not suitable for properties which explicitly implement interfaces.
-		public override object Text => prefix + Language.EntityToString(analyzedProperty, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames);
+		public override object Text => CreateHighlightedSignatureText(prefix + Language.EntityToString(analyzedProperty, ConversionFlags.ShowDeclaringType | ConversionFlags.UseFullyQualifiedEntityNames));
 
 		protected override void LoadChildren()
 		{

--- a/ILSpy/Analyzers/TreeNodes/AnalyzedTypeTreeNode.cs
+++ b/ILSpy/Analyzers/TreeNodes/AnalyzedTypeTreeNode.cs
@@ -39,7 +39,7 @@ namespace ICSharpCode.ILSpy.Analyzers.TreeNodes
 
 		public override object Icon => TypeTreeNode.GetIcon(analyzedType);
 
-		public override object Text => Language.TypeToString(analyzedType);
+		public override object Text => CreateHighlightedSignatureText(Language.TypeToString(analyzedType));
 
 		protected override void LoadChildren()
 		{


### PR DESCRIPTION
## Summary

- Syntax-highlight analyzer result entries (types, methods, fields, properties, events) using the same C# highlighting as documentation signatures, making type names easier to spot in long lists.
- Fix typo: `assmbly` → `assembly` in `ilspycmd` help text and README.

## Motivation

Fixes #2164 — Analyze panel lists were plain text; type names were hard to distinguish in long qualified signatures.

## Notes

- Builds on the approach discussed in the issue thread (highlighted `TextBlock` instead of plain strings).
- Selected-row contrast on dark themes may still need follow-up (called out in the original discussion).

## Test plan

- [ ] Open Analyze on a type with many "Used By" / "Uses" entries and confirm signatures show syntax colors
- [ ] `dotnet build ILSpy/ILSpy.csproj` (not run here — no .NET SDK in agent environment)