### PR TITLE
Give menu dropdown rows WPF-like height with centred content

### DIFF
--- a/ILSpy/App.axaml
+++ b/ILSpy/App.axaml
@@ -255,6 +255,19 @@
         <Style Selector="MenuItem">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="Foreground" Value="{DynamicResource ILSpy.MenuForeground}" />
+            <!-- The Simple theme sizes a dropdown row to its 16px icon plus margins (~24px), tighter
+                 than the classic WPF menu. Give rows more vertical breathing room to match. -->
+            <Setter Property="MinHeight" Value="28" />
+        </Style>
+        <!-- Centre the icon and label in the taller row instead of letting them sit at the top. -->
+        <Style Selector="MenuItem /template/ ContentPresenter#PART_IconPresenter">
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="MenuItem /template/ ContentPresenter#PART_HeaderPresenter">
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="MenuItem /template/ TextBlock#PART_InputGestureText">
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
         <Style Selector="ContextMenu">
             <Setter Property="Background" Value="{DynamicResource ILSpy.MenuBackground}" />


### PR DESCRIPTION
The Simple theme sizes a menu row to its 16px icon plus margins (~24px), tighter than the classic WPF menu. Raise MinHeight so the rows have comparable vertical breathing room, and centre the icon, label and input-gesture text in the taller row (the theme template leaves their VerticalAlignment unset, so a style reaches them) instead of letting them sit at the top.

Assisted-by: Claude:claude-opus-4-8:Claude Code

<img width="388" height="397" alt="image" src="https://github.com/user-attachments/assets/2608a6a1-f226-477f-bcfa-632936f8bace" />

