### PR TITLE
feat(decompiler): link override keyword to base member definition

### DIFF
--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -240,7 +240,33 @@ namespace ICSharpCode.Decompiler
 					return;
 				}
 			}
+			if (keyword == "override")
+			{
+				var overriddenMember = GetOverrideMemberFromNodeStack();
+				if (overriddenMember != null)
+				{
+					var baseMember = InheritanceHelper.GetBaseMember(overriddenMember);
+					if (baseMember != null)
+					{
+						output.WriteReference(baseMember, keyword);
+						return;
+					}
+				}
+			}
 			output.Write(keyword);
+		}
+
+		IMember? GetOverrideMemberFromNodeStack()
+		{
+			foreach (var node in nodeStack)
+			{
+				if (node is EntityDeclaration entityDeclaration
+					&& entityDeclaration.GetSymbol() is IMember { IsOverride: true } member)
+				{
+					return member;
+				}
+			}
+			return null;
 		}
 
 		static bool NeedsFold(AstNode node)

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -156,7 +156,7 @@ Examples:
 			include = generateDiagrammerCmd + "-include";
 
 		[Option(generateDiagrammerCmd, "Generates an interactive HTML diagrammer app from selected types in the target assembly" +
-			" - to the --outputdir or in a 'diagrammer' folder next to to the assembly by default.", CommandOptionType.NoValue)]
+			" - to the --outputdir or in a 'diagrammer' folder next to the assembly by default.", CommandOptionType.NoValue)]
 		public bool GenerateDiagrammer { get; }
 
 		[Option(include, "An optional regular expression matching Type.FullName used to whitelist types to include in the generated diagrammer.", CommandOptionType.SingleValue)]
@@ -171,8 +171,8 @@ Examples:
 		public bool ReportExcludedTypes { get; set; }
 
 		[Option(generateDiagrammerCmd + "-docs", "The path or file:// URI of the XML file containing the target assembly's documentation comments." +
-			" You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the assmbly." +
-			" To enable XML documentation output for your assmbly, see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#create-xml-documentation-output",
+			" You only need to set this if a) you want your diagrams annotated with them and b) the file name differs from that of the assembly." +
+			" To enable XML documentation output for your assembly, see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#create-xml-documentation-output",
 			CommandOptionType.SingleValue)]
 		public string XmlDocs { get; set; }
 

--- a/ICSharpCode.ILSpyCmd/README.md
+++ b/ICSharpCode.ILSpyCmd/README.md
@@ -57,7 +57,7 @@ Options:
   --disable-updatecheck                   If using ilspycmd in a tight loop or fully automated scenario, you might want
                                           to disable the automatic update check.
   --generate-diagrammer                   Generates an interactive HTML diagrammer app from selected types in the target
-                                          assembly - to the --outputdir or in a 'diagrammer' folder next to to the
+                                          assembly - to the --outputdir or in a 'diagrammer' folder next to the
                                           assembly by default.
   --generate-diagrammer-include           An optional regular expression matching Type.FullName used to whitelist types
                                           to include in the generated diagrammer.
@@ -70,8 +70,8 @@ Options:
                                           your regular expressions.
   --generate-diagrammer-docs              The path or file:// URI of the XML file containing the target assembly's
                                           documentation comments. You only need to set this if a) you want your diagrams
-                                          annotated with them and b) the file name differs from that of the assmbly. To
-                                          enable XML documentation output for your assmbly, see
+                                          annotated with them and b) the file name differs from that of the assembly. To
+                                          enable XML documentation output for your assembly, see
                                           https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#create-xml-documentation-output
   --generate-diagrammer-strip-namespaces  Optional space-separated namespace names that are removed for brevity from XML
                                           documentation comments. Note that the order matters: e.g. replace


### PR DESCRIPTION
## Summary

Fixes #2035

When decompiling C# with syntax highlighting enabled, the `override` modifier is now emitted as a hyperlink to the nearest overridden member (via `InheritanceHelper.GetBaseMember`), similar to Visual Studio go-to-definition on `override`.

Implementation is in `TextTokenWriter.WriteKeyword`, alongside the existing `this`/`base` constructor-initializer references.

Also fixes a duplicate word typo (`next to to` → `next to the`) in `ilspycmd --generate-diagrammer` help text.

## Test plan

- [ ] Open an assembly with overridden methods in ILSpy, decompile a derived type, Ctrl+click `override` and confirm navigation to the base member
- [ ] CI: decompiler / ILSpy build

I do not have a local .NET SDK in this environment; changes were not built locally.