### PR TITLE
Fix #3799 and three related stackalloc initializer decompilation defects

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
@@ -257,6 +257,33 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return UsePointer((byte*)ptr);
 		}
 
+		// A buffer that is only partially written through a reinterpreting cast is not an
+		// initializer: the fourth int is never assigned, so it must stay a sequence of stores
+		// rather than be reconstructed as 'stackalloc int[4] { 1, v, 3 }' (too few elements).
+		public unsafe string PartialReinterpret(int v)
+		{
+#if OPT
+			byte* num = stackalloc byte[16];
+			*(int*)num = 1;
+			((int*)num)[1] = v;
+			((int*)num)[2] = 3;
+			long num2 = 0L;
+			return UseBytePointer(num, &num2);
+#else
+			byte* ptr = stackalloc byte[16];
+			*(int*)ptr = 1;
+			((int*)ptr)[1] = v;
+			((int*)ptr)[2] = 3;
+			long num = 0L;
+			return UseBytePointer(ptr, &num);
+#endif
+		}
+
+		public unsafe static string UseBytePointer(byte* ptr, long* length)
+		{
+			return ((int*)ptr)->ToString();
+		}
+
 		public unsafe string NegativeOffsets(int a, int b, int c)
 		{
 #if OPT

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
@@ -257,6 +257,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return UsePointer((byte*)ptr);
 		}
 
+		// A pointer-typed stackalloc passed to a call must stay a local: inlining it into the
+		// argument would retype it as Span<T>, which does not convert to the pointer parameter.
+		public unsafe void StackAllocPassedToPointerCall(int v)
+		{
+			int* ptr = stackalloc int[3] { 1, 2, v };
+			UseIntPointer(ptr);
+		}
+
+		public unsafe static void UseIntPointer(int* ptr)
+		{
+		}
+
 		// A buffer that is only partially written through a reinterpreting cast is not an
 		// initializer: the fourth int is never assigned, so it must stay a sequence of stores
 		// rather than be reconstructed as 'stackalloc int[4] { 1, v, 3 }' (too few elements).

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
@@ -212,6 +212,23 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return UsePointer((byte*)ptr);
 		}
 
+		// Mixed constant/non-constant floating-point initializers go through the constant data
+		// blob; reading a 'float'/'double' element as the integer of the same width produced the
+		// raw bit pattern as the literal (e.g. 1f decoded as 1.0653532E+09f).
+		public unsafe string SimpleStackAllocSingle(float a)
+		{
+			float* ptr = stackalloc float[4] { 1f, 2f, 3f, a };
+			Console.WriteLine(*ptr);
+			return UsePointer((byte*)ptr);
+		}
+
+		public unsafe string SimpleStackAllocDouble(double a)
+		{
+			double* ptr = stackalloc double[4] { 1.0, 2.0, 3.0, a };
+			Console.WriteLine(*ptr);
+			return UsePointer((byte*)ptr);
+		}
+
 		public unsafe string SimpleStackAllocInt32NonConstant(int a, int b, int c)
 		{
 			int* ptr = stackalloc int[6] { 0, 1, 0, a, b, c };

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CS73_StackAllocInitializers.cs
@@ -219,6 +219,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return UsePointer((byte*)ptr);
 		}
 
+		// The buffer is only passed to a static call, never dereferenced as a typed pointer, so
+		// some compilers keep it on the stack as a native int rather than in an int* local.
+		// Combined with the constant allocation size being folded to a byte count, that previously
+		// made the decompiler lose the element type and throw "given Block is invalid!".
+		public unsafe string Issue3799(int pid)
+		{
+			int* ptr = stackalloc int[4] { 1, 14, 1, pid };
+			long num = 0L;
+			return UseTwoPointers(ptr, &num);
+		}
+
 		public unsafe string NotAnInitializer(int a, int b, int c)
 		{
 			int* ptr = stackalloc int[6];
@@ -253,6 +264,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public unsafe string UsePointer(byte* ptr)
 		{
 			return ptr->ToString();
+		}
+
+		public unsafe static string UseTwoPointers(int* ptr, long* length)
+		{
+			return ((byte*)ptr)->ToString();
 		}
 
 		public string GetSpan()

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -3713,7 +3713,13 @@ namespace ICSharpCode.Decompiler.CSharp
 			IType elementType;
 			if (block.Instructions.Count < 2 || !block.Instructions[1].MatchStObj(out _, out _, out var t))
 				throw new ArgumentException("given Block is invalid!");
-			if (typeHint is PointerType pt && !TypeUtils.IsCompatibleTypeForMemoryAccess(t, pt.ElementType))
+			// Derive the element type from the type actually being stored when the type hint does
+			// not pin it down. The hint is unreliable here: when the allocation size is a folded
+			// constant (e.g. 'localloc 16' for 'stackalloc int[4]') the element type can no longer
+			// be read off a 'count * sizeof(T)' expression, and the surrounding context may type the
+			// buffer as a plain native int rather than a T*. In both cases falling back to 't' keeps
+			// the element type consistent with the stores in the block.
+			if (!(typeHint is PointerType pt) || !TypeUtils.IsCompatibleTypeForMemoryAccess(t, pt.ElementType))
 			{
 				typeHint = new PointerType(t);
 			}

--- a/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ILInlining.cs
@@ -249,6 +249,19 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (r.Type == FindResultType.Found || r.Type == FindResultType.NamedArgument)
 			{
 				var loadInst = r.LoadInst;
+				// A stackalloc whose result is a pointer (rather than a Span<T>) is only valid C# as
+				// the initializer of a pointer-typed local. Inlining it into any expression position
+				// retypes it as Span<T>, which breaks every pointer use (dereference, a pointer-typed
+				// argument, a reinterpreting cast). Moving it into a local store keeps it a local
+				// initializer, and the Span<T>/ReadOnlySpan<T> constructor is the one position where
+				// reinterpreting it as a span is exactly the point; everything else must not inline.
+				if (inlinedExpression.ResultType == StackType.I
+					&& (inlinedExpression is LocAlloc || inlinedExpression is Block { Kind: BlockKind.StackAllocInitializer })
+					&& loadInst.Parent is not StLoc
+					&& !IsStackAllocSpanConstructorArgument(loadInst))
+				{
+					return false;
+				}
 				if (loadInst.OpCode == OpCode.LdLoca)
 				{
 					if (!IsGeneratedTemporaryForAddressOf((LdLoca)loadInst, v, inlinedExpression, options))
@@ -289,6 +302,21 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return true;
 			}
 			return false;
+		}
+
+		/// <summary>
+		/// Returns true if <paramref name="loadInst"/> is the pointer argument of a
+		/// <c>new Span&lt;T&gt;(pointer, length)</c> / <c>new ReadOnlySpan&lt;T&gt;(pointer, length)</c>
+		/// constructor, i.e. the one position where a pointer-typed stackalloc may be inlined
+		/// (TransformSpanTCtorContainingStackAlloc turns it into a span stackalloc afterwards).
+		/// </summary>
+		static bool IsStackAllocSpanConstructorArgument(ILInstruction loadInst)
+		{
+			return loadInst.Parent is NewObj newObj
+				&& newObj.Arguments.Count == 2
+				&& newObj.Arguments[0] == loadInst
+				&& (newObj.Method.DeclaringType.IsKnownType(KnownTypeCode.SpanOfT)
+					|| newObj.Method.DeclaringType.IsKnownType(KnownTypeCode.ReadOnlySpanOfT));
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -515,8 +515,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				elementCount++;
 			}
 
-			if (values == null || store.Kind != VariableKind.StackSlot || store.StoreCount != 1
-				|| store.AddressCount != 0 || store.LoadCount > values.Length + 1)
+			// Every element must be written, either from the constant data blob or by an explicit
+			// store. A gap means the buffer is only partially initialized (e.g. a 'stackalloc
+			// byte[16]' reinterpreted and written through a few elements), which cannot be
+			// represented as an initializer and has to stay a sequence of individual stores.
+			if (values == null || Array.IndexOf(values, null) >= 0 || store.Kind != VariableKind.StackSlot
+				|| store.StoreCount != 1 || store.AddressCount != 0 || store.LoadCount > values.Length + 1)
 				return false;
 
 			if (store.LoadInstructions.Last().Parent is StLoc finalStore)

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -325,6 +325,16 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		private ILInstruction ReadElement(ref BlobReader blob, IType elementType)
 		{
+			// Floating-point elements must be read as their actual type: their stored bytes are
+			// not the integer of the same width, and the resulting constant has to match the
+			// element type's stack type (see StObj.CheckInvariant).
+			switch (ReflectionHelper.GetTypeCode(elementType))
+			{
+				case TypeCode.Single:
+					return new LdcF4(blob.ReadSingle());
+				case TypeCode.Double:
+					return new LdcF8(blob.ReadDouble());
+			}
 			switch (elementType.GetSize())
 			{
 				case 1:


### PR DESCRIPTION
Fixes #3799, and bundles three independent `stackalloc` initializer decompilation defects found alongside it.

Only the first change below is the reported crash and the actual #3799 fix. The other three were uncovered by an exploratory testing sweep over the surrounding code (varying element types, element positions, allocation shapes, and use contexts, validating each result by recompiling it); they are unrelated improvements and do not reference the issue.

## 1. Element type lost when the type hint is not a pointer (the reported crash, fixes #3799)

A constant-size `stackalloc` initializer whose buffer is passed to a static call without being dereferenced threw `given Block is invalid!` (reproduced on the reporter's `JetBrains.HabitatDetector.dll`). The element type is recovered from the surrounding type hint, but for this shape the folded constant size erases the `sizeof` and optimized codegen keeps the buffer as a native int, so the hint is not a pointer and the element type fell back to `byte`. Derive it from the type actually being stored.

## 2. float/double constants decoded as raw integer bits

A mixed float/double initializer stores its constant prefix through a data blob; `ReadElement` decoded each element by width, so `1f` was read as `Int32` and emitted as `1.0653532E+09f` (and the wrong stack type tripped `StObj.CheckInvariant`). Dispatch on the type code so `Single`/`Double` are read as floating-point, matching the heap-array decoder.

## 3. Partially written reinterpreted buffer reconstructed as an initializer

`byte* p = stackalloc byte[16]` written through three of its four `int` slots decompiled to `stackalloc int[4] { 1, v, 3 }` — an initializer with fewer elements than the length, which does not compile. Only form the initializer when every element is written; otherwise keep individual stores.

## 4. Pointer-typed stackalloc inlined into an expression

A single-use pointer stackalloc was inlined into its use, producing `K.V(stackalloc int[3] { 1, 2, v })` or `*stackalloc ...`; in expression position the stackalloc is typed `Span<T>`, which does not convert to a pointer, so the output did not compile. Keep it a local; inlining into a local store (its declaration) and into the `Span<T>`/`ReadOnlySpan<T>` constructor stay allowed.

## Tests

Each fix adds a regression case to `CS73_StackAllocInitializers` (red without the fix in the relevant configurations, green with it). No regressions across the stackalloc/span/pointer-touching suites: `CS73_StackAllocInitializers`, `InitializerTests`, `UnsafeCode`, `InlineArrayTests`, `RefFields`, `IndexRangeTest`, `ParamsCollections`, `PointerArithmetic`, `CompoundAssignmentTest`, `ExpressionTrees` (Pretty), and `UnsafeCode`/`InitializerTests` (Correctness). The minimal repro and the real `JetBrains.HabitatDetector` method decompile correctly.

---
_This PR description was written by an AI agent (Claude, claude-opus-4-8, via Claude Code)._
