### PR TITLE
Add opt-in SortSwitchSections setting (#3749)

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -339,6 +339,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await Run();
 		}
 
+		[Test]
+		public async Task SortSwitchSections()
+		{
+			await Run(settings: new DecompilerSettings { SortSwitchSections = true, FileScopedNamespaces = false });
+		}
+
 		async Task Run([CallerMemberName] string testName = null, DecompilerSettings settings = null,
 			AssemblerOptions assemblerOptions = AssemblerOptions.Library)
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/SortSwitchSections.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/SortSwitchSections.cs
@@ -1,0 +1,35 @@
+// Copyright (c) AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
+{
+	public static class SortSwitchSections
+	{
+		public static int PickValue(int n)
+		{
+			return n switch {
+				0 => 100,
+				1 => 200,
+				2 => 300,
+				3 => 400,
+				4 => 500,
+				_ => -1,
+			};
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/SortSwitchSections.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/SortSwitchSections.il
@@ -1,0 +1,64 @@
+// Test fixture for the SortSwitchSections decompiler setting.
+//
+// The IL `switch` table targets are placed at non-monotonic offsets,
+// simulating obfuscator block-reordering. With SortSwitchSections=false
+// (default) the decompiler would emit cases in IL-offset order (3, 0, 4, 1, 2);
+// with the setting enabled they are emitted in label-value order (0..4).
+// The matching .cs file is the expected output with the setting enabled.
+
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )
+  .ver 4:0:0:0
+}
+.assembly SortSwitchSections
+{
+  .ver 1:0:0:0
+}
+.module SortSwitchSections.dll
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+
+.class public auto ansi abstract sealed beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.ILPretty.SortSwitchSections
+    extends [mscorlib]System.Object
+{
+    .method public hidebysig static int32 PickValue(int32 n) cil managed
+    {
+        .maxstack 1
+        IL_0000: ldarg.0
+        IL_0001: switch (
+            LBL_0,
+            LBL_1,
+            LBL_2,
+            LBL_3,
+            LBL_4)
+        IL_001a: br.s LBL_DEFAULT
+
+    LBL_3:
+        IL_001c: ldc.i4 400
+        IL_0021: ret
+
+    LBL_0:
+        IL_0022: ldc.i4 100
+        IL_0027: ret
+
+    LBL_4:
+        IL_0028: ldc.i4 500
+        IL_002d: ret
+
+    LBL_1:
+        IL_002e: ldc.i4 200
+        IL_0033: ret
+
+    LBL_2:
+        IL_0034: ldc.i4 300
+        IL_0039: ret
+
+    LBL_DEFAULT:
+        IL_003a: ldc.i4.m1
+        IL_003b: ret
+    }
+}

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -2375,6 +2375,26 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		bool sortSwitchSections = false;
+
+		/// <summary>
+		/// Sort switch sections by their label value instead of by IL offset.
+		/// Useful when diffing decompiler output across rebuilds of obfuscated assemblies,
+		/// where IL block layout is unstable but the case-to-value mapping is not.
+		/// </summary>
+		[Category("DecompilerSettings.Other")]
+		[Description("DecompilerSettings.SortSwitchSections")]
+		public bool SortSwitchSections {
+			get { return sortSwitchSections; }
+			set {
+				if (sortSwitchSections != value)
+				{
+					sortSwitchSections = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
 		bool checkForOverflowUnderflow = false;
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/IL/ControlFlow/SwitchDetection.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/SwitchDetection.cs
@@ -208,7 +208,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 
 				controlFlowGraph = null; // control flow graph is no-longer valid
 				blockContainerNeedsCleanup = true;
-				SortSwitchSections(sw);
+				SortSwitchSections(sw, context);
 			}
 			else
 			{
@@ -249,16 +249,23 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 					return false;
 				});
 			AdjustLabels(sw, context);
-			SortSwitchSections(sw);
+			SortSwitchSections(sw, context);
 		}
 
-		static void SortSwitchSections(SwitchInstruction sw)
+		static void SortSwitchSections(SwitchInstruction sw, ILTransformContext context)
 		{
-			sw.Sections.ReplaceList(sw.Sections.OrderBy(s => s.Body switch {
-				Branch b => b.TargetILOffset,
-				Leave l => l.StartILOffset,
-				_ => (int?)null
-			}).ThenBy(s => s.Labels.Values.FirstOrDefault()));
+			if (context.Settings.SortSwitchSections)
+			{
+				sw.Sections.ReplaceList(sw.Sections.OrderBy(s => s.Labels.Values.FirstOrDefault()));
+			}
+			else
+			{
+				sw.Sections.ReplaceList(sw.Sections.OrderBy(s => s.Body switch {
+					Branch b => b.TargetILOffset,
+					Leave l => l.StartILOffset,
+					_ => (int?)null
+				}).ThenBy(s => s.Labels.Values.FirstOrDefault()));
+			}
 		}
 
 		static void AdjustLabels(SwitchInstruction sw, ILTransformContext context)

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1423,7 +1423,16 @@ namespace ICSharpCode.ILSpy.Properties {
                 return ResourceManager.GetString("DecompilerSettings.SortCustomAttributes", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sort switch sections by case label value.
+        /// </summary>
+        public static string DecompilerSettings_SortSwitchSections {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.SortSwitchSections", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Detect switch on integer even if IL code does not use a jump table.
         /// </summary>

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -504,6 +504,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.SortCustomAttributes" xml:space="preserve">
     <value>Sort custom attributes</value>
   </data>
+  <data name="DecompilerSettings.SortSwitchSections" xml:space="preserve">
+    <value>Sort switch sections by case label value</value>
+  </data>
   <data name="DecompilerSettings.SparseIntegerSwitch" xml:space="preserve">
     <value>Detect switch on integer even if IL code does not use a jump table</value>
   </data>


### PR DESCRIPTION
Closes #3749.

### Problem

`SortSwitchSections` in `SwitchDetection.cs` orders sections primarily by the target block's IL offset, with the label value as a tiebreaker. That matches source order for non-obfuscated assemblies and is the right default (which is the position the maintainers took when #2071 was closed).

For obfuscated assemblies the situation is different: many obfuscators reshuffle basic-block layout on every build, so the IL offsets behind a `switch` come out in arbitrary order even when the case-to-value mapping is identical. Decompiling the same logical method across two consecutive builds then produces a textual diff that is purely a reordering of the case arms, with no real behavior change. Diffing decompiled output across versions of a closed-source app is a real workflow (it's what motivated the issue, and #3494 was filed for the same kind of use case).

### Solution

Add a new opt-in `SortSwitchSections` bool on `DecompilerSettings`, defaulting to `false` so current output is unchanged. When `true`, `SortSwitchSections(sw, context)` orders sections by `s.Labels.Values.FirstOrDefault()` instead of by IL offset. This mirrors the precedent set by `SortCustomAttributes` (#2716), which addressed the same "non-significant per the spec, but unstable in IL across rebuilds" problem for attribute order; the end-to-end plumbing through `ilspycmd` via `-ds Name=Value` (#3494 / #3505) already exists.

A few notes on the approach:

* `SortSwitchSections` now takes `ILTransformContext` so it can read `context.Settings`. The two call sites (`ProcessBlock`, `SimplifySwitchInstruction`) already had `context` in scope.
* Section reordering is purely cosmetic for the C# output. `StatementBuilder.TranslateSwitch` resolves the default section via `inst.GetDefaultSection()` (picked by label count, not position) and emits each `case X:` label explicitly, so position in the list is not load-bearing. Inter-section transitions (`goto case`, `goto default`) are explicit gotos at the IL level. The Resources.resx entry is added so the WPF settings UI shows a proper label rather than the raw key.

The most attention-worthy bit is the test fixture: the `.il` file uses a hand-written switch table whose targets are at non-monotonic IL offsets (simulating obfuscator block-reordering), and the `.cs` expected file is the sorted output with the setting enabled. The assembly was built locally with the runtime.linux-x64 ilasm package and the expected output verified end-to-end via `ilspycmd`; CI on this branch has confirmed it passes the test runner's formatter as well.

* [x] At least one test covering the code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)