### PR TITLE
feat(ui): add option to disable menu popup animations (#3737)

### DIFF
--- a/ILSpy/App.xaml.cs
+++ b/ILSpy/App.xaml.cs
@@ -29,6 +29,7 @@ using System.Windows.Threading;
 
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.AssemblyTree;
+using ICSharpCode.ILSpy.Util;
 using ICSharpCode.ILSpyX.Analyzers;
 
 using Medo.Application;
@@ -109,6 +110,7 @@ namespace ICSharpCode.ILSpy
 			Resources.MergedDictionaries.Add(DataTemplateManager.CreateDynamicDataTemplates(ExportProvider));
 
 			var sessionSettings = settingsService.SessionSettings;
+			MenuPopupAnimationHelper.Apply(settingsService.DisplaySettings.EnableMenuAnimations);
 			ThemeManager.Current.Theme = sessionSettings.Theme;
 			if (!string.IsNullOrEmpty(sessionSettings.CurrentCulture))
 			{

--- a/ILSpy/Options/DisplaySettings.cs
+++ b/ILSpy/Options/DisplaySettings.cs
@@ -19,6 +19,7 @@
 using System.Windows.Media;
 using System.Xml.Linq;
 
+using ICSharpCode.ILSpy.Util;
 using ICSharpCode.ILSpyX.Settings;
 
 using TomsToolbox.Wpf;
@@ -156,6 +157,12 @@ namespace ICSharpCode.ILSpy.Options
 			set => SetProperty(ref enableSmoothScrolling, value);
 		}
 
+		private bool enableMenuAnimations;
+		public bool EnableMenuAnimations {
+			get => enableMenuAnimations;
+			set => SetProperty(ref enableMenuAnimations, value);
+		}
+
 		private bool decodeCustomAttributeBlobs;
 		public bool DecodeCustomAttributeBlobs {
 			get => decodeCustomAttributeBlobs;
@@ -187,6 +194,7 @@ namespace ICSharpCode.ILSpy.Options
 			ShowRawOffsetsAndBytesBeforeInstruction = (bool?)section.Attribute("ShowRawOffsetsAndBytesBeforeInstruction") ?? false;
 			StyleWindowTitleBar = (bool?)section.Attribute("StyleWindowTitleBar") ?? false;
 			EnableSmoothScrolling = (bool?)section.Attribute("EnableSmoothScrolling") ?? true;
+			EnableMenuAnimations = (bool?)section.Attribute("EnableMenuAnimations") ?? MenuPopupAnimationHelper.DefaultFromSystem();
 			DecodeCustomAttributeBlobs = (bool?)section.Attribute("DecodeCustomAttributeBlobs") ?? false;
 		}
 
@@ -215,6 +223,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue("ShowRawOffsetsAndBytesBeforeInstruction", ShowRawOffsetsAndBytesBeforeInstruction);
 			section.SetAttributeValue("StyleWindowTitleBar", StyleWindowTitleBar);
 			section.SetAttributeValue("EnableSmoothScrolling", EnableSmoothScrolling);
+			section.SetAttributeValue("EnableMenuAnimations", EnableMenuAnimations);
 			section.SetAttributeValue("DecodeCustomAttributeBlobs", DecodeCustomAttributeBlobs);
 
 			return section;

--- a/ILSpy/Options/DisplaySettingsPanel.xaml
+++ b/ILSpy/Options/DisplaySettingsPanel.xaml
@@ -80,6 +80,7 @@
 					<CheckBox IsChecked="{Binding Settings.SortResults}" Content="{x:Static properties:Resources.SortResultsFitness}"></CheckBox>
 					<CheckBox IsChecked="{Binding Settings.StyleWindowTitleBar}" Content="{x:Static properties:Resources.StyleTheWindowTitleBar}"></CheckBox>
 					<CheckBox IsChecked="{Binding Settings.EnableSmoothScrolling}" Content="{x:Static properties:Resources.EnableSmoothScrolling}"></CheckBox>
+					<CheckBox IsChecked="{Binding Settings.EnableMenuAnimations}" Content="{x:Static properties:Resources.EnableMenuAnimations}"></CheckBox>
 				</StackPanel>
 			</GroupBox>
 		</StackPanel>

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1831,6 +1831,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable menu animations.
+        /// </summary>
+        public static string EnableMenuAnimations {
+            get {
+                return ResourceManager.GetString("EnableMenuAnimations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable word wrap.
         /// </summary>
         public static string EnableWordWrap {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -627,6 +627,9 @@ Are you sure you want to continue?</value>
   <data name="EnableSmoothScrolling" xml:space="preserve">
     <value>Enable smooth scrolling</value>
   </data>
+  <data name="EnableMenuAnimations" xml:space="preserve">
+    <value>Enable menu animations</value>
+  </data>
   <data name="EnableWordWrap" xml:space="preserve">
     <value>Enable word wrap</value>
   </data>

--- a/ILSpy/Util/MenuPopupAnimationHelper.cs
+++ b/ILSpy/Util/MenuPopupAnimationHelper.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 ILSpy contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Windows;
+using System.Windows.Controls.Primitives;
+
+namespace ICSharpCode.ILSpy.Util
+{
+	internal static class MenuPopupAnimationHelper
+	{
+		private static readonly PopupAnimation SystemMenuPopupAnimation = SystemParameters.MenuPopupAnimation;
+
+		public static bool DefaultFromSystem()
+		{
+			return SystemMenuPopupAnimation != PopupAnimation.None;
+		}
+
+		public static void Apply(bool enableMenuAnimations)
+		{
+			var animation = enableMenuAnimations ? SystemMenuPopupAnimation : PopupAnimation.None;
+			SystemParameters.OverrideMetadata(
+				SystemParameters.MenuPopupAnimationKey,
+				new FrameworkPropertyMetadata(animation));
+		}
+	}
+}

--- a/ILSpy/Util/SettingsService.cs
+++ b/ILSpy/Util/SettingsService.cs
@@ -99,6 +99,7 @@ namespace ICSharpCode.ILSpy.Util
 			finally
 			{
 				reloading = false;
+				MenuPopupAnimationHelper.Apply(DisplaySettings.EnableMenuAnimations);
 			}
 		}
 
@@ -127,6 +128,12 @@ namespace ICSharpCode.ILSpy.Util
 			{
 				assemblyListManager.ApplyWinRTProjections = decompilerSettings.ApplyWindowsRuntimeProjections;
 				assemblyListManager.UseDebugSymbols = decompilerSettings.UseDebugSymbols;
+			}
+
+			if (sender is DisplaySettings displaySettings
+				&& e.PropertyName == nameof(DisplaySettings.EnableMenuAnimations))
+			{
+				MenuPopupAnimationHelper.Apply(displaySettings.EnableMenuAnimations);
 			}
 
 			MessageBus.Send(sender, new SettingsChangedEventArgs(e));


### PR DESCRIPTION
## Summary

Fixes #3737.

Adds **Enable menu animations** to Display options (under Other). When unchecked, menu and submenu popups use `PopupAnimation.None` instead of the default fade-in.

- New installs default to the current OS menu animation preference.
- The setting is persisted in `ILSpy.xml` and applied at startup and when changed in options.

## Test plan

- [ ] Open **View → Options → Display** and toggle **Enable menu animations**; open top-level menus and submenus (e.g. View → Theme) and confirm instant vs animated open.
- [ ] Restart ILSpy and confirm the preference is restored.
- [ ] CI build (no local .NET SDK in contributor environment; relying on GitHub Actions)