### PR TITLE
Toggle the fold under the right-click, not at the caret

### DIFF
--- a/ILSpy.Tests/Editor/FoldingContextMenuTests.cs
+++ b/ILSpy.Tests/Editor/FoldingContextMenuTests.cs
@@ -16,6 +16,7 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Linq;
 using System.Threading.Tasks;
 
 using Avalonia.Headless.NUnit;
@@ -83,5 +84,70 @@ public class FoldingContextMenuTests
 		after1.Should().NotBe(after2, "Toggle all folding must flip the fold state");
 		System.Math.Min(after1, after2).Should().Be(0, "one toggle state is fully expanded");
 		System.Math.Max(after1, after2).Should().BeGreaterThan(0, "the other toggle state is fully collapsed");
+	}
+
+	[AvaloniaTest]
+	public async Task Toggle_Folding_Entry_Acts_On_The_Right_Clicked_Line_Not_The_Caret()
+	{
+		// Right-clicking a fold marker and choosing "Toggle folding" must collapse the fold under the
+		// pointer, even when the caret sits in a completely different fold. The menu passes the clicked
+		// offset via TextViewContext.TextLocation; reading the caret instead would toggle the wrong block.
+		var (window, vm) = await TestHarness.BootAsync(3);
+
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(coreLibName, "System", "System.Object");
+		vm.AssemblyTreeModel.SelectNode(typeNode);
+		await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		var view = await window.WaitForComponent<DecompilerTextView>();
+		for (int i = 0; i < 8; i++)
+		{
+			Dispatcher.UIThread.RunJobs();
+			await Task.Delay(25);
+		}
+
+		// ILSpy collapses method-body folds by default, leaving the outer type-body fold open. Two of
+		// those collapsed method folds are disjoint siblings: right-click "Toggle folding" on one while
+		// the caret is parked elsewhere. The clicked fold must expand; the other fold must not move.
+		var collapsedSiblings = view.GetFoldingsForTest()
+			.Where(f => f.IsFolded)
+			.OrderBy(f => f.Start)
+			.ToList();
+		(int Start, int End)? caretSpan = null, clickedSpan = null;
+		for (int a = 0; a < collapsedSiblings.Count && clickedSpan == null; a++)
+		{
+			for (int b = a + 1; b < collapsedSiblings.Count; b++)
+			{
+				bool disjoint = collapsedSiblings[b].Start > collapsedSiblings[a].End
+					|| collapsedSiblings[a].Start > collapsedSiblings[b].End;
+				if (disjoint)
+				{
+					caretSpan = (collapsedSiblings[a].Start, collapsedSiblings[a].End);
+					clickedSpan = (collapsedSiblings[b].Start, collapsedSiblings[b].End);
+					break;
+				}
+			}
+		}
+		clickedSpan.Should().NotBeNull("two disjoint collapsed folds are needed to tell the caret from the click");
+
+		// Midpoints so each offset unambiguously lands inside its own fold.
+		int caretFold = (caretSpan!.Value.Start + caretSpan.Value.End) / 2;
+		int clickedFold = (clickedSpan!.Value.Start + clickedSpan.Value.End) / 2;
+
+		// Keep the caret well clear of both folds. (Setting it inside a collapsed fold would make
+		// AvaloniaEdit auto-expand that fold, which is exactly the behaviour we don't want to depend on.)
+		view.Editor.TextArea.Caret.Offset = 0;
+		view.IsFoldedAt(caretFold).Should().BeTrue("precondition: the caret-side fold is collapsed");
+		view.IsFoldedAt(clickedFold).Should().BeTrue("precondition: the clicked fold is collapsed");
+
+		var toggleOne = AppComposition.Current.GetExport<ContextMenuEntryRegistry>()
+			.GetEntry(nameof(Resources._ToggleFolding));
+		// The caret is parked at offset 0 -- nowhere near either fold. A caret-driven implementation
+		// would toggle the fold at offset 0 (or nothing); the mouse-driven one toggles the clicked fold.
+		toggleOne.Execute(new TextViewContext { TextView = view, TextLocation = clickedFold });
+		Dispatcher.UIThread.RunJobs();
+
+		view.IsFoldedAt(clickedFold).Should().BeFalse("the fold under the right-click must expand");
+		view.IsFoldedAt(caretFold).Should().BeTrue("the unrelated fold must stay collapsed -- the action follows the mouse, not the caret");
 	}
 }

--- a/ILSpy/Commands/FoldingContextMenuEntries.cs
+++ b/ILSpy/Commands/FoldingContextMenuEntries.cs
@@ -23,8 +23,8 @@ using ICSharpCode.ILSpy.Properties;
 namespace ICSharpCode.ILSpy.Commands
 {
 	/// <summary>
-	/// Right-click in the decompiled code → "Toggle folding": folds/unfolds the innermost block at the
-	/// caret. The menu equivalent of Ctrl+M. Only shown when the document actually has foldings.
+	/// Right-click in the decompiled code → "Toggle folding": folds/unfolds the innermost block under
+	/// the clicked line. The menu equivalent of Ctrl+M. Only shown when the document actually has foldings.
 	/// </summary>
 	[ExportContextMenuEntry(Header = nameof(Resources._ToggleFolding), Category = nameof(Resources.Folding), Order = 300)]
 	[Shared]
@@ -34,7 +34,17 @@ namespace ICSharpCode.ILSpy.Commands
 
 		public bool IsEnabled(TextViewContext context) => true;
 
-		public void Execute(TextViewContext context) => context.TextView?.ToggleFoldingAtCaret();
+		public void Execute(TextViewContext context)
+		{
+			if (context.TextView is not { } view)
+				return;
+			// Toggle the fold the user right-clicked on. TextLocation is the offset under the pointer;
+			// fall back to the caret only when the menu was raised without a recorded click position.
+			if (context.TextLocation is { } offset)
+				view.ToggleFoldingAt(offset);
+			else
+				view.ToggleFoldingAtCaret();
+		}
 	}
 
 	/// <summary>

--- a/ILSpy/ContextMenuEntry.cs
+++ b/ILSpy/ContextMenuEntry.cs
@@ -67,6 +67,12 @@ namespace ICSharpCode.ILSpy
 		/// <summary>The reference under the pointer in the text view, or the focused list/grid item, when applicable.</summary>
 		public ReferenceSegment? Reference { get; init; }
 
+		/// <summary>The document offset under the pointer at the time the text-view menu opened, or null
+		/// when the menu wasn't opened on the text view (or the click missed the text). Entries that act on
+		/// a position (e.g. toggle the fold under the click) use this rather than the caret, which may sit
+		/// on an entirely different line than the one the user right-clicked.</summary>
+		public int? TextLocation { get; init; }
+
 		/// <summary>The visual element the original event came from — useful for context-aware entries that need to inspect the click target.</summary>
 		public Visual? OriginalSource { get; init; }
 	}

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -88,6 +88,10 @@ namespace ICSharpCode.ILSpy.TextView
 		ScrollViewer? editorScrollViewer;
 		DisplaySettings? currentDisplaySettings;
 		ReferenceSegment? lastRightClickedSegment;
+		// Document offset under the pointer at the last right-click, or null if the click missed the
+		// text. Position-relative menu entries (e.g. "Toggle folding") read this so they act on the
+		// clicked line rather than wherever the caret happens to sit.
+		int? lastRightClickedOffset;
 		IReadOnlyList<IContextMenuEntryExport> contextMenuEntries = Array.Empty<IContextMenuEntryExport>();
 		Popup richPopup = null!;
 		double distanceToPopupLimit;
@@ -379,16 +383,41 @@ namespace ICSharpCode.ILSpy.TextView
 		/// <summary>Number of currently-collapsed folds (test observation point for the folding commands).</summary>
 		internal int FoldedFoldingCount => activeFoldingManager is { } mgr ? mgr.AllFoldings.Count(f => f.IsFolded) : 0;
 
-		/// <summary>Toggles the innermost fold containing the caret (the "Toggle folding" command / Ctrl+M).</summary>
-		public void ToggleFoldingAtCaret()
+		/// <summary>The active foldings as (Start, End, IsFolded) tuples (test observation point for
+		/// verifying which fold a positional command acted on).</summary>
+		internal IReadOnlyList<(int Start, int End, bool IsFolded)> GetFoldingsForTest()
+			=> activeFoldingManager is { } mgr
+				? mgr.AllFoldings.Select(f => (f.StartOffset, f.EndOffset, f.IsFolded)).ToArray()
+				: Array.Empty<(int, int, bool)>();
+
+		/// <summary>True when the innermost fold containing <paramref name="offset"/> is collapsed.
+		/// Returns false when no fold contains it (test observation point).</summary>
+		internal bool IsFoldedAt(int offset)
 		{
 			if (activeFoldingManager is not { } mgr)
-				return;
-			var caret = Editor.TextArea.Caret.Offset;
+				return false;
 			FoldingSection? target = null;
 			foreach (var f in mgr.AllFoldings)
 			{
-				if (f.StartOffset <= caret && caret <= f.EndOffset)
+				if (f.StartOffset <= offset && offset <= f.EndOffset && (target == null || f.StartOffset > target.StartOffset))
+					target = f;
+			}
+			return target?.IsFolded == true;
+		}
+
+		/// <summary>Toggles the innermost fold containing the caret (the "Toggle folding" command / Ctrl+M).</summary>
+		public void ToggleFoldingAtCaret() => ToggleFoldingAt(Editor.TextArea.Caret.Offset);
+
+		/// <summary>Toggles the innermost fold containing <paramref name="offset"/>. The right-click menu
+		/// passes the offset under the pointer so it acts on the clicked line, not the caret line.</summary>
+		public void ToggleFoldingAt(int offset)
+		{
+			if (activeFoldingManager is not { } mgr)
+				return;
+			FoldingSection? target = null;
+			foreach (var f in mgr.AllFoldings)
+			{
+				if (f.StartOffset <= offset && offset <= f.EndOffset)
 				{
 					if (target == null || f.StartOffset > target.StartOffset)
 						target = f;
@@ -576,13 +605,19 @@ namespace ICSharpCode.ILSpy.TextView
 			if (!e.GetCurrentPoint(Editor.TextArea.TextView).Properties.IsRightButtonPressed)
 				return;
 			var pos = GetPositionFromPointer(e);
-			if (pos == null || DataContext is not DecompilerTabPageModel model || model.References == null)
+			if (pos == null)
 			{
 				lastRightClickedSegment = null;
+				lastRightClickedOffset = null;
 				return;
 			}
 			var offset = Editor.Document.GetOffset(pos.Value.Line, pos.Value.Column);
-			lastRightClickedSegment = model.References.FindSegmentsContaining(offset).FirstOrDefault();
+			lastRightClickedOffset = offset;
+			// References and foldings are independent: a document may carry foldings but no clickable
+			// references, so the offset is recorded above before this reference lookup can bail.
+			lastRightClickedSegment = DataContext is DecompilerTabPageModel model && model.References != null
+				? model.References.FindSegmentsContaining(offset).FirstOrDefault()
+				: null;
 		}
 
 		void OnContextMenuOpening(object? sender, CancelEventArgs e)
@@ -592,6 +627,7 @@ namespace ICSharpCode.ILSpy.TextView
 			var ctx = new TextViewContext {
 				TextView = this,
 				Reference = lastRightClickedSegment,
+				TextLocation = lastRightClickedOffset,
 			};
 			menu.Items.Clear();
 


### PR DESCRIPTION
The decompiled-view "Toggle folding" context-menu entry folded the block at the **caret**, so right-clicking a fold on a different line than the caret toggled the wrong block.

## Fix

Record the document offset under the pointer when the text-view menu opens and expose it on `TextViewContext` as `TextLocation`; the folding entry acts on that offset, falling back to the caret only when no click position was recorded (the keyboard `Ctrl+M` path). `ToggleFoldingAtCaret()` is now a thin wrapper over a positional `ToggleFoldingAt(int offset)`.

The pointer handler now records the offset **before** the reference lookup, which also fixes a latent bug: a document with foldings but no clickable references previously recorded no position at all.

## Test

New headless `Toggle_Folding_Entry_Acts_On_The_Right_Clicked_Line_Not_The_Caret` parks the caret at offset 0, right-clicks a collapsed method fold elsewhere, and asserts that fold expands while an unrelated fold stays collapsed (verified red before the fix, green after). Full `ILSpy.Tests` suite passes (884).

_This PR was prepared with the assistance of an AI agent._