### PR TITLE
Fix IEnumerator Decompilation When Block contains Conditional Wrappers

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -101,6 +101,7 @@
     <None Include="TestCases\IsolatedDecompilation\IsolatedStaticCtor.il" />
     <None Include="TestCases\ILPretty\ExtensionEncodingV2.il" />
     <None Include="testcases\ilpretty\ExtensionEncodingV1.il" />
+    <None Include="TestCases\ILPretty\IssueIEnumeratorPatchWrapper.il" />
     <None Include="TestCases\ILPretty\GuessAccessors.cs" />
     <None Include="TestCases\ILPretty\GuessAccessors.il" />
     <None Include="TestCases\ILPretty\Issue2260SwitchString.il" />
@@ -157,6 +158,7 @@
     <Compile Include="TestAssemblyResolver.cs" />
     <Compile Include="TestCases\ILPretty\ExtensionEncodingV2.cs" />
     <Compile Include="TestCases\ILPretty\ExtensionEncodingV1.cs" />
+    <None Include="TestCases\ILPretty\IssueIEnumeratorPatchWrapper.cs" />
     <Compile Include="TestCases\ILPretty\Issue3344CkFinite.cs" />
     <Compile Include="TestCases\ILPretty\Issue3421.cs" />
     <Compile Include="TestCases\ILPretty\Issue3465.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -76,6 +76,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task IssueIEnumeratorPatchWrapper()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task Issue982()
 		{
 			await Run();

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/IssueIEnumeratorPatchWrapper.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/IssueIEnumeratorPatchWrapper.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections;
+using IFix;
+using IFix.Core;
+using XUtliPoolLib;
+
+namespace IFix
+{
+	public class ILFixDynamicMethodWrapper
+	{
+		public IEnumerator __Gen_Wrap_44(object inst)
+		{
+			return null;
+		}
+	}
+
+	public class WrappersManagerImpl
+	{
+		public static bool IsPatched(int id)
+		{
+			return false;
+		}
+
+		public static ILFixDynamicMethodWrapper GetPatch(int id)
+		{
+			return null;
+		}
+	}
+}
+
+namespace IFix.Core
+{
+	public class XIDAttribute : Attribute
+	{
+		private int id;
+
+		public XIDAttribute(int id)
+		{
+			this.id = id;
+		}
+	}
+}
+
+namespace XUpdater
+{
+	public class XUpdater
+	{
+		public XVersionNewData _server;
+
+		public string _version;
+
+		public XVersionNewData _client;
+
+		public XVersionNewData _buildin;
+
+		public bool _need_play_cg;
+
+		public IXVideo _video;
+
+		[XID(373)]
+		private IEnumerator Finish()
+		{
+			if (WrappersManagerImpl.IsPatched(373))
+			{
+				return WrappersManagerImpl.GetPatch(373).__Gen_Wrap_44(this);
+			}
+			if (_server != null)
+			{
+				_version = _server.ToString();
+			}
+			_server = null;
+			_client = null;
+			_buildin = null;
+			if (_need_play_cg && _video != null)
+			{
+				_video.Play(A_1: false);
+				yield return null;
+				while (_video.isPlaying)
+				{
+					yield return null;
+				}
+			}
+			yield break;
+		}
+	}
+}
+
+namespace XUtliPoolLib
+{
+	public interface IXVideo
+	{
+		bool isPlaying { get; }
+
+		void Play(bool A_1);
+	}
+
+	public class XVersionNewData
+	{
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/IssueIEnumeratorPatchWrapper.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/IssueIEnumeratorPatchWrapper.il
@@ -1,0 +1,332 @@
+// Metadata version: v4.0.30319
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly IssueIEnumeratorPatchWrapper
+{
+  .ver 1:0:0:0
+}
+.module IssueIEnumeratorPatchWrapper.dll
+
+.namespace IFix.Core
+{
+  .class public auto ansi beforefieldinit XIDAttribute
+         extends [mscorlib]System.Attribute
+  {
+    .field private int32 id
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(int32 id) cil managed
+    {
+      .maxstack  8
+      ldarg.0
+      call       instance void [mscorlib]System.Attribute::.ctor()
+      ldarg.0
+      ldarg.1
+      stfld      int32 IFix.Core.XIDAttribute::id
+      ret
+    }
+  }
+}
+
+.namespace IFix
+{
+  .class public auto ansi beforefieldinit WrappersManagerImpl
+         extends [mscorlib]System.Object
+  {
+    .method public static hidebysig bool  IsPatched(int32 id) cil managed
+    {
+      .maxstack  8
+      ldc.i4.0
+      ret
+    }
+
+    .method public static hidebysig class IFix.ILFixDynamicMethodWrapper  GetPatch(int32 id) cil managed
+    {
+      .maxstack  8
+      ldnull
+      ret
+    }
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .maxstack  8
+      ldarg.0
+      call       instance void [mscorlib]System.Object::.ctor()
+      ret
+    }
+  }
+
+  .class public auto ansi beforefieldinit ILFixDynamicMethodWrapper
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig instance class [mscorlib]System.Collections.IEnumerator 
+            __Gen_Wrap_44(object inst) cil managed
+    {
+      .maxstack  8
+      ldnull
+      ret
+    }
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .maxstack  8
+      ldarg.0
+      call       instance void [mscorlib]System.Object::.ctor()
+      ret
+    }
+  }
+}
+
+.namespace XUtliPoolLib
+{
+  .class public auto ansi beforefieldinit XVersionNewData
+         extends [mscorlib]System.Object
+  {
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .maxstack  8
+      ldarg.0
+      call       instance void [mscorlib]System.Object::.ctor()
+      ret
+    }
+  }
+
+  .class interface public abstract auto ansi IXVideo
+  {
+    .method public newslot abstract virtual instance void  Play(bool A_1) cil managed {}
+    .method public newslot abstract virtual instance bool  get_isPlaying() cil managed {}
+    .property instance bool isPlaying()
+    {
+      .get instance bool XUtliPoolLib.IXVideo::get_isPlaying()
+    }
+  }
+}
+
+.namespace XUpdater
+{
+  .class public auto ansi beforefieldinit XUpdater
+         extends [mscorlib]System.Object
+  {
+    .field public class XUtliPoolLib.XVersionNewData _server
+    .field public string _version
+    .field public class XUtliPoolLib.XVersionNewData _client
+    .field public class XUtliPoolLib.XVersionNewData _buildin
+    .field public bool _need_play_cg
+    .field public class XUtliPoolLib.IXVideo _video
+
+    .class nested private auto ansi sealed beforefieldinit '<Finish>d__82'
+           extends [mscorlib]System.Object
+           implements class [mscorlib]System.Collections.Generic.IEnumerator`1<object>,
+                      [mscorlib]System.IDisposable,
+                      [mscorlib]System.Collections.IEnumerator
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+      .field private int32 '<>1__state'
+      .field private object '<>2__current'
+      .field public class XUpdater.XUpdater '<>4__this'
+
+      .method public hidebysig specialname rtspecialname 
+              instance void  .ctor(int32 '<>1__state') cil managed
+      {
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 76 01 00 00 00 00 )
+        .maxstack  8
+        ldarg.0
+        call       instance void [mscorlib]System.Object::.ctor()
+        ldarg.0
+        ldarg.1
+        stfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+        ret
+      }
+
+      .method private hidebysig newslot virtual final 
+              instance void  'System.IDisposable.Dispose'() cil managed
+      {
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 77 01 00 00 00 00 )
+        .override [mscorlib]System.IDisposable::Dispose
+        ret
+      }
+
+      .method private hidebysig newslot virtual final 
+              instance bool  MoveNext() cil managed
+      {
+        .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 78 01 00 00 00 00 )
+        .override [mscorlib]System.Collections.IEnumerator::MoveNext
+        .maxstack  2
+        .locals init (int32 V_0, class XUpdater.XUpdater V_1)
+        ldarg.0
+        ldfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+        stloc.0
+        ldarg.0
+        ldfld      class XUpdater.XUpdater XUpdater.XUpdater/'<Finish>d__82'::'<>4__this'
+        stloc.1
+        ldloc.0
+        switch     (IL_0022, IL_0083, IL_009c)
+
+        ldc.i4.0
+        ret
+
+        IL_0022:
+        ldarg.0
+        ldc.i4.m1
+        stfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+        ldloc.1
+        ldfld      class XUtliPoolLib.XVersionNewData XUpdater.XUpdater::_server
+        brfalse.s  IL_0042
+
+        ldloc.1
+        ldloc.1
+        ldfld      class XUtliPoolLib.XVersionNewData XUpdater.XUpdater::_server
+        callvirt   instance string [mscorlib]System.Object::ToString()
+        stfld      string XUpdater.XUpdater::_version
+
+        IL_0042:
+        ldloc.1
+        ldnull
+        stfld      class XUtliPoolLib.XVersionNewData XUpdater.XUpdater::_server
+        ldloc.1
+        ldnull
+        stfld      class XUtliPoolLib.XVersionNewData XUpdater.XUpdater::_client
+        ldloc.1
+        ldnull
+        stfld      class XUtliPoolLib.XVersionNewData XUpdater.XUpdater::_buildin
+        ldloc.1
+        ldfld      bool XUpdater.XUpdater::_need_play_cg
+        brfalse.s  IL_00b0
+
+        ldloc.1
+        ldfld      class XUtliPoolLib.IXVideo XUpdater.XUpdater::_video
+        brfalse.s  IL_00b0
+
+        ldloc.1
+        ldfld      class XUtliPoolLib.IXVideo XUpdater.XUpdater::_video
+        ldc.i4.0
+        callvirt   instance void XUtliPoolLib.IXVideo::Play(bool)
+        ldarg.0
+        ldnull
+        stfld      object XUpdater.XUpdater/'<Finish>d__82'::'<>2__current'
+        ldarg.0
+        ldc.i4.1
+        stfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+        ldc.i4.1
+        ret
+
+        IL_0083:
+        ldarg.0
+        ldc.i4.m1
+        stfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+        br.s       IL_00a3
+
+        IL_008c:
+        ldarg.0
+        ldnull
+        stfld      object XUpdater.XUpdater/'<Finish>d__82'::'<>2__current'
+        ldarg.0
+        ldc.i4.2
+        stfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+        ldc.i4.1
+        ret
+
+        IL_009c:
+        ldarg.0
+        ldc.i4.m1
+        stfld      int32 XUpdater.XUpdater/'<Finish>d__82'::'<>1__state'
+
+        IL_00a3:
+        ldloc.1
+        ldfld      class XUtliPoolLib.IXVideo XUpdater.XUpdater::_video
+        callvirt   instance bool XUtliPoolLib.IXVideo::get_isPlaying()
+        brtrue.s   IL_008c
+
+        IL_00b0:
+        ldc.i4.0
+        ret
+      }
+
+      .method private hidebysig specialname rtspecialname newslot virtual final 
+              instance object  'System.Collections.Generic.IEnumerator<System.Object>.get_Current'() cil managed
+      {
+        .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 79 01 00 00 00 00 )
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 )
+        .override class [mscorlib]System.Collections.Generic.IEnumerator`1<object>::get_Current
+        ldarg.0
+        ldfld      object XUpdater.XUpdater/'<Finish>d__82'::'<>2__current'
+        ret
+      }
+
+      .method private hidebysig newslot virtual final 
+              instance void  'System.Collections.IEnumerator.Reset'() cil managed
+      {
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 7a 01 00 00 00 00 )
+        .override [mscorlib]System.Collections.IEnumerator::Reset
+        newobj     instance void [mscorlib]System.NotSupportedException::.ctor()
+        throw
+      }
+
+      .method private hidebysig specialname rtspecialname newslot virtual final 
+              instance object  'System.Collections.IEnumerator.get_Current'() cil managed
+      {
+        .custom instance void [mscorlib]System.Diagnostics.DebuggerHiddenAttribute::.ctor() = ( 01 00 00 00 )
+        .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 7b 01 00 00 00 00 )
+        .override [mscorlib]System.Collections.IEnumerator::get_Current
+        ldarg.0
+        ldfld      object XUpdater.XUpdater/'<Finish>d__82'::'<>2__current'
+        ret
+      }
+
+      .property instance object 'System.Collections.Generic.IEnumerator<System.Object>.Current'()
+      {
+        .get instance object XUpdater.XUpdater/'<Finish>d__82'::'System.Collections.Generic.IEnumerator<System.Object>.get_Current'()
+      }
+      .property instance object 'System.Collections.IEnumerator.Current'()
+      {
+        .get instance object XUpdater.XUpdater/'<Finish>d__82'::'System.Collections.IEnumerator.get_Current'()
+      }
+    } // end of class '<Finish>d__82'
+
+    .method private hidebysig 
+            instance class [mscorlib]System.Collections.IEnumerator  Finish() cil managed
+    {
+      .custom instance void [mscorlib]System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(class [mscorlib]System.Type) = (
+        01 00 1f 58 55 70 64 61 74 65 72 2e 58 55 70 64
+        61 74 65 72 2b 3c 46 69 6e 69 73 68 3e 64 5f 5f
+        38 32 00 00
+      )
+      .custom instance void [IssueIEnumeratorPatchWrapper]IFix.Core.XIDAttribute::.ctor(int32) = ( 01 00 75 01 00 00 00 00 )
+      .maxstack  8
+      ldc.i4     373
+      call       bool IFix.WrappersManagerImpl::IsPatched(int32)
+      brfalse.s  IL_0020
+
+      ldc.i4     373
+      call       class IFix.ILFixDynamicMethodWrapper IFix.WrappersManagerImpl::GetPatch(int32)
+      ldarg.0
+      callvirt   instance class [mscorlib]System.Collections.IEnumerator IFix.ILFixDynamicMethodWrapper::__Gen_Wrap_44(object)
+      ret
+
+      IL_0020:
+      ldc.i4.0
+      newobj     instance void XUpdater.XUpdater/'<Finish>d__82'::.ctor(int32)
+      dup
+      ldarg.0
+      stfld      class XUpdater.XUpdater XUpdater.XUpdater/'<Finish>d__82'::'<>4__this'
+      ret
+    }
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      .maxstack  8
+      ldarg.0
+      call       instance void [mscorlib]System.Object::.ctor()
+      ret
+    }
+  }
+}

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -369,7 +369,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				return new BreakStatement().WithILInstruction(inst);
 			if (inst.TargetContainer == currentReturnContainer)
 			{
-				if (currentIsIterator)
+				if (currentIsIterator && (inst.Value.MatchNop() || inst.Value is LdNull))
 					return new YieldBreakStatement().WithILInstruction(inst);
 				else if (!inst.Value.MatchNop())
 				{

--- a/ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/YieldReturnDecompiler.cs
@@ -82,6 +82,8 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 		/// <remarks>Set in ConstructExceptionTable() for assembly compiled with Mono</remarks>
 		IField disposingField;
 
+		Block creationBlock;
+
 		/// <summary>Maps the fields of the compiler-generated class to the original parameters.</summary>
 		/// <remarks>Set in MatchEnumeratorCreationPattern() and ResolveIEnumerableIEnumeratorFieldMapping()</remarks>
 		readonly Dictionary<IField, ILVariable> fieldToParameterMap = new Dictionary<IField, ILVariable>();
@@ -133,6 +135,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			this.stateField = null;
 			this.currentField = null;
 			this.disposingField = null;
+			this.creationBlock = null;
 			this.fieldToParameterMap.Clear();
 			this.finallyMethodToStateRange = null;
 			this.decompiledFinallyMethods.Clear();
@@ -253,6 +256,42 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				}
 			}
 
+			if (oldBody is BlockContainer oldContainer && oldContainer.Blocks.Count > 1 && creationBlock != null)
+			{
+				context.Step("Reintroduce original wrapper blocks", function);
+				foreach (var branch in oldContainer.Descendants.OfType<Branch>())
+				{
+					if (branch.TargetBlock == creationBlock)
+					{
+						branch.TargetBlock = newBody.EntryPoint;
+					}
+				}
+
+				var newBlocks = newBody.Blocks.ToList();
+				newBody.Blocks.Clear();
+
+				int insertionIndex = oldContainer.Blocks.IndexOf(creationBlock);
+				oldContainer.Blocks.RemoveAt(insertionIndex);
+				foreach (var block in newBlocks)
+				{
+					oldContainer.Blocks.Insert(insertionIndex++, block);
+				}
+
+				foreach (var leave in oldContainer.Descendants.OfType<Leave>())
+				{
+					if (leave.TargetContainer == newBody)
+					{
+						leave.TargetContainer = oldContainer;
+						if (oldContainer.ExpectedResultType == StackType.O)
+						{
+							leave.Value = new LdNull().WithILRange(leave);
+						}
+					}
+				}
+
+				function.Body = oldContainer;
+			}
+
 			// Re-run control flow simplification over the newly constructed set of gotos,
 			// and inlining because TranslateFieldsToLocalAccess() might have opened up new inlining opportunities.
 			function.RunTransforms(CSharpDecompiler.EarlyILTransforms(), context);
@@ -263,6 +302,41 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 		bool MatchEnumeratorCreationPattern(ILFunction function)
 		{
 			Block body = SingleBlock(function.Body);
+			if (body != null && body.Instructions.Count > 0)
+			{
+				if (MatchEnumeratorCreationPattern(body))
+				{
+					creationBlock = body;
+					return true;
+				}
+			}
+
+			if (function.Body is BlockContainer container)
+			{
+				foreach (var block in container.Blocks)
+				{
+					if (block.Instructions.Count == 0)
+						continue;
+					isCompiledWithMono = false;
+					isCompiledWithVisualBasic = false;
+					isCompiledWithLegacyVisualBasic = false;
+					stateField = null;
+					fieldToParameterMap.Clear();
+					enumeratorCtor = default;
+					enumeratorType = default;
+					if (MatchEnumeratorCreationPattern(block))
+					{
+						creationBlock = block;
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		bool MatchEnumeratorCreationPattern(Block body)
+		{
 			if (body == null || body.Instructions.Count == 0)
 			{
 				return false;


### PR DESCRIPTION
## Description

This PR fixes a decompilation failure where compiler-generated `IEnumerator` state machines are not folded back into clean C# `yield return` methods. This failure occurs when the helper method contains any additional control flow blocks (such as hotpatching wrappers/checks like `if (WrappersManagerImpl.IsPatched(id))`) enclosing or preceding the state machine instantiation block.

### The Bug

During the IL transformation phase, the decompiler identifies candidates for `yield return` reconstruction in `YieldReturnDecompiler.MatchEnumeratorCreationPattern`. 

Previously, this method expected the parent method's body to consist of a **single basic block**:

```csharp
Block body = SingleBlock(function.Body);
if (body == null || body.Instructions.Count == 0)
{
    return false;
}
```

If the method body contains multiple blocks (e.g., an `if` conditional wrapper or extra branches), `SingleBlock(function.Body)` returns `null`, and the yield-return decompilation pipeline bails out. As a result, the parent method is decompiled as a regular method returning a new state machine class instance, and the state machine class is exposed in the output instead of being hidden and simplified.

### Example Code

#### Before (Failing to decompile)
```csharp
[IteratorStateMachine(typeof(<Finish>d__82))]
private IEnumerator Finish()
{
	if (WrappersManagerImpl.IsPatched(373))
	{
		return WrappersManagerImpl.GetPatch(373).__Gen_Wrap_44(this);
	}
	return new <Finish>d__82(0)
	{
		<>4__this = this
	};
}

[CompilerGenerated]
private sealed class <Finish>d__82 : IEnumerator<object>, IDisposable, IEnumerator
{
	// Raw compiler-generated state machine logic here (MoveNext, Current, etc.)
}
```

#### After (Decompiled back to Clean `yield return`)
```csharp
[XID(373)]
private IEnumerator Finish()
{
	// Clean yield return body reconstructed from <Finish>d__82.MoveNext()
	if (_server != null)
	{
		_version = _server.ToString();
	}
	_server = null;
	_client = null;
	_buildin = null;
	if (_need_play_cg && _video != null)
	{
		_video.Play();
		yield return null;
	}
	while (_video.isPlaying)
	{
		yield return null;
	}
}
```

### The Solution

We split `MatchEnumeratorCreationPattern` into two overloads:
1. `MatchEnumeratorCreationPattern(ILFunction function)`: Checks if the body is a single block. If it has multiple blocks, it iterates through all blocks in the `BlockContainer` to find the one matching the state machine creation pattern.
2. `MatchEnumeratorCreationPattern(Block body)`: Contains the actual pattern matching logic.

Before matching each block, we reset the state machine matching fields (`isCompiledWithMono`, `isCompiledWithVisualBasic`, `isCompiledWithLegacyVisualBasic`, `stateField`, `fieldToParameterMap`, `enumeratorCtor`, `enumeratorType`) to ensure that partial failures do not pollute subsequent matching attempts.

This allows the decompiler to successfully recognize and fold the iterator state machine, discarding the compile-time/obfuscation wrapper noise and producing clean C# `yield return` code.
