### PR TITLE
Fix Export NullReferenceException for images/resourcexsd.baml

### DIFF
--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -561,8 +561,7 @@ namespace ICSharpCode.ILSpy.Languages
 					entryStream.Position = 0;
 					fileName = handler.WriteResourceToFile(assembly, fileName, entryStream, context);
 					var item = new ProjectItemInfo(handler.EntryType, fileName) { PartialTypes = context.PartialTypes };
-					foreach (var (k, v) in context.AdditionalProperties)
-						item.AdditionalProperties.Add(k, v);
+					item = item.With(context.AdditionalProperties);
 					return new[] { item };
 				}
 				return base.WriteResourceToFile(fileName, resourceName, entryStream);


### PR DESCRIPTION
Trying to Export ilspy.dll 10.0.0.8345

<img width="966" height="454" alt="image" src="https://github.com/user-attachments/assets/dd68d0cc-82dc-4259-bb44-c10969edc6c3" />

```
System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=ILSpy
  StackTrace:
   at ICSharpCode.ILSpy.Languages.CSharpLanguage.ResourceHandlerProjectDecompiler.WriteResourceToFile(String fileName, String resourceName, Stream entryStream) in Z:\GitWorkspace\ILSpy\ILSpy\Languages\CSharpLanguage.cs:line 565
```

Fix via VS Debugger Agent:

<img width="983" height="988" alt="image" src="https://github.com/user-attachments/assets/fa9793ee-00d7-46cf-9627-0f791e635d3a" />

