### PR TITLE
Honor the user's decompiler settings in all decompilation paths

### DIFF
--- a/ILSpy.Tests.Windows/ImageList/ImageListResourceEntryNodeTests.cs
+++ b/ILSpy.Tests.Windows/ImageList/ImageListResourceEntryNodeTests.cs
@@ -127,7 +127,7 @@ public class ImageListResourceEntryNodeTests
 		var output = new AvaloniaEditTextOutput();
 		var language = AppComposition.Current.GetExport<LanguageService>().CurrentLanguage;
 
-		node.Decompile(language, output, new DecompilationOptions());
+		node.Decompile(language, output, new DecompilationOptions(new DecompilerSettings()));
 
 		output.UIElements.Should().HaveCount(1,
 			"the parent's Decompile contributes exactly one inline preview panel");

--- a/ILSpy.Tests/AssemblyList/AssemblyListDecompileTests.cs
+++ b/ILSpy.Tests/AssemblyList/AssemblyListDecompileTests.cs
@@ -53,7 +53,7 @@ public class AssemblyListDecompileTests
 		var output = new PlainTextOutput();
 		// Decompiling every assembly is far too slow for a test, so cancel up front: the header
 		// and the first rule are written before the first member decompilation observes the token.
-		var options = new DecompilationOptions { CancellationToken = new CancellationToken(true) };
+		var options = new DecompilationOptions(new DecompilerSettings()) { CancellationToken = new CancellationToken(true) };
 
 		try
 		{

--- a/ILSpy.Tests/Languages/CSharpILMixedLanguageTests.cs
+++ b/ILSpy.Tests/Languages/CSharpILMixedLanguageTests.cs
@@ -23,6 +23,7 @@ using Avalonia.Headless.NUnit;
 
 using AwesomeAssertions;
 
+using ICSharpCode.Decompiler;
 using ICSharpCode.ILSpy;
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.Languages;
@@ -60,7 +61,7 @@ public class CSharpILMixedLanguageTests
 		string Decompile(Language language)
 		{
 			var output = new AvaloniaEditTextOutput();
-			language.DecompileMethod(method, output, new DecompilationOptions());
+			language.DecompileMethod(method, output, new DecompilationOptions(new DecompilerSettings()));
 			return output.GetText();
 		}
 

--- a/ILSpy.Tests/Languages/ProjectExportTests.cs
+++ b/ILSpy.Tests/Languages/ProjectExportTests.cs
@@ -79,7 +79,7 @@ public class ProjectExportTests
 		Directory.CreateDirectory(tempDir);
 		try
 		{
-			var options = new ICSharpCode.ILSpy.DecompilationOptions {
+			var options = new ICSharpCode.ILSpy.DecompilationOptions(new DecompilerSettings()) {
 				FullDecompilation = true,
 				SaveAsProjectDirectory = tempDir,
 			};

--- a/ILSpy.Tests/Languages/ShowMemberSettingsTests.cs
+++ b/ILSpy.Tests/Languages/ShowMemberSettingsTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+using Avalonia.Headless.NUnit;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.Languages;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.Languages;
+
+// CSharpLanguage.ShowMember drives which members the assembly tree shows at all: every member
+// tree node consults it (unless the API-visibility filter is set to "All"). It must evaluate
+// CSharpDecompiler.MemberIsHidden against the LIVE decompiler settings, not a default-constructed
+// DecompilerSettings — otherwise toggling a decompiler option that unhides compiler-generated
+// members (here: ArrayInitializers, which hides "<PrivateImplementationDetails>") has no effect
+// on the tree.
+[TestFixture]
+public class ShowMemberSettingsTests
+{
+	/// <summary>
+	/// Emits an assembly containing a top-level [CompilerGenerated] type named
+	/// "&lt;PrivateImplementationDetails&gt;" and returns its type definition.
+	/// MemberIsHidden hides that type iff <c>DecompilerSettings.ArrayInitializers</c> is set,
+	/// which makes it a minimal settings-sensitive probe for ShowMember.
+	/// </summary>
+	static ITypeDefinition EmitPrivateImplementationDetails()
+	{
+		const string name = "ShowMemberFixture";
+		var ab = new PersistedAssemblyBuilder(new AssemblyName(name), typeof(object).Assembly);
+		var module = ab.DefineDynamicModule(name);
+
+		var details = module.DefineType("<PrivateImplementationDetails>",
+			TypeAttributes.NotPublic | TypeAttributes.Class | TypeAttributes.Sealed);
+		details.SetCustomAttribute(new CustomAttributeBuilder(
+			typeof(CompilerGeneratedAttribute).GetConstructor(Type.EmptyTypes)!, []));
+		details.CreateType();
+
+		var dir = Path.Combine(Path.GetTempPath(), $"ILSpyShowMember_{Guid.NewGuid():N}");
+		Directory.CreateDirectory(dir);
+		var path = Path.Combine(dir, $"{name}.dll");
+		ab.Save(path);
+
+		var file = new PEFile(path);
+		var resolver = new UniversalAssemblyResolver(path, throwOnError: false,
+			targetFramework: file.DetectTargetFrameworkId());
+		var typeSystem = new DecompilerTypeSystem(file, resolver);
+		return typeSystem.MainModule.TypeDefinitions
+			.Single(t => t.Name == "<PrivateImplementationDetails>");
+	}
+
+	[AvaloniaTest]
+	public void ShowMember_hides_PrivateImplementationDetails_under_default_settings()
+	{
+		var language = AppComposition.Current.GetExport<LanguageService>().GetLanguage("C#");
+
+		language.ShowMember(EmitPrivateImplementationDetails()).Should().BeFalse(
+			"ArrayInitializers defaults to true, which hides <PrivateImplementationDetails>");
+	}
+
+	[AvaloniaTest]
+	public void ShowMember_honours_the_live_decompiler_settings()
+	{
+		var settingsService = AppComposition.Current.GetExport<SettingsService>();
+		settingsService.DecompilerSettings.ArrayInitializers = false;
+
+		var language = AppComposition.Current.GetExport<LanguageService>().GetLanguage("C#");
+
+		language.ShowMember(EmitPrivateImplementationDetails()).Should().BeTrue(
+			"with ArrayInitializers off, MemberIsHidden no longer hides <PrivateImplementationDetails>, " +
+			"so the tree must show it");
+	}
+}

--- a/ILSpy.Tests/Languages/SolutionExportTests.cs
+++ b/ILSpy.Tests/Languages/SolutionExportTests.cs
@@ -18,12 +18,14 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Avalonia.Headless.NUnit;
 
 using AwesomeAssertions;
 
+using ICSharpCode.Decompiler;
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.Languages;
 
@@ -60,7 +62,7 @@ public class SolutionExportTests
 		var slnPath = Path.Combine(tempDir, "Solution.sln");
 		try
 		{
-			var result = await ICSharpCode.ILSpy.SolutionWriter.CreateSolutionAsync(slnPath, language, assemblies);
+			var result = await ICSharpCode.ILSpy.SolutionWriter.CreateSolutionAsync(slnPath, language, assemblies, CancellationToken.None, new DecompilerSettings());
 
 			result.Success.Should().BeTrue(
 				"the solution export should succeed for valid assemblies. Status:\n" + result.StatusText);
@@ -106,7 +108,7 @@ public class SolutionExportTests
 			// The same assembly twice collides on ShortName: the writer must refuse rather than
 			// clobber one project directory with another.
 			var result = await ICSharpCode.ILSpy.SolutionWriter.CreateSolutionAsync(
-				slnPath, language, new[] { assembly, assembly });
+				slnPath, language, new[] { assembly, assembly }, CancellationToken.None, new DecompilerSettings());
 
 			result.Success.Should().BeFalse("duplicate assembly names cannot produce a valid solution");
 			result.StatusText.Should().Contain("Duplicate assembly names");

--- a/ILSpy.Tests/Resources/BamlResourceTests.cs
+++ b/ILSpy.Tests/Resources/BamlResourceTests.cs
@@ -94,7 +94,7 @@ public class BamlResourceTests
 		// (the handler doesn't touch the options for CanHandle).
 		EnsureComposition();
 		var handler = new BamlResourceFileHandler();
-		var context = new ResourceFileHandlerContext(new DecompilationOptions());
+		var context = new ResourceFileHandlerContext(new DecompilationOptions(new DecompilerSettings()));
 
 		// Act + Assert — three positive variants and two rejections.
 		handler.CanHandle("MainWindow.baml", context).Should().BeTrue();

--- a/ILSpy.Tests/Resources/ResourceFactoryTests.cs
+++ b/ILSpy.Tests/Resources/ResourceFactoryTests.cs
@@ -125,7 +125,7 @@ public class ResourceFactoryTests
 		var language = AppComposition.Current.GetExport<LanguageService>().CurrentLanguage;
 
 		// Act — decompile the resource node into the AvaloniaEdit text output.
-		node.Decompile(language, output, new DecompilationOptions());
+		node.Decompile(language, output, new DecompilationOptions(new DecompilerSettings()));
 
 		// Assert — exactly three UI elements (string grid + object grid + inherited Save button)
 		// and they all materialise as Avalonia Controls.

--- a/ILSpy.Tests/TextView/DisplaySettingsBridgeTests.cs
+++ b/ILSpy.Tests/TextView/DisplaySettingsBridgeTests.cs
@@ -42,7 +42,7 @@ public class DisplaySettingsBridgeTests
 		var display = new DisplaySettings { FoldBraces = true, ShowDebugInfo = true };
 		var settings = new DecompilerSettings { FoldBraces = false, ShowDebugInfo = false };
 
-		DecompilerTabPageModel.ApplyDisplaySettings(settings, display);
+		SettingsService.ApplyDisplaySettings(settings, display);
 
 		settings.FoldBraces.Should().BeTrue();
 		settings.ShowDebugInfo.Should().BeTrue();
@@ -54,7 +54,7 @@ public class DisplaySettingsBridgeTests
 		var display = new DisplaySettings { IndentationUseTabs = false, IndentationSize = 2 };
 		var settings = new DecompilerSettings();
 
-		DecompilerTabPageModel.ApplyDisplaySettings(settings, display);
+		SettingsService.ApplyDisplaySettings(settings, display);
 
 		settings.CSharpFormattingOptions.IndentationString.Should().Be("  ", "two spaces");
 	}
@@ -65,7 +65,7 @@ public class DisplaySettingsBridgeTests
 		var display = new DisplaySettings { IndentationUseTabs = true, IndentationSize = 4, IndentationTabSize = 4 };
 		var settings = new DecompilerSettings();
 
-		DecompilerTabPageModel.ApplyDisplaySettings(settings, display);
+		SettingsService.ApplyDisplaySettings(settings, display);
 
 		settings.CSharpFormattingOptions.IndentationString.Should().Be("\t", "one tab");
 	}
@@ -76,7 +76,7 @@ public class DisplaySettingsBridgeTests
 		var display = new DisplaySettings { ExpandUsingDeclarations = true, ExpandMemberDefinitions = true };
 		var settings = new DecompilerSettings { ExpandUsingDeclarations = false, ExpandMemberDefinitions = false };
 
-		DecompilerTabPageModel.ApplyDisplaySettings(settings, display);
+		SettingsService.ApplyDisplaySettings(settings, display);
 
 		settings.ExpandUsingDeclarations.Should().BeTrue();
 		settings.ExpandMemberDefinitions.Should().BeTrue();

--- a/ILSpy.Tests/TreeNodes/TypeSystemSharingTests.cs
+++ b/ILSpy.Tests/TreeNodes/TypeSystemSharingTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+using Avalonia.Headless.NUnit;
+
+using AwesomeAssertions;
+
+using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.Languages;
+using ICSharpCode.ILSpy.Search;
+using ICSharpCode.ILSpy.TreeNodes;
+using ICSharpCode.ILSpyX;
+using ICSharpCode.ILSpyX.Extensions;
+using ICSharpCode.ILSpyX.Search;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TreeNodes;
+
+// LoadedAssembly caches ONE type system per TypeSystemOptions value
+// (GetTypeSystemOrNull(options)). The tree, the search, and anything else that resolves
+// entities for display must all derive their options from the user's current decompiler
+// settings: that keeps them consistent with what decompilation elides AND makes them share
+// the single cached instance instead of materialising a second type system per module.
+[TestFixture]
+public class TypeSystemSharingTests
+{
+	[AvaloniaTest]
+	public async Task Tree_nodes_resolve_through_the_settings_derived_type_system()
+	{
+		var (_, vm) = await TestHarness.BootAsync();
+		var settingsService = AppComposition.Current.GetExport<SettingsService>();
+		var fixture = await vm.OpenFixtureAsync();
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			fixture.ShortName, fixture.ShortName, $"{fixture.ShortName}.{FixtureAssembly.TypeName}");
+		Assert.That(typeNode, Is.Not.Null);
+
+		var module = fixture.GetMetadataFileOrNull()!;
+		var expected = module.GetTypeSystemWithDecompilerSettingsOrNull(
+			settingsService.CreateEffectiveDecompilerSettings());
+
+		typeNode!.Member!.Compilation.Should().BeSameAs(expected,
+			"the tree must resolve entities through the cached type system derived from the " +
+			"current decompiler settings, not a separate default-options one");
+	}
+
+	[AvaloniaTest]
+	public async Task Search_reuses_the_same_cached_type_system_as_the_tree()
+	{
+		var (_, vm) = await TestHarness.BootAsync();
+		var settingsService = AppComposition.Current.GetExport<SettingsService>();
+		// A non-default option that changes the derived TypeSystemOptions: a search that
+		// ignores the live settings materialises a second, default-options type system.
+		settingsService.DecompilerSettings.NullableReferenceTypes = false;
+		var fixture = await vm.OpenFixtureAsync();
+		var module = fixture.GetMetadataFileOrNull()!;
+		var language = AppComposition.Current.GetExport<LanguageService>().CurrentLanguage;
+
+		var search = new RunningSearch(
+			new[] { fixture }, FixtureAssembly.TypeName, SearchMode.TypeAndMember, language,
+			ApiVisibility.PublicAndInternal, new AvaloniaSearchResultFactory(language),
+			new ObservableCollection<SearchResult>(), SearchResult.ComparerByName);
+		var request = search.BuildRequest();
+
+		var fromSearch = module.GetTypeSystemWithDecompilerSettingsOrNull(request.DecompilerSettings);
+		var effective = module.GetTypeSystemWithDecompilerSettingsOrNull(
+			settingsService.CreateEffectiveDecompilerSettings());
+
+		fromSearch.Should().BeSameAs(effective,
+			"the search must derive its type system from the current decompiler settings so it " +
+			"shares the per-module cache with the tree and respects the user's options");
+	}
+}

--- a/ILSpy/Commands/DecompileAllCommand.cs
+++ b/ILSpy/Commands/DecompileAllCommand.cs
@@ -66,6 +66,8 @@ namespace ICSharpCode.ILSpy.Commands
 
 		async Task ExecuteAsync()
 		{
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new ICSharpCode.Decompiler.DecompilerSettings();
 			// Run in a dedicated frozen tab so navigation cannot cancel this long run.
 			await dockWorkspace.RunInNewTabAsync("Decompiling all assemblies…", token => Task.Run(() => {
 				var output = new AvaloniaEditTextOutput { Title = "Decompile All" };
@@ -82,7 +84,7 @@ namespace ICSharpCode.ILSpy.Commands
 						try
 						{
 							using var writer = new StreamWriter(path);
-							var options = new DecompilationOptions {
+							var options = new DecompilationOptions(settings) {
 								CancellationToken = token,
 								FullDecompilation = true,
 							};
@@ -133,6 +135,8 @@ namespace ICSharpCode.ILSpy.Commands
 
 		async Task ExecuteAsync()
 		{
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new ICSharpCode.Decompiler.DecompilerSettings();
 			// Run in a dedicated frozen tab so navigation cannot cancel this long run.
 			await dockWorkspace.RunInNewTabAsync("Disassembling all assemblies…", token => Task.Run(() => {
 				var output = new AvaloniaEditTextOutput { Title = "Disassemble All" };
@@ -150,7 +154,7 @@ namespace ICSharpCode.ILSpy.Commands
 						try
 						{
 							using var writer = new StreamWriter(path);
-							var options = new DecompilationOptions {
+							var options = new DecompilationOptions(settings) {
 								CancellationToken = token,
 								FullDecompilation = true,
 							};
@@ -204,10 +208,12 @@ namespace ICSharpCode.ILSpy.Commands
 			var nodes = assemblyTreeModel.SelectedItems.OfType<ILSpyTreeNode>().ToArray();
 			if (nodes.Length == 0)
 				return;
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new ICSharpCode.Decompiler.DecompilerSettings();
 			// Run in a dedicated frozen tab so navigation cannot cancel this long run.
 			await dockWorkspace.RunInNewTabAsync("Decompiling 100×…", token => Task.Run(() => {
 				var watch = Stopwatch.StartNew();
-				var options = new DecompilationOptions { CancellationToken = token };
+				var options = new DecompilationOptions(settings) { CancellationToken = token };
 				for (int i = 0; i < NumRuns; i++)
 				{
 					foreach (var node in nodes)

--- a/ILSpy/Commands/PdbGenerator.cs
+++ b/ILSpy/Commands/PdbGenerator.cs
@@ -32,6 +32,7 @@ using ICSharpCode.ILSpy.Properties;
 using ICSharpCode.ILSpyX;
 using ICSharpCode.ILSpyX.TreeView;
 
+using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.Docking;
 using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.TreeNodes;
@@ -106,6 +107,11 @@ namespace ICSharpCode.ILSpy.Commands
 				? string.Format(Resources.GeneratingPortablePDB, supported.Keys.First().ShortName)
 				: string.Format(Resources.GeneratingPortablePDB, supported.Count + " assemblies");
 
+			// The PDB embeds decompiled sources, so honor the user's current decompiler settings
+			// (snapshot once; the generation runs off the UI thread).
+			var settings = AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new DecompilerSettings();
+
 			// Run in a dedicated frozen tab so browsing the tree while PDBs generate can't cancel it.
 			await dockWorkspace.RunInNewTabAsync(title, token => Task.Run(() => {
 				var output = new AvaloniaEditTextOutput { Title = "Generate Portable PDB" };
@@ -117,7 +123,6 @@ namespace ICSharpCode.ILSpy.Commands
 					{
 						using var stream = new FileStream(pdbFileName, FileMode.Create, FileAccess.Write);
 						var resolver = assembly.GetAssemblyResolver();
-						var settings = new DecompilerSettings();
 						var decompiler = new CSharpDecompiler(file, resolver, settings) {
 							CancellationToken = token,
 						};

--- a/ILSpy/Commands/SaveCodeHelper.cs
+++ b/ILSpy/Commands/SaveCodeHelper.cs
@@ -107,7 +107,9 @@ namespace ICSharpCode.ILSpy.Commands
 			ArgumentNullException.ThrowIfNull(node);
 			ArgumentNullException.ThrowIfNull(language);
 
-			var options = new DecompilationOptions {
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new ICSharpCode.Decompiler.DecompilerSettings();
+			var options = new DecompilationOptions(settings) {
 				FullDecompilation = true,
 				EscapeInvalidIdentifiers = true,
 				CancellationToken = ct,

--- a/ILSpy/Commands/SolutionExport.cs
+++ b/ILSpy/Commands/SolutionExport.cs
@@ -73,10 +73,15 @@ namespace ICSharpCode.ILSpy.Commands
 			if (string.IsNullOrEmpty(path))
 				return;
 
+			// Snapshot the user's current decompiler settings for the whole export, like the
+			// per-project export path does.
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new ICSharpCode.Decompiler.DecompilerSettings();
+
 			// Run in a dedicated frozen tab so browsing the tree while the export runs can't cancel it.
 			await dockWorkspace.RunInNewTabAsync("Exporting solution", async (token, progress) => {
 				var result = await SolutionWriter.CreateSolutionAsync(path, language, assemblies, token,
-						settings: null, strongNameKeyFile: null, progress: progress)
+						settings, strongNameKeyFile: null, progress: progress)
 					.ConfigureAwait(false);
 				var o = new AvaloniaEditTextOutput { Title = Resources._SaveCode };
 				o.Write(result.StatusText);

--- a/ILSpy/DecompilationOptions.cs
+++ b/ILSpy/DecompilationOptions.cs
@@ -75,11 +75,13 @@ namespace ICSharpCode.ILSpy
 		/// </summary>
 		public IProgress<DecompilationProgress>? ProgressIndicator { get; set; }
 
+		// Deliberately no parameterless constructor: every decompilation must make an explicit
+		// choice of settings. Callers inside the app want the user's current settings (see
+		// SettingsService.CreateEffectiveDecompilerSettings), and a silent new DecompilerSettings()
+		// default has repeatedly masked exactly that bug.
 		public DecompilationOptions(DecompilerSettings settings)
 		{
 			DecompilerSettings = settings;
 		}
-
-		public DecompilationOptions() : this(new DecompilerSettings()) { }
 	}
 }

--- a/ILSpy/ExtensionMethods.cs
+++ b/ILSpy/ExtensionMethods.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.ILSpyX;
+
+namespace ICSharpCode.ILSpy
+{
+	public static class ExtensionMethods
+	{
+		/// <summary>
+		/// Returns the cached type system for <paramref name="file"/> derived from the user's
+		/// current decompiler settings (see
+		/// <see cref="SettingsService.CreateEffectiveDecompilerSettings"/>). Everything that
+		/// resolves entities for display — tree nodes, search, metadata views — should go
+		/// through this so it agrees with what decompilation produces and shares the
+		/// per-module type-system cache instead of materialising another instance. Falls back
+		/// to default settings when composition is unavailable (design-time, minimal test
+		/// hosts).
+		/// </summary>
+		public static ICompilation? GetTypeSystemWithCurrentOptionsOrNull(this MetadataFile file)
+		{
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new Decompiler.DecompilerSettings();
+			return file.GetTypeSystemWithDecompilerSettingsOrNull(settings);
+		}
+	}
+}

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -257,7 +257,12 @@ namespace ICSharpCode.ILSpy.Languages
 			var assembly = member.ParentModule?.MetadataFile;
 			if (assembly == null)
 				return true;
-			return !CSharpDecompiler.MemberIsHidden(assembly, member.MetadataToken, new DecompilerSettings());
+			// Use the effective settings, not defaults: which members MemberIsHidden hides
+			// depends on the decompiler options (and language version), and the tree must agree
+			// with what the text view actually elides.
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new DecompilerSettings();
+			return !CSharpDecompiler.MemberIsHidden(assembly, member.MetadataToken, settings);
 		}
 
 		public override RichText GetRichTextTooltip(IEntity entity)

--- a/ILSpy/Metadata/MetadataNavigator.cs
+++ b/ILSpy/Metadata/MetadataNavigator.cs
@@ -75,7 +75,7 @@ namespace ICSharpCode.ILSpy.Metadata
 				.FirstOrDefault(a => ReferenceEquals(a.GetMetadataFileOrNull(), file));
 			if (owningAssembly is null)
 				return null;
-			if (owningAssembly.GetTypeSystemOrNull()?.MainModule is not MetadataModule metadataModule)
+			if (file?.GetTypeSystemWithCurrentOptionsOrNull()?.MainModule is not MetadataModule metadataModule)
 				return null;
 			IEntity? entity;
 			try

--- a/ILSpy/Options/DisplaySettingReactions.cs
+++ b/ILSpy/Options/DisplaySettingReactions.cs
@@ -61,7 +61,7 @@ namespace ICSharpCode.ILSpy.Options
 			[nameof(DisplaySettings.UseNestedNamespaceNodes)] = DisplaySettingReaction.TreeShape,
 			[nameof(DisplaySettings.HideEmptyMetadataTables)] = DisplaySettingReaction.TreeShape,
 
-			// Decompiler / disassembler output (see DecompilerTabPageModel.ApplyDisplaySettings +
+			// Decompiler / disassembler output (see SettingsService.ApplyDisplaySettings +
 			// GetIndentationString, and CSharpILMixedLanguage / ILLanguage for the IL-detail ones).
 			[nameof(DisplaySettings.FoldBraces)] = DisplaySettingReaction.Redecompile,
 			[nameof(DisplaySettings.ExpandMemberDefinitions)] = DisplaySettingReaction.Redecompile,

--- a/ILSpy/Search/RunningSearch.cs
+++ b/ILSpy/Search/RunningSearch.cs
@@ -254,15 +254,18 @@ namespace ICSharpCode.ILSpy.Search
 			Completed?.Invoke(this);
 		}
 
-		SearchRequest BuildRequest()
+		internal SearchRequest BuildRequest()
 		{
 			var request = ParseInput(searchTerm ?? string.Empty, mode);
 			request.SearchResultFactory = resultFactory;
-			// MemberSearchStrategy.Search resolves a type system via
-			// module.GetTypeSystemWithDecompilerSettingsOrNull(request.DecompilerSettings);
-			// passing null short-circuits to zero results. Default settings are fine for
-			// search — we only need the type system to materialise.
-			request.DecompilerSettings = new DecompilerSettings();
+			// The search strategies resolve a type system via
+			// module.GetTypeSystemWithDecompilerSettingsOrNull(request.DecompilerSettings),
+			// which caches ONE type system per options value on the LoadedAssembly. Derive the
+			// settings from the user's current options so search hits the same cached instance
+			// the tree resolves through, instead of materialising a second type system per
+			// module (and disagreeing with the tree about settings-dependent entity shapes).
+			request.DecompilerSettings = AppEnv.AppComposition.TryGetExport<SettingsService>()
+				?.CreateEffectiveDecompilerSettings() ?? new DecompilerSettings();
 			return request;
 		}
 

--- a/ILSpy/SettingsService.cs
+++ b/ILSpy/SettingsService.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.ComponentModel;
 using System.Composition;
 
@@ -56,6 +57,52 @@ namespace ICSharpCode.ILSpy
 		public DisplaySettings DisplaySettings => GetSettings<DisplaySettings>();
 
 		public MiscSettings MiscSettings => GetSettings<MiscSettings>();
+
+		/// <summary>
+		/// Returns the effective decompiler settings a decompilation started right now would
+		/// use: a clone of <see cref="DecompilerSettings"/> with the Display options bridged in
+		/// and the language version selected in the toolbar applied. Mutating the returned
+		/// instance does not affect the persisted settings.
+		/// </summary>
+		public Decompiler.DecompilerSettings CreateEffectiveDecompilerSettings()
+		{
+			var settings = DecompilerSettings.Clone();
+			ApplyDisplaySettings(settings, DisplaySettings);
+			// No LanguageService (non-C# language or minimal test host) leaves the version
+			// null, so the language version falls back to Latest below.
+			var version = AppEnv.AppComposition.TryGetExport<Languages.LanguageService>()?.CurrentVersion;
+			if (Enum.TryParse<Decompiler.CSharp.LanguageVersion>(version?.Version, out var languageVersion))
+				settings.SetLanguageVersion(languageVersion);
+			else
+				settings.SetLanguageVersion(Decompiler.CSharp.LanguageVersion.Latest);
+			return settings;
+		}
+
+		/// <summary>
+		/// Bridges the Display options that affect decompiler output into <paramref name="settings"/>:
+		/// the fold-expansion flags (TextTokenWriter reads them to set each fold's DefaultClosed),
+		/// brace folding, debug-symbol info, and the indentation string. Without this these Display
+		/// options would have no effect on the produced source.
+		/// </summary>
+		internal static void ApplyDisplaySettings(Decompiler.DecompilerSettings settings, DisplaySettings display)
+		{
+			settings.ExpandUsingDeclarations = display.ExpandUsingDeclarations;
+			settings.ExpandMemberDefinitions = display.ExpandMemberDefinitions;
+			settings.FoldBraces = display.FoldBraces;
+			settings.ShowDebugInfo = display.ShowDebugInfo;
+			settings.CSharpFormattingOptions.IndentationString = GetIndentationString(display);
+		}
+
+		static string GetIndentationString(DisplaySettings display)
+		{
+			if (display.IndentationUseTabs)
+			{
+				int tabs = display.IndentationSize / display.IndentationTabSize;
+				int spaces = display.IndentationSize % display.IndentationTabSize;
+				return new string('\t', tabs) + new string(' ', spaces);
+			}
+			return new string(' ', display.IndentationSize);
+		}
 
 		public Updates.UpdateSettings UpdateSettings => GetSettings<Updates.UpdateSettings>();
 

--- a/ILSpy/SolutionWriter.cs
+++ b/ILSpy/SolutionWriter.cs
@@ -56,20 +56,20 @@ namespace ICSharpCode.ILSpy
 		/// or whitespace.</exception>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="language"/> or
 		/// <paramref name="assemblies"/> is null.</exception>
-		/// <param name="settings">Decompiler settings each project is decompiled with. When null,
-		/// each project uses the language's own defaults (preserves the quick "Save Code" path).</param>
+		/// <param name="settings">Decompiler settings each project is decompiled with.</param>
 		/// <param name="strongNameKeyFile">Optional <c>.snk</c> copied into every project and emitted
 		/// as <c>&lt;AssemblyOriginatorKeyFile&gt;</c>.</param>
 		public static Task<SolutionExportResult> CreateSolutionAsync(string solutionFilePath,
 			Language language, IReadOnlyList<LoadedAssembly> assemblies,
-			CancellationToken cancellationToken = default,
-			DecompilerSettings? settings = null, string? strongNameKeyFile = null,
+			CancellationToken cancellationToken,
+			DecompilerSettings settings, string? strongNameKeyFile = null,
 			IProgress<DecompilationProgress>? progress = null)
 		{
 			if (string.IsNullOrWhiteSpace(solutionFilePath))
 				throw new ArgumentException("The solution file path cannot be null or empty.", nameof(solutionFilePath));
 			ArgumentNullException.ThrowIfNull(language);
 			ArgumentNullException.ThrowIfNull(assemblies);
+			ArgumentNullException.ThrowIfNull(settings);
 
 			return new SolutionWriter(solutionFilePath, settings, strongNameKeyFile, progress)
 				.CreateSolutionAsync(assemblies, language, cancellationToken);
@@ -77,14 +77,14 @@ namespace ICSharpCode.ILSpy
 
 		readonly string solutionFilePath;
 		readonly string solutionDirectory;
-		readonly DecompilerSettings? settings;
+		readonly DecompilerSettings settings;
 		readonly string? strongNameKeyFile;
 		readonly IProgress<DecompilationProgress>? progress;
 		readonly ConcurrentBag<ProjectItem> projects;
 		readonly ConcurrentBag<string> statusOutput;
 		int completedAssemblies;
 
-		SolutionWriter(string solutionFilePath, DecompilerSettings? settings, string? strongNameKeyFile,
+		SolutionWriter(string solutionFilePath, DecompilerSettings settings, string? strongNameKeyFile,
 			IProgress<DecompilationProgress>? progress)
 		{
 			this.solutionFilePath = solutionFilePath;
@@ -224,7 +224,7 @@ namespace ICSharpCode.ILSpy
 
 			try
 			{
-				var options = settings != null ? new DecompilationOptions(settings) : new DecompilationOptions();
+				var options = new DecompilationOptions(settings);
 				options.FullDecompilation = true;
 				options.EscapeInvalidIdentifiers = true;
 				options.CancellationToken = ct;

--- a/ILSpy/TextView/DecompilerTabPageModel.cs
+++ b/ILSpy/TextView/DecompilerTabPageModel.cs
@@ -514,17 +514,14 @@ namespace ICSharpCode.ILSpy.TextView
 				{
 					(output, _) = await Task.Run(() => {
 						var output = new AvaloniaEditTextOutput { LengthLimit = outputLengthLimit };
-						var options = decompilerSettings != null
-							? new DecompilationOptions(decompilerSettings) {
-								CancellationToken = cts.Token,
-								StepLimit = stepLimit,
-								IsDebug = isDebug,
-							}
-							: new DecompilationOptions {
-								CancellationToken = cts.Token,
-								StepLimit = stepLimit,
-								IsDebug = isDebug,
-							};
+						// decompilerSettings is null only in design-time / minimal test hosts
+						// without composition; fall back to defaults there.
+						var options = new DecompilationOptions(
+							decompilerSettings ?? new ICSharpCode.Decompiler.DecompilerSettings()) {
+							CancellationToken = cts.Token,
+							StepLimit = stepLimit,
+							IsDebug = isDebug,
+						};
 						try
 						{
 							for (int i = 0; i < nodes.Count; i++)
@@ -714,52 +711,10 @@ namespace ICSharpCode.ILSpy.TextView
 			Text = text;
 		}
 
-		// Pulls the live DecompilerSettings via MEF and returns a clone for this run. Also
-		// bakes the active LanguageService.CurrentVersion into the clone — without this the
-		// toolbar's Language-Version dropdown writes-through to LanguageSettings but never
-		// reaches the decompiler. Resolves go through TryGetExport so design-time / minimal test
-		// hosts that bypass composition fall back to default settings rather than throwing.
+		// Pulls the effective DecompilerSettings (clone + Display options + toolbar language
+		// version) for this run. Resolves via TryGetExport so design-time / minimal test hosts
+		// that bypass composition fall back to default settings rather than throwing.
 		static ICSharpCode.Decompiler.DecompilerSettings? TryGetLiveDecompilerSettings()
-		{
-			var settingsService = AppEnv.AppComposition.TryGetExport<SettingsService>();
-			if (settingsService is null)
-				return null;
-			var settings = settingsService.DecompilerSettings.Clone();
-			ApplyDisplaySettings(settings, settingsService.DisplaySettings);
-			// No LanguageService (non-C# language or minimal host) leaves version null, so the
-			// language version falls back to Latest below.
-			var version = AppEnv.AppComposition.TryGetExport<Languages.LanguageService>()?.CurrentVersion;
-			if (Enum.TryParse<ICSharpCode.Decompiler.CSharp.LanguageVersion>(version?.Version, out var languageVersion))
-				settings.SetLanguageVersion(languageVersion);
-			else
-				settings.SetLanguageVersion(ICSharpCode.Decompiler.CSharp.LanguageVersion.Latest);
-			return settings;
-		}
-
-		/// <summary>
-		/// Bridges the Display options that affect decompiler output into <paramref name="settings"/>:
-		/// the fold-expansion flags (TextTokenWriter reads them to set each fold's DefaultClosed),
-		/// brace folding, debug-symbol info, and the indentation string. Without this these Display
-		/// options would have no effect on the produced source.
-		/// </summary>
-		internal static void ApplyDisplaySettings(ICSharpCode.Decompiler.DecompilerSettings settings, DisplaySettings display)
-		{
-			settings.ExpandUsingDeclarations = display.ExpandUsingDeclarations;
-			settings.ExpandMemberDefinitions = display.ExpandMemberDefinitions;
-			settings.FoldBraces = display.FoldBraces;
-			settings.ShowDebugInfo = display.ShowDebugInfo;
-			settings.CSharpFormattingOptions.IndentationString = GetIndentationString(display);
-		}
-
-		static string GetIndentationString(DisplaySettings display)
-		{
-			if (display.IndentationUseTabs)
-			{
-				int tabs = display.IndentationSize / display.IndentationTabSize;
-				int spaces = display.IndentationSize % display.IndentationTabSize;
-				return new string('\t', tabs) + new string(' ', spaces);
-			}
-			return new string(' ', display.IndentationSize);
-		}
+			=> AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings();
 	}
 }

--- a/ILSpy/TreeNodes/AssemblyReferenceTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyReferenceTreeNode.cs
@@ -91,7 +91,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			var parentModule = parentAssembly.LoadedAssembly.GetMetadataFileOrNull();
 			if (parentModule != null)
 			{
-				var parentTypeSystem = (MetadataModule?)parentModule.GetTypeSystemOrNull()?.MainModule;
+				var parentTypeSystem = (MetadataModule?)parentModule.GetTypeSystemWithCurrentOptionsOrNull()?.MainModule;
 				if (parentTypeSystem != null)
 					Children.Add(new AssemblyReferenceReferencedTypesTreeNode(parentTypeSystem, reference));
 			}

--- a/ILSpy/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyTreeNode.cs
@@ -194,8 +194,10 @@ namespace ICSharpCode.ILSpy.TreeNodes
 			var ext = Path.GetExtension(path);
 			var isProject = string.Equals(ext, language.ProjectFileExtension, StringComparison.OrdinalIgnoreCase);
 
+			var settings = AppEnv.AppComposition.TryGetExport<SettingsService>()?.CreateEffectiveDecompilerSettings()
+				?? new ICSharpCode.Decompiler.DecompilerSettings();
 			await Task.Run(() => {
-				var options = new DecompilationOptions {
+				var options = new DecompilationOptions(settings) {
 					FullDecompilation = true,
 					EscapeInvalidIdentifiers = true,
 				};

--- a/ILSpy/TreeNodes/ExtensionTreeNode.cs
+++ b/ILSpy/TreeNodes/ExtensionTreeNode.cs
@@ -69,10 +69,11 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				| ConversionFlags.UseFullyQualifiedEntityNames
 				| ConversionFlags.SupportExtensionDeclarations);
 
-		// Avalonia uses the constructor-time marker reference directly. WPF re-resolves
-		// through GetTypeSystemWithCurrentOptionsOrNull so language-version flips refresh
-		// the display string immediately; the Avalonia port doesn't yet expose that helper
-		// (see `extension-methods-tree` follow-ups in the tracker).
+		// Uses the constructor-time marker reference directly. The marker comes from the
+		// parent TypeTreeNode, which resolves through GetTypeSystemWithCurrentOptionsOrNull,
+		// so the chain is consistent with the current settings; per-access re-resolution (so
+		// language-version flips refresh the display string without rebuilding the node, as
+		// WPF does) remains a follow-up (see `extension-methods-tree` in the tracker).
 		ITypeDefinition GetTypeDefinition() => MarkerMethod.DeclaringTypeDefinition!;
 
 		protected override void LoadChildren()

--- a/ILSpy/TreeNodes/NamespaceTreeNode.cs
+++ b/ILSpy/TreeNodes/NamespaceTreeNode.cs
@@ -94,7 +94,9 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override void Decompile(Language language, ITextOutput output, DecompilationOptions options)
 		{
-			var typeSystem = module.GetTypeSystemOrNull();
+			// Enumerate via the type system matching this run's settings so the namespace
+			// listing agrees with what the per-type decompilation below produces.
+			var typeSystem = module.GetTypeSystemWithDecompilerSettingsOrNull(options.DecompilerSettings);
 			if (typeSystem == null)
 			{
 				language.WriteCommentLine(output, "(type system unavailable)");

--- a/ILSpy/TreeNodes/TypeTreeNode.cs
+++ b/ILSpy/TreeNodes/TypeTreeNode.cs
@@ -137,7 +137,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		ITypeDefinition? ResolveTypeDefinition()
 		{
-			var typeSystem = module.GetTypeSystemOrNull();
+			var typeSystem = module.GetTypeSystemWithCurrentOptionsOrNull();
 			if (typeSystem == null)
 				return null;
 			return ((MetadataModule)typeSystem.MainModule).GetDefinition(handle);


### PR DESCRIPTION
### Problem

The Avalonia port gave `DecompilationOptions` a parameterless constructor that silently defaulted to `new DecompilerSettings()`. Several decompilation paths picked it up and decompiled with **default** settings where the WPF version used the user's **current** options, so user-configured settings were ignored in:

- tree member filtering (`CSharpLanguage.ShowMember`)
- PDB generation
- the single-file / project / solution Save Code paths
- the DEBUG decompile-all commands

Separately, `LoadedAssembly` caches one type system per `TypeSystemOptions` value, but the consumers disagreed on which one to use: tree nodes and the metadata navigator resolved through `GetTypeSystemOrNull` (a separate default-options instance) and search built its request with default settings. Each module could materialise several type systems, and none of the display surfaces respected settings that change entity shapes (nullability, tuples, extension methods, ...). WPF routed all of these through `GetTypeSystemWithCurrentOptionsOrNull`.

### Solution

* Promote the live-snapshot logic that was private to `DecompilerTabPageModel` (settings clone + Display-option bridge + toolbar language version) to `SettingsService.CreateEffectiveDecompilerSettings`, and use it at every decompilation entry point.
* Remove the parameterless `DecompilationOptions` constructor and make `SolutionWriter` require settings, so reaching for defaults is an explicit choice rather than a silent fallback — that default is exactly what masked these regressions. Search deliberately keeps default settings (it only needs a type system to materialise).
* Reintroduce `GetTypeSystemWithCurrentOptionsOrNull` on top of `CreateEffectiveDecompilerSettings` and use it in `TypeTreeNode`, `AssemblyReferenceTreeNode`, and the metadata navigator; the search request now derives its settings the same way, so all of them hit the same cached instance. `NamespaceTreeNode.Decompile` enumerates through the type system matching the decompilation options it was handed.
* [x] At least one test covering the code changed (`ShowMemberSettingsTests`, `TypeSystemSharingTests`, plus updates to existing export/bridge tests)
