### PR TITLE
Show tree connector lines in the Analyze panel

### DIFF
--- a/ILSpy/Analyzers/AnalyzerTreeView.axaml
+++ b/ILSpy/Analyzers/AnalyzerTreeView.axaml
@@ -7,5 +7,5 @@
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200"
              x:Class="ICSharpCode.ILSpy.Analyzers.AnalyzerTreeView"
              x:DataType="analyzers:AnalyzerTreeViewModel">
-	<tv:SharpTreeView Name="Tree" ShowRoot="False" ShowLines="False" />
+	<tv:SharpTreeView Name="Tree" ShowRoot="False" ShowLines="True" />
 </UserControl>


### PR DESCRIPTION
The Analyze panel's tree was missing the connector lines that the assembly-list tree (and the rest of the app) shows. The two panes already host the **same** `SharpTreeView` control and templates, and the line geometry is driven entirely by the generic node `Level`/`IsLast` state, so the analyzer hierarchy renders them correctly — the analyzer view just declared `ShowLines="False"` while the assembly tree uses `"True"`.

`ShowLinesProperty` defaults to `true`; the analyzer pane was the only place actively turning lines off, an unconsidered default carried in when the pane was migrated to `SharpTreeView` (commit `6746a47c8`, with no rationale). Align it with `"True"`.

_This PR was prepared with the assistance of an AI agent._