### PR TITLE
Round-trip the legacy WPF SessionSettings shape

### DIFF
--- a/ILSpy.Tests/SessionSettingsTests.cs
+++ b/ILSpy.Tests/SessionSettingsTests.cs
@@ -16,6 +16,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Xml.Linq;
+
 using Avalonia;
 using Avalonia.Controls;
 
@@ -68,5 +70,133 @@ public class SessionSettingsTests
 		loaded.LoadFromXml(xml);
 
 		loaded.ActiveTreeViewPath.Should().Equal("My.Assembly.dll", "MyNamespace.MyType", "M:MyMethod");
+	}
+
+	// Legacy SessionSettings XML emitted by the WPF host (ILSpy 10.x) must still load.
+	// WindowBounds was a CSV element value (Rect TypeConverter format "L,T,W,H"); the new
+	// attribute form is forward-only. ActiveTreeViewPath node values were \xNNNN-hex-escaped
+	// so non-alphanumeric chars survive XML round-trips, and the restored path must compare
+	// equal to the live tree-node ToString()s — escaped strings will never match.
+	[Test]
+	public void Load_accepts_legacy_WindowBounds_csv_body()
+	{
+		var section = XElement.Parse(@"<SessionSettings>
+			<WindowState>Normal</WindowState>
+			<WindowBounds>882.6666666666666,342,750,550</WindowBounds>
+		</SessionSettings>");
+
+		var loaded = new SessionSettings();
+		loaded.LoadFromXml(section);
+
+		loaded.WindowPosition.Should().Be(new PixelPoint(882, 342));
+		loaded.WindowSize.Should().Be(new Size(750, 550));
+	}
+
+	[Test]
+	public void Load_unescapes_legacy_ActiveTreeViewPath_node_values()
+	{
+		// \x002E -> '.', \x003A -> ':', \x005C -> '\' (the escape the WPF SessionSettings.Escape
+		// helper applied to every non-letter-or-digit char).
+		var section = XElement.Parse(@"<SessionSettings>
+			<ActiveTreeViewPath>
+				<Node>D\x003A\x005CProjects\x005CILSpy\x005CILSpy\x002Edll</Node>
+				<Node>TomsToolbox\x002EWpf</Node>
+				<Node>TomsToolbox\x002EWpf\x002EDelegateCommand</Node>
+			</ActiveTreeViewPath>
+		</SessionSettings>");
+
+		var loaded = new SessionSettings();
+		loaded.LoadFromXml(section);
+
+		loaded.ActiveTreeViewPath.Should().Equal(
+			@"D:\Projects\ILSpy\ILSpy.dll",
+			"TomsToolbox.Wpf",
+			"TomsToolbox.Wpf.DelegateCommand");
+	}
+
+	[Test]
+	public void Load_accepts_full_legacy_SessionSettings_section()
+	{
+		// Top-level structure the WPF host wrote to ILSpy.xml. DockLayout is intentionally
+		// not asserted — the AvalonDock schema doesn't translate to the Avalonia Dock host
+		// and is rebuilt from the new layout descriptors.
+		var section = XElement.Parse(@"<SessionSettings>
+			<FilterSettings>
+				<ShowAPILevel>1</ShowAPILevel>
+				<Language></Language>
+				<LanguageVersion></LanguageVersion>
+			</FilterSettings>
+			<ActiveAssemblyList>.NET 4 (WPF)</ActiveAssemblyList>
+			<ActiveTreeViewPath>
+				<Node>D\x003A\x005CProjects\x005CILSpy\x005CILSpy\x002Edll</Node>
+				<Node>TomsToolbox\x002EWpf</Node>
+			</ActiveTreeViewPath>
+			<WindowState>Normal</WindowState>
+			<WindowBounds>882.6666666666666,342,750,550</WindowBounds>
+			<SelectedSearchMode>TypeAndMember</SelectedSearchMode>
+			<Theme>Light</Theme>
+		</SessionSettings>");
+
+		var loaded = new SessionSettings();
+		loaded.LoadFromXml(section);
+
+		loaded.ActiveAssemblyList.Should().Be(".NET 4 (WPF)");
+		loaded.WindowState.Should().Be(WindowState.Normal);
+		loaded.WindowPosition.Should().Be(new PixelPoint(882, 342));
+		loaded.WindowSize.Should().Be(new Size(750, 550));
+		loaded.Theme.Should().Be("Light");
+		loaded.ActiveTreeViewPath.Should().Equal(
+			@"D:\Projects\ILSpy\ILSpy.dll",
+			"TomsToolbox.Wpf");
+		loaded.LanguageSettings.Should().NotBeNull();
+		loaded.LanguageSettings.ShowApiLevel.Should().Be(ICSharpCode.ILSpyX.ApiVisibility.PublicAndInternal);
+	}
+
+	// Forward-compat with retired or future SessionSettings children: unknown elements at
+	// load time must be silently ignored, and SaveToXml must not echo them back. The dock
+	// layout below is the AvalonDock schema (WPF host); it's incompatible with the Avalonia
+	// Dock host and would persist forever as dead state if we round-tripped it.
+	[Test]
+	public void Load_silently_ignores_unknown_children()
+	{
+		var section = XElement.Parse(@"<SessionSettings>
+			<ActiveAssemblyList>my-list</ActiveAssemblyList>
+			<DockLayout>
+				<LayoutRoot>
+					<RootPanel Orientation=""Horizontal"">
+						<LayoutAnchorablePaneGroup Orientation=""Horizontal"" DockWidth=""300"" />
+					</RootPanel>
+				</LayoutRoot>
+			</DockLayout>
+			<SelectedSearchMode>TypeAndMember</SelectedSearchMode>
+			<ActiveAutoLoadedAssembly>foo.dll</ActiveAutoLoadedAssembly>
+			<FutureFeatureFlag value=""xyz"">
+				<Nested>123</Nested>
+			</FutureFeatureFlag>
+		</SessionSettings>");
+
+		var loaded = new SessionSettings();
+		var act = () => loaded.LoadFromXml(section);
+
+		act.Should().NotThrow();
+		loaded.ActiveAssemblyList.Should().Be("my-list");
+	}
+
+	[Test]
+	public void Save_does_not_emit_unknown_children_seen_at_load()
+	{
+		var loaded = new SessionSettings();
+		loaded.LoadFromXml(XElement.Parse(@"<SessionSettings>
+			<ActiveAssemblyList>my-list</ActiveAssemblyList>
+			<DockLayout><LayoutRoot /></DockLayout>
+			<SelectedSearchMode>TypeAndMember</SelectedSearchMode>
+			<FutureFeatureFlag value=""xyz"" />
+		</SessionSettings>"));
+
+		var saved = loaded.SaveToXml();
+
+		saved.Element("DockLayout").Should().BeNull();
+		saved.Element("SelectedSearchMode").Should().BeNull();
+		saved.Element("FutureFeatureFlag").Should().BeNull();
 	}
 }

--- a/ILSpy.Tests/SessionSettingsTests.cs
+++ b/ILSpy.Tests/SessionSettingsTests.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Linq;
 using System.Xml.Linq;
 
 using Avalonia;
@@ -183,20 +184,82 @@ public class SessionSettingsTests
 	}
 
 	[Test]
-	public void Save_does_not_emit_unknown_children_seen_at_load()
+	public void Save_preserves_unknown_children_seen_at_load()
 	{
+		// Verbatim round-trip of children outside the known set: the AvalonDock layout
+		// blob stays on disk (incompatible with the Avalonia Dock host, but writing zeros
+		// over it would discard the WPF user's saved layout forever), and a future field
+		// added in a newer build survives an older build's load+save cycle.
+		var dockLayout = "<DockLayout><LayoutRoot><RootPanel Orientation=\"Horizontal\" /></LayoutRoot></DockLayout>";
+		var future = "<FutureFeatureFlag value=\"xyz\"><Nested>123</Nested></FutureFeatureFlag>";
 		var loaded = new SessionSettings();
-		loaded.LoadFromXml(XElement.Parse(@"<SessionSettings>
+		loaded.LoadFromXml(XElement.Parse($@"<SessionSettings>
 			<ActiveAssemblyList>my-list</ActiveAssemblyList>
-			<DockLayout><LayoutRoot /></DockLayout>
-			<SelectedSearchMode>TypeAndMember</SelectedSearchMode>
-			<FutureFeatureFlag value=""xyz"" />
+			{dockLayout}
+			{future}
 		</SessionSettings>"));
 
 		var saved = loaded.SaveToXml();
 
-		saved.Element("DockLayout").Should().BeNull();
-		saved.Element("SelectedSearchMode").Should().BeNull();
-		saved.Element("FutureFeatureFlag").Should().BeNull();
+		saved.Element("DockLayout").Should().NotBeNull();
+		saved.Element("DockLayout")!.ToString(SaveOptions.DisableFormatting).Should().Be(dockLayout);
+		saved.Element("FutureFeatureFlag").Should().NotBeNull();
+		saved.Element("FutureFeatureFlag")!.ToString(SaveOptions.DisableFormatting).Should().Be(future);
+	}
+
+	[Test]
+	public void Save_emits_legacy_WindowBounds_csv_body_and_escaped_nodes()
+	{
+		// The Avalonia build writes the file in the legacy shape so a) the diff against
+		// a pre-existing ILSpy.xml stays small, and b) an older WPF ILSpy install can
+		// still read the file (the Rect TypeConverter only understands the CSV form, and
+		// its tree-node Unescape only understands \xNNNN-escaped values).
+		var session = new SessionSettings {
+			WindowPosition = new PixelPoint(882, 342),
+			WindowSize = new Size(750, 550),
+			ActiveTreeViewPath = ["TomsToolbox.Wpf", "DelegateCommand"],
+		};
+
+		var saved = session.SaveToXml();
+
+		var bounds = saved.Element("WindowBounds");
+		bounds.Should().NotBeNull();
+		bounds!.HasAttributes.Should().BeFalse();
+		bounds.Value.Should().Be("882,342,750,550");
+		saved.Element("ActiveTreeViewPath")!.Elements("Node").Select(n => n.Value).Should().Equal(
+			"TomsToolbox\\x002EWpf",
+			"DelegateCommand");
+	}
+
+	[Test]
+	public void Save_then_Load_round_trips_SelectedSearchMode_and_ActiveAutoLoadedAssembly()
+	{
+		var original = new SessionSettings {
+			SelectedSearchMode = "Type",
+			ActiveAutoLoadedAssembly = @"C:\deps\foo.dll",
+		};
+
+		var xml = original.SaveToXml();
+
+		var loaded = new SessionSettings();
+		loaded.LoadFromXml(xml);
+
+		loaded.SelectedSearchMode.Should().Be("Type");
+		loaded.ActiveAutoLoadedAssembly.Should().Be(@"C:\deps\foo.dll");
+	}
+
+	[Test]
+	public void Load_picks_up_legacy_SelectedSearchMode_and_ActiveAutoLoadedAssembly()
+	{
+		var section = XElement.Parse(@"<SessionSettings>
+			<SelectedSearchMode>TypeAndMember</SelectedSearchMode>
+			<ActiveAutoLoadedAssembly>C:\deps\foo.dll</ActiveAutoLoadedAssembly>
+		</SessionSettings>");
+
+		var loaded = new SessionSettings();
+		loaded.LoadFromXml(section);
+
+		loaded.SelectedSearchMode.Should().Be("TypeAndMember");
+		loaded.ActiveAutoLoadedAssembly.Should().Be(@"C:\deps\foo.dll");
 	}
 }

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -226,6 +226,10 @@ namespace ILSpy.AssemblyTree
 			// notified, and the saved path must follow the new primary.
 			OnPropertyChanged(nameof(SelectedItem));
 			settingsService.SessionSettings.ActiveTreeViewPath = GetPathForNode(SelectedItem);
+			// Auto-loaded (dependency-resolved) assemblies are not part of the saved list, so
+			// on next launch the tree-path walk would stop at the assembly-list node. Storing
+			// the file lets the restore re-add it before walking the path.
+			settingsService.SessionSettings.ActiveAutoLoadedAssembly = GetAutoLoadedAssemblyPath(SelectedItem);
 
 			// Pub-sub fan-out: panes (e.g. Debug Steps) that need to invalidate their state
 			// when the selection moves listen on this message.
@@ -382,6 +386,14 @@ namespace ILSpy.AssemblyTree
 			if (App.CommandLineArguments?.NavigateTo is { Length: > 0 })
 				return;
 			var savedPath = settingsService.SessionSettings.ActiveTreeViewPath;
+			// Re-open the previously auto-loaded dependency assembly before walking the saved
+			// path -- otherwise the walk stops at the assembly-list root and the selection
+			// silently doesn't restore. File.Exists guards against the user having moved or
+			// deleted the file between sessions; a missing dependency just degrades to "tree
+			// path doesn't resolve" instead of crashing startup.
+			var autoLoaded = settingsService.SessionSettings.ActiveAutoLoadedAssembly;
+			if (!string.IsNullOrEmpty(autoLoaded) && System.IO.File.Exists(autoLoaded))
+				AssemblyList?.OpenAssembly(autoLoaded, isAutoLoaded: true);
 			_ = RestoreSelectedPathAsync(savedPath, isInitial);
 		}
 
@@ -558,6 +570,23 @@ namespace ILSpy.AssemblyTree
 		/// </summary>
 		public static string[]? GetPathForNode(SharpTreeNode? node)
 			=> TreeNodeLocator.GetPathForNode(node);
+
+		/// <summary>
+		/// File path of the auto-loaded assembly under <paramref name="node"/>'s ancestor
+		/// chain, or null when the selection lives in an explicitly-listed assembly. Mirrors
+		/// the WPF host's <c>GetAutoLoadedAssemblyNode</c> contract.
+		/// </summary>
+		static string? GetAutoLoadedAssemblyPath(SharpTreeNode? node)
+		{
+			while (node != null && node is not TreeNodes.AssemblyTreeNode)
+				node = node.Parent;
+			if (node is not TreeNodes.AssemblyTreeNode asmNode)
+				return null;
+			var loaded = asmNode.LoadedAssembly;
+			if (!loaded.IsLoaded || !loaded.IsAutoLoaded)
+				return null;
+			return loaded.FileName;
+		}
 
 		internal AssemblyTreeNode? FindAssemblyNode(LoadedAssembly asm)
 			=> assemblyListTreeNode?.FindAssemblyNode(asm);

--- a/ILSpy/Search/SearchPaneModel.cs
+++ b/ILSpy/Search/SearchPaneModel.cs
@@ -61,7 +61,7 @@ namespace ILSpy.Search
 		{
 			Id = PaneContentId;
 			Title = "Search";
-			SelectedSearchMode = SearchModes[0];
+			SelectedSearchMode = ResolvePersistedMode() ?? SearchModes[0];
 			PropertyChanged += OnPropertyChangedDispatch;
 			// Refresh search results when the active assembly list mutates. Skip the
 			// restart when ONLY auto-loaded (dependency) assemblies are added — those
@@ -87,6 +87,29 @@ namespace ILSpy.Search
 		{
 			if (e.PropertyName is nameof(SearchTerm) or nameof(SelectedSearchMode))
 				RestartSearch();
+			if (e.PropertyName == nameof(SelectedSearchMode))
+				PersistSelectedMode();
+		}
+
+		SearchModeEntry? ResolvePersistedMode()
+		{
+			// Lookup is best-effort: during the very first composition pass SettingsService may
+			// not have materialised yet; the default entry from SearchModes[0] is fine in that
+			// case and gets overwritten the first time the user picks a mode.
+			var saved = AppComposition.TryGetExport<SettingsService>()?.SessionSettings?.SelectedSearchMode;
+			if (string.IsNullOrEmpty(saved))
+				return null;
+			if (!Enum.TryParse(saved, ignoreCase: false, out SearchMode mode))
+				return null;
+			return SearchModes.FirstOrDefault(m => m.Mode == mode);
+		}
+
+		void PersistSelectedMode()
+		{
+			var sessionSettings = AppComposition.TryGetExport<SettingsService>()?.SessionSettings;
+			if (sessionSettings == null)
+				return;
+			sessionSettings.SelectedSearchMode = SelectedSearchMode?.Mode.ToString();
 		}
 
 		/// <summary>

--- a/ILSpy/SessionSettings.cs
+++ b/ILSpy/SessionSettings.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 using Avalonia;
@@ -102,7 +103,7 @@ namespace ILSpy
 
 			ActiveAssemblyList = (string?)section.Element("ActiveAssemblyList");
 			ActiveLanguageName = (string?)section.Element("ActiveLanguageName");
-			ActiveTreeViewPath = section.Element("ActiveTreeViewPath")?.Elements().Select(e => (string)e).ToArray();
+			ActiveTreeViewPath = section.Element("ActiveTreeViewPath")?.Elements().Select(e => UnescapeNode((string)e)).ToArray();
 			WindowState = ParseEnum(section.Element("WindowState")?.Value, WindowState.Normal);
 			Theme = (string?)section.Element(nameof(Theme));
 			var culture = (string?)section.Element(nameof(CurrentCulture));
@@ -113,12 +114,31 @@ namespace ILSpy
 			var bounds = section.Element("WindowBounds");
 			if (bounds != null)
 			{
-				int left = ParseInt(bounds.Attribute("Left")?.Value, DefaultWindowPosition.X);
-				int top = ParseInt(bounds.Attribute("Top")?.Value, DefaultWindowPosition.Y);
-				double width = ParseDouble(bounds.Attribute("Width")?.Value, DefaultWindowSize.Width);
-				double height = ParseDouble(bounds.Attribute("Height")?.Value, DefaultWindowSize.Height);
-				WindowPosition = new PixelPoint(left, top);
-				WindowSize = new Size(width, height);
+				// Legacy WPF host wrote bounds as a CSV body "Left,Top,Width,Height" (Rect
+				// TypeConverter format). Honour that shape for users upgrading from ILSpy 10.x
+				// so a saved window position survives the move to the Avalonia attribute form.
+				if (bounds.HasAttributes)
+				{
+					int left = ParseInt(bounds.Attribute("Left")?.Value, DefaultWindowPosition.X);
+					int top = ParseInt(bounds.Attribute("Top")?.Value, DefaultWindowPosition.Y);
+					double width = ParseDouble(bounds.Attribute("Width")?.Value, DefaultWindowSize.Width);
+					double height = ParseDouble(bounds.Attribute("Height")?.Value, DefaultWindowSize.Height);
+					WindowPosition = new PixelPoint(left, top);
+					WindowSize = new Size(width, height);
+				}
+				else
+				{
+					var parts = bounds.Value.Split(',');
+					if (parts.Length == 4)
+					{
+						double left = ParseDouble(parts[0], DefaultWindowPosition.X);
+						double top = ParseDouble(parts[1], DefaultWindowPosition.Y);
+						double width = ParseDouble(parts[2], DefaultWindowSize.Width);
+						double height = ParseDouble(parts[3], DefaultWindowSize.Height);
+						WindowPosition = new PixelPoint((int)left, (int)top);
+						WindowSize = new Size(width, height);
+					}
+				}
 			}
 
 			FilterStates.Clear();
@@ -189,5 +209,18 @@ namespace ILSpy
 
 		static double ParseDouble(string? value, double defaultValue)
 			=> double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result) ? result : defaultValue;
+
+		// Legacy WPF host hex-escaped every non-letter-or-digit char in tree-view path nodes
+		// (TomsToolbox.Wpf -> TomsToolbox\x002EWpf). The Avalonia host writes node values raw,
+		// but old ILSpy.xml files still hold the escaped form — decode so a restored path
+		// compares equal to the live tree-node ToString()s.
+		static readonly Regex EscapedCharPattern = new(@"\\x(?<num>[0-9A-Fa-f]{4})", RegexOptions.Compiled);
+
+		static string UnescapeNode(string value)
+		{
+			if (string.IsNullOrEmpty(value) || value.IndexOf(@"\x", StringComparison.Ordinal) < 0)
+				return value;
+			return EscapedCharPattern.Replace(value, m => ((char)int.Parse(m.Groups["num"].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture)).ToString());
+		}
 	}
 }

--- a/ILSpy/SessionSettings.cs
+++ b/ILSpy/SessionSettings.cs
@@ -79,6 +79,24 @@ namespace ILSpy
 		/// </summary>
 		public string[]? ActiveTreeViewPath { get; set; }
 
+		/// <summary>
+		/// File path of the auto-loaded (dependency-resolved) assembly the user last
+		/// selected into. The Avalonia host re-opens this file on startup before the
+		/// <see cref="ActiveTreeViewPath"/> walk so the saved path can still resolve;
+		/// otherwise the selection sits inside an assembly that isn't part of any
+		/// persisted list and the restore silently fails.
+		/// </summary>
+		[ObservableProperty]
+		private string? activeAutoLoadedAssembly;
+
+		/// <summary>
+		/// Last-used entry in the search pane's mode picker, persisted as the
+		/// <see cref="ICSharpCode.ILSpyX.Search.SearchMode"/> name. <see cref="Search.SearchPaneModel"/>
+		/// reads it on construction and writes back on every change.
+		/// </summary>
+		[ObservableProperty]
+		private string? selectedSearchMode;
+
 		public WindowState WindowState { get; set; } = WindowState.Normal;
 
 		public PixelPoint WindowPosition { get; set; } = DefaultWindowPosition;
@@ -95,6 +113,28 @@ namespace ILSpy
 		public Dictionary<(string PageKey, string ColumnName), XElement> FilterStates { get; }
 			= new();
 
+		// Set of child element names LoadFromXml interprets. Children outside this set
+		// (legacy AvalonDock layout, a future ILSpy version's new field, …) are stashed
+		// in <see cref="unknownChildren"/> and re-emitted unchanged by SaveToXml so we
+		// don't strip data we don't understand.
+		static readonly HashSet<string> KnownChildren = new(StringComparer.Ordinal) {
+			"FilterSettings",
+			"ActiveAssemblyList",
+			"ActiveLanguageName",
+			"ActiveTreeViewPath",
+			"ActiveAutoLoadedAssembly",
+			"SelectedSearchMode",
+			"WindowState",
+			nameof(Theme),
+			nameof(CurrentCulture),
+			nameof(MultiLineDocumentTabs),
+			nameof(MouseWheelTogglesTabStripRows),
+			"WindowBounds",
+			"FilterStates",
+		};
+
+		List<XElement> unknownChildren = new();
+
 		public void LoadFromXml(XElement section)
 		{
 			XElement filterSettings = section.Element("FilterSettings") ?? new XElement("FilterSettings");
@@ -104,6 +144,8 @@ namespace ILSpy
 			ActiveAssemblyList = (string?)section.Element("ActiveAssemblyList");
 			ActiveLanguageName = (string?)section.Element("ActiveLanguageName");
 			ActiveTreeViewPath = section.Element("ActiveTreeViewPath")?.Elements().Select(e => UnescapeNode((string)e)).ToArray();
+			ActiveAutoLoadedAssembly = (string?)section.Element("ActiveAutoLoadedAssembly");
+			SelectedSearchMode = (string?)section.Element("SelectedSearchMode");
 			WindowState = ParseEnum(section.Element("WindowState")?.Value, WindowState.Normal);
 			Theme = (string?)section.Element(nameof(Theme));
 			var culture = (string?)section.Element(nameof(CurrentCulture));
@@ -156,6 +198,11 @@ namespace ILSpy
 					FilterStates[(pageKey, columnName)] = new XElement(stateXml);
 				}
 			}
+
+			unknownChildren = section.Elements()
+				.Where(e => !KnownChildren.Contains(e.Name.LocalName))
+				.Select(e => new XElement(e))
+				.ToList();
 		}
 
 		public XElement SaveToXml()
@@ -168,13 +215,19 @@ namespace ILSpy
 			if (!string.IsNullOrEmpty(ActiveLanguageName))
 				section.Add(new XElement("ActiveLanguageName", ActiveLanguageName));
 			if (ActiveTreeViewPath is { Length: > 0 } path)
-				section.Add(new XElement("ActiveTreeViewPath", path.Select(p => new XElement("Node", p))));
+				section.Add(new XElement("ActiveTreeViewPath", path.Select(p => new XElement("Node", EscapeNode(p)))));
+			if (!string.IsNullOrEmpty(ActiveAutoLoadedAssembly))
+				section.Add(new XElement("ActiveAutoLoadedAssembly", ActiveAutoLoadedAssembly));
+			if (!string.IsNullOrEmpty(SelectedSearchMode))
+				section.Add(new XElement("SelectedSearchMode", SelectedSearchMode));
 			section.Add(new XElement("WindowState", WindowState.ToString()));
-			section.Add(new XElement("WindowBounds",
-				new XAttribute("Left", WindowPosition.X.ToString(CultureInfo.InvariantCulture)),
-				new XAttribute("Top", WindowPosition.Y.ToString(CultureInfo.InvariantCulture)),
-				new XAttribute("Width", WindowSize.Width.ToString(CultureInfo.InvariantCulture)),
-				new XAttribute("Height", WindowSize.Height.ToString(CultureInfo.InvariantCulture))));
+			// Bounds as a CSV body ("L,T,W,H", the Rect TypeConverter format the WPF host used).
+			// Keeping the legacy shape on write means a file written by this Avalonia build
+			// can still be read by an older ILSpy 10.x install, and the file diff stays small
+			// during the WPF -> Avalonia transition.
+			section.Add(new XElement("WindowBounds", string.Format(
+				CultureInfo.InvariantCulture, "{0},{1},{2},{3}",
+				WindowPosition.X, WindowPosition.Y, WindowSize.Width, WindowSize.Height)));
 			if (!string.IsNullOrEmpty(Theme))
 				section.Add(new XElement(nameof(Theme), Theme));
 			if (!string.IsNullOrEmpty(CurrentCulture))
@@ -198,6 +251,12 @@ namespace ILSpy
 				}
 				section.Add(filterStates);
 			}
+
+			// Re-emit children we didn't interpret so unknown / future / retired-but-still-on-disk
+			// elements (e.g. the AvalonDock <DockLayout> blob) survive a load+save cycle untouched.
+			foreach (var unknown in unknownChildren)
+				section.Add(new XElement(unknown));
+
 			return section;
 		}
 
@@ -211,9 +270,10 @@ namespace ILSpy
 			=> double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result) ? result : defaultValue;
 
 		// Legacy WPF host hex-escaped every non-letter-or-digit char in tree-view path nodes
-		// (TomsToolbox.Wpf -> TomsToolbox\x002EWpf). The Avalonia host writes node values raw,
-		// but old ILSpy.xml files still hold the escaped form — decode so a restored path
-		// compares equal to the live tree-node ToString()s.
+		// (TomsToolbox.Wpf -> TomsToolbox\x002EWpf). Both directions of the conversion stay
+		// here so a file written by this build keeps the legacy on-disk shape — an older
+		// ILSpy 10.x install can still read it, and the diff against a pre-existing
+		// ILSpy.xml stays small.
 		static readonly Regex EscapedCharPattern = new(@"\\x(?<num>[0-9A-Fa-f]{4})", RegexOptions.Compiled);
 
 		static string UnescapeNode(string value)
@@ -221,6 +281,21 @@ namespace ILSpy
 			if (string.IsNullOrEmpty(value) || value.IndexOf(@"\x", StringComparison.Ordinal) < 0)
 				return value;
 			return EscapedCharPattern.Replace(value, m => ((char)int.Parse(m.Groups["num"].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture)).ToString());
+		}
+
+		static string EscapeNode(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+				return value;
+			var sb = new System.Text.StringBuilder(value.Length);
+			foreach (var ch in value)
+			{
+				if (char.IsLetterOrDigit(ch))
+					sb.Append(ch);
+				else
+					sb.AppendFormat(CultureInfo.InvariantCulture, @"\x{0:X4}", (int)ch);
+			}
+			return sb.ToString();
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The Avalonia rewrite changed the on-disk shape of `<SessionSettings>` in `ILSpy.xml`. Users upgrading from ILSpy 10.x silently lose their saved window position, restored tree-view selection, search-mode pick, and auto-loaded dependency on first launch — the new code reads the new shape only, ignores the legacy CSV/escape encodings, and writes a fresh subset that drops anything it doesn't recognise (including the AvalonDock `<DockLayout>` blob).

This branch makes the load+save cycle non-lossy against a real WPF-era `ILSpy.xml`.

* **Two-direction compatibility with the legacy shape.** `WindowBounds` accepts both the new `Left/Top/Width/Height` attribute form and the WPF `<WindowBounds>L,T,W,H</WindowBounds>` CSV body; `<ActiveTreeViewPath><Node>` values are `\xNNNN`-hex-decoded on read and re-encoded on write. With both directions in the file an older ILSpy 10.x install can still read what the Avalonia build writes, and the diff against a pre-existing `ILSpy.xml` stays small during the transition.
* **Unknown children stay untouched.** `LoadFromXml` stashes any child whose name isn't in `KnownChildren` (e.g. the AvalonDock `<DockLayout>` blob, a future field added in a newer build); `SaveToXml` re-emits them verbatim after the known section. We don't try to interpret the WPF dock layout — but writing zeros over it would discard the user's saved layout the first time they launched the Avalonia build.
* **Wire `SelectedSearchMode` and `ActiveAutoLoadedAssembly`.** Both were read into properties that nothing in the Avalonia code wrote to. Now `SearchPaneModel` restores the saved mode on construction and writes back on change via `SettingsService`; `AssemblyTreeModel` walks the selection's ancestor chain to find the owning `AssemblyTreeNode`, stores its `LoadedAssembly.FileName` when `IsAutoLoaded`, and re-opens that file (when it still exists) before `RestoreSelectedPathAsync` so the saved tree path can resolve into the dependency.

The `EnableSmoothScrolling` attribute is intentionally not re-added — that feature was removed in the rewrite (per maintainer note) and now flows through `DisplaySettings`' own attribute-passthrough so it doesn't crash the load.

## Test plan

- [x] Unit tests in `ILSpy.Tests/SessionSettingsTests.cs` cover: legacy CSV `WindowBounds` body, `\xNNNN` `Node` unescape, the full WPF-era section shape, unknown-children load (ignored, no throw), unknown-children save (re-emitted verbatim), legacy WPF encodings on save (CSV + escaped nodes), and round-trip of `SelectedSearchMode` + `ActiveAutoLoadedAssembly`. Full ILSpy.Tests suite still green (817 passing, 3 skipped — same as `master`).
- [x] End-to-end smoke: launched the built app against a sandbox `ILSpy.xml` containing the WPF-era SessionSettings shape from a real 10.x user (with `<WindowBounds>882.6666666666666,342,750,550</WindowBounds>`, `\x002E`-escaped `<Node>` values, `<SelectedSearchMode>TypeAndMember</SelectedSearchMode>`, and the AvalonDock `<DockLayout>` blob); closed via `WM_CLOSE` so `SettingsService.Save` ran; verified the file came back with `<WindowBounds>882,342,750,550</WindowBounds>` (CSV body, no attributes), `TomsToolbox\x002EWpf` still escaped, `<SelectedSearchMode>` retained, and `<DockLayout>` preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)