### PR TITLE
Fix #3793: stop accidental text selection after clicking a reference

### DIFF
--- a/ILSpy.Tests/Editor/ReferenceClickTests.cs
+++ b/ILSpy.Tests/Editor/ReferenceClickTests.cs
@@ -115,4 +115,21 @@ public class ReferenceClickTests
 
 		navigated.Should().BeTrue("a click without dragging follows the link");
 	}
+
+	[AvaloniaTest]
+	public async Task Click_On_A_Link_Then_Moving_The_Mouse_Does_Not_Select_Text()
+	{
+		var (window, view, tab) = await SetupAsync();
+		var (_, point) = FindVisibleReference(window, view, tab);
+		tab.NavigateRequested += _ => { };
+
+		// A stationary click navigates; the gesture must end cleanly so that afterwards moving
+		// the mouse with no button held does not extend a selection (issue #3793).
+		window.MouseDown(point, MouseButton.Left);
+		window.MouseUp(point, MouseButton.Left);
+		window.MouseMove(point + new Point(60, 0));
+
+		view.Editor.TextArea.Selection.IsEmpty.Should().BeTrue(
+			"moving the mouse after a click, with no button held, must not select text");
+	}
 }

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -157,15 +157,22 @@ namespace ICSharpCode.ILSpy.TextView
 
 			// Reference navigation fires on pointer-RELEASE without drag (WPF parity: the WPF
 			// view used TextArea.PreviewMouseDown/Up the same way), so a press-and-drag over a
-			// link starts a text selection instead of navigating away. Tunnel routing mirrors
-			// WPF's Preview events and sees the gesture before AvaloniaEdit's own handlers.
+			// link starts a text selection instead of navigating away. The press handler only
+			// records the start position, so tunnel routing (before AvaloniaEdit consumes the
+			// press) is fine.
 			Editor.TextArea.AddHandler(InputElement.PointerPressedEvent,
 				OnTextAreaPointerPressedForReferenceClick,
 				RoutingStrategies.Tunnel,
 				handledEventsToo: true);
+			// The release handler must run AFTER AvaloniaEdit's own PointerReleased: AvaloniaEdit's
+			// SelectionMouseHandler captures the pointer and enters selection mode on press, and
+			// only its release handler resets that mode and releases the capture. AvaloniaEdit
+			// subscribes in the bubble phase from the TextArea constructor (before this view adds
+			// its handlers), so a bubble handler here is guaranteed to run after it. handledEventsToo
+			// keeps us running even though AvaloniaEdit marks the release handled.
 			Editor.TextArea.AddHandler(InputElement.PointerReleasedEvent,
 				OnTextAreaPointerReleasedForReferenceClick,
-				RoutingStrategies.Tunnel,
+				RoutingStrategies.Bubble,
 				handledEventsToo: true);
 		}
 
@@ -200,9 +207,10 @@ namespace ICSharpCode.ILSpy.TextView
 				ClearLocalReferenceMarks();
 				return;
 			}
-			// Cancel the caret-click selection AvaloniaEdit started on press, and stop its
-			// release processing, so the navigation's caret move doesn't grow a selection
-			// between the old anchor and the new position.
+			// AvaloniaEdit's own release handler has already reset its selection mode and released
+			// the pointer capture (it runs first in the bubble phase). Clear the empty caret-click
+			// selection it leaves behind, then navigate; marking the release handled stops it from
+			// bubbling further now that it has been consumed as a link click.
 			Editor.TextArea.ClearSelection();
 			e.Handled = true;
 			OnReferenceClicked(segment);


### PR DESCRIPTION
Fixes #3793.

## Symptoms

Two "accidental text selection" reports, shown in the two videos on the issue:

1. **Selection on navigation** – click a reference to navigate, then move the mouse, and text gets selected.
2. **Selection follows the cursor after clicking a variable** – click a local variable (which highlights its other occurrences), then move the mouse, and a selection is dragged out even though no button is held.

These turned out to be the **same bug**, just triggered by a cross-document reference vs. a local one.

## Hypotheses considered

- **(A) We programmatically select text during navigation** (caret move from the old anchor to the jump target grows a selection). Rejected: the handler already calls `ClearSelection()` before jumping, and the selection only appears *after* a subsequent mouse move, not at navigation time.
- **(B) The press handler fails to release pointer capture / doesn't mark the press handled**, so AvaloniaEdit keeps tracking. Partially on the right track but misattributed – the press path is fine (we *want* AvaloniaEdit to handle the press so press-and-drag over a link still selects link text).
- **(C, landed) Marking the pointer-*release* handled in the tunnel phase suppresses AvaloniaEdit's own release handler**, which is the only thing that resets its selection-drag mode and releases the pointer capture.

I confirmed (C) by decompiling `Avalonia.AvaloniaEdit 12.0.0` (using this repo's `ilspycmd`) and reading `SelectionMouseHandler`:

- On press it captures the pointer and sets `_mode = Normal`.
- `TextArea_MouseMove` extends the selection whenever `_mode == Normal` — it keys off the **mode, not whether a button is pressed**. So a captured TextArea left in `Normal` mode selects on *any* pointer move.
- `TextArea_MouseLeftButtonUp` is the only place that resets `_mode = None` and calls `ReleasePointerCapture`, and it **early-returns if `e.Handled` is already true**.

Our reference-click handler ran in the **tunnel** phase and set `e.Handled = true` *before* AvaloniaEdit's bubble-phase release handler, so AvaloniaEdit's cleanup was skipped → mode stuck in `Normal`, pointer still captured → the next move dragged out a selection. (Clicks on empty space already returned early *without* setting `Handled`, which is why only clicks on references were affected.)

## The fix

Move the reference-click **release** handler from the tunnel phase to the **bubble** phase (keeping `handledEventsToo: true`). It then runs *after* AvaloniaEdit's own release handler has reset the mode and released the capture, so the gesture ends cleanly and a later move no longer selects.

## Control-limitation workaround / interesting bits

- `SelectionMouseHandler._mode` is **private internal state** with no public reset, so there's no way to "un-stick" the selection mode directly. The fix instead relies on letting AvaloniaEdit's *own* mouse-up perform that reset.
- That requires deterministic handler ordering. AvaloniaEdit subscribes to `PointerReleased` (bubble) from the **`TextArea` constructor** (`ActiveInputHandler = DefaultInputHandler` → `Attach()`), which runs before `DecompilerTextView` attaches its handlers — so a bubble handler added by the view is guaranteed to run after AvaloniaEdit's. This let me keep **navigation synchronous** (no `Dispatcher.Post`), which also means the existing "stationary click navigates" test keeps passing without pumping the dispatcher.
- `TextEditorOptions.ExtendSelectionOnMouseUp` defaults to `true`, so AvaloniaEdit's mouse-up creates an empty/at-most-one-char selection on a plain click; the handler still calls `ClearSelection()` before navigating to clear it.
- The **press** handler stays on the tunnel phase — it only records the start position, so ordering there doesn't matter, and AvaloniaEdit must still own the press so press-and-drag over a link selects its text instead of navigating.

## Tests

Added a regression test `Click_On_A_Link_Then_Moving_The_Mouse_Does_Not_Select_Text` to `ReferenceClickTests` (reuses the existing headless pointer harness). It fails red on the old code (mode stuck → move selects) and passes green after the fix. The two existing reference-click tests (stationary-click-navigates, drag-selects-without-navigating) remain green, and the full `ILSpy.Tests` project passes (878 passed, 3 pre-existing skips).