### PR TITLE
dev: fix editorconfig parsing on some editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,8 @@
 root = true
 
 [*]
-charset = utf-8 # standardize on no BOM (except resx, see below)
+# standardize on no BOM (except resx, see below)
+charset = utf-8
 indent_style = tab
 indent_size = 4
 guidelines = 110


### PR DESCRIPTION
Some editors following the newer EditorConfig spec will not tolerate inline comments.

Link to issue(s) this covers
Fixes: 1d082e712863fa89e5dbd6afcaeabe3cd52e8b2d

### Problem
https://spec.editorconfig.org/#no-inline-comments

