### PR TITLE
Fix the decompiler text-view context-menu ordering

### DIFF
--- a/ILSpy/Commands/DecompileInNewViewCommand.cs
+++ b/ILSpy/Commands/DecompileInNewViewCommand.cs
@@ -36,10 +36,10 @@ namespace ICSharpCode.ILSpy.Commands
 	/// </summary>
 	[ExportContextMenuEntry(
 		Header = nameof(Resources.DecompileToNewPanel),
-		Category = "Navigate",
+		Category = "Navigation",
 		Icon = "Images/ViewCode",
 		InputGestureText = "MMB",
-		Order = 100)]
+		Order = 160)]
 	[Shared]
 	internal sealed class DecompileInNewViewCommand : IContextMenuEntry
 	{

--- a/ILSpy/Commands/DecompileReferenceContextMenuEntry.cs
+++ b/ILSpy/Commands/DecompileReferenceContextMenuEntry.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.ILSpy.Commands
 	/// of clicking the hyperlink. Visible only when the click landed on a reference that resolves to
 	/// an <see cref="IEntity"/>.
 	/// </summary>
-	[ExportContextMenuEntry(Header = nameof(Resources.Decompile), Category = "Navigation", Order = 10)]
+	[ExportContextMenuEntry(Header = nameof(Resources.Decompile), Category = "Navigation", Order = 150)]
 	[Shared]
 	public sealed class DecompileReferenceContextMenuEntry : IContextMenuEntry
 	{

--- a/ILSpy/Commands/ShowInMetadataContextMenuEntry.cs
+++ b/ILSpy/Commands/ShowInMetadataContextMenuEntry.cs
@@ -33,7 +33,7 @@ namespace ICSharpCode.ILSpy.Commands
 	/// <see cref="IEntity"/> backed by a real metadata file; firing it routes through the
 	/// dock workspace to open the matching CLI metadata table at the entity's row.
 	/// </summary>
-	[ExportContextMenuEntry(Header = nameof(Resources.GoToToken), Category = "Navigation", Order = 200)]
+	[ExportContextMenuEntry(Header = nameof(Resources.GoToToken), Category = "Navigation", Order = 170)]
 	[Shared]
 	public sealed class ShowInMetadataContextMenuEntry : IContextMenuEntry
 	{


### PR DESCRIPTION
The right-click context menu on the decompiled-code text view rendered its entries in a near-random order.

## Why

Context-menu entries come from one shared MEF registry, and `ContextMenuProvider.Build` orders them by a single global `Order` value, using `Category` **only** to decide where separators go — category blocks fall out implicitly from whichever member has the lowest `Order`. A few defects scrambled the text-view result:

- `DecompileReferenceContextMenuEntry` had `Order = 10`, forcing **Decompile** above Copy / Select all at the very top.
- `DecompileInNewViewCommand` sat in a misspelt `"Navigate"` category (vs the `"Navigation"` the sibling entries use), producing a stray extra separator.
- It also tied Copy at `Order = 100`, and "Go to token" (`ShowInMetadata`) tied Analyze at `Order = 200`, so two categories interleaved on the discovery-order tiebreak.

## Fix

Pull the three navigation entries into a contiguous `150–170` band so they form one block between the Editor (100s) and Analyze (200s) bands, and fix the spelling so they share the `"Navigation"` category:

| Entry | Before | After |
|---|---|---|
| Decompile (`DecompileReference`) | `Navigation` / 10 | `Navigation` / 150 |
| Decompile to new panel (`DecompileInNewView`) | `Navigate` / 100 | `Navigation` / 160 |
| Go to token (`ShowInMetadata`) | `Navigation` / 200 | `Navigation` / 170 |

The text-view menu now reads: *Copy · Select all* → *Decompile · Decompile to new panel · Go to token* → *Analyze · Scope to assembly/namespace · Search MSDN* → *Toggle folding…*

No change to `ContextMenuProvider`: the existing by-hundreds category layout is left intact, so the tree / search / metadata menus that share the same registry stay coherent (the only ripple is that "Decompile to new panel" and "Go to token" now sit just before Analyze instead of tying it).

A principled follow-up — giving the provider an explicit inter-category order so this can't recur — is deliberately out of scope here; this is the minimal, low-risk fix.

_This PR was prepared with the assistance of an AI agent._
