### PR TITLE
Display the IL 'tail.' prefix in C# output

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -136,6 +136,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task TailCall()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task CS1xSwitch_Debug()
 		{
 			await Run(settings: new DecompilerSettings { SwitchExpressions = false, FileScopedNamespaces = false });

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TailCall.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TailCall.cs
@@ -1,0 +1,11 @@
+internal class TailCall
+{
+	public static int Callee(int x)
+	{
+		return x;
+	}
+	public static int Caller(int x)
+	{
+		return /*tail.*/Callee(x);
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TailCall.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TailCall.il
@@ -1,0 +1,38 @@
+#define CORE_ASSEMBLY "System.Runtime"
+
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:0:0:0
+}
+
+.assembly TailCall { }
+
+.class private auto ansi beforefieldinit TailCall
+    extends [CORE_ASSEMBLY]System.Object
+{
+    .method public hidebysig static int32 Callee (int32 x) cil managed
+    {
+        .maxstack 8
+        ldarg.0
+        ret
+    }
+
+    .method public hidebysig static int32 Caller (int32 x) cil managed
+    {
+        .maxstack 8
+        ldarg.0
+        tail.
+        call int32 TailCall::Callee(int32)
+        ret
+    }
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .maxstack 8
+        ldarg.0
+        call instance void [CORE_ASSEMBLY]System.Object::.ctor()
+        ret
+    }
+}

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -238,8 +238,15 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				return BuildStringConcat(inst.Method, operands).WithILInstruction(inst);
 			}
-			return Build(inst.OpCode, inst.Method, inst.Arguments, constrainedTo: inst.ConstrainedTo)
+			var result = Build(inst.OpCode, inst.Method, inst.Arguments, constrainedTo: inst.ConstrainedTo)
 				.WithILInstruction(inst);
+			if (inst.IsTail)
+			{
+				// Surface the IL 'tail.' prefix as an inline marker, e.g. '/*tail.*/Callee(x)'.
+				// F# emits tail calls pervasively, and the prefix is otherwise dropped entirely.
+				result.Expression.AddLeadingTrivia(new Comment("tail.", CommentType.MultiLine));
+			}
+			return result;
 		}
 
 		private ExpressionWithResolveResult BuildStringConcat(IMethod method, List<(ILInstruction Instruction, KnownTypeCode TypeCode)> operands)


### PR DESCRIPTION
Fixes #3817.

F# emits tail calls pervasively, but the IL `tail.` prefix was dropped entirely at the C# output stage, so the information never reached the decompiled text. This surfaces it as an inline `/*tail.*/` marker before the call:

```csharp
public static int Caller(int x)
{
    return /*tail.*/Callee(x);
}
```

The flag (`CallInstruction.IsTail`) was already tracked end-to-end through the IL pipeline; it was simply discarded when the call became a C# invocation. The implementation mirrors the existing `constrained.`-prefix comment already emitted in `CallBuilder`.

### Notes
- Always on, no setting/toggle.
- No existing fixtures contain a real `tail.` opcode (the "tail" hits in the F# fixtures are `get_TailOrNull()` substrings), so the change has zero churn on the rest of the suite.
- `calli` (`CallIndirect`) does not model `IsTail`, so tail-prefixed indirect calls are not marked (rare; out of scope).

### Test
New ILPretty fixture `TailCall.il`/`TailCall.cs` exercising a `tail. call` followed by `ret`.

---
🤖 This PR was prepared by Claude Code (claude-opus-4-8) on behalf of @siegfriedpammer.
