### PR TITLE
Add Open from NuGet feed dialog for browsing and opening packages

### DIFF
--- a/ILSpy.ReadyToRun/packages.lock.json
+++ b/ILSpy.ReadyToRun/packages.lock.json
@@ -317,6 +317,49 @@
           "System.Xml.XDocument": "4.3.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TDp+qHzRBy1zjwiJGCbfpdO0jMG5hH/bk7p1EABLKv9p5SIykDPGnbuYXm2iZO0QJ/H+hOI/vo5LfqM17Q+G0w==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Configuration": "7.6.0",
+          "NuGet.Versioning": "7.6.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TpZxfOoQBQk/0r/2uc1A1qNYIKHkJGgOrWP+ax3nsNAUN/1BOQMDrgmGADogSA4hOXH1ZJiyeYg4Ca+vUW0sEg=="
+      },
       "Onigwrap": {
         "type": "Transitive",
         "resolved": "1.0.10",
@@ -1089,6 +1132,11 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1355,6 +1403,7 @@
           "Microsoft.DiaSymReader.Converter.Xml": "[1.1.0-beta2-22171-02, )",
           "Microsoft.DiaSymReader.Native": "[17.0.0-beta1.21524.1, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "NuGet.Protocol": "[7.6.0, )",
           "ProDataGrid": "[12.0.0, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.11, )",
           "System.Composition.AttributedModel": "[10.0.9, )",
@@ -1524,6 +1573,15 @@
         "resolved": "0.11.6",
         "contentHash": "f33RkDtZO8VlGXCtmQIviOtxgnUdym9xx/b1p9h91CRGOsJFxCFOFK1FDbVt1OCf1aWwYejUFa2MOQyFWTFjbA=="
       },
+      "NuGet.Protocol": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "Ccb9dJG9hW0FdHFjXoHmhJBBJRYSCeSJArLdZjyZj6/FEAIKezLn75KFQNrTPE5UiAp4HVrjBizufZ/0IXhfKQ==",
+        "dependencies": {
+          "NuGet.Packaging": "7.6.0"
+        }
+      },
       "ProDataGrid": {
         "type": "CentralTransitive",
         "requested": "[12.0.0, )",
@@ -1622,6 +1680,12 @@
           "runtime.native.System.Net.Http": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.2"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       },
       "System.Text.RegularExpressions": {
         "type": "CentralTransitive",
@@ -2567,6 +2631,12 @@
           "Microsoft.NETCore.Targets": "1.1.3",
           "runtime.unix.System.Private.Uri": "4.3.0"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     },
     "net10.0/osx-arm64": {
@@ -3487,6 +3557,12 @@
           "Microsoft.NETCore.Targets": "1.1.3",
           "runtime.unix.System.Private.Uri": "4.3.0"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     },
     "net10.0/win-arm64": {
@@ -4390,6 +4466,12 @@
           "Microsoft.NETCore.Platforms": "1.1.1",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     },
     "net10.0/win-x64": {
@@ -5293,6 +5375,12 @@
           "Microsoft.NETCore.Platforms": "1.1.1",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     }
   }

--- a/ILSpy.Tests.Windows/packages.lock.json
+++ b/ILSpy.Tests.Windows/packages.lock.json
@@ -539,6 +539,49 @@
           "System.Xml.XDocument": "4.3.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TDp+qHzRBy1zjwiJGCbfpdO0jMG5hH/bk7p1EABLKv9p5SIykDPGnbuYXm2iZO0QJ/H+hOI/vo5LfqM17Q+G0w==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Configuration": "7.6.0",
+          "NuGet.Versioning": "7.6.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TpZxfOoQBQk/0r/2uc1A1qNYIKHkJGgOrWP+ax3nsNAUN/1BOQMDrgmGADogSA4hOXH1ZJiyeYg4Ca+vUW0sEg=="
+      },
       "Onigwrap": {
         "type": "Transitive",
         "resolved": "1.0.10",
@@ -1309,6 +1352,11 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1575,6 +1623,7 @@
           "Microsoft.DiaSymReader.Converter.Xml": "[1.1.0-beta2-22171-02, )",
           "Microsoft.DiaSymReader.Native": "[17.0.0-beta1.21524.1, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "NuGet.Protocol": "[7.6.0, )",
           "ProDataGrid": "[12.0.0, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.11, )",
           "System.Composition.AttributedModel": "[10.0.9, )",
@@ -1751,6 +1800,15 @@
         "resolved": "0.11.6",
         "contentHash": "f33RkDtZO8VlGXCtmQIviOtxgnUdym9xx/b1p9h91CRGOsJFxCFOFK1FDbVt1OCf1aWwYejUFa2MOQyFWTFjbA=="
       },
+      "NuGet.Protocol": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "Ccb9dJG9hW0FdHFjXoHmhJBBJRYSCeSJArLdZjyZj6/FEAIKezLn75KFQNrTPE5UiAp4HVrjBizufZ/0IXhfKQ==",
+        "dependencies": {
+          "NuGet.Packaging": "7.6.0"
+        }
+      },
       "ProDataGrid": {
         "type": "CentralTransitive",
         "requested": "[12.0.0, )",
@@ -1861,6 +1919,12 @@
         "requested": "[6.1.2, )",
         "resolved": "6.1.2",
         "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       },
       "System.Text.RegularExpressions": {
         "type": "CentralTransitive",

--- a/ILSpy.Tests/NuGetFeeds/FakeNuGetFeedClient.cs
+++ b/ILSpy.Tests/NuGetFeeds/FakeNuGetFeedClient.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ILSpy.NuGetFeeds;
+
+namespace ICSharpCode.ILSpy.Tests.NuGetFeeds;
+
+/// <summary>
+/// Scriptable in-memory <see cref="INuGetFeedClient"/>: records every call, returns
+/// configurable results, throws configurable exceptions, and can hold a download open
+/// on a <see cref="TaskCompletionSource"/> so cancellation paths become testable.
+/// </summary>
+public sealed class FakeNuGetFeedClient : INuGetFeedClient
+{
+	public sealed record SearchCall(string FeedUrl, string SearchText, bool IncludePrerelease, int Skip, int Take);
+	public sealed record VersionsCall(string FeedUrl, string PackageId, bool IncludePrerelease, int MaxCount);
+	public sealed record DownloadCall(string FeedUrl, string PackageId, string Version);
+
+	public List<SearchCall> SearchCalls { get; } = new();
+	public List<VersionsCall> VersionsCalls { get; } = new();
+	public List<DownloadCall> DownloadCalls { get; } = new();
+
+	/// <summary>Computes search results per call; defaults to one well-known package.</summary>
+	public Func<SearchCall, IReadOnlyList<NuGetPackageInfo>> SearchHandler { get; set; }
+		= call => new[] { MakePackage("Newtonsoft.Json") };
+
+	public Exception? SearchException { get; set; }
+
+	public IReadOnlyList<string> VersionsToReturn { get; set; } = new[] { "13.0.3", "13.0.2", "12.0.1" };
+
+	public Exception? VersionsException { get; set; }
+
+	public string DownloadResultPath { get; set; }
+		= @"C:\nuget-cache\newtonsoft.json\13.0.3\newtonsoft.json.13.0.3.nupkg";
+
+	public Exception? DownloadException { get; set; }
+
+	/// <summary>
+	/// When set, downloads do not complete until this source is resolved (or the call's
+	/// cancellation token fires), letting tests cancel a download mid-flight.
+	/// </summary>
+	public TaskCompletionSource<string>? PendingDownload { get; set; }
+
+	public static NuGetPackageInfo MakePackage(string id, string version = "1.0.0") => new(
+		Id: id,
+		LatestVersion: version,
+		Description: $"Description of {id}",
+		Authors: "Test Author",
+		IconUrl: null,
+		LicenseUrl: "https://licenses.example/MIT",
+		ProjectUrl: $"https://github.example/{id}",
+		Tags: "test fake",
+		DownloadCount: 42,
+		Published: new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero));
+
+	public static IReadOnlyList<NuGetPackageInfo> MakePage(int count, int offset = 0)
+		=> Enumerable.Range(offset, count).Select(i => MakePackage($"Package{i:D3}")).ToArray();
+
+	public Task<IReadOnlyList<NuGetPackageInfo>> SearchAsync(
+		string feedUrl, string searchText, bool includePrerelease,
+		int skip, int take, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		var call = new SearchCall(feedUrl, searchText, includePrerelease, skip, take);
+		SearchCalls.Add(call);
+		if (SearchException != null)
+			return Task.FromException<IReadOnlyList<NuGetPackageInfo>>(SearchException);
+		return Task.FromResult(SearchHandler(call));
+	}
+
+	public Task<IReadOnlyList<string>> GetVersionsAsync(
+		string feedUrl, string packageId, bool includePrerelease,
+		int maxCount, CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		VersionsCalls.Add(new VersionsCall(feedUrl, packageId, includePrerelease, maxCount));
+		if (VersionsException != null)
+			return Task.FromException<IReadOnlyList<string>>(VersionsException);
+		return Task.FromResult(VersionsToReturn);
+	}
+
+	public async Task<string> DownloadToGlobalPackagesFolderAsync(
+		string feedUrl, string packageId, string version,
+		CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		DownloadCalls.Add(new DownloadCall(feedUrl, packageId, version));
+		if (DownloadException != null)
+			throw DownloadException;
+		if (PendingDownload != null)
+			return await PendingDownload.Task.WaitAsync(cancellationToken);
+		return DownloadResultPath;
+	}
+}

--- a/ILSpy.Tests/NuGetFeeds/NuGetFeedSettingsTests.cs
+++ b/ILSpy.Tests/NuGetFeeds/NuGetFeedSettingsTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
+using System.Xml.Linq;
+
+using AwesomeAssertions;
+
+using ILSpy.NuGetFeeds;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.NuGetFeeds;
+
+/// <summary>
+/// Pins the persistence contract of the "Open from NuGet feed" dialog's settings section:
+/// the nuget.org feed is always available even after loading damaged settings XML, the
+/// feed MRU stays bounded and free of case-duplicates, and the selected feed plus the
+/// prerelease toggle survive a save/load round-trip.
+/// </summary>
+[TestFixture]
+public class NuGetFeedSettingsTests
+{
+	const string CustomFeed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json";
+
+	[Test]
+	public void Defaults_Offer_The_NuGetOrg_Feed_Selected_Without_Prerelease()
+	{
+		var settings = new NuGetFeedSettings();
+
+		settings.Feeds.Should().Equal(new[] { NuGetFeedSettings.DefaultFeed },
+			"a fresh install must offer exactly the official nuget.org V3 feed");
+		settings.SelectedFeed.Should().Be(NuGetFeedSettings.DefaultFeed);
+		settings.IncludePrerelease.Should().BeFalse("stable-only is the conventional default");
+	}
+
+	[Test]
+	public void SaveToXml_LoadFromXml_RoundTrips_Feeds_Selection_And_Prerelease()
+	{
+		var settings = new NuGetFeedSettings();
+		settings.RememberFeed(CustomFeed);
+		settings.SelectedFeed = CustomFeed;
+		settings.IncludePrerelease = true;
+
+		var restored = new NuGetFeedSettings();
+		restored.LoadFromXml(settings.SaveToXml());
+
+		restored.Feeds.Should().Equal(settings.Feeds);
+		restored.SelectedFeed.Should().Be(CustomFeed);
+		restored.IncludePrerelease.Should().BeTrue();
+	}
+
+	[Test]
+	public void LoadFromXml_On_An_Empty_Section_Falls_Back_To_Defaults()
+	{
+		var settings = new NuGetFeedSettings();
+		settings.RememberFeed(CustomFeed);
+		settings.SelectedFeed = CustomFeed;
+		settings.IncludePrerelease = true;
+
+		settings.LoadFromXml(new XElement("NuGetFeedSettings"));
+
+		settings.Feeds.Should().Equal(new[] { NuGetFeedSettings.DefaultFeed });
+		settings.SelectedFeed.Should().Be(NuGetFeedSettings.DefaultFeed);
+		settings.IncludePrerelease.Should().BeFalse();
+	}
+
+	[Test]
+	public void LoadFromXml_Ignores_Garbage_Content_And_Keeps_The_Default_Feed_Present()
+	{
+		var settings = new NuGetFeedSettings();
+		var section = new XElement("NuGetFeedSettings",
+			new XElement("Feeds",
+				new XElement("Feed", "   "),
+				new XElement("Feed", CustomFeed)),
+			new XElement("SelectedFeed", "https://feed.example/that/was/never/remembered"),
+			new XElement("IncludePrerelease", "not-a-bool"));
+
+		settings.LoadFromXml(section);
+
+		settings.Feeds.Should().Contain(NuGetFeedSettings.DefaultFeed,
+			"the nuget.org feed must survive any settings file content");
+		settings.Feeds.Should().Contain(CustomFeed);
+		settings.Feeds.Should().NotContain(f => string.IsNullOrWhiteSpace(f));
+		settings.Feeds.Should().Contain(settings.SelectedFeed,
+			"the selection must always point at an offered feed");
+		settings.IncludePrerelease.Should().BeFalse("malformed booleans fall back to the default");
+	}
+
+	[Test]
+	public void RememberFeed_Dedupes_Case_Insensitively_And_Ignores_Blank_Urls()
+	{
+		var settings = new NuGetFeedSettings();
+
+		settings.RememberFeed(CustomFeed);
+		settings.RememberFeed(CustomFeed.ToUpperInvariant());
+		settings.RememberFeed("  " + CustomFeed + "  ");
+		settings.RememberFeed("");
+		settings.RememberFeed("   ");
+
+		settings.Feeds.Should().HaveCount(2, "the default feed plus one custom feed, no duplicates");
+		settings.Feeds.Count(f => string.Equals(f, CustomFeed, System.StringComparison.OrdinalIgnoreCase))
+			.Should().Be(1);
+	}
+
+	[Test]
+	public void RememberFeed_Caps_The_List_But_Never_Evicts_The_Default_Feed()
+	{
+		var settings = new NuGetFeedSettings();
+		for (int i = 0; i < 25; i++)
+			settings.RememberFeed($"https://feed{i}.example/v3/index.json");
+
+		settings.Feeds.Count.Should().BeLessThanOrEqualTo(NuGetFeedSettings.MaxFeeds);
+		settings.Feeds.Should().Contain(NuGetFeedSettings.DefaultFeed);
+		settings.Feeds.Should().Contain("https://feed24.example/v3/index.json",
+			"the most recently used feed must survive the cap");
+	}
+}

--- a/ILSpy.Tests/NuGetFeeds/OpenFromNuGetFeedViewModelTests.cs
+++ b/ILSpy.Tests/NuGetFeeds/OpenFromNuGetFeedViewModelTests.cs
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Avalonia.Headless.NUnit;
+
+using AwesomeAssertions;
+
+using ILSpy.NuGetFeeds;
+using ILSpy.ViewModels;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.NuGetFeeds;
+
+/// <summary>
+/// Behavior of the "Open from NuGet feed" dialog's view model against a fake feed client:
+/// search runs against the persisted feed with the persisted prerelease flag, typing is
+/// debounced into a single query, paging appends via skip/take, and feed errors land in
+/// <c>ErrorMessage</c> instead of escaping. The fake records every call, so the assertions
+/// pin the exact requests the real NuGet client would receive.
+/// </summary>
+[TestFixture]
+public class OpenFromNuGetFeedViewModelTests
+{
+	const string CustomFeed = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json";
+
+	static (OpenFromNuGetFeedDialogViewModel vm, FakeNuGetFeedClient client, NuGetFeedSettings settings)
+		CreateViewModel(TimeSpan? debounceDelay = null, NuGetFeedSettings? settings = null)
+	{
+		var client = new FakeNuGetFeedClient();
+		settings ??= new NuGetFeedSettings();
+		var vm = new OpenFromNuGetFeedDialogViewModel(client, settings, debounceDelay ?? TimeSpan.Zero);
+		return (vm, client, settings);
+	}
+
+	[AvaloniaTest]
+	public async Task Refresh_Searches_The_Persisted_Feed_With_Empty_Term_And_Persisted_Prerelease()
+	{
+		var settings = new NuGetFeedSettings { IncludePrerelease = true };
+		settings.RememberFeed(CustomFeed);
+		settings.SelectedFeed = CustomFeed;
+		var (vm, client, _) = CreateViewModel(settings: settings);
+
+		vm.RefreshCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.Packages.Count > 0);
+
+		client.SearchCalls.Should().ContainSingle()
+			.Which.Should().Be(new FakeNuGetFeedClient.SearchCall(
+				CustomFeed, "", true, 0, OpenFromNuGetFeedDialogViewModel.PageSize),
+				"the initial listing must use the persisted feed, prerelease flag, an empty term, and the first page");
+		vm.IsSearching.Should().BeFalse();
+	}
+
+	[AvaloniaTest]
+	public async Task Typing_Is_Debounced_Into_A_Single_Search_With_The_Final_Term()
+	{
+		var (vm, client, _) = CreateViewModel(debounceDelay: TimeSpan.FromMilliseconds(75));
+
+		vm.SearchText = "n";
+		vm.SearchText = "ne";
+		vm.SearchText = "newtonsoft";
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count > 0);
+		// Allow a full extra debounce window to elapse so stale timers would have fired.
+		await Task.Delay(150);
+
+		client.SearchCalls.Should().ContainSingle("intermediate keystrokes must be coalesced")
+			.Which.SearchText.Should().Be("newtonsoft");
+	}
+
+	[AvaloniaTest]
+	public async Task Toggling_Prerelease_Reruns_The_Search_And_Persists_The_Flag()
+	{
+		var (vm, client, settings) = CreateViewModel();
+
+		vm.IncludePrerelease = true;
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count > 0);
+
+		client.SearchCalls.Last().IncludePrerelease.Should().BeTrue();
+		settings.IncludePrerelease.Should().BeTrue("the toggle must survive an app restart");
+	}
+
+	[AvaloniaTest]
+	public async Task Switching_To_A_New_Feed_Searches_It_And_Remembers_It_After_Success()
+	{
+		var (vm, client, settings) = CreateViewModel();
+
+		vm.SelectedFeedUrl = CustomFeed;
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count > 0);
+		await Waiters.WaitForAsync(() => vm.FeedUrls.Contains(CustomFeed));
+
+		client.SearchCalls.Last().FeedUrl.Should().Be(CustomFeed);
+		settings.Feeds.Should().Contain(CustomFeed,
+			"a feed that produced results is worth offering again next time");
+		settings.SelectedFeed.Should().Be(CustomFeed);
+	}
+
+	[AvaloniaTest]
+	public async Task A_Failing_Feed_Does_Not_Get_Remembered()
+	{
+		var (vm, client, settings) = CreateViewModel();
+		client.SearchException = new HttpRequestException("503 Service Unavailable");
+
+		vm.SelectedFeedUrl = CustomFeed;
+		await Waiters.WaitForAsync(() => vm.ErrorMessage != null);
+
+		settings.Feeds.Should().NotContain(CustomFeed,
+			"feeds are only added to the MRU once they answered a search");
+	}
+
+	[AvaloniaTest]
+	public async Task A_Full_Page_Enables_LoadMore_Which_Appends_The_Next_Page()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.SearchHandler = call => FakeNuGetFeedClient.MakePage(
+			count: call.Skip == 0 ? OpenFromNuGetFeedDialogViewModel.PageSize : 3,
+			offset: call.Skip);
+
+		vm.RefreshCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.Packages.Count == OpenFromNuGetFeedDialogViewModel.PageSize);
+		vm.CanLoadMore.Should().BeTrue("a full first page suggests more results exist");
+
+		vm.LoadMoreCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.Packages.Count == OpenFromNuGetFeedDialogViewModel.PageSize + 3);
+
+		client.SearchCalls.Should().HaveCount(2);
+		client.SearchCalls[1].Skip.Should().Be(OpenFromNuGetFeedDialogViewModel.PageSize,
+			"the second page must start where the first ended");
+		vm.CanLoadMore.Should().BeFalse("a short page means the listing is exhausted");
+		vm.Packages.Select(p => p.Id).Should().OnlyHaveUniqueItems();
+	}
+
+	[AvaloniaTest]
+	public async Task ClearSearch_Resets_The_Term_And_Lists_The_Feed_Defaults_Again()
+	{
+		var (vm, client, _) = CreateViewModel();
+		vm.SearchText = "newtonsoft";
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count == 1);
+
+		vm.ClearSearchCommand.Execute(null);
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count >= 2);
+
+		vm.SearchText.Should().BeEmpty();
+		client.SearchCalls.Last().SearchText.Should().BeEmpty();
+	}
+
+	[AvaloniaTest]
+	public async Task Selecting_A_Package_Loads_Its_Versions_And_Preselects_The_Newest()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.VersionsToReturn = new[] { "13.0.3", "13.0.2", "12.0.1" };
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.Versions.Count == 3);
+
+		vm.Versions.Should().Equal(new[] { "13.0.3", "13.0.2", "12.0.1" },
+			"the dropdown lists versions in the order the client returns them (newest first)");
+		vm.SelectedVersion.Should().Be("13.0.3", "the newest version is the most likely pick");
+		client.VersionsCalls.Should().ContainSingle()
+			.Which.Should().Be(new FakeNuGetFeedClient.VersionsCall(
+				NuGetFeedSettings.DefaultFeed, "Newtonsoft.Json", false,
+				OpenFromNuGetFeedDialogViewModel.MaxVersions));
+	}
+
+	[AvaloniaTest]
+	public async Task Version_Load_Respects_The_Prerelease_Toggle()
+	{
+		var (vm, client, _) = CreateViewModel();
+		vm.IncludePrerelease = true;
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count > 0);
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => client.VersionsCalls.Count > 0);
+
+		client.VersionsCalls.Last().IncludePrerelease.Should().BeTrue();
+	}
+
+	[AvaloniaTest]
+	public async Task Switching_Packages_Replaces_The_Version_List()
+	{
+		var (vm, client, _) = CreateViewModel();
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("PackageA");
+		await Waiters.WaitForAsync(() => vm.Versions.Count > 0);
+
+		client.VersionsToReturn = new[] { "2.0.0" };
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("PackageB");
+		await Waiters.WaitForAsync(() => vm.Versions.Count == 1);
+
+		vm.Versions.Should().Equal(new[] { "2.0.0" });
+		vm.SelectedVersion.Should().Be("2.0.0");
+		client.VersionsCalls.Last().PackageId.Should().Be("PackageB");
+	}
+
+	[AvaloniaTest]
+	public async Task A_Cleared_Version_Selection_Snaps_Back_To_The_Latest_Version()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.VersionsToReturn = new[] { "13.0.3", "13.0.2" };
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.SelectedVersion != null);
+
+		// A ComboBox resets its SelectedItem to null when its items change under it;
+		// the view model must answer by reselecting the latest version, never sitting
+		// on an empty selection while versions are available.
+		vm.SelectedVersion = null;
+
+		vm.SelectedVersion.Should().Be("13.0.3");
+	}
+
+	[AvaloniaTest]
+	public async Task Version_Load_Failure_Surfaces_In_ErrorMessage()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.VersionsException = new HttpRequestException("flat container unavailable");
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.ErrorMessage != null);
+
+		vm.ErrorMessage.Should().Contain("flat container unavailable");
+		vm.Versions.Should().BeEmpty();
+		vm.SelectedVersion.Should().BeNull();
+	}
+
+	[AvaloniaTest]
+	public async Task Open_Is_Disabled_Until_A_Version_Is_Available()
+	{
+		var (vm, client, _) = CreateViewModel();
+		vm.OpenPackageCommand.CanExecute(null).Should().BeFalse(
+			"there is nothing to download before a package/version is selected");
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.SelectedVersion != null);
+
+		vm.OpenPackageCommand.CanExecute(null).Should().BeTrue();
+	}
+
+	[AvaloniaTest]
+	public async Task Open_Downloads_The_Selected_Version_And_Requests_Close_With_The_Nupkg_Path()
+	{
+		var (vm, client, _) = CreateViewModel();
+		string? closedWith = null;
+		vm.CloseRequested += path => closedWith = path;
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.SelectedVersion != null);
+		vm.SelectedVersion = "13.0.2";
+
+		vm.OpenPackageCommand.Execute(null);
+		await Waiters.WaitForAsync(() => closedWith != null);
+
+		closedWith.Should().Be(client.DownloadResultPath,
+			"the dialog result is the cached .nupkg the command then opens");
+		vm.DownloadedPackagePath.Should().Be(client.DownloadResultPath);
+		client.DownloadCalls.Should().ContainSingle()
+			.Which.Should().Be(new FakeNuGetFeedClient.DownloadCall(
+				NuGetFeedSettings.DefaultFeed, "Newtonsoft.Json", "13.0.2"));
+		vm.IsDownloading.Should().BeFalse();
+	}
+
+	[AvaloniaTest]
+	public async Task Cancelling_A_Download_Leaves_The_Dialog_Open_Without_An_Error()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.PendingDownload = new TaskCompletionSource<string>();
+		bool closeRaised = false;
+		vm.CloseRequested += _ => closeRaised = true;
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.SelectedVersion != null);
+		vm.OpenPackageCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.IsDownloading);
+
+		vm.OpenPackageCommand.CanExecute(null).Should().BeFalse(
+			"a second download must not start while one is running");
+
+		vm.CancelDownloadCommand.Execute(null);
+		await Waiters.WaitForAsync(() => !vm.IsDownloading);
+
+		closeRaised.Should().BeFalse("a cancelled download must keep the dialog open");
+		vm.ErrorMessage.Should().BeNull("user-initiated cancellation is not an error");
+		vm.OpenPackageCommand.CanExecute(null).Should().BeTrue("the user can retry");
+	}
+
+	[AvaloniaTest]
+	public async Task A_Failed_Download_Surfaces_The_Error_And_Keeps_The_Dialog_Open()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.DownloadException = new HttpRequestException("connection reset by peer");
+		bool closeRaised = false;
+		vm.CloseRequested += _ => closeRaised = true;
+
+		vm.SelectedPackage = FakeNuGetFeedClient.MakePackage("Newtonsoft.Json");
+		await Waiters.WaitForAsync(() => vm.SelectedVersion != null);
+		vm.OpenPackageCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.ErrorMessage != null);
+
+		vm.ErrorMessage.Should().Contain("connection reset by peer");
+		closeRaised.Should().BeFalse();
+		vm.IsDownloading.Should().BeFalse();
+		vm.OpenPackageCommand.CanExecute(null).Should().BeTrue("the user can retry after a failure");
+	}
+
+	[AvaloniaTest]
+	public async Task Feed_Errors_Surface_In_ErrorMessage_And_Clear_On_The_Next_Success()
+	{
+		var (vm, client, _) = CreateViewModel();
+		client.SearchException = new HttpRequestException("name or service not known");
+
+		vm.RefreshCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.ErrorMessage != null);
+
+		vm.ErrorMessage.Should().Contain("name or service not known",
+			"the user must see why the feed produced nothing");
+		vm.IsSearching.Should().BeFalse();
+		vm.Packages.Should().BeEmpty();
+
+		client.SearchException = null;
+		vm.RefreshCommand.Execute(null);
+		await Waiters.WaitForAsync(() => vm.Packages.Count > 0);
+		vm.ErrorMessage.Should().BeNull("a successful retry must dismiss the stale error");
+	}
+}

--- a/ILSpy.Tests/Views/MainMenuTests.cs
+++ b/ILSpy.Tests/Views/MainMenuTests.cs
@@ -52,6 +52,33 @@ public class MainMenuTests
 	}
 
 	[AvaloniaTest]
+	public void OpenFromNuGetFeed_item_sits_between_GAC_and_Reload_and_works_on_every_OS()
+	{
+		var window = new Window();
+		MainMenu.Attach(window);
+
+		var menu = NativeMenu.GetMenu(window);
+		menu.Should().NotBeNull();
+
+		var nuget = Find(menu!, i => i.Header?.Contains("NuGet feed", StringComparison.OrdinalIgnoreCase) == true);
+		nuget.Should().NotBeNull("the File menu must contain an 'Open from NuGet feed' item");
+		nuget!.IsEnabled.Should().BeTrue("NuGet feeds are reachable from every OS, unlike the GAC");
+
+		var fileSubmenu = menu!.Items.OfType<NativeMenuItem>()
+			.Select(i => i.Menu)
+			.First(m => m != null && m.Items.OfType<NativeMenuItem>()
+				.Any(i => i.Header?.Contains("GAC", StringComparison.OrdinalIgnoreCase) == true));
+		var items = fileSubmenu!.Items.OfType<NativeMenuItem>().ToList();
+		int gacIndex = items.FindIndex(i => i.Header?.Contains("GAC", StringComparison.OrdinalIgnoreCase) == true);
+		int nugetIndex = items.FindIndex(i => i.Header?.Contains("NuGet feed", StringComparison.OrdinalIgnoreCase) == true);
+		int reloadIndex = items.FindIndex(i => i.Header?.Contains("Reload", StringComparison.OrdinalIgnoreCase) == true);
+
+		nugetIndex.Should().BeGreaterThan(gacIndex,
+			"the WPF File menu groups the open-from sources right below Open, GAC first");
+		nugetIndex.Should().BeLessThan(reloadIndex, "Reload ends the open group");
+	}
+
+	[AvaloniaTest]
 	public void OpenFromGac_item_enabled_state_follows_the_command()
 	{
 		var window = new Window();

--- a/ILSpy.Tests/Views/OpenFromNuGetFeedDialogStructureTests.cs
+++ b/ILSpy.Tests/Views/OpenFromNuGetFeedDialogStructureTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+
+using AwesomeAssertions;
+
+using ICSharpCode.ILSpy.Properties;
+using ICSharpCode.ILSpy.Tests.NuGetFeeds;
+
+using ILSpy.ViewModels;
+using ILSpy.Views;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.Views;
+
+/// <summary>
+/// Pins the package-chooser dialog's shape:
+/// search box, pre-release toggle, refresh, an editable package-source ComboBox,
+/// a results list, a version dropdown with an Open button, a Cancel button, and an
+/// error bar that appears when the feed reports a problem. The editable-ComboBox
+/// assertion doubles as a canary for the Simple theme actually templating
+/// PART_EditableTextBox - if a theme change drops it, custom feed URLs become untypable.
+/// </summary>
+[TestFixture]
+public class OpenFromNuGetFeedDialogStructureTests
+{
+	static OpenFromNuGetFeedDialog CreateDialog()
+		=> new(settingsService: null, client: new FakeNuGetFeedClient());
+
+	[AvaloniaTest]
+	public void Dialog_Title_And_Captions_Come_From_Localised_Resources()
+	{
+		var dialog = CreateDialog();
+
+		dialog.Title.Should().Be(Resources.NuGetFeedSelectPackage);
+		dialog.FindControl<CheckBox>("PrereleaseCheckBox")!.Content
+			.Should().Be(Resources.NuGetFeedShowPrerelease);
+		dialog.FindControl<Button>("OpenButton")!.Content
+			.Should().Be(Resources.OpenListDialog__Open);
+		dialog.FindControl<Button>("CancelButton")!.Content
+			.Should().Be(Resources.Cancel);
+	}
+
+	[AvaloniaTest]
+	public void Dialog_Contains_The_Package_Chooser_Controls()
+	{
+		var dialog = CreateDialog();
+
+		dialog.FindControl<TextBox>("SearchBox").Should().NotBeNull("packages are found by searching");
+		dialog.FindControl<Button>("RefreshButton").Should().NotBeNull();
+		dialog.FindControl<CheckBox>("PrereleaseCheckBox").Should().NotBeNull();
+		dialog.FindControl<ListBox>("PackagesList").Should().NotBeNull("search hits go into the left-hand list");
+		dialog.FindControl<ComboBox>("VersionsCombo").Should().NotBeNull("the version is picked from a dropdown");
+		dialog.FindControl<Button>("LoadMoreButton").Should().NotBeNull("results are paged");
+		dialog.FindControl<Button>("CancelDownloadButton").Should().NotBeNull("long downloads must be abortable");
+
+		var errorBar = dialog.FindControl<Border>("ErrorBar");
+		errorBar.Should().NotBeNull("feed failures surface in an in-dialog status bar");
+		errorBar!.IsVisible.Should().BeFalse("no error is showing before anything went wrong");
+	}
+
+	[AvaloniaTest]
+	public async Task Feed_ComboBox_Is_Editable_So_Custom_Feed_Urls_Can_Be_Typed()
+	{
+		var dialog = CreateDialog();
+		dialog.Show();
+
+		var feedCombo = dialog.FindControl<ComboBox>("FeedCombo");
+		feedCombo.Should().NotBeNull();
+		feedCombo!.IsEditable.Should().BeTrue("users must be able to type arbitrary V3 feed URLs");
+
+		// The editable text box is an optional template part; this pins that the active
+		// theme's ComboBox template actually provides it.
+		await Waiters.WaitForAsync(() => feedCombo.GetVisualDescendants()
+			.OfType<TextBox>().Any(t => t.Name == "PART_EditableTextBox"));
+	}
+
+	[AvaloniaTest]
+	public async Task Error_Bar_Shows_The_ViewModels_Error_Message()
+	{
+		var dialog = CreateDialog();
+		dialog.Show();
+		var vm = (OpenFromNuGetFeedDialogViewModel)dialog.DataContext!;
+
+		vm.ErrorMessage = "the feed is on fire";
+		await Waiters.WaitForAsync(() => dialog.FindControl<Border>("ErrorBar")!.IsVisible);
+
+		dialog.FindControl<Border>("ErrorBar")!.GetVisualDescendants().OfType<TextBlock>()
+			.Should().Contain(t => t.Text == "the feed is on fire");
+	}
+
+	[AvaloniaTest]
+	public async Task Clear_Button_Lives_Inside_The_Search_Box_And_Only_Shows_While_It_Has_Text()
+	{
+		var dialog = CreateDialog();
+		dialog.Show();
+
+		var searchBox = dialog.FindControl<TextBox>("SearchBox")!;
+		var clearButton = searchBox.InnerRightContent.Should().BeOfType<Button>(
+			"the clear affordance sits inside the search box, like the Search pane's").Subject;
+		clearButton.IsVisible.Should().BeFalse("there is nothing to clear in an empty box");
+
+		var vm = (OpenFromNuGetFeedDialogViewModel)dialog.DataContext!;
+		vm.SearchText = "newtonsoft";
+		await Waiters.WaitForAsync(() => clearButton.IsVisible);
+
+		clearButton.Command.Should().BeSameAs(vm.ClearSearchCommand);
+	}
+
+	[AvaloniaTest]
+	public async Task Selecting_A_Package_Preselects_The_Latest_Version_In_The_Dropdown()
+	{
+		var client = new FakeNuGetFeedClient();
+		client.VersionsToReturn = new[] { "13.0.3", "13.0.2", "12.0.1" };
+		var dialog = new OpenFromNuGetFeedDialog(settingsService: null, client: client);
+		dialog.Show();
+
+		var vm = (OpenFromNuGetFeedDialogViewModel)dialog.DataContext!;
+		await Waiters.WaitForAsync(() => vm.Packages.Count > 0);
+		vm.SelectedPackage = vm.Packages[0];
+
+		var combo = dialog.FindControl<ComboBox>("VersionsCombo")!;
+		await Waiters.WaitForAsync(() => Equals(combo.SelectedItem, "13.0.3"),
+			TimeSpan.FromSeconds(5));
+		combo.SelectedIndex.Should().Be(0, "the newest version leads the list and starts selected");
+	}
+
+	[AvaloniaTest]
+	public async Task Opening_The_Dialog_Lists_The_Feeds_Default_Packages()
+	{
+		var client = new FakeNuGetFeedClient();
+		var dialog = new OpenFromNuGetFeedDialog(settingsService: null, client: client);
+		dialog.Show();
+
+		await Waiters.WaitForAsync(() => client.SearchCalls.Count > 0);
+		client.SearchCalls[0].SearchText.Should().BeEmpty(
+			"the dialog must not open empty - the feed's default listing gives the user something to browse");
+
+		var vm = (OpenFromNuGetFeedDialogViewModel)dialog.DataContext!;
+		await Waiters.WaitForAsync(() => vm.Packages.Count > 0);
+		var list = dialog.FindControl<ListBox>("PackagesList")!;
+		list.ItemCount.Should().Be(vm.Packages.Count, "the list shows exactly the search hits");
+	}
+}

--- a/ILSpy.Tests/packages.lock.json
+++ b/ILSpy.Tests/packages.lock.json
@@ -502,6 +502,49 @@
           "System.Xml.XDocument": "4.3.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TDp+qHzRBy1zjwiJGCbfpdO0jMG5hH/bk7p1EABLKv9p5SIykDPGnbuYXm2iZO0QJ/H+hOI/vo5LfqM17Q+G0w==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Configuration": "7.6.0",
+          "NuGet.Versioning": "7.6.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TpZxfOoQBQk/0r/2uc1A1qNYIKHkJGgOrWP+ax3nsNAUN/1BOQMDrgmGADogSA4hOXH1ZJiyeYg4Ca+vUW0sEg=="
+      },
       "Onigwrap": {
         "type": "Transitive",
         "resolved": "1.0.10",
@@ -1272,6 +1315,11 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1538,6 +1586,7 @@
           "Microsoft.DiaSymReader.Converter.Xml": "[1.1.0-beta2-22171-02, )",
           "Microsoft.DiaSymReader.Native": "[17.0.0-beta1.21524.1, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "NuGet.Protocol": "[7.6.0, )",
           "ProDataGrid": "[12.0.0, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.11, )",
           "System.Composition.AttributedModel": "[10.0.9, )",
@@ -1726,6 +1775,15 @@
         "resolved": "0.11.6",
         "contentHash": "f33RkDtZO8VlGXCtmQIviOtxgnUdym9xx/b1p9h91CRGOsJFxCFOFK1FDbVt1OCf1aWwYejUFa2MOQyFWTFjbA=="
       },
+      "NuGet.Protocol": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "Ccb9dJG9hW0FdHFjXoHmhJBBJRYSCeSJArLdZjyZj6/FEAIKezLn75KFQNrTPE5UiAp4HVrjBizufZ/0IXhfKQ==",
+        "dependencies": {
+          "NuGet.Packaging": "7.6.0"
+        }
+      },
       "ProDataGrid": {
         "type": "CentralTransitive",
         "requested": "[12.0.0, )",
@@ -1836,6 +1894,12 @@
         "requested": "[6.1.2, )",
         "resolved": "6.1.2",
         "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       },
       "System.Text.RegularExpressions": {
         "type": "CentralTransitive",

--- a/ILSpy/Commands/FileCommands.cs
+++ b/ILSpy/Commands/FileCommands.cs
@@ -33,6 +33,7 @@ using ILSpy.AppEnv;
 using ILSpy.AssemblyTree;
 using ILSpy.Docking;
 using ILSpy.Languages;
+using ILSpy.NuGetFeeds;
 using ILSpy.TreeNodes;
 using ILSpy.Views;
 
@@ -119,6 +120,34 @@ namespace ILSpy.Commands
 				return;
 			foreach (var name in fileNames)
 				assemblyTreeModel.AssemblyList?.OpenAssembly(name);
+		}
+	}
+
+	[ExportMainMenuCommand(ParentMenuID = nameof(Resources._File), Header = nameof(Resources.OpenFrom_NuGetFeed), MenuIcon = "Images/NuGet", MenuCategory = nameof(Resources.Open), MenuOrder = 1.5)]
+	[Shared]
+	[method: ImportingConstructor]
+	sealed class OpenFromNuGetFeedCommand(AssemblyTreeModel assemblyTreeModel, SettingsService settingsService) : SimpleCommand
+	{
+		// One client for the command's lifetime so the per-feed service-index discovery
+		// and the NuGet HTTP cache survive across dialog invocations.
+		readonly NuGetFeedClient feedClient = new();
+
+		public override void Execute(object? parameter)
+		{
+			var owner = UiContext.MainWindow;
+			if (owner == null)
+				return;
+			ShowAsync(owner).HandleExceptions();
+		}
+
+		async Task ShowAsync(global::Avalonia.Controls.Window owner)
+		{
+			var dlg = new Views.OpenFromNuGetFeedDialog(settingsService, feedClient);
+			// The dialog result is the absolute path of the .nupkg in the global packages
+			// folder; ILSpy opens .nupkg natively (ArchiveFileLoader/LoadedPackage).
+			var path = await dlg.ShowDialog<string?>(owner);
+			if (!string.IsNullOrEmpty(path))
+				assemblyTreeModel.OpenFiles(new[] { path });
 		}
 	}
 

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -116,6 +116,10 @@
 
     <!-- CLI parsing -->
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
+
+    <!-- NuGet V3 feed client for the "Open from NuGet feed" dialog: search, version
+         enumeration, and download into the global packages folder. -->
+    <PackageReference Include="NuGet.Protocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy/NuGetFeeds/INuGetFeedClient.cs
+++ b/ILSpy/NuGetFeeds/INuGetFeedClient.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ILSpy.NuGetFeeds
+{
+	/// <summary>
+	/// One search hit from a NuGet feed, reduced to what the package-chooser dialog
+	/// displays. Deliberately free of NuGet.* types so view models and tests don't
+	/// take a dependency on the NuGet client libraries.
+	/// </summary>
+	public sealed record NuGetPackageInfo(
+		string Id,
+		string LatestVersion,
+		string? Description,
+		string? Authors,
+		string? IconUrl,
+		string? LicenseUrl,
+		string? ProjectUrl,
+		string? Tags,
+		long? DownloadCount,
+		DateTimeOffset? Published);
+
+	/// <summary>
+	/// Feed operations the "Open from NuGet feed" dialog needs. The production
+	/// implementation (<see cref="NuGetFeedClient"/>) talks to NuGet V3 feeds;
+	/// tests substitute a fake so no network is involved.
+	/// </summary>
+	public interface INuGetFeedClient
+	{
+		/// <summary>
+		/// Searches <paramref name="feedUrl"/> for packages matching <paramref name="searchText"/>
+		/// (an empty string yields the feed's default listing, like the NuGet gallery front page).
+		/// </summary>
+		Task<IReadOnlyList<NuGetPackageInfo>> SearchAsync(
+			string feedUrl, string searchText, bool includePrerelease,
+			int skip, int take, CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Returns at most <paramref name="maxCount"/> versions of <paramref name="packageId"/>,
+		/// newest first, excluding prerelease versions unless <paramref name="includePrerelease"/>.
+		/// </summary>
+		Task<IReadOnlyList<string>> GetVersionsAsync(
+			string feedUrl, string packageId, bool includePrerelease,
+			int maxCount, CancellationToken cancellationToken);
+
+		/// <summary>
+		/// Downloads the package into the NuGet global packages folder (reusing an already
+		/// cached copy) and returns the absolute path of the stored .nupkg file.
+		/// </summary>
+		Task<string> DownloadToGlobalPackagesFolderAsync(
+			string feedUrl, string packageId, string version,
+			CancellationToken cancellationToken);
+	}
+}

--- a/ILSpy/NuGetFeeds/NuGetFeedClient.cs
+++ b/ILSpy/NuGetFeeds/NuGetFeedClient.cs
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace ILSpy.NuGetFeeds
+{
+	/// <summary>
+	/// <see cref="INuGetFeedClient"/> backed by the NuGet client libraries, talking to
+	/// V3 feeds. Downloads land in the user's NuGet global packages folder (honoring
+	/// NuGet.Config / NUGET_PACKAGES overrides), so packages fetched here are shared
+	/// with every other NuGet consumer on the machine and never downloaded twice.
+	/// </summary>
+	public sealed class NuGetFeedClient : INuGetFeedClient
+	{
+		static readonly ILogger Logger = NullLogger.Instance;
+
+		readonly ConcurrentDictionary<string, SourceRepository> repositories =
+			new(StringComparer.OrdinalIgnoreCase);
+		readonly SourceCacheContext cache = new();
+
+		SourceRepository GetRepository(string feedUrl)
+			=> repositories.GetOrAdd(feedUrl, url => Repository.Factory.GetCoreV3(url));
+
+		public async Task<IReadOnlyList<NuGetPackageInfo>> SearchAsync(
+			string feedUrl, string searchText, bool includePrerelease,
+			int skip, int take, CancellationToken cancellationToken)
+		{
+			var search = await GetRepository(feedUrl)
+				.GetResourceAsync<PackageSearchResource>(cancellationToken).ConfigureAwait(false)
+				?? throw new InvalidOperationException($"The feed '{feedUrl}' does not support searching.");
+			var results = await search.SearchAsync(
+				searchText, new SearchFilter(includePrerelease), skip, take,
+				Logger, cancellationToken).ConfigureAwait(false);
+			return results.Select(m => new NuGetPackageInfo(
+				Id: m.Identity.Id,
+				LatestVersion: m.Identity.Version.ToNormalizedString(),
+				Description: m.Description,
+				Authors: m.Authors,
+				IconUrl: m.IconUrl?.ToString(),
+				LicenseUrl: m.LicenseUrl?.ToString(),
+				ProjectUrl: m.ProjectUrl?.ToString(),
+				Tags: m.Tags,
+				DownloadCount: m.DownloadCount,
+				Published: m.Published)).ToArray();
+		}
+
+		public async Task<IReadOnlyList<string>> GetVersionsAsync(
+			string feedUrl, string packageId, bool includePrerelease,
+			int maxCount, CancellationToken cancellationToken)
+		{
+			var byId = await GetRepository(feedUrl)
+				.GetResourceAsync<FindPackageByIdResource>(cancellationToken).ConfigureAwait(false);
+			var versions = await byId.GetAllVersionsAsync(
+				packageId, cache, Logger, cancellationToken).ConfigureAwait(false);
+			return versions
+				.Where(v => includePrerelease || !v.IsPrerelease)
+				.OrderByDescending(v => v)
+				.Take(maxCount)
+				.Select(v => v.ToNormalizedString())
+				.ToArray();
+		}
+
+		public async Task<string> DownloadToGlobalPackagesFolderAsync(
+			string feedUrl, string packageId, string version,
+			CancellationToken cancellationToken)
+		{
+			var identity = new PackageIdentity(packageId, NuGetVersion.Parse(version));
+			var nugetSettings = Settings.LoadDefaultSettings(root: null);
+			string packagesFolder = SettingsUtility.GetGlobalPackagesFolder(nugetSettings);
+			string nupkgPath = new VersionFolderPathResolver(packagesFolder)
+				.GetPackageFilePath(identity.Id, identity.Version);
+
+			// Already installed (by ILSpy or any other NuGet consumer): reuse it.
+			var cached = GlobalPackagesFolderUtility.GetPackage(identity, packagesFolder);
+			if (cached != null)
+			{
+				cached.Dispose();
+				if (File.Exists(nupkgPath))
+					return nupkgPath;
+			}
+
+			var byId = await GetRepository(feedUrl)
+				.GetResourceAsync<FindPackageByIdResource>(cancellationToken).ConfigureAwait(false);
+			using var packageStream = new MemoryStream();
+			bool found = await byId.CopyNupkgToStreamAsync(
+				identity.Id, identity.Version, packageStream, cache,
+				Logger, cancellationToken).ConfigureAwait(false);
+			if (!found)
+			{
+				throw new InvalidOperationException(
+					$"Package {packageId} {version} was not found on '{feedUrl}'.");
+			}
+
+			packageStream.Position = 0;
+			var clientPolicy = ClientPolicyContext.GetClientPolicy(nugetSettings, Logger);
+			var added = await GlobalPackagesFolderUtility.AddPackageAsync(
+				feedUrl, identity, packageStream, packagesFolder, parentId: Guid.Empty,
+				clientPolicy, Logger, cancellationToken).ConfigureAwait(false);
+			added.Dispose();
+			return nupkgPath;
+		}
+	}
+}

--- a/ILSpy/NuGetFeeds/NuGetFeedSettings.cs
+++ b/ILSpy/NuGetFeeds/NuGetFeedSettings.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using ICSharpCode.ILSpyX.Settings;
+
+namespace ILSpy.NuGetFeeds
+{
+	/// <summary>
+	/// Persisted state of the "Open from NuGet feed" dialog: the MRU list of feed URLs the
+	/// user has searched (always including the official nuget.org V3 feed), the feed that
+	/// was active when the dialog was last used, and the pre-release toggle. The selected
+	/// feed is guaranteed to be one of <see cref="Feeds"/>, and the list is bounded by
+	/// <see cref="MaxFeeds"/> with the default feed exempt from eviction.
+	/// </summary>
+	public sealed partial class NuGetFeedSettings : ObservableObject, ISettingsSection
+	{
+		public const string DefaultFeed = "https://api.nuget.org/v3/index.json";
+
+		/// <summary>
+		/// Upper bound of the feed MRU. Eviction drops the oldest custom feed first; the
+		/// default feed never leaves the list.
+		/// </summary>
+		public const int MaxFeeds = 10;
+
+		readonly List<string> feeds = new() { DefaultFeed };
+
+		[ObservableProperty]
+		string selectedFeed = DefaultFeed;
+
+		[ObservableProperty]
+		bool includePrerelease;
+
+		public XName SectionName => "NuGetFeedSettings";
+
+		public IReadOnlyList<string> Feeds => feeds;
+
+		/// <summary>
+		/// Adds <paramref name="feedUrl"/> to the feed MRU (most recent last). Blank input
+		/// and case-insensitive duplicates are ignored; when the cap is hit, the oldest
+		/// custom feed is evicted.
+		/// </summary>
+		public void RememberFeed(string? feedUrl)
+		{
+			feedUrl = feedUrl?.Trim();
+			if (string.IsNullOrEmpty(feedUrl))
+				return;
+			if (feeds.Any(f => string.Equals(f, feedUrl, StringComparison.OrdinalIgnoreCase)))
+				return;
+			feeds.Add(feedUrl);
+			while (feeds.Count > MaxFeeds)
+			{
+				int oldestCustom = feeds.FindIndex(f => !string.Equals(f, DefaultFeed, StringComparison.OrdinalIgnoreCase));
+				if (oldestCustom < 0)
+					break;
+				feeds.RemoveAt(oldestCustom);
+			}
+			OnPropertyChanged(nameof(Feeds));
+		}
+
+		public void LoadFromXml(XElement section)
+		{
+			feeds.Clear();
+			feeds.Add(DefaultFeed);
+			foreach (var feed in section.Element("Feeds")?.Elements("Feed") ?? Enumerable.Empty<XElement>())
+				RememberFeed(feed.Value);
+
+			var selected = ((string?)section.Element("SelectedFeed"))?.Trim();
+			SelectedFeed = feeds.FirstOrDefault(f => string.Equals(f, selected, StringComparison.OrdinalIgnoreCase))
+				?? DefaultFeed;
+
+			bool prerelease;
+			try
+			{
+				prerelease = (bool?)section.Element("IncludePrerelease") ?? false;
+			}
+			catch (FormatException)
+			{
+				// Malformed boolean in a hand-edited settings file; fall back to stable-only.
+				prerelease = false;
+			}
+			IncludePrerelease = prerelease;
+		}
+
+		public XElement SaveToXml()
+		{
+			return new XElement(SectionName,
+				new XElement("Feeds", feeds.Select(f => new XElement("Feed", f))),
+				new XElement("SelectedFeed", SelectedFeed),
+				new XElement("IncludePrerelease", IncludePrerelease));
+		}
+	}
+}

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -2237,6 +2237,141 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Author(s):.
+        /// </summary>
+        public static string NuGetFeedAuthors {
+            get {
+                return ResourceManager.GetString("NuGetFeedAuthors", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        public static string NuGetFeedDescription {
+            get {
+                return ResourceManager.GetString("NuGetFeedDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Downloading package....
+        /// </summary>
+        public static string NuGetFeedDownloading {
+            get {
+                return ResourceManager.GetString("NuGetFeedDownloading", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Downloads:.
+        /// </summary>
+        public static string NuGetFeedDownloads {
+            get {
+                return ResourceManager.GetString("NuGetFeedDownloads", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to License:.
+        /// </summary>
+        public static string NuGetFeedLicense {
+            get {
+                return ResourceManager.GetString("NuGetFeedLicense", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Load more.
+        /// </summary>
+        public static string NuGetFeedLoadMore {
+            get {
+                return ResourceManager.GetString("NuGetFeedLoadMore", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to _Package source:.
+        /// </summary>
+        public static string NuGetFeedPackageSource {
+            get {
+                return ResourceManager.GetString("NuGetFeedPackageSource", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Project URL:.
+        /// </summary>
+        public static string NuGetFeedProjectUrl {
+            get {
+                return ResourceManager.GetString("NuGetFeedProjectUrl", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Date published:.
+        /// </summary>
+        public static string NuGetFeedPublished {
+            get {
+                return ResourceManager.GetString("NuGetFeedPublished", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Refresh.
+        /// </summary>
+        public static string NuGetFeedRefresh {
+            get {
+                return ResourceManager.GetString("NuGetFeedRefresh", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Search packages.
+        /// </summary>
+        public static string NuGetFeedSearchWatermark {
+            get {
+                return ResourceManager.GetString("NuGetFeedSearchWatermark", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Select Package.
+        /// </summary>
+        public static string NuGetFeedSelectPackage {
+            get {
+                return ResourceManager.GetString("NuGetFeedSelectPackage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show pre-release packages.
+        /// </summary>
+        public static string NuGetFeedShowPrerelease {
+            get {
+                return ResourceManager.GetString("NuGetFeedShowPrerelease", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tags:.
+        /// </summary>
+        public static string NuGetFeedTags {
+            get {
+                return ResourceManager.GetString("NuGetFeedTags", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to _Version:.
+        /// </summary>
+        public static string NuGetFeedVersion {
+            get {
+                return ResourceManager.GetString("NuGetFeedVersion", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Nuget Package Browser.
         /// </summary>
         public static string NugetPackageBrowser {
@@ -2287,6 +2422,15 @@ namespace ICSharpCode.ILSpy.Properties {
         public static string OpenFrom_GAC {
             get {
                 return ResourceManager.GetString("OpenFrom_GAC", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Open from _NuGet feed....
+        /// </summary>
+        public static string OpenFrom_NuGetFeed {
+            get {
+                return ResourceManager.GetString("OpenFrom_NuGetFeed", resourceCulture);
             }
         }
         

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -772,6 +772,51 @@ Please disable all filters that might hide the item (i.e. activate "View &gt; Sh
   <data name="NewTab" xml:space="preserve">
     <value>New Tab</value>
   </data>
+  <data name="NuGetFeedAuthors" xml:space="preserve">
+    <value>Author(s):</value>
+  </data>
+  <data name="NuGetFeedDescription" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="NuGetFeedDownloading" xml:space="preserve">
+    <value>Downloading package...</value>
+  </data>
+  <data name="NuGetFeedDownloads" xml:space="preserve">
+    <value>Downloads:</value>
+  </data>
+  <data name="NuGetFeedLicense" xml:space="preserve">
+    <value>License:</value>
+  </data>
+  <data name="NuGetFeedLoadMore" xml:space="preserve">
+    <value>Load more</value>
+  </data>
+  <data name="NuGetFeedPackageSource" xml:space="preserve">
+    <value>_Package source:</value>
+  </data>
+  <data name="NuGetFeedProjectUrl" xml:space="preserve">
+    <value>Project URL:</value>
+  </data>
+  <data name="NuGetFeedPublished" xml:space="preserve">
+    <value>Date published:</value>
+  </data>
+  <data name="NuGetFeedRefresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="NuGetFeedSearchWatermark" xml:space="preserve">
+    <value>Search packages</value>
+  </data>
+  <data name="NuGetFeedSelectPackage" xml:space="preserve">
+    <value>Select Package</value>
+  </data>
+  <data name="NuGetFeedShowPrerelease" xml:space="preserve">
+    <value>Show pre-release packages</value>
+  </data>
+  <data name="NuGetFeedTags" xml:space="preserve">
+    <value>Tags:</value>
+  </data>
+  <data name="NuGetFeedVersion" xml:space="preserve">
+    <value>_Version:</value>
+  </data>
   <data name="NugetPackageBrowser" xml:space="preserve">
     <value>Nuget Package Browser</value>
   </data>
@@ -789,6 +834,9 @@ Please disable all filters that might hide the item (i.e. activate "View &gt; Sh
   </data>
   <data name="OpenFrom_GAC" xml:space="preserve">
     <value>Open from _GAC...</value>
+  </data>
+  <data name="OpenFrom_NuGetFeed" xml:space="preserve">
+    <value>Open from _NuGet feed...</value>
   </data>
   <data name="OpenListDialog__Delete" xml:space="preserve">
     <value>_Delete</value>

--- a/ILSpy/ViewModels/OpenFromNuGetFeedDialogViewModel.cs
+++ b/ILSpy/ViewModels/OpenFromNuGetFeedDialogViewModel.cs
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+using ILSpy.NuGetFeeds;
+
+namespace ILSpy.ViewModels
+{
+	/// <summary>
+	/// Drives the "Open from NuGet feed" dialog: debounced search against the selected
+	/// V3 feed, skip/take paging, a version list for the selected package, and a
+	/// cancellable download into the global packages folder. All feed I/O goes through
+	/// <see cref="INuGetFeedClient"/>; feed errors land in <see cref="ErrorMessage"/>.
+	/// The dialog closes itself when <see cref="CloseRequested"/> fires with the path
+	/// of the downloaded .nupkg.
+	/// </summary>
+	public sealed partial class OpenFromNuGetFeedDialogViewModel : ViewModelBase
+	{
+		public const int PageSize = 25;
+		public const int MaxVersions = 100;
+
+		readonly INuGetFeedClient client;
+		readonly NuGetFeedSettings settings;
+		readonly TimeSpan debounceDelay;
+
+		CancellationTokenSource? searchCts;
+		// Distinguishes the most recent search from superseded ones: a stale search must
+		// neither publish its results nor flip IsSearching off under the active one.
+		int searchGeneration;
+
+		CancellationTokenSource? versionsCts;
+		int versionsGeneration;
+
+		CancellationTokenSource? downloadCts;
+
+		[ObservableProperty]
+		string searchText = string.Empty;
+
+		[ObservableProperty]
+		bool includePrerelease;
+
+		[ObservableProperty]
+		string selectedFeedUrl;
+
+		[ObservableProperty]
+		NuGetPackageInfo? selectedPackage;
+
+		[ObservableProperty]
+		[NotifyCanExecuteChangedFor(nameof(OpenPackageCommand))]
+		string? selectedVersion;
+
+		[ObservableProperty]
+		bool isSearching;
+
+		[ObservableProperty]
+		[NotifyCanExecuteChangedFor(nameof(OpenPackageCommand))]
+		bool isDownloading;
+
+		[ObservableProperty]
+		bool canLoadMore;
+
+		[ObservableProperty]
+		string? errorMessage;
+
+		[ObservableProperty]
+		string? downloadedPackagePath;
+
+		public ObservableCollection<string> FeedUrls { get; }
+		public ObservableCollection<NuGetPackageInfo> Packages { get; } = new();
+		public ObservableCollection<string> Versions { get; } = new();
+
+		/// <summary>
+		/// Raised with the path of the downloaded .nupkg once it is ready to be opened;
+		/// the view responds by closing the dialog with that path as its result.
+		/// </summary>
+		public event Action<string?>? CloseRequested;
+
+		public OpenFromNuGetFeedDialogViewModel(
+			INuGetFeedClient client, NuGetFeedSettings settings, TimeSpan? debounceDelay = null)
+		{
+			this.client = client;
+			this.settings = settings;
+			this.debounceDelay = debounceDelay ?? TimeSpan.FromMilliseconds(300);
+			FeedUrls = new ObservableCollection<string>(settings.Feeds);
+			selectedFeedUrl = settings.SelectedFeed;
+			includePrerelease = settings.IncludePrerelease;
+		}
+
+		partial void OnSearchTextChanged(string value) => StartSearch(debounce: true);
+
+		partial void OnIncludePrereleaseChanged(bool value)
+		{
+			settings.IncludePrerelease = value;
+			StartSearch(debounce: true);
+		}
+
+		partial void OnSelectedFeedUrlChanged(string value) => StartSearch(debounce: true);
+
+		partial void OnSelectedPackageChanged(NuGetPackageInfo? value)
+			=> _ = LoadVersionsAsync(value);
+
+		partial void OnSelectedVersionChanged(string? value)
+		{
+			// A ComboBox resets its SelectedItem to null when its items change under it;
+			// never sit on an empty selection while versions are available - the latest
+			// (first) version is always the default.
+			if (value == null && Versions.Count > 0)
+				SelectedVersion = Versions[0];
+		}
+
+		[RelayCommand]
+		void Refresh() => StartSearch(debounce: false);
+
+		[RelayCommand]
+		void ClearSearch()
+		{
+			if (SearchText.Length == 0)
+				StartSearch(debounce: false);
+			else
+				SearchText = string.Empty;
+		}
+
+		[RelayCommand]
+		void LoadMore() => StartSearch(debounce: false, append: true);
+
+		bool CanOpenPackage => SelectedVersion != null && !IsDownloading;
+
+		[RelayCommand(CanExecute = nameof(CanOpenPackage))]
+		async Task OpenPackage()
+		{
+			var package = SelectedPackage;
+			var version = SelectedVersion;
+			if (package == null || version == null)
+				return;
+
+			downloadCts?.Cancel();
+			var cts = downloadCts = new CancellationTokenSource();
+			IsDownloading = true;
+			try
+			{
+				string path = await client.DownloadToGlobalPackagesFolderAsync(
+					SelectedFeedUrl?.Trim() ?? string.Empty, package.Id, version, cts.Token);
+				ErrorMessage = null;
+				DownloadedPackagePath = path;
+				CloseRequested?.Invoke(path);
+			}
+			catch (OperationCanceledException)
+			{
+				// User hit Cancel (or closed the dialog); not an error, no close.
+			}
+			catch (Exception ex)
+			{
+				ErrorMessage = ex.Message;
+			}
+			finally
+			{
+				IsDownloading = false;
+			}
+		}
+
+		[RelayCommand]
+		void CancelDownload() => downloadCts?.Cancel();
+
+		/// <summary>Cancels every in-flight feed operation; called when the dialog closes.</summary>
+		public void CancelAllOperations()
+		{
+			searchCts?.Cancel();
+			versionsCts?.Cancel();
+			downloadCts?.Cancel();
+		}
+
+		async Task LoadVersionsAsync(NuGetPackageInfo? package)
+		{
+			versionsCts?.Cancel();
+			var cts = versionsCts = new CancellationTokenSource();
+			int generation = ++versionsGeneration;
+			Versions.Clear();
+			SelectedVersion = null;
+			if (package == null)
+				return;
+			try
+			{
+				var versions = await client.GetVersionsAsync(
+					SelectedFeedUrl?.Trim() ?? string.Empty, package.Id, IncludePrerelease,
+					MaxVersions, cts.Token);
+				if (generation != versionsGeneration)
+					return;
+				foreach (var version in versions)
+					Versions.Add(version);
+				SelectedVersion = Versions.FirstOrDefault();
+			}
+			catch (OperationCanceledException)
+			{
+				// Selection moved on or the dialog closed.
+			}
+			catch (Exception ex)
+			{
+				if (generation == versionsGeneration)
+					ErrorMessage = ex.Message;
+			}
+		}
+
+		void StartSearch(bool debounce, bool append = false)
+			=> _ = RunSearchAsync(debounce, append);
+
+		async Task RunSearchAsync(bool debounce, bool append)
+		{
+			searchCts?.Cancel();
+			var cts = searchCts = new CancellationTokenSource();
+			int generation = ++searchGeneration;
+			try
+			{
+				if (debounce && debounceDelay > TimeSpan.Zero)
+					await Task.Delay(debounceDelay, cts.Token);
+
+				IsSearching = true;
+				string feed = SelectedFeedUrl?.Trim() ?? string.Empty;
+				int skip = append ? Packages.Count : 0;
+				var results = await client.SearchAsync(
+					feed, SearchText, IncludePrerelease, skip, PageSize, cts.Token);
+				if (generation != searchGeneration)
+					return;
+
+				ErrorMessage = null;
+				if (!append)
+				{
+					Packages.Clear();
+					SelectedPackage = null;
+				}
+				foreach (var package in results)
+					Packages.Add(package);
+				CanLoadMore = results.Count == PageSize;
+
+				// Only a feed that actually answered earns a spot in the persisted MRU.
+				settings.RememberFeed(feed);
+				settings.SelectedFeed = settings.Feeds.FirstOrDefault(
+					f => string.Equals(f, feed, StringComparison.OrdinalIgnoreCase)) ?? feed;
+				if (!FeedUrls.Contains(settings.SelectedFeed, StringComparer.OrdinalIgnoreCase))
+					FeedUrls.Add(settings.SelectedFeed);
+			}
+			catch (OperationCanceledException)
+			{
+				// Superseded by a newer search or the dialog closed.
+			}
+			catch (Exception ex)
+			{
+				if (generation == searchGeneration)
+				{
+					ErrorMessage = ex.Message;
+					Packages.Clear();
+					SelectedPackage = null;
+					CanLoadMore = false;
+				}
+			}
+			finally
+			{
+				if (generation == searchGeneration)
+					IsSearching = false;
+			}
+		}
+	}
+}

--- a/ILSpy/Views/OpenFromNuGetFeedDialog.axaml
+++ b/ILSpy/Views/OpenFromNuGetFeedDialog.axaml
@@ -1,0 +1,160 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:img="using:ILSpy.Images"
+        xmlns:nf="using:ILSpy.NuGetFeeds"
+        xmlns:vm="using:ILSpy.ViewModels"
+        x:Class="ILSpy.Views.OpenFromNuGetFeedDialog"
+        x:DataType="vm:OpenFromNuGetFeedDialogViewModel"
+        Width="1000" Height="650" MinWidth="700" MinHeight="400"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True">
+	<Grid Margin="12,8" RowDefinitions="Auto,*,Auto,Auto" RowSpacing="8">
+
+		<!-- Top bar: search + refresh + prerelease toggle, package source on the right. -->
+		<Grid Grid.Row="0" ColumnDefinitions="2*,Auto,Auto,Auto,Auto,3*" ColumnSpacing="8">
+			<TextBox Grid.Column="0" Name="SearchBox" Text="{Binding SearchText, Mode=TwoWay}">
+				<TextBox.InnerRightContent>
+					<!-- Inline clear affordance, mirroring SearchPane's: borderless, transparent,
+					     and only visible while there is something to clear. -->
+					<Button Name="ClearSearchButton"
+					        IsVisible="{Binding SearchText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+					        Background="Transparent" BorderThickness="0"
+					        Padding="4,0" Margin="0"
+					        Command="{Binding ClearSearchCommand}">
+						<TextBlock Text="✕" FontSize="11" VerticalAlignment="Center" />
+					</Button>
+				</TextBox.InnerRightContent>
+			</TextBox>
+			<Button Grid.Column="1" Name="RefreshButton" Command="{Binding RefreshCommand}">
+				<Image Width="16" Height="16" Source="{x:Static img:Images.Refresh}" />
+			</Button>
+			<CheckBox Grid.Column="2" Name="PrereleaseCheckBox"
+			          IsChecked="{Binding IncludePrerelease, Mode=TwoWay}" />
+			<Label Grid.Column="4" Name="PackageSourceLabel" Target="{Binding #FeedCombo}"
+			       VerticalAlignment="Center" />
+			<ComboBox Grid.Column="5" Name="FeedCombo" IsEditable="True"
+			          HorizontalAlignment="Stretch"
+			          ItemsSource="{Binding FeedUrls}"
+			          Text="{Binding SelectedFeedUrl, Mode=TwoWay}" />
+		</Grid>
+
+		<!-- Main area: results list left, detail pane right. -->
+		<Grid Grid.Row="1" ColumnDefinitions="3*,2*" ColumnSpacing="12">
+			<Grid Grid.Column="0" RowDefinitions="*">
+				<ListBox Grid.Row="0" Name="PackagesList"
+				         ItemsSource="{Binding Packages}"
+				         SelectedItem="{Binding SelectedPackage, Mode=TwoWay}">
+					<ListBox.ItemTemplate>
+						<DataTemplate x:DataType="nf:NuGetPackageInfo">
+							<!-- MinHeight reserves the two description lines (MaxLines below caps
+							     them), so rows stay uniform whether a package has a long, short,
+							     or missing description. -->
+							<Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8" Margin="2"
+							      MinHeight="52">
+								<Image Grid.Column="0" Width="32" Height="32" VerticalAlignment="Top"
+								       Source="{x:Static img:Images.NuGet}" />
+								<StackPanel Grid.Column="1" Spacing="2">
+									<StackPanel Orientation="Horizontal" Spacing="4">
+										<TextBlock FontWeight="Bold" Text="{Binding Id}" />
+										<TextBlock Opacity="0.75"
+										           IsVisible="{Binding Authors, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+										           Text="{Binding Authors, StringFormat='by {0}'}" />
+									</StackPanel>
+									<TextBlock Opacity="0.75" TextWrapping="Wrap" MaxLines="2"
+									           TextTrimming="CharacterEllipsis"
+									           Text="{Binding Description}" />
+								</StackPanel>
+								<TextBlock Grid.Column="2" VerticalAlignment="Top"
+								           Text="{Binding LatestVersion, StringFormat='v{0}'}" />
+							</Grid>
+						</DataTemplate>
+					</ListBox.ItemTemplate>
+				</ListBox>
+				<ProgressBar Grid.Row="0" Name="SearchProgressBar" Height="6"
+				             VerticalAlignment="Bottom" IsIndeterminate="True"
+				             IsVisible="{Binding IsSearching}" />
+			</Grid>
+
+			<ScrollViewer Grid.Column="1"
+			              IsVisible="{Binding SelectedPackage, Converter={x:Static ObjectConverters.IsNotNull}}">
+				<StackPanel Name="DetailPane" Spacing="8" Margin="0,0,4,0">
+					<StackPanel Orientation="Horizontal" Spacing="8">
+						<Image Width="32" Height="32" Source="{x:Static img:Images.NuGet}" />
+						<TextBlock FontSize="20" FontWeight="Bold" VerticalAlignment="Center"
+						           Text="{Binding SelectedPackage.Id}" />
+					</StackPanel>
+
+					<StackPanel Orientation="Horizontal" Spacing="6">
+						<Label Name="VersionLabel" Target="{Binding #VersionsCombo}"
+						       VerticalAlignment="Center" />
+						<ComboBox Name="VersionsCombo" MinWidth="150"
+						          ItemsSource="{Binding Versions}"
+						          SelectedItem="{Binding SelectedVersion, Mode=TwoWay}" />
+						<Button Name="OpenButton" IsDefault="True" MinWidth="72"
+						        Command="{Binding OpenPackageCommand}" />
+					</StackPanel>
+
+					<StackPanel Orientation="Horizontal" Spacing="6"
+					            IsVisible="{Binding IsDownloading}">
+						<TextBlock Name="DownloadingLabel" VerticalAlignment="Center" />
+						<ProgressBar Name="DownloadProgressBar" Width="160" Height="8"
+						             IsIndeterminate="True" />
+						<Button Name="CancelDownloadButton"
+						        Command="{Binding CancelDownloadCommand}" />
+					</StackPanel>
+
+					<TextBlock Name="DescriptionHeaderLabel" FontWeight="Bold" />
+					<TextBlock TextWrapping="Wrap" Text="{Binding SelectedPackage.Description}" />
+
+					<Grid ColumnDefinitions="Auto,*" ColumnSpacing="12"
+					      RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="4">
+						<TextBlock Grid.Row="0" Grid.Column="0" Name="AuthorsLabel" FontWeight="Bold" />
+						<TextBlock Grid.Row="0" Grid.Column="1" TextWrapping="Wrap"
+						           Text="{Binding SelectedPackage.Authors}" />
+
+						<TextBlock Grid.Row="1" Grid.Column="0" Name="LicenseLabel" FontWeight="Bold" />
+						<TextBlock Grid.Row="1" Grid.Column="1" Name="LicenseLink"
+						           TextDecorations="Underline" Foreground="#1B6EC2" Cursor="Hand"
+						           TextWrapping="Wrap"
+						           Text="{Binding SelectedPackage.LicenseUrl}" />
+
+						<TextBlock Grid.Row="2" Grid.Column="0" Name="PublishedLabel" FontWeight="Bold" />
+						<TextBlock Grid.Row="2" Grid.Column="1"
+						           Text="{Binding SelectedPackage.Published, StringFormat='{}{0:D}'}" />
+
+						<TextBlock Grid.Row="3" Grid.Column="0" Name="ProjectUrlLabel" FontWeight="Bold" />
+						<TextBlock Grid.Row="3" Grid.Column="1" Name="ProjectUrlLink"
+						           TextDecorations="Underline" Foreground="#1B6EC2" Cursor="Hand"
+						           TextWrapping="Wrap"
+						           Text="{Binding SelectedPackage.ProjectUrl}" />
+
+						<TextBlock Grid.Row="4" Grid.Column="0" Name="DownloadsLabel" FontWeight="Bold" />
+						<TextBlock Grid.Row="4" Grid.Column="1"
+						           Text="{Binding SelectedPackage.DownloadCount, StringFormat='{}{0:N0}'}" />
+
+						<TextBlock Grid.Row="5" Grid.Column="0" Name="TagsLabel" FontWeight="Bold" />
+						<TextBlock Grid.Row="5" Grid.Column="1" TextWrapping="Wrap"
+						           Text="{Binding SelectedPackage.Tags}" />
+					</Grid>
+				</StackPanel>
+			</ScrollViewer>
+		</Grid>
+
+		<!-- Error bar: status strip for feed/download failures. Fixed beige
+		     background with explicit black text so it stays readable in dark themes. -->
+		<Border Grid.Row="2" Name="ErrorBar" Background="#FFF4CE" CornerRadius="2" Padding="8,4"
+		        IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+			<TextBlock Name="ErrorText" Foreground="Black" TextWrapping="Wrap"
+			           Text="{Binding ErrorMessage}" />
+		</Border>
+
+		<!-- Bottom row: "Load more" hugs the left edge of the results list above it;
+		     Cancel stays at the dialog's right edge on the same row. -->
+		<Grid Grid.Row="3" ColumnDefinitions="*,Auto">
+			<Button Grid.Column="0" Name="LoadMoreButton" HorizontalAlignment="Left"
+			        Command="{Binding LoadMoreCommand}"
+			        IsVisible="{Binding CanLoadMore}" />
+			<Button Grid.Column="1" Name="CancelButton" IsCancel="True" MinWidth="72" />
+		</Grid>
+	</Grid>
+</Window>

--- a/ILSpy/Views/OpenFromNuGetFeedDialog.axaml.cs
+++ b/ILSpy/Views/OpenFromNuGetFeedDialog.axaml.cs
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Diagnostics;
+
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+
+using ILSpy.NuGetFeeds;
+using ILSpy.ViewModels;
+
+// Alias the WPF-shared Resources class — Window inherits an IResourceDictionary Resources
+// property that would otherwise shadow ICSharpCode.ILSpy.Properties.Resources, turning every
+// `Resources.X` into an IResourceDictionary indexer lookup that doesn't compile.
+using Loc = ICSharpCode.ILSpy.Properties.Resources;
+
+namespace ILSpy.Views
+{
+	/// <summary>
+	/// "Open from NuGet feed" package-chooser dialog:
+	/// search a V3 feed (editable package-source ComboBox, pre-release toggle, paged
+	/// results), pick a version from a dropdown, and Open downloads the package into the
+	/// global packages folder. Closes with the absolute path of the cached .nupkg, or
+	/// null when cancelled; all behavior lives in
+	/// <see cref="OpenFromNuGetFeedDialogViewModel"/>.
+	/// </summary>
+	public partial class OpenFromNuGetFeedDialog : Window
+	{
+		readonly OpenFromNuGetFeedDialogViewModel viewModel;
+
+		// Runtime-loader/designer constructor; production callers and tests use the
+		// overload below to inject the settings service and (in tests) a fake client.
+		public OpenFromNuGetFeedDialog()
+			: this(settingsService: null, client: new NuGetFeedClient())
+		{
+		}
+
+		public OpenFromNuGetFeedDialog(
+			SettingsService? settingsService,
+			INuGetFeedClient client,
+			TimeSpan? debounceDelay = null)
+		{
+			InitializeComponent();
+
+			var settings = settingsService?.GetSettings<NuGetFeedSettings>() ?? new NuGetFeedSettings();
+			viewModel = new OpenFromNuGetFeedDialogViewModel(client, settings, debounceDelay);
+			DataContext = viewModel;
+
+			Title = Loc.NuGetFeedSelectPackage;
+			var searchBox = this.FindControl<TextBox>("SearchBox")!;
+			searchBox.PlaceholderText = Loc.NuGetFeedSearchWatermark;
+			ToolTip.SetTip(this.FindControl<Button>("RefreshButton")!, Loc.NuGetFeedRefresh);
+			this.FindControl<CheckBox>("PrereleaseCheckBox")!.Content = Loc.NuGetFeedShowPrerelease;
+			this.FindControl<Label>("PackageSourceLabel")!.Content = Loc.NuGetFeedPackageSource;
+			this.FindControl<Button>("LoadMoreButton")!.Content = Loc.NuGetFeedLoadMore;
+			this.FindControl<Label>("VersionLabel")!.Content = Loc.NuGetFeedVersion;
+			this.FindControl<Button>("OpenButton")!.Content = Loc.OpenListDialog__Open;
+			this.FindControl<TextBlock>("DownloadingLabel")!.Text = Loc.NuGetFeedDownloading;
+			this.FindControl<Button>("CancelDownloadButton")!.Content = Loc.Cancel;
+			this.FindControl<TextBlock>("DescriptionHeaderLabel")!.Text = Loc.NuGetFeedDescription;
+			this.FindControl<TextBlock>("AuthorsLabel")!.Text = Loc.NuGetFeedAuthors;
+			this.FindControl<TextBlock>("LicenseLabel")!.Text = Loc.NuGetFeedLicense;
+			this.FindControl<TextBlock>("PublishedLabel")!.Text = Loc.NuGetFeedPublished;
+			this.FindControl<TextBlock>("ProjectUrlLabel")!.Text = Loc.NuGetFeedProjectUrl;
+			this.FindControl<TextBlock>("DownloadsLabel")!.Text = Loc.NuGetFeedDownloads;
+			this.FindControl<TextBlock>("TagsLabel")!.Text = Loc.NuGetFeedTags;
+			var cancelButton = this.FindControl<Button>("CancelButton")!;
+			cancelButton.Content = Loc.Cancel;
+
+			// Enter searches immediately, skipping the typing debounce.
+			searchBox.KeyDown += (_, e) => {
+				if (e.Key == Key.Enter)
+				{
+					viewModel.RefreshCommand.Execute(null);
+					e.Handled = true;
+				}
+			};
+
+			this.FindControl<TextBlock>("LicenseLink")!.PointerReleased +=
+				(s, _) => OpenInBrowser(((TextBlock)s!).Text);
+			this.FindControl<TextBlock>("ProjectUrlLink")!.PointerReleased +=
+				(s, _) => OpenInBrowser(((TextBlock)s!).Text);
+
+			cancelButton.Click += (_, _) => Close(null);
+			viewModel.CloseRequested += path => Close(path);
+			Closed += (_, _) => viewModel.CancelAllOperations();
+
+			// Populate the dialog with the feed's default listing so it never opens empty.
+			Opened += (_, _) => viewModel.RefreshCommand.Execute(null);
+			Opened += (_, _) => searchBox.Focus();
+		}
+
+		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+		static void OpenInBrowser(string? url)
+		{
+			if (string.IsNullOrWhiteSpace(url)
+				|| !Uri.TryCreate(url, UriKind.Absolute, out var uri)
+				|| (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+			{
+				return;
+			}
+			Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+		}
+	}
+}

--- a/ILSpy/packages.lock.json
+++ b/ILSpy/packages.lock.json
@@ -167,6 +167,15 @@
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
       },
+      "NuGet.Protocol": {
+        "type": "Direct",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "Ccb9dJG9hW0FdHFjXoHmhJBBJRYSCeSJArLdZjyZj6/FEAIKezLn75KFQNrTPE5UiAp4HVrjBizufZ/0IXhfKQ==",
+        "dependencies": {
+          "NuGet.Packaging": "7.6.0"
+        }
+      },
       "ProDataGrid": {
         "type": "Direct",
         "requested": "[12.0.0, )",
@@ -506,6 +515,49 @@
           "System.Xml.ReaderWriter": "4.3.0",
           "System.Xml.XDocument": "4.3.0"
         }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TDp+qHzRBy1zjwiJGCbfpdO0jMG5hH/bk7p1EABLKv9p5SIykDPGnbuYXm2iZO0QJ/H+hOI/vo5LfqM17Q+G0w==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Configuration": "7.6.0",
+          "NuGet.Versioning": "7.6.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TpZxfOoQBQk/0r/2uc1A1qNYIKHkJGgOrWP+ax3nsNAUN/1BOQMDrgmGADogSA4hOXH1ZJiyeYg4Ca+vUW0sEg=="
       },
       "Onigwrap": {
         "type": "Transitive",
@@ -1279,6 +1331,11 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1591,6 +1648,12 @@
         "requested": "[6.1.2, )",
         "resolved": "6.1.2",
         "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       },
       "System.Text.RegularExpressions": {
         "type": "CentralTransitive",
@@ -2520,6 +2583,12 @@
           "Microsoft.NETCore.Targets": "1.1.3",
           "runtime.unix.System.Private.Uri": "4.3.0"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     },
     "net10.0/osx-arm64": {
@@ -3440,6 +3509,12 @@
           "Microsoft.NETCore.Targets": "1.1.3",
           "runtime.unix.System.Private.Uri": "4.3.0"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     },
     "net10.0/win-arm64": {
@@ -4343,6 +4418,12 @@
           "Microsoft.NETCore.Platforms": "1.1.1",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     },
     "net10.0/win-x64": {
@@ -5246,6 +5327,12 @@
           "Microsoft.NETCore.Platforms": "1.1.1",
           "Microsoft.NETCore.Targets": "1.1.3"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       }
     }
   }

--- a/TestPlugin/packages.lock.json
+++ b/TestPlugin/packages.lock.json
@@ -299,6 +299,49 @@
           "System.Xml.XDocument": "4.3.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NuGet.Common": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "uyXLqkbbZmkMvdHOR23l1EHW2hRmULtzoG3Ocj84VpGptnNfkODVboHGJfDfcn9Gi9oUNDs8/VjL4FZcST6zVg==",
+        "dependencies": {
+          "NuGet.Frameworks": "7.6.0"
+        }
+      },
+      "NuGet.Configuration": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "+bNj+YneC5CNg1vR+WZjLAakscJlsi0KhADZUgIJPn4pwh8/jeCUMC5ik5cpET/i+QOplDy7aJVTGkpdfrlPww==",
+        "dependencies": {
+          "NuGet.Common": "7.6.0",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "rJ7QtKN45XzLXCrMATve6eFLiUyUGEkA1rFSb6U6Fw6laM4hEAcKOrcdbgWlcFUlCK2158qP1LF00hg/ivF3nw=="
+      },
+      "NuGet.Packaging": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TDp+qHzRBy1zjwiJGCbfpdO0jMG5hH/bk7p1EABLKv9p5SIykDPGnbuYXm2iZO0QJ/H+hOI/vo5LfqM17Q+G0w==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "NuGet.Configuration": "7.6.0",
+          "NuGet.Versioning": "7.6.0",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "NuGet.Versioning": {
+        "type": "Transitive",
+        "resolved": "7.6.0",
+        "contentHash": "TpZxfOoQBQk/0r/2uc1A1qNYIKHkJGgOrWP+ax3nsNAUN/1BOQMDrgmGADogSA4hOXH1ZJiyeYg4Ca+vUW0sEg=="
+      },
       "Onigwrap": {
         "type": "Transitive",
         "resolved": "1.0.10",
@@ -1071,6 +1114,11 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1337,6 +1385,7 @@
           "Microsoft.DiaSymReader.Converter.Xml": "[1.1.0-beta2-22171-02, )",
           "Microsoft.DiaSymReader.Native": "[17.0.0-beta1.21524.1, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.9, )",
+          "NuGet.Protocol": "[7.6.0, )",
           "ProDataGrid": "[12.0.0, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.11, )",
           "System.Composition.AttributedModel": "[10.0.9, )",
@@ -1497,6 +1546,15 @@
         "resolved": "0.11.6",
         "contentHash": "f33RkDtZO8VlGXCtmQIviOtxgnUdym9xx/b1p9h91CRGOsJFxCFOFK1FDbVt1OCf1aWwYejUFa2MOQyFWTFjbA=="
       },
+      "NuGet.Protocol": {
+        "type": "CentralTransitive",
+        "requested": "[7.6.0, )",
+        "resolved": "7.6.0",
+        "contentHash": "Ccb9dJG9hW0FdHFjXoHmhJBBJRYSCeSJArLdZjyZj6/FEAIKezLn75KFQNrTPE5UiAp4HVrjBizufZ/0IXhfKQ==",
+        "dependencies": {
+          "NuGet.Packaging": "7.6.0"
+        }
+      },
       "ProDataGrid": {
         "type": "CentralTransitive",
         "requested": "[12.0.0, )",
@@ -1607,6 +1665,12 @@
         "requested": "[6.1.2, )",
         "resolved": "6.1.2",
         "contentHash": "2hBr6zdbIBTDE3EhK7NSVNdX58uTK6iHW/P/Axmm9sl1xoGSLqDvMtpecn226TNwHByFokYwJmt/aQQNlO5CRw=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "aud6Ox9eSPayMBNu6qL+Zk7yDB6ShrRxg1aMJ1uPqFTGAFVisrjFeKj6RE9SimjNKcbl+chwmiYIK4b3hvc61A=="
       },
       "System.Text.RegularExpressions": {
         "type": "CentralTransitive",


### PR DESCRIPTION

<img width="1002" height="682" alt="image" src="https://github.com/user-attachments/assets/ace624a4-ccf2-4f2c-8aad-60327e1c484d" />


Implements the feature requested in #2313: a new **File > Open from NuGet feed...** command (between "Open from GAC" and "Reload") that opens a package-chooser dialog.

## What it does
- Searches any public NuGet V3 feed: debounced search-as-you-type (Enter = immediate), pre-release toggle, paged results with a "Load more" button
- Editable **Package source** ComboBox; feeds that answered a search are persisted as an MRU (capped, nuget.org always present) together with the selected feed and the pre-release flag
- Detail pane with description, authors, license/project links, published date, downloads, tags, and a version dropdown (latest 100, newest preselected) with an **Open** button
- Open downloads into the **NuGet global packages folder** (honoring NuGet.Config / NUGET_PACKAGES, reusing already-cached packages) with a progress bar and a cancellable download, then opens the cached .nupkg exactly like the regular Open command
- Feed and download failures surface in an in-dialog status bar instead of crashing

## Design notes
- MVVM: all behavior lives in `OpenFromNuGetFeedDialogViewModel` behind a small `INuGetFeedClient` abstraction; the production `NuGetFeedClient` wraps NuGet.Protocol (already in Directory.Packages.props, newly referenced by ILSpy.csproj - lock files regenerated via updatedeps.ps1)
- 32 new headless tests (settings round-trip, search/debounce/paging/error behavior, version + download flows incl. cancellation, dialog structure, menu placement) run against a scriptable fake client - no network in tests
- The dialog-structure test doubles as a canary that the Simple theme templates `PART_EditableTextBox` for editable ComboBoxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)