### PR TITLE
Fix decompiler tests project inside VS

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -7,7 +7,7 @@
     <!-- A single (host) RID makes the build copy the native DiaSymReader.Native assets the
          Windows PDB tests need; the explicit RID list makes packages.lock.json carry every RID
          (host-independent), so the lock does not drift between Linux and Windows restores. -->
-    <RuntimeIdentifier>$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
     <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;osx-arm64</RuntimeIdentifiers>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
`System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier` is available in .NET 5+ so .NET Framework hosts like VS fail to load the project. `NETCoreSdkRuntimeIdentifier` does the same job, but is an MSBuild property independent of host's .NET version