### PR TITLE
Re-decompile frozen tabs on language and display-setting changes

### DIFF
--- a/ILSpy.Tests/Docking/FrozenTabRefreshTests.cs
+++ b/ILSpy.Tests/Docking/FrozenTabRefreshTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia.Headless.NUnit;
+
+using AwesomeAssertions;
+
+using ILSpy;
+using ILSpy.AppEnv;
+using ILSpy.Docking;
+using ILSpy.Languages;
+using ILSpy.TextView;
+using ILSpy.TreeNodes;
+using ILSpy.ViewModels;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests;
+
+/// <summary>
+/// Frozen tabs keep their own <see cref="DecompilerTabPageModel"/> with cached output.
+/// Output-affecting global changes — the language/version combos and the
+/// Redecompile-class display settings — must re-decompile EVERY decompiler tab, not just
+/// the active preview tab, or frozen tabs silently keep showing stale output.
+/// </summary>
+[TestFixture]
+public class FrozenTabRefreshTests
+{
+	/// <summary>
+	/// Boots the app, decompiles Enumerable.Select into the preview tab, freezes it, then
+	/// routes Enumerable.Where into a fresh preview tab. Returns both tab models settled.
+	/// </summary>
+	static async Task<(DecompilerTabPageModel Frozen, DecompilerTabPageModel Preview, MainWindowViewModel Vm)> BootWithFrozenAndPreviewTabsAsync()
+	{
+		var (_, vm) = await TestHarness.BootAsync(3);
+
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		typeNode.IsExpanded = true;
+		var selectNode = typeNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Select" && m.MethodDefinition.Parameters.Count == 2);
+		var whereNode = typeNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Where" && m.MethodDefinition.Parameters.Count == 2);
+
+		vm.AssemblyTreeModel.SelectNode(selectNode);
+		vm.DockWorkspace.SettleSelection();
+		var frozen = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		vm.DockWorkspace.FreezeCurrentTab();
+
+		vm.AssemblyTreeModel.SelectNode(whereNode);
+		vm.DockWorkspace.SettleSelection();
+		var preview = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		preview.Should().NotBeSameAs(frozen,
+			"setup precondition — selecting after freeze must route to a fresh preview tab");
+		return (frozen, preview, vm);
+	}
+
+	[AvaloniaTest]
+	public async Task Switching_The_Language_Redecompiles_Frozen_Tabs_Too()
+	{
+		var (frozen, preview, _) = await BootWithFrozenAndPreviewTabsAsync();
+		var frozenCSharp = frozen.Text;
+		var previewCSharp = preview.Text;
+
+		var languageService = AppComposition.Current.GetExport<LanguageService>();
+		languageService.CurrentLanguage = languageService.GetLanguage("IL");
+
+		await Waiters.WaitForAsync(
+			() => !frozen.IsDecompiling && !preview.IsDecompiling
+				&& frozen.Text != frozenCSharp && preview.Text != previewCSharp,
+			TimeSpan.FromSeconds(15),
+			"both the frozen tab and the preview tab to re-decompile after the language change");
+
+		frozen.Language.Name.Should().Be("IL",
+			"the frozen tab must adopt the newly selected language");
+		frozen.Text.Should().Contain(".method",
+			"the frozen tab must show IL output after the switch");
+		preview.Text.Should().Contain(".method",
+			"the preview tab must show IL output after the switch");
+	}
+
+	[AvaloniaTest]
+	public async Task Toggling_A_Redecompile_Display_Setting_Refreshes_Frozen_Tabs_Too()
+	{
+		var (frozen, preview, _) = await BootWithFrozenAndPreviewTabsAsync();
+		var frozenBefore = frozen.Text;
+		var previewBefore = preview.Text;
+
+		// IndentationUseTabs is in the Redecompile reaction class (DisplaySettingReactions)
+		// and changes every indented line, so the refresh is observable on any output.
+		var display = AppComposition.Current.GetExport<SettingsService>().DisplaySettings;
+		display.IndentationUseTabs = !display.IndentationUseTabs;
+
+		await Waiters.WaitForAsync(
+			() => !frozen.IsDecompiling && !preview.IsDecompiling
+				&& frozen.Text != frozenBefore && preview.Text != previewBefore,
+			TimeSpan.FromSeconds(15),
+			"both the frozen tab and the preview tab to re-decompile after the display-setting change");
+
+		frozen.Text.Should().NotBe(frozenBefore,
+			"the frozen tab must re-render with the new indentation setting");
+	}
+}

--- a/ILSpy/Docking/DockWorkspace.cs
+++ b/ILSpy/Docking/DockWorkspace.cs
@@ -440,15 +440,26 @@ namespace ILSpy.Docking
 		/// </summary>
 		internal Task CancelPendingOperationsAsync()
 		{
-			if (Layout is not IDockable root)
-				return Task.CompletedTask;
-			var pending = FlattenDocumentDocks(root)
-				.SelectMany(dock => dock.VisibleDockables?.OfType<ContentTabPage>() ?? Enumerable.Empty<ContentTabPage>())
-				.Select(tab => tab.Content)
-				.OfType<TextView.DecompilerTabPageModel>()
+			var pending = AllDecompilerTabs()
 				.Select(tab => tab.CancelPendingAsync())
 				.ToArray();
 			return pending.Length == 0 ? Task.CompletedTask : Task.WhenAll(pending);
+		}
+
+		/// <summary>
+		/// Every decompiler tab model across all document docks, including docks in floating
+		/// windows: the preview tab, frozen tabs, and static-content pages alike. Callers
+		/// that must skip static content (e.g. output refreshes) filter on
+		/// <see cref="TextView.DecompilerTabPageModel.IsStaticContent"/> themselves.
+		/// </summary>
+		IEnumerable<TextView.DecompilerTabPageModel> AllDecompilerTabs()
+		{
+			if (Layout is not IDockable root)
+				return [];
+			return FlattenDocumentDocks(root)
+				.SelectMany(dock => dock.VisibleDockables?.OfType<ContentTabPage>() ?? Enumerable.Empty<ContentTabPage>())
+				.Select(tab => tab.Content)
+				.OfType<TextView.DecompilerTabPageModel>();
 		}
 
 		// Set true while syncing the tree's selection FROM the active tab so the
@@ -632,15 +643,16 @@ namespace ILSpy.Docking
 		{
 			if (e.PropertyName is nameof(LanguageService.CurrentLanguage) or nameof(LanguageService.CurrentVersion))
 			{
-				if (ActiveDecompilerTab is { } tab)
+				// Every decompiler tab caches its own output, so every one re-decompiles —
+				// frozen tabs included, not just the active preview tab. The language
+				// version is read per-run inside TryGetLiveDecompilerSettings, so assigning
+				// the language and re-running covers both combo boxes.
+				foreach (var tab in AllDecompilerTabs())
 				{
+					if (tab.IsStaticContent)
+						continue;
 					tab.Language = languageService.CurrentLanguage;
-					// Re-decompile by re-assigning the same node so the tab refreshes for the new
-					// language or language version (the version is read inside
-					// TryGetLiveDecompilerSettings, which builds the per-run DecompilerSettings).
-					var node = tab.CurrentNode;
-					tab.CurrentNode = null;
-					tab.CurrentNode = node;
+					tab.Redecompile();
 				}
 			}
 		}
@@ -720,14 +732,21 @@ namespace ILSpy.Docking
 		}
 
 		/// <summary>
-		/// Re-decompile the decompiler tab's content in place so an output-affecting display setting
-		/// takes effect, WITHOUT activating or navigating to it. Unlike <see cref="ForceRefreshActiveTab"/>
-		/// (which re-projects the tree selection via <c>ShowSelectedNode</c> and so activates the preview
-		/// tab), changing an option must not steal the user's current tab. Refreshes the cached
-		/// decompiler content directly, so it is up to date even when another tab is showing.
+		/// Re-decompiles every decompiler tab's content in place so an output-affecting display
+		/// setting takes effect, WITHOUT activating or navigating to any of them. Unlike
+		/// <see cref="ForceRefreshActiveTab"/> (which re-projects the tree selection via
+		/// <c>ShowSelectedNode</c> and so activates the preview tab), changing an option must not
+		/// steal the user's current tab. Covers frozen tabs and floated tabs, whose models each
+		/// cache their own output.
 		/// </summary>
 		public void RefreshDecompilerOutputInPlace()
-			=> decompilerContent?.Redecompile();
+		{
+			foreach (var tab in AllDecompilerTabs())
+			{
+				if (!tab.IsStaticContent)
+					tab.Redecompile();
+			}
+		}
 
 		void ShowSelectedNode()
 		{


### PR DESCRIPTION
Frozen tabs each cache their own decompiled output, but two refresh paths only reached the preview tab, so frozen (and floated) tabs kept showing stale output until manually re-selected:

- `DockWorkspace.OnLanguagePropertyChanged` only refreshed `ActiveDecompilerTab`, which is hard-wired to the preview `MainTab`. The handler predates the tab-freeze feature, which introduced multiple sibling decompiler tabs without widening it.
- `RefreshDecompilerOutputInPlace` (output-affecting display settings) only re-decompiled the preview tab's cached content model — which is even nulled on freeze.

Both paths now iterate **every decompiler tab across all document docks, including floating windows** — reusing the dock walk `CancelPendingOperationsAsync` already had, extracted as `AllDecompilerTabs()`. The language handler also switches from the `CurrentNode` null/re-assignment hack to the `Redecompile()` API that exists for exactly this case.

New headless regression tests (`FrozenTabRefreshTests`) boot the app, freeze a tab, open a second preview tab, then flip the language combo / toggle a Redecompile-class display setting and assert **both** tabs re-render. Both tests were red before the fix (timed out waiting for the frozen tab) and green after. Full suite: 794 passed, 0 failed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)