### PR TITLE
Fix #3777: decompile runtime async without a separate C# 15 setting

### DIFF
--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -177,16 +177,10 @@ namespace ICSharpCode.Decompiler
 				extensionMembers = false;
 				firstClassSpanTypes = false;
 			}
-			if (languageVersion < CSharp.LanguageVersion.CSharp15_0)
-			{
-				runtimeAsync = false;
-			}
 		}
 
 		public CSharp.LanguageVersion GetMinimumRequiredVersion()
 		{
-			if (runtimeAsync)
-				return CSharp.LanguageVersion.CSharp15_0;
 			if (extensionMembers || firstClassSpanTypes)
 				return CSharp.LanguageVersion.CSharp14_0;
 			if (paramsCollections)
@@ -2199,24 +2193,6 @@ namespace ICSharpCode.Decompiler
 				if (firstClassSpanTypes != value)
 				{
 					firstClassSpanTypes = value;
-					OnPropertyChanged();
-				}
-			}
-		}
-
-		bool runtimeAsync = true;
-
-		/// <summary>
-		/// Gets/Sets whether runtime async should be used.
-		/// </summary>
-		[Category("C# 15.0 / VS 202x.yy")]
-		[Description("DecompilerSettings.RuntimeAsync")]
-		public bool RuntimeAsync {
-			get { return runtimeAsync; }
-			set {
-				if (runtimeAsync != value)
-				{
-					runtimeAsync = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -122,7 +122,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			moveNextLeaves.Clear();
 			if (!MatchTaskCreationPattern(function) && !MatchAsyncEnumeratorCreationPattern(function))
 			{
-				if (function.IsAsync && context.Settings.RuntimeAsync)
+				if (function.IsAsync)
 				{
 					TranslateThisCopyAccess(function);
 					RuntimeAsyncManualAwaitTransform.Run(function, context);

--- a/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
@@ -188,7 +188,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		// rewritten into IL that the surrounding non-async control flow can't represent.
 		internal static bool TransformAsyncHelpersAwaitToAwait(Call inst, ILTransformContext context)
 		{
-			if (!context.Settings.RuntimeAsync || !context.Function.IsAsync)
+			if (!context.Settings.AsyncAwait || !context.Function.IsAsync)
 				return false;
 			if (!inst.Method.IsStatic || inst.Arguments.Count != 1 || !IsAsyncHelpersMethod(inst.Method, "Await"))
 				return false;

--- a/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/DecompilerTypeSystem.cs
@@ -212,7 +212,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				typeSystemOptions |= TypeSystemOptions.FirstClassSpanTypes;
 			if (settings.ExtensionMembers)
 				typeSystemOptions |= TypeSystemOptions.ExtensionMembers;
-			if (settings.RuntimeAsync)
+			if (settings.AsyncAwait)
 				typeSystemOptions |= TypeSystemOptions.RuntimeAsync;
 			return typeSystemOptions;
 		}

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1380,15 +1380,6 @@ namespace ICSharpCode.ILSpy.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Decompile runtime-async (System.Runtime.CompilerServices.AsyncHelpers) methods.
-        /// </summary>
-        public static string DecompilerSettings_RuntimeAsync {
-            get {
-                return ResourceManager.GetString("DecompilerSettings.RuntimeAsync", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to &apos;scoped&apos; lifetime annotation.
         /// </summary>
         public static string DecompilerSettings_ScopedRef {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -489,9 +489,6 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.RequiredMembers" xml:space="preserve">
     <value>Required members</value>
   </data>
-  <data name="DecompilerSettings.RuntimeAsync" xml:space="preserve">
-    <value>Decompile runtime-async (System.Runtime.CompilerServices.AsyncHelpers) methods</value>
-  </data>
   <data name="DecompilerSettings.ScopedRef" xml:space="preserve">
     <value>'scoped' lifetime annotation</value>
   </data>


### PR DESCRIPTION
Fixes #3777.

Runtime async is a *compiler* feature, not a language feature: there is no `dotnet/csharplang` spec for it, and Roslyn emits it even in older language versions when enabled. ILSpy decompiles runtime-async methods back into ordinary `async`/`await`, which is a C# 5 construct. Gating that reconstruction on **C# 15** needlessly produced worse output whenever a lower language version was selected.

Rather than just re-gate the toggle to C# 5, this removes the standalone `RuntimeAsync` setting entirely and folds its behavior into the existing `AsyncAwait` ("Decompile async methods") setting. The separate toggle was redundant: `AsyncAwaitDecompiler.Run` already early-returns when `AsyncAwait` is disabled, so the runtime-async transforms were always nested inside that gate. Runtime async now follows the single async/await toggle, exactly like state-machine async.

### Changes
- Remove the `RuntimeAsync` property from `DecompilerSettings` (plus its C# 15 version-gating in `SetLanguageVersion`/`GetMinimumRequiredVersion`) and its resource string.
- Route the three consumers (`DecompilerTypeSystem.GetOptions`, `AsyncAwaitDecompiler`, `EarlyExpressionTransforms`) through `AsyncAwait`.

### Notes
- Settings persistence is reflection-based, so a stale `RuntimeAsync` attribute in saved settings is silently ignored on load; no migration needed.
- The orphaned "C# 15.0" options group disappears automatically since the UI reflects properties.

### Testing
- Built the desktop solution filter cleanly (0 warnings/errors).
- Ran the `RuntimeAsync*` pretty tests locally (`RuntimeAsync`, `RuntimeAsyncForeach`, `RuntimeAsyncMain`, `RuntimeAsyncStreams`, `RuntimeAsyncUsing`, `RuntimeAsyncCustomTaskType`): all 12 cases pass.
