### PR TITLE
Use cross-platform separators for the FSharp.Core.dll test path

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -371,7 +371,7 @@ namespace ICSharpCode.Decompiler.Tests
 			{
 				if (File.Exists(Path.Combine(TestCasePath, "FSharp.Core.dll")))
 					return;
-				string fsharpCoreDll = Path.Combine(TestCasePath, "..\\..\\..\\ILSpy-tests\\FSharp\\FSharp.Core.dll");
+				string fsharpCoreDll = Path.Combine(TestCasePath, "..", "..", "..", "ILSpy-tests", "FSharp", "FSharp.Core.dll");
 				if (!File.Exists(fsharpCoreDll))
 					Assert.Ignore("Ignored because of missing ILSpy-tests repo. Must be checked out separately from https://github.com/icsharpcode/ILSpy-tests!");
 				File.Copy(fsharpCoreDll, Path.Combine(TestCasePath, "FSharp.Core.dll"));


### PR DESCRIPTION
## Problem

`ILPrettyTestRunner.CopyFSharpCoreDll()` locates `ILSpy-tests/FSharp/FSharp.Core.dll` with a hardcoded Windows path:

```csharp
string fsharpCoreDll = Path.Combine(TestCasePath, "..\\..\\..\\ILSpy-tests\\FSharp\\FSharp.Core.dll");
```

On non-Windows, `\` is an ordinary filename character, so this becomes a single bogus path, `File.Exists` always returns `false`, and the FSharp ILPretty tests (`FSharpLoops`, `FSharpUsing`) get `Assert.Ignore`'d — **even when `ILSpy-tests` is checked out**. They have effectively never run on Linux/macOS.

## Fix

Build the path from `Path.Combine` segments so it resolves on every platform. Same target (three levels up from the `ILPretty` test-case directory, which is where the `ILSpy-tests` submodule lives), just no embedded separators.

## Verification (Linux)

With `ILSpy-tests` checked out, `FSharpLoops_Debug`/`_Release` now **run and pass** instead of being skipped:

```
total: 2  succeeded: 2  skipped: 0
```

Test-only change; no production code affected.