### PR TITLE
Restore IL-view hover tooltips and fix decompiler-view tooltip/navigation issues

### DIFF
--- a/ICSharpCode.Decompiler/Documentation/XmlDocLoader.cs
+++ b/ICSharpCode.Decompiler/Documentation/XmlDocLoader.cs
@@ -42,8 +42,11 @@ namespace ICSharpCode.Decompiler.Documentation
 				?? FindXmlDocumentation("mscorlib.dll", TargetRuntime.Net_2_0);
 			if (xmlDocFile != null)
 				return new XmlDocumentationProvider(xmlDocFile);
-			else
-				return null;
+			// On modern .NET there is no .NET Framework reference-assembly documentation;
+			// fall back to the ref pack parallel to the runtime hosting us (corlib lives in
+			// dotnet/shared/Microsoft.NETCore.App/<version>/, the docs in the matching
+			// dotnet/packs/Microsoft.NETCore.App.Ref/<version>/ref/<tfm>/ directory).
+			return TryLoadModernRefPackDocumentation(typeof(object).Assembly.Location);
 		}
 
 		public static XmlDocumentationProvider MscorlibDocumentation {

--- a/ILSpy.Tests/Editor/CaretHighlightAdornerTests.cs
+++ b/ILSpy.Tests/Editor/CaretHighlightAdornerTests.cs
@@ -96,8 +96,8 @@ public class CaretHighlightAdornerTests
 		((object?)memberDef).Should().NotBeNull(
 			"the decompiled Enumerable class contains at least one member-definition reference");
 
-		// Same code path a real pointer-press on the member name routes through.
-		generator.OnReferenceClicked(memberDef!);
+		// Same code path a real stationary click on the member name routes through.
+		view.OnReferenceClicked(memberDef!);
 
 		renderers.Should().Contain(r => r is CaretHighlightAdorner,
 			"clicking a member definition must route through DecompilerTextView.OnReferenceClicked "

--- a/ILSpy.Tests/Editor/DocumentationLinkTests.cs
+++ b/ILSpy.Tests/Editor/DocumentationLinkTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using ILSpy.AssemblyTree;
+using ILSpy.TextView;
+using ILSpy.TreeNodes;
+using ILSpy.Util;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// Pins the hyperlink behaviour of documentation tooltips: a resolvable
+/// <c>&lt;see cref="..."/&gt;</c> must render as a clickable link that requests
+/// navigation to the referenced entity (via <see cref="MessageBus{T}"/> with
+/// <see cref="NavigateToReferenceEventArgs"/>, the same channel the analyzer uses) and
+/// must notify the hosting popup through <see cref="DocumentationRenderer.LinkClicked"/>
+/// so it can close.
+/// </summary>
+[TestFixture]
+public class DocumentationLinkTests
+{
+	[AvaloniaTest]
+	public async Task SeeCref_Renders_As_A_Link_That_Navigates_On_Click()
+	{
+		var (_, vm) = await TestHarness.BootAsync();
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var stringType = (IEntity)vm.AssemblyTreeModel
+			.FindNode<TypeTreeNode>(coreLibName, "System", "System.String").Member!;
+
+		var renderer = new DocumentationRenderer(
+			new CSharpAmbience(),
+			new FontFamily("Consolas, Menlo, Monospace"),
+			12);
+		renderer.AddXmlDocumentation(
+			"""<summary>Implemented by <see cref="T:System.String"/> instances.</summary>""",
+			declaringEntity: null,
+			resolver: id => id == "T:System.String" ? stringType : null);
+
+		var window = new Window { Content = renderer.CreateView() };
+		window.Show();
+		AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+		Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+		window.UpdateLayout();
+
+		var link = window.GetVisualDescendants().OfType<TextBlock>()
+			.FirstOrDefault(tb => tb.Classes.Contains("doc-link"));
+		link.Should().NotBeNull("a resolvable cref must render as a clickable link");
+		link!.Cursor.Should().NotBeNull("links show the hand cursor as a click affordance");
+
+		object? navigated = null;
+		var linkClickedRaised = false;
+		renderer.LinkClicked += (_, _) => linkClickedRaised = true;
+		EventHandler<NavigateToReferenceEventArgs> capture = (_, e) => navigated = e.Reference;
+		MessageBus<NavigateToReferenceEventArgs>.Subscribers += capture;
+		try
+		{
+			var centre = link.TranslatePoint(
+				new Point(link.Bounds.Width / 2, link.Bounds.Height / 2), window)!.Value;
+			window.MouseDown(centre, MouseButton.Left);
+			window.MouseUp(centre, MouseButton.Left);
+		}
+		finally
+		{
+			MessageBus<NavigateToReferenceEventArgs>.Subscribers -= capture;
+		}
+
+		navigated.Should().BeSameAs(stringType,
+			"clicking the link must request navigation to the referenced entity");
+		linkClickedRaised.Should().BeTrue(
+			"the hosting popup closes itself when a link is followed");
+	}
+
+	[AvaloniaTest]
+	public void Unresolvable_Cref_Falls_Back_To_Plain_Text()
+	{
+		var renderer = new DocumentationRenderer(
+			new CSharpAmbience(),
+			new FontFamily("Consolas, Menlo, Monospace"),
+			12);
+		renderer.AddXmlDocumentation(
+			"""<summary>See <see cref="T:Does.Not.Exist"/>.</summary>""",
+			declaringEntity: null,
+			resolver: _ => null);
+
+		var window = new Window { Content = renderer.CreateView() };
+		window.Show();
+		window.UpdateLayout();
+
+		window.GetVisualDescendants().OfType<TextBlock>()
+			.Should().NotContain(tb => tb.Classes.Contains("doc-link"),
+				"an unresolvable cref renders as plain text, not a dead link");
+	}
+
+	[AvaloniaTest]
+	public async Task FindEntityInRelevantAssemblies_Resolves_A_Type_IdString()
+	{
+		var (_, vm) = await TestHarness.BootAsync();
+		var list = vm.AssemblyTreeModel.AssemblyList!;
+
+		var entity = AssemblyTreeModel.FindEntityInRelevantAssemblies(
+			"T:System.String", list.GetAssemblies());
+
+		entity.Should().NotBeNull("the doc-comment cref resolver feeds on id strings");
+		entity!.FullName.Should().Be("System.String");
+	}
+}

--- a/ILSpy.Tests/Editor/DocumentationLinkTests.cs
+++ b/ILSpy.Tests/Editor/DocumentationLinkTests.cs
@@ -105,6 +105,58 @@ public class DocumentationLinkTests
 	}
 
 	[AvaloniaTest]
+	public async Task Pressing_Inside_The_Popup_To_Select_Does_Not_Close_It()
+	{
+		var (window, vm) = await TestHarness.BootAsync();
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var stringNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(coreLibName, "System", "System.String");
+		vm.AssemblyTreeModel.SelectNode(stringNode);
+		await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		window.UpdateLayout();
+
+		var view = window.GetVisualDescendants().OfType<DecompilerTextView>().First();
+		var renderer = new DocumentationRenderer(
+			new CSharpAmbience(),
+			new FontFamily("Consolas, Menlo, Monospace"),
+			12);
+		renderer.AddXmlDocumentation(
+			"""<summary>Some text the user may want to select and copy.</summary>""",
+			declaringEntity: null,
+			resolver: _ => null);
+		var content = renderer.CreateView();
+		view.OpenRichPopup(content);
+		AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+		Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+		window.UpdateLayout();
+
+		var popup = view.FindControl<Avalonia.Controls.Primitives.Popup>("RichHoverPopup")!;
+		popup.IsOpen.Should().BeTrue("setup precondition — the popup must be open before the press");
+
+		var paragraph = content.GetVisualDescendants().OfType<SelectableTextBlock>().First();
+		var inside = paragraph.TranslatePoint(
+			new Point(10, paragraph.Bounds.Height / 2), window)!.Value;
+
+		window.MouseDown(inside, MouseButton.Left);
+		popup.IsOpen.Should().BeTrue("holding LMB inside the popup starts a text selection, not a dismiss");
+		window.MouseMove(inside + new Point(25, 0));
+		popup.IsOpen.Should().BeTrue("dragging a selection inside the popup must not close it");
+
+		// Selecting to the end of a line routinely sweeps the pointer past the popup edge
+		// while the button is still held — the popup must survive that.
+		var farOutside = inside + new Point(600, 80);
+		window.MouseMove(farOutside);
+		popup.IsOpen.Should().BeTrue("a selection drag sweeping past the popup edge must not close it");
+
+		// Finish the selection back over the popup and release: the pointer is still over the
+		// popup, so it stays open for the copy. (Releasing far outside the popup is left to
+		// normal leave-to-close behaviour, which differs by platform focus model.)
+		window.MouseMove(inside + new Point(40, 0));
+		window.MouseUp(inside + new Point(40, 0), MouseButton.Left);
+		Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+		popup.IsOpen.Should().BeTrue("the selection just finished over the popup — it stays for the copy");
+	}
+
+	[AvaloniaTest]
 	public void Unresolvable_Cref_Falls_Back_To_Plain_Text()
 	{
 		var renderer = new DocumentationRenderer(

--- a/ILSpy.Tests/Editor/ILLanguageTooltipTests.cs
+++ b/ILSpy.Tests/Editor/ILLanguageTooltipTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler.Disassembler;
+using ICSharpCode.Decompiler.Documentation;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using ILSpy;
+using ILSpy.AppEnv;
+using ILSpy.Languages;
+using ILSpy.TextView;
+using ILSpy.TreeNodes;
+using ILSpy.ViewModels;
+using ILSpy.Views;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// Pins the IL-specific halves of the decompiler-view hover tooltip. In the IL language
+/// view, hovering a member reference must show the member's disassembled IL header
+/// (".method ...", ".class ...", ".field ..."), not a C#-style one-liner — that is what
+/// <see cref="ILLanguage.GetRichTextTooltip"/> produces. Hovering an opcode must show the
+/// opcode's XML documentation, which comes from
+/// <see cref="XmlDocLoader.MscorlibDocumentation"/> via the
+/// "F:System.Reflection.Emit.OpCodes.*" doc ids.
+/// </summary>
+[TestFixture]
+public class ILLanguageTooltipTests
+{
+	static async Task<TypeTreeNode> LoadCoreLibStringNodeAsync()
+	{
+		var window = AppComposition.Current.GetExport<MainWindow>();
+		window.Show();
+		var vm = (MainWindowViewModel)window.DataContext!;
+		await vm.AssemblyTreeModel.WaitForAssembliesAsync(minimumCount: 1);
+
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var stringNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(coreLibName, "System", "System.String");
+		stringNode.IsExpanded = true;
+		return stringNode;
+	}
+
+	static ILLanguage GetILLanguage()
+		=> (ILLanguage)AppComposition.Current.GetExport<LanguageService>().Languages.Single(l => l.Name == "IL");
+
+	[AvaloniaTest]
+	public async Task Method_Tooltip_Is_The_Disassembled_IL_Header()
+	{
+		var stringNode = await LoadCoreLibStringNodeAsync();
+		var concat = stringNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Concat" && m.MethodDefinition.Parameters.Count == 2)
+			.MethodDefinition;
+
+		var tooltip = GetILLanguage().GetRichTextTooltip(concat);
+
+		tooltip.Should().NotBeNull();
+		tooltip!.Text.Should().StartWith(".method",
+			"the IL hover tooltip must show the disassembled method header, not an ambience one-liner");
+		tooltip.Text.Should().Contain("Concat");
+		tooltip.Text.Should().NotContain("\n",
+			"the header must be collapsed to a single line for the tooltip");
+	}
+
+	[AvaloniaTest]
+	public async Task Type_Tooltip_Is_The_Disassembled_IL_Header()
+	{
+		var stringNode = await LoadCoreLibStringNodeAsync();
+		var stringType = (ITypeDefinition)stringNode.Member!;
+
+		var tooltip = GetILLanguage().GetRichTextTooltip(stringType);
+
+		tooltip.Should().NotBeNull();
+		tooltip!.Text.Should().StartWith(".class");
+		tooltip.Text.Should().Contain("String");
+		tooltip.Text.Should().NotContain("\n");
+	}
+
+	[AvaloniaTest]
+	public async Task Field_Tooltip_Is_The_Disassembled_IL_Header()
+	{
+		var stringNode = await LoadCoreLibStringNodeAsync();
+		var empty = stringNode.Children.OfType<FieldTreeNode>()
+			.First(f => f.FieldDefinition.Name == "Empty")
+			.FieldDefinition;
+
+		var tooltip = GetILLanguage().GetRichTextTooltip(empty);
+
+		tooltip.Should().NotBeNull();
+		tooltip!.Text.Should().StartWith(".field");
+		tooltip.Text.Should().Contain("Empty");
+		tooltip.Text.Should().NotContain("\n");
+	}
+
+	[AvaloniaTest]
+	public async Task OpCode_Hover_Builds_Rich_Content_With_Documentation()
+	{
+		var stringNode = await LoadCoreLibStringNodeAsync();
+		var vm = (MainWindowViewModel)AppComposition.Current.GetExport<MainWindow>().DataContext!;
+		vm.AssemblyTreeModel.SelectNode(stringNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		var view = new DecompilerTextView { DataContext = tab };
+		var segment = new ReferenceSegment {
+			Reference = new OpCodeInfo(System.Reflection.Metadata.ILOpCode.Ldloc_0, "ldloc.0"),
+		};
+
+		var content = view.BuildHoverContent(tab, segment);
+
+		content.Should().NotBeNull("hovering an opcode must produce a tooltip");
+		content!.Value.IsRich.Should().BeTrue(
+			"with opcode documentation available, the tooltip must be the rich documentation popup");
+		var text = string.Concat(content.Value.Control.GetLogicalDescendants()
+			.OfType<TextBlock>()
+			.Select(tb => tb.Inlines is { Count: > 0 }
+				? string.Concat(tb.Inlines.OfType<Run>().Select(r => r.Text))
+				: tb.Text));
+		text.Should().Contain("ldloc.0", "the signature line shows the opcode name");
+		text.Should().Contain("local variable", "the OpCodes.Ldloc_0 summary must be rendered");
+	}
+
+	[AvaloniaTest]
+	public async Task EntityReference_Hover_Resolves_To_A_Rich_Tooltip()
+	{
+		// IL-view member references arrive as unresolved EntityReferences, not IEntity —
+		// this covers the resolve half of the hover chain (BuildHoverContent ->
+		// ResolveEntity -> EntityReference.Resolve via the tab's current node).
+		var stringNode = await LoadCoreLibStringNodeAsync();
+		var vm = (MainWindowViewModel)AppComposition.Current.GetExport<MainWindow>().DataContext!;
+		vm.AssemblyTreeModel.SelectNode(stringNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		var concat = stringNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Concat" && m.MethodDefinition.Parameters.Count == 2)
+			.MethodDefinition;
+		var view = new DecompilerTextView { DataContext = tab };
+		var segment = new ReferenceSegment {
+			Reference = new EntityReference(concat.ParentModule!.MetadataFile!, concat.MetadataToken),
+		};
+
+		var content = view.BuildHoverContent(tab, segment);
+
+		content.Should().NotBeNull("a member reference under the pointer must resolve to a tooltip");
+		content!.Value.IsRich.Should().BeTrue("entity tooltips render via the documentation popup");
+	}
+
+	[AvaloniaTest]
+	public void MscorlibDocumentation_Surfaces_OpCode_Documentation()
+	{
+		// On modern .NET there are no .NET Framework reference-assembly docs; the loader
+		// must fall back to the runtime's parallel ref pack (same layout assumption as
+		// XmlDocumentationTests for per-module docs).
+		var provider = XmlDocLoader.MscorlibDocumentation;
+		((object?)provider).Should().NotBeNull(
+			"opcode hover tooltips have no documentation source without MscorlibDocumentation");
+
+		var documentation = provider!.GetDocumentation("F:System.Reflection.Emit.OpCodes.Ldloc_0");
+		documentation.Should().NotBeNullOrEmpty(
+			"the IL view opcode tooltip looks docs up by the OpCodes field doc id");
+		documentation.Should().Contain("<summary");
+	}
+}

--- a/ILSpy.Tests/Editor/ReferenceClickTests.cs
+++ b/ILSpy.Tests/Editor/ReferenceClickTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+
+using AvaloniaEdit;
+using AvaloniaEdit.Rendering;
+
+using AwesomeAssertions;
+
+using ILSpy.TextView;
+using ILSpy.TreeNodes;
+using ILSpy.ViewModels;
+using ILSpy.Views;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// Pins the reference-link click gesture in the decompiled view (WPF parity): navigation
+/// happens on mouse-UP and only when the pointer did not drag, so text that belongs to a
+/// link can still be selected by press-and-drag.
+/// </summary>
+[TestFixture]
+public class ReferenceClickTests
+{
+	static async Task<(MainWindow Window, DecompilerTextView View, DecompilerTabPageModel Tab)> SetupAsync()
+	{
+		var (window, vm) = await TestHarness.BootAsync();
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var stringNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(coreLibName, "System", "System.String");
+		vm.AssemblyTreeModel.SelectNode(stringNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		var view = window.GetVisualDescendants().OfType<DecompilerTextView>().First();
+		AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+		Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+		window.UpdateLayout();
+		view.Editor.TextArea.TextView.EnsureVisualLines();
+		return (window, view, tab);
+	}
+
+	/// <summary>
+	/// Picks a navigable reference (cross-document, not a definition) within the visible
+	/// top of the document and returns a window-space point inside its text.
+	/// </summary>
+	static (ReferenceSegment Segment, Point Point) FindVisibleReference(
+		MainWindow window, DecompilerTextView view, DecompilerTabPageModel tab)
+	{
+		var textView = view.Editor.TextArea.TextView;
+		var segment = tab.References!
+			.First(r => r.Reference != null && !r.IsLocal && !r.IsDefinition);
+		var line = view.Editor.Document.GetLineByOffset(segment.StartOffset);
+		view.Editor.ScrollTo(line.LineNumber, segment.StartOffset - line.Offset + 1);
+		window.UpdateLayout();
+		textView.EnsureVisualLines();
+		var position = new TextViewPosition(line.LineNumber, segment.StartOffset - line.Offset + 2);
+		var visual = textView.GetVisualPosition(position, VisualYPosition.LineMiddle) - textView.ScrollOffset;
+		var point = textView.TranslatePoint(visual, window)!.Value;
+		return (segment, point);
+	}
+
+	[AvaloniaTest]
+	public async Task Dragging_Over_A_Link_Selects_Text_Without_Navigating()
+	{
+		var (window, view, tab) = await SetupAsync();
+		var (_, point) = FindVisibleReference(window, view, tab);
+
+		var navigated = false;
+		tab.NavigateRequested += _ => navigated = true;
+
+		window.MouseDown(point, MouseButton.Left);
+		window.MouseMove(point + new Point(60, 0));
+		window.MouseUp(point + new Point(60, 0), MouseButton.Left);
+
+		navigated.Should().BeFalse("a press-and-drag over a link is a text selection, not a click");
+		view.Editor.TextArea.Selection.IsEmpty.Should().BeFalse(
+			"dragging across link text must produce a selection");
+	}
+
+	[AvaloniaTest]
+	public async Task Stationary_Click_On_A_Link_Navigates()
+	{
+		var (window, view, tab) = await SetupAsync();
+		var (_, point) = FindVisibleReference(window, view, tab);
+
+		var navigated = false;
+		tab.NavigateRequested += _ => navigated = true;
+
+		window.MouseDown(point, MouseButton.Left);
+		window.MouseUp(point, MouseButton.Left);
+
+		navigated.Should().BeTrue("a click without dragging follows the link");
+	}
+}

--- a/ILSpy/AppEnv/ILSpyTraceListener.cs
+++ b/ILSpy/AppEnv/ILSpyTraceListener.cs
@@ -36,7 +36,20 @@ namespace ILSpy.AppEnv
 		{
 			Trace.Listeners.Clear();
 			Trace.Listeners.Add(new ILSpyTraceListener());
+			// Don't serialize trace output through TraceInternal's global lock. A decompiler
+			// Debug.Assert runs Fail() under that lock, and Fail() blocks on the UI thread to
+			// show the dialog; meanwhile the UI thread emits its own trace output (Avalonia
+			// logs binding errors during a layout pass) and would block acquiring the same
+			// lock -> deadlock. With the global lock off and the listener declaring itself
+			// thread-safe, TraceInternal calls the listener directly, so the asserting thread
+			// and the UI thread no longer contend on it.
+			Trace.UseGlobalLock = false;
 		}
+
+		// Tells TraceInternal it may invoke this listener without taking the global lock; the
+		// dialog show is marshalled to the UI thread and guarded against re-entrancy, and the
+		// listener's own mutable state is lock-protected below.
+		public override bool IsThreadSafe => true;
 
 		ILSpyTraceListener()
 		{

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -733,7 +733,7 @@ namespace ILSpy.AssemblyTree
 			}
 		}
 
-		static IEntity? FindEntityInRelevantAssemblies(string navigateTo, IEnumerable<LoadedAssembly> relevantAssemblies)
+		internal static IEntity? FindEntityInRelevantAssemblies(string navigateTo, IEnumerable<LoadedAssembly> relevantAssemblies)
 		{
 			ITypeReference typeRef;
 			IMemberReference? memberRef = null;

--- a/ILSpy/Languages/ILLanguage.cs
+++ b/ILSpy/Languages/ILLanguage.cs
@@ -21,6 +21,10 @@ using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
 using System.Reflection.Metadata;
+using System.Threading;
+
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Highlighting;
 
 using ICSharpCode.Decompiler;
 using ICSharpCode.Decompiler.Disassembler;
@@ -28,6 +32,8 @@ using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.Solution;
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpyX;
+
+using ILSpy.TextView;
 
 namespace ILSpy.Languages
 {
@@ -72,6 +78,57 @@ namespace ILSpy.Languages
 			dis.AssemblyResolver = module.GetAssemblyResolver();
 			dis.DebugInfo = module.GetDebugInfoOrNull();
 			return dis;
+		}
+
+		/// <summary>
+		/// The hover tooltip for an entity in IL view is its disassembled IL header (signature
+		/// only, no body), collapsed to a single line and highlighted with the IL definition.
+		/// </summary>
+		public override RichText GetRichTextTooltip(IEntity entity)
+		{
+			ArgumentNullException.ThrowIfNull(entity);
+			var module = entity.ParentModule?.MetadataFile;
+			if (module == null)
+				return base.GetRichTextTooltip(entity);
+
+			var output = new AvaloniaEditTextOutput { IgnoreNewLineAndIndent = true };
+			// A header never reaches the settings the full Decompile* paths feed into
+			// CreateDisassembler (sequence points, member expansion, ...), so a plain
+			// disassembler suffices here.
+			var disasm = new ReflectionDisassembler(output, CancellationToken.None) {
+				DetectControlStructure = detectControlStructure,
+			};
+			switch (entity.SymbolKind)
+			{
+				case SymbolKind.TypeDefinition:
+					disasm.DisassembleTypeHeader(module, (TypeDefinitionHandle)entity.MetadataToken);
+					break;
+				case SymbolKind.Field:
+					disasm.DisassembleFieldHeader(module, (FieldDefinitionHandle)entity.MetadataToken);
+					break;
+				case SymbolKind.Property:
+				case SymbolKind.Indexer:
+					disasm.DisassemblePropertyHeader(module, (PropertyDefinitionHandle)entity.MetadataToken);
+					break;
+				case SymbolKind.Event:
+					disasm.DisassembleEventHeader(module, (EventDefinitionHandle)entity.MetadataToken);
+					break;
+				case SymbolKind.Method:
+				case SymbolKind.Operator:
+				case SymbolKind.Constructor:
+				case SymbolKind.Destructor:
+				case SymbolKind.Accessor:
+					disasm.DisassembleMethodHeader(module, (MethodDefinitionHandle)entity.MetadataToken);
+					break;
+				default:
+					return base.GetRichTextTooltip(entity);
+			}
+
+			var text = output.GetText().TrimEnd();
+			var highlighting = HighlightingService.GetByExtension(FileExtension);
+			if (highlighting == null)
+				return new RichText(text);
+			return new DocumentHighlighter(new TextDocument(text), highlighting).HighlightLine(1).ToRichText();
 		}
 
 		public override void DecompileMethod(IMethod method, ITextOutput output, DecompilationOptions options)

--- a/ILSpy/TextView/AvaloniaEditTextOutput.cs
+++ b/ILSpy/TextView/AvaloniaEditTextOutput.cs
@@ -110,21 +110,32 @@ namespace ILSpy.TextView
 
 		public string IndentationString { get; set; } = "\t";
 
+		/// <summary>
+		/// When set, newlines are written as single spaces and indentation is suppressed, so
+		/// multi-line writer output (e.g. a disassembled member header) collapses to one
+		/// line. Used for single-line surfaces like the hover tooltip.
+		/// </summary>
+		public bool IgnoreNewLineAndIndent { get; set; }
+
 		public int TextLength => builder.Length;
 
 		public string GetText() => builder.ToString();
 
-		public void Indent() => indent++;
+		public void Indent()
+		{
+			if (!IgnoreNewLineAndIndent)
+				indent++;
+		}
 
 		public void Unindent()
 		{
-			if (indent > 0)
+			if (!IgnoreNewLineAndIndent && indent > 0)
 				indent--;
 		}
 
 		void WriteIndentIfNeeded()
 		{
-			if (!needsIndent)
+			if (IgnoreNewLineAndIndent || !needsIndent)
 				return;
 			needsIndent = false;
 			for (int i = 0; i < indent; i++)
@@ -147,6 +158,12 @@ namespace ILSpy.TextView
 
 		public void WriteLine()
 		{
+			if (IgnoreNewLineAndIndent)
+			{
+				builder.Append(' ');
+				CheckLength();
+				return;
+			}
 			builder.Append('\n');
 			lineNumber++;
 			needsIndent = true;

--- a/ILSpy/TextView/DecompilerTextView.axaml
+++ b/ILSpy/TextView/DecompilerTextView.axaml
@@ -79,5 +79,12 @@
 		     font size unless DisplaySettings.AlwaysShowZoomButtons is on. Bound at code-
 		     behind time once DisplaySettings is resolvable from composition. -->
 		<textView:ZoomButtons Name="ZoomButtons" />
+		<!-- Hover documentation popup (configured in SetupRichPopup). It must be declared
+		     here rather than constructed detached: with overlay popups (see
+		     X11PlatformOptions.OverlayPopups in Program.cs) the popup host is an
+		     OverlayPopupHost that resolves its control theme through the Popup's LOGICAL
+		     parent. A detached Popup leaves the host template-less, so its content never
+		     materialises and the popup is invisible. Renders nothing while closed. -->
+		<Popup Name="RichHoverPopup" />
 	</Grid>
 </UserControl>

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -850,10 +850,14 @@ namespace ILSpy.TextView
 		{
 			if (richPopup.IsOpen)
 			{
-				// TODO: refuse to close while the popup has keyboard focus (the user is
-				// reading / clicking links inside it). Not tracked yet — for now the popup
-				// is always replaceable.
-				_ = mouseClick;
+				// While the pointer is over the popup or keyboard focus is inside it (the
+				// user is reading, selecting text to copy, or reaching for a link), only a
+				// forced close (document change) may take it down.
+				if (!mouseClick && richPopup.Child is { } child
+					&& (child.IsPointerOver || child.IsKeyboardFocusWithin))
+				{
+					return false;
+				}
 				CloseRichPopup();
 				return true;
 			}
@@ -907,7 +911,7 @@ namespace ILSpy.TextView
 			ToolTip.SetIsOpen(Editor.TextArea.TextView, true);
 		}
 
-		void OpenRichPopup(Control content)
+		internal void OpenRichPopup(Control content)
 		{
 			richPopup.Child = content;
 			// While the pointer is over the popup, the editor no longer receives the moves
@@ -920,6 +924,14 @@ namespace ILSpy.TextView
 
 		void OnRichPopupContentPointerExited(object? sender, PointerEventArgs e)
 		{
+			// A selection drag that sweeps past the popup edge keeps the pointer captured
+			// inside the popup — that's a wide swipe, not a leave. The over/focus vetoes in
+			// TryCloseExistingPopup don't see the capture, so check it here.
+			if (e.Pointer.Captured is Visual captured && richPopup.Child is { } child
+				&& (ReferenceEquals(captured, child) || captured.GetVisualAncestors().Contains(child)))
+			{
+				return;
+			}
 			TryCloseExistingPopup(mouseClick: false);
 		}
 

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -197,18 +197,15 @@ namespace ILSpy.TextView
 
 		void SetupRichPopup()
 		{
-			richPopup = new Popup {
-				PlacementTarget = Editor.TextArea.TextView,
-				// Pointer placement: Avalonia anchors the popup at the current cursor location when
-				// Open() is called, with a small offset below to avoid covering the token.
-				Placement = PlacementMode.Pointer,
-				HorizontalOffset = 0,
-				VerticalOffset = 16,
-				IsLightDismissEnabled = false,
-			};
+			richPopup = RichHoverPopup;
+			richPopup.PlacementTarget = Editor.TextArea.TextView;
+			// Pointer placement: Avalonia anchors the popup at the current cursor location when
+			// Open() is called, with a small offset below to avoid covering the token.
+			richPopup.Placement = PlacementMode.Pointer;
+			richPopup.HorizontalOffset = 0;
+			richPopup.VerticalOffset = 16;
+			richPopup.IsLightDismissEnabled = false;
 			richPopup.Closed += OnRichPopupClosed;
-			// Popup.Open uses PlacementTarget to find its TopLevel, so the popup itself doesn't need
-			// to be in any visual tree of ours.
 		}
 
 		void SetupZoomAndCopy()

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -137,11 +137,62 @@ namespace ILSpy.TextView
 		void SetupElementGenerators()
 		{
 			referenceElementGenerator = new ReferenceElementGenerator(static segment => segment.Reference != null);
-			referenceElementGenerator.ReferenceClicked += OnReferenceClicked;
 			Editor.TextArea.TextView.ElementGenerators.Add(referenceElementGenerator);
 
 			uiElementGenerator = new UIElementGenerator();
 			Editor.TextArea.TextView.ElementGenerators.Add(uiElementGenerator);
+
+			// Reference navigation fires on pointer-RELEASE without drag (WPF parity: the WPF
+			// view used TextArea.PreviewMouseDown/Up the same way), so a press-and-drag over a
+			// link starts a text selection instead of navigating away. Tunnel routing mirrors
+			// WPF's Preview events and sees the gesture before AvaloniaEdit's own handlers.
+			Editor.TextArea.AddHandler(InputElement.PointerPressedEvent,
+				OnTextAreaPointerPressedForReferenceClick,
+				RoutingStrategies.Tunnel,
+				handledEventsToo: true);
+			Editor.TextArea.AddHandler(InputElement.PointerReleasedEvent,
+				OnTextAreaPointerReleasedForReferenceClick,
+				RoutingStrategies.Tunnel,
+				handledEventsToo: true);
+		}
+
+		// Position of the last left-button press, in this control's coordinates; null while no
+		// press is in flight. The release compares against it to tell a click from a drag.
+		Point? referenceClickStart;
+
+		// WPF used SystemParameters.MinimumHorizontal/VerticalDragDistance, which default to 4.
+		const double MinimumDragDistance = 4;
+
+		void OnTextAreaPointerPressedForReferenceClick(object? sender, PointerPressedEventArgs e)
+		{
+			referenceClickStart = e.GetCurrentPoint(this).Properties.IsLeftButtonPressed
+				? e.GetPosition(this)
+				: null;
+		}
+
+		void OnTextAreaPointerReleasedForReferenceClick(object? sender, PointerReleasedEventArgs e)
+		{
+			var start = referenceClickStart;
+			referenceClickStart = null;
+			if (start == null || e.InitialPressMouseButton != MouseButton.Left)
+				return;
+			var delta = e.GetPosition(this) - start.Value;
+			if (Math.Abs(delta.X) >= MinimumDragDistance || Math.Abs(delta.Y) >= MinimumDragDistance)
+				return;
+
+			var segment = GetReferenceSegmentAtPointer(e);
+			if (segment?.Reference == null)
+			{
+				// A click on empty space dismisses the local-reference highlight.
+				ClearLocalReferenceMarks();
+				return;
+			}
+			// Cancel the caret-click selection AvaloniaEdit started on press, and stop its
+			// release processing, so the navigation's caret move doesn't grow a selection
+			// between the old anchor and the new position.
+			Editor.TextArea.ClearSelection();
+			e.Handled = true;
+			OnReferenceClicked(segment);
 		}
 
 		// Background renderers that live for the view's lifetime: the local-reference highlight (marks
@@ -743,7 +794,18 @@ namespace ILSpy.TextView
 				e.Handled = true;
 		}
 
-		void OnReferenceClicked(ReferenceSegment segment)
+		ReferenceSegment? GetReferenceSegmentAtPointer(PointerEventArgs e)
+		{
+			if (DataContext is not DecompilerTabPageModel model || model.References == null)
+				return null;
+			var pos = GetPositionFromPointer(e);
+			if (pos == null)
+				return null;
+			var offset = Editor.Document.GetOffset(pos.Value.Line, pos.Value.Column);
+			return model.References.FindSegmentsContaining(offset).FirstOrDefault();
+		}
+
+		internal void OnReferenceClicked(ReferenceSegment segment)
 		{
 			if (DataContext is not DecompilerTabPageModel model || segment.Reference == null)
 				return;
@@ -823,13 +885,9 @@ namespace ILSpy.TextView
 			// pointer.
 			if (!TryCloseExistingPopup(mouseClick: false))
 				return;
-			if (DataContext is not DecompilerTabPageModel model || model.References == null)
+			if (DataContext is not DecompilerTabPageModel model)
 				return;
-			var pos = GetPositionFromPointer(e);
-			if (pos == null)
-				return;
-			var offset = Editor.Document.GetOffset(pos.Value.Line, pos.Value.Column);
-			var segment = model.References.FindSegmentsContaining(offset).FirstOrDefault();
+			var segment = GetReferenceSegmentAtPointer(e);
 			if (segment?.Reference == null)
 				return;
 

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -53,7 +53,7 @@ namespace ILSpy.TextView
 	{
 		// Two-track output of BuildHoverContent: rich content opens the sticky Popup with the
 		// pointer-distance corridor; plain content uses Avalonia's ToolTip attached property.
-		readonly record struct HoverContent(Control Control, bool IsRich);
+		internal readonly record struct HoverContent(Control Control, bool IsRich);
 
 		// Local-reference highlight colours: light-yellow "GreenYellow" for matches and a
 		// softer green for the actual definition.
@@ -947,7 +947,7 @@ namespace ILSpy.TextView
 			distanceToPopupLimit = double.PositiveInfinity;
 		}
 
-		HoverContent? BuildHoverContent(DecompilerTabPageModel model, ReferenceSegment segment)
+		internal HoverContent? BuildHoverContent(DecompilerTabPageModel model, ReferenceSegment segment)
 		{
 			var language = model.Language;
 			var resolved = ResolveEntity(model, segment.Reference);
@@ -965,6 +965,20 @@ namespace ILSpy.TextView
 					AppendXmlDocumentation(renderer, entity);
 					return new HoverContent(renderer.CreateView(), IsRich: true);
 				case OpCodeInfo op:
+					// Opcode docs are published as field documentation on
+					// System.Reflection.Emit.OpCodes, so the mscorlib provider serves them.
+					var opDocs = XmlDocLoader.MscorlibDocumentation
+						?.GetDocumentation("F:System.Reflection.Emit.OpCodes." + op.EncodedName);
+					if (opDocs != null)
+					{
+						var opRenderer = new DocumentationRenderer(
+							new CSharpAmbience(),
+							new FontFamily("Consolas, Menlo, Monospace"),
+							12);
+						opRenderer.AddSignatureBlock(new RichText($"{op.Name} (0x{op.Code:x})"));
+						opRenderer.AddXmlDocumentation(opDocs, declaringEntity: null, resolver: null);
+						return new HoverContent(opRenderer.CreateView(), IsRich: true);
+					}
 					var opBlock = new SelectableTextBlock {
 						FontFamily = new FontFamily("Consolas, Menlo, Monospace"),
 						FontSize = 12,

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -886,9 +886,15 @@ namespace ILSpy.TextView
 		void OnTextViewPointerExited(object? sender, PointerEventArgs e)
 		{
 			// Don't close the rich popup if the pointer just moved from the editor onto the
-			// popup itself — the user is reaching for it. Plain tooltips always close.
-			if (richPopup.IsOpen && richPopup.Child is { IsPointerOver: true })
+			// popup itself — the user is reaching for it. The overlay popup delivers the
+			// editor's exit BEFORE the popup child's IsPointerOver flips, so the flag alone
+			// would close the popup right under the pointer; the distance check covers that
+			// ordering. Plain tooltips always close.
+			if (richPopup.IsOpen
+				&& (richPopup.Child is { IsPointerOver: true } || GetDistanceToPopup(e) <= MaxMovementAwayFromPopup))
+			{
 				return;
+			}
 			TryCloseExistingPopup(mouseClick: false);
 		}
 
@@ -904,8 +910,17 @@ namespace ILSpy.TextView
 		void OpenRichPopup(Control content)
 		{
 			richPopup.Child = content;
+			// While the pointer is over the popup, the editor no longer receives the moves
+			// that drive the distance corridor — the popup's lifetime is governed by leaving
+			// its own content instead.
+			content.PointerExited += OnRichPopupContentPointerExited;
 			richPopup.Open();
 			distanceToPopupLimit = double.PositiveInfinity;
+		}
+
+		void OnRichPopupContentPointerExited(object? sender, PointerEventArgs e)
+		{
+			TryCloseExistingPopup(mouseClick: false);
 		}
 
 		double GetDistanceToPopup(PointerEventArgs e)
@@ -936,7 +951,11 @@ namespace ILSpy.TextView
 		void CloseRichPopup()
 		{
 			if (richPopup.IsOpen)
+			{
+				if (richPopup.Child is { } child)
+					child.PointerExited -= OnRichPopupContentPointerExited;
 				richPopup.Close();
+			}
 		}
 
 		void OnRichPopupClosed(object? sender, EventArgs e)
@@ -954,10 +973,7 @@ namespace ILSpy.TextView
 					var rich = language.GetRichTextTooltip(entity);
 					if (rich == null || string.IsNullOrEmpty(rich.Text))
 						return null;
-					var renderer = new DocumentationRenderer(
-						new CSharpAmbience(),
-						new FontFamily("Consolas, Menlo, Monospace"),
-						12);
+					var renderer = CreateTooltipRenderer();
 					renderer.AddSignatureBlock(rich);
 					AppendXmlDocumentation(renderer, entity);
 					return new HoverContent(renderer.CreateView(), IsRich: true);
@@ -968,12 +984,9 @@ namespace ILSpy.TextView
 						?.GetDocumentation("F:System.Reflection.Emit.OpCodes." + op.EncodedName);
 					if (opDocs != null)
 					{
-						var opRenderer = new DocumentationRenderer(
-							new CSharpAmbience(),
-							new FontFamily("Consolas, Menlo, Monospace"),
-							12);
+						var opRenderer = CreateTooltipRenderer();
 						opRenderer.AddSignatureBlock(new RichText($"{op.Name} (0x{op.Code:x})"));
-						opRenderer.AddXmlDocumentation(opDocs, declaringEntity: null, resolver: null);
+						opRenderer.AddXmlDocumentation(opDocs, declaringEntity: null, resolver: ResolveDocReference);
 						return new HoverContent(opRenderer.CreateView(), IsRich: true);
 					}
 					var opBlock = new SelectableTextBlock {
@@ -989,7 +1002,19 @@ namespace ILSpy.TextView
 			}
 		}
 
-		static void AppendXmlDocumentation(DocumentationRenderer renderer, IEntity entity)
+		// Hover tooltips share one renderer setup: monospace signature font, and any followed
+		// documentation link closes the popup so the navigation is visible underneath.
+		DocumentationRenderer CreateTooltipRenderer()
+		{
+			var renderer = new DocumentationRenderer(
+				new CSharpAmbience(),
+				new FontFamily("Consolas, Menlo, Monospace"),
+				12);
+			renderer.LinkClicked += (_, _) => CloseRichPopup();
+			return renderer;
+		}
+
+		void AppendXmlDocumentation(DocumentationRenderer renderer, IEntity entity)
 		{
 			try
 			{
@@ -1001,14 +1026,24 @@ namespace ILSpy.TextView
 				var documentation = XmlDocLoader.LoadDocumentation(metadata)?.GetDocumentation(entity.GetIdString());
 				if (documentation == null)
 					return;
-				// First-cut: no cref resolver, so <see cref="..."/> falls back to printing the
-				// raw cref text. Wiring resolution against the visible assembly list is a follow-up.
-				renderer.AddXmlDocumentation(documentation, entity, resolver: null);
+				renderer.AddXmlDocumentation(documentation, entity, resolver: ResolveDocReference);
 			}
 			catch (XmlException)
 			{
 				// Malformed .xml — render signature only.
 			}
+		}
+
+		/// <summary>
+		/// Resolves a doc-comment cref id string (e.g. <c>T:System.String</c>) against the
+		/// assembly list the current tab decompiled from.
+		/// </summary>
+		IEntity? ResolveDocReference(string idString)
+		{
+			if (DataContext is not DecompilerTabPageModel model || model.CurrentNode is not { } node)
+				return null;
+			var list = node.AncestorsAndSelf().OfType<TreeNodes.AssemblyListTreeNode>().FirstOrDefault()?.AssemblyList;
+			return list == null ? null : AssemblyTree.AssemblyTreeModel.FindEntityInRelevantAssemblies(idString, list.GetAssemblies());
 		}
 
 		object? ResolveEntity(DecompilerTabPageModel model, object? reference)

--- a/ILSpy/TextView/DocumentationRenderer.cs
+++ b/ILSpy/TextView/DocumentationRenderer.cs
@@ -143,7 +143,7 @@ namespace ILSpy.TextView
 			currentPanel.Children.Add(block);
 		}
 
-		public void AddXmlDocumentation(string xmlDocumentation, IEntity declaringEntity, Func<string, IEntity?>? resolver)
+		public void AddXmlDocumentation(string xmlDocumentation, IEntity? declaringEntity, Func<string, IEntity?>? resolver)
 		{
 			if (xmlDocumentation == null)
 				return;

--- a/ILSpy/TextView/DocumentationRenderer.cs
+++ b/ILSpy/TextView/DocumentationRenderer.cs
@@ -27,6 +27,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 
@@ -35,6 +36,8 @@ using AvaloniaEdit.Highlighting;
 using ICSharpCode.Decompiler.Documentation;
 using ICSharpCode.Decompiler.Output;
 using ICSharpCode.Decompiler.TypeSystem;
+
+using ILSpy.Util;
 
 namespace ILSpy.TextView
 {
@@ -45,8 +48,6 @@ namespace ILSpy.TextView
 	/// </summary>
 	public sealed class DocumentationRenderer
 	{
-		// Hyperlink colour for non-clickable <see cref> renderings. Plain accent + underline gives
-		// users the visual cue that this is a reference; click navigation is a follow-up change.
 		static readonly IBrush HyperlinkBrush = new SolidColorBrush(Color.FromRgb(0x00, 0x66, 0xCC));
 
 		readonly IAmbience ambience;
@@ -96,6 +97,12 @@ namespace ILSpy.TextView
 		public bool ShowAllParameters { get; set; }
 
 		public string? ParameterName { get; set; }
+
+		/// <summary>
+		/// Raised after the user follows any link in the rendered documentation, so a
+		/// hosting popup can close itself while the navigation takes effect.
+		/// </summary>
+		public event EventHandler? LinkClicked;
 
 		/// <summary>
 		/// Wraps the accumulated content in a chrome border + scroll viewer and returns the
@@ -377,12 +384,70 @@ namespace ILSpy.TextView
 
 		Inline ConvertReference(IEntity referencedEntity)
 		{
-			// First-cut rendering: styled like a hyperlink (accent + underline) but not yet
-			// clickable. Wiring NavigateRequested on the host TabPageModel is a follow-up.
-			return new Run(ambience.ConvertSymbol(referencedEntity)) {
+			var linkText = CreateLinkTextBlock();
+			linkText.Text = ambience.ConvertSymbol(referencedEntity);
+			return CreateLink(linkText, () => MessageBus.Send(this, new NavigateToReferenceEventArgs(referencedEntity)));
+		}
+
+		// Inlines (Run/Span) are not InputElements in Avalonia, so a clickable link is an
+		// embedded TextBlock inside an InlineUIContainer.
+		static TextBlock CreateLinkTextBlock()
+		{
+			return new TextBlock {
 				Foreground = HyperlinkBrush,
 				TextDecorations = TextDecorations.Underline,
+				Cursor = new Cursor(StandardCursorType.Hand),
+				// A null background makes the TextBlock hit-test invisible — clicks would
+				// fall through to the surrounding paragraph.
+				Background = Brushes.Transparent,
+				Classes = { "doc-link" },
 			};
+		}
+
+		Inline CreateLink(TextBlock linkText, Action onClick)
+		{
+			// Press is handled so the surrounding SelectableTextBlock doesn't start a text
+			// selection (its capture would also swallow the release); the click fires on
+			// release over the link, like a button.
+			bool pressed = false;
+			linkText.PointerPressed += (_, e) => {
+				if (!e.GetCurrentPoint(linkText).Properties.IsLeftButtonPressed)
+					return;
+				pressed = true;
+				e.Handled = true;
+			};
+			linkText.PointerReleased += (_, e) => {
+				if (!pressed)
+					return;
+				pressed = false;
+				e.Handled = true;
+				onClick();
+				LinkClicked?.Invoke(this, EventArgs.Empty);
+			};
+			return new InlineUIContainer(linkText) { BaselineAlignment = BaselineAlignment.TextBottom };
+		}
+
+		/// <summary>
+		/// Renders <paramref name="children"/> into a clickable link (used by
+		/// <c>&lt;see&gt;</c> elements that carry their own display text).
+		/// </summary>
+		void AddLinkSpan(Action onClick, IList<XmlDocumentationElement> children)
+		{
+			var linkText = CreateLinkTextBlock();
+			linkText.Inlines = new InlineCollection();
+			AddInline(CreateLink(linkText, onClick));
+			var oldInline = inlineCollection;
+			try
+			{
+				inlineCollection = linkText.Inlines;
+				foreach (var child in children)
+					AddDocumentationElement(child);
+				FlushAddedText(false);
+			}
+			finally
+			{
+				inlineCollection = oldInline;
+			}
 		}
 
 		void AddParam(string? name, IEnumerable<XmlDocumentationElement> children)
@@ -420,11 +485,9 @@ namespace ILSpy.TextView
 			{
 				if (element.Children.Count > 0)
 				{
-					var link = new Span {
-						Foreground = HyperlinkBrush,
-						TextDecorations = TextDecorations.Underline,
-					};
-					AddSpan(link, element.Children);
+					AddLinkSpan(
+						() => MessageBus.Send(this, new NavigateToReferenceEventArgs(referencedEntity)),
+						element.Children);
 				}
 				else
 				{
@@ -437,20 +500,17 @@ namespace ILSpy.TextView
 			}
 			else if (element.GetAttribute("href") is { } href)
 			{
-				if (Uri.TryCreate(href, UriKind.Absolute, out _))
+				if (Uri.TryCreate(href, UriKind.Absolute, out var uri))
 				{
 					if (element.Children.Count > 0)
 					{
-						AddSpan(
-							new Span { Foreground = HyperlinkBrush, TextDecorations = TextDecorations.Underline },
-							element.Children);
+						AddLinkSpan(() => OpenExternalUri(uri), element.Children);
 					}
 					else
 					{
-						AddInline(new Run(href) {
-							Foreground = HyperlinkBrush,
-							TextDecorations = TextDecorations.Underline,
-						});
+						var linkText = CreateLinkTextBlock();
+						linkText.Text = href;
+						AddInline(CreateLink(linkText, () => OpenExternalUri(uri)));
 					}
 				}
 			}
@@ -459,6 +519,14 @@ namespace ILSpy.TextView
 				// Invalid reference: print the cref value
 				AddText(element.GetAttribute("cref") ?? string.Empty);
 			}
+		}
+
+		void OpenExternalUri(Uri uri)
+		{
+			// The rendered view lives in a popup whose root is a TopLevel once shown, so
+			// the launcher is resolvable from any control of the tree.
+			if (TopLevel.GetTopLevel(rootStack) is { } topLevel)
+				topLevel.Launcher.LaunchUriAsync(uri).HandleExceptions();
 		}
 
 		public void AddInline(Inline inline)

--- a/ILSpy/TextView/ReferenceElementGenerator.cs
+++ b/ILSpy/TextView/ReferenceElementGenerator.cs
@@ -33,11 +33,6 @@ namespace ILSpy.TextView
 
 		public TextSegmentCollection<ReferenceSegment>? References { get; set; }
 
-		/// <summary>Raised when a clickable reference span is activated.</summary>
-		public event Action<ReferenceSegment>? ReferenceClicked;
-
-		internal void OnReferenceClicked(ReferenceSegment segment) => ReferenceClicked?.Invoke(segment);
-
 		public ReferenceElementGenerator(Predicate<ReferenceSegment> isLink)
 		{
 			this.isLink = isLink ?? throw new ArgumentNullException(nameof(isLink));

--- a/ILSpy/TextView/VisualLineReferenceText.cs
+++ b/ILSpy/TextView/VisualLineReferenceText.cs
@@ -24,8 +24,9 @@ namespace ILSpy.TextView
 {
 	/// <summary>
 	/// A clickable piece of text that maps back to a <see cref="ReferenceSegment"/>. Sets a hand
-	/// cursor for cross-document references and an arrow for in-document ones. The actual click
-	/// is handled by the parent generator, which routes the segment to the document's navigator.
+	/// cursor for cross-document references and an arrow for in-document ones. Clicks are NOT
+	/// handled here: navigation fires on pointer-release without drag (see the reference-click
+	/// handlers in <see cref="DecompilerTextView"/>), so a press-and-drag can select link text.
 	/// </summary>
 	sealed class VisualLineReferenceText : VisualLineText
 	{
@@ -56,14 +57,6 @@ namespace ILSpy.TextView
 			// OnQueryCursor with the live PointerEventArgs, and marking it handled there
 			// suppresses PointerHoverLogic's tracking of pointer position over reference
 			// segments. Without this, hover events fire with stale args from outside the segment.
-		}
-
-		protected override void OnPointerPressed(PointerPressedEventArgs e)
-		{
-			if (e.Handled || !e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
-				return;
-			parent.OnReferenceClicked(referenceSegment);
-			e.Handled = true;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Restores the IL-view hover tooltips lost in the Avalonia port, fixes the regression that made the decompiler-view hover popup invisible, makes tooltip documentation references clickable, and fixes an assertion-dialog deadlock and a link-selection gap discovered along the way. All changes were verified live on Linux (Wayland/KDE).

## Commits

- **Restore IL-specific hover tooltips in the IL language view** — hovering a member reference in IL view shows the disassembled IL header (`.method`/`.class`/`.field`) instead of a bare one-liner, and hovering an opcode shows its documentation. `ILLanguage.GetRichTextTooltip` was never ported; opcode docs additionally needed a modern-.NET source, so `XmlDocLoader.MscorlibDocumentation` now falls back to the runtime's parallel ref pack.
- **Root the hover popup in the view so the overlay popup host gets styled** — the hover popup had been invisible since `OverlayPopups` was enabled: an `OverlayPopupHost` resolves its control theme through the Popup's logical parent, and the popup was constructed detached, so the host stayed template-less and never materialised its content. Declaring the popup in the view's XAML gives the host a styling root.
- **Make documentation tooltip references clickable hyperlinks** — `<see cref="..."/>` references resolve against the current tab's assembly list and navigate via the same `NavigateToReferenceEventArgs` channel the analyzer uses; `href` links open via the `TopLevel` launcher. Avalonia inlines aren't input elements, so links are hit-testable `TextBlock`s in an `InlineUIContainer`.
- **Keep the hover popup open while the user interacts with it** — selecting text inside the popup (or dragging a selection past its edge) no longer dismisses it, so the documentation can be read and copied.
- **Fix deadlock when a decompiler assertion fires during navigation** — a `Debug.Assert` on a background decompile thread runs through `TraceInternal.Fail` holding the global trace lock while blocking on the UI thread to show the assertion dialog; meanwhile the UI thread logs a binding error (raised by a virtualizing-panel layout pass during navigation) via `Trace.WriteLine`, which blocks acquiring that same lock. Marking the listener thread-safe and disabling the global trace lock removes the contention. (Pre-existing bug, independent of the tooltip work — fine to cherry-pick on its own.)
- **Navigate references on click-release so link text stays selectable** — reference links navigated on pointer-press, so a press-drag over a link could never select its text. Navigation now fires on pointer-release and only when the pointer didn't drag past the click threshold, matching the WPF view's mouse-up handling.

## Test plan

- New headless tests: `ILLanguageTooltipTests`, `DocumentationLinkTests`, `ReferenceClickTests`, plus updated `CaretHighlightAdornerTests`. Full `ILSpy.Tests` suite green locally.
- The deadlock fix was diagnosed from a process dump (the UI thread blocked in `Monitor.Enter` on `TraceInternal.critSec`) and verified live; it can't be exercised headlessly.
- Manually verified in the running app on Linux: IL-view opcode/member tooltips, clickable doc links, popup interaction, drag-to-select over links, and the assertion dialog appearing without freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
