### PR TITLE
Fix #3820: decompile dynamic ~ as ~x instead of an unsupported-opcode error

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DynamicTests.cs
@@ -24,6 +24,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			PrintResult((ref dynamic x) => x = x / 2.0, 5);
 			PrintResult((ref dynamic x) => x = x / 2, 5.0);
 			PrintResult((ref dynamic x) => x = x / 2, 5);
+			PrintResult((ref dynamic x) => x = ~x, 5);
+			PrintResult((ref dynamic x) => x = -x, 5);
+			PrintResult((ref dynamic x) => x = +x, 5);
+			PrintResult((ref dynamic x) => x = !x, true);
 		}
 
 		private static void PrintResult(RefAction<dynamic> p, dynamic arg)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
@@ -394,6 +394,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			//++a;
 			DynamicTests.Casts(-a);
 			DynamicTests.Casts(+a);
+			DynamicTests.Casts(~a);
 		}
 
 		private static void Loops(dynamic list)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
@@ -369,6 +369,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			a.Setter2 -= b;
 			a.Setter2 *= b;
 			a.Setter2 /= b;
+			a.Setter2 %= b;
+			a.Setter2 &= b;
+			a.Setter2 |= b;
+			a.Setter2 ^= b;
+			a.Setter2 <<= b;
+			a.Setter2 >>= b;
 			field.Setter += 5;
 			field.Setter -= 5;
 		}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
@@ -310,6 +310,23 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		private static void BitwiseAndShiftBinaryOperators(dynamic a, dynamic b)
+		{
+			DynamicTests.MemberAccess(a & b);
+			DynamicTests.MemberAccess(a & 1);
+			DynamicTests.MemberAccess(a & null);
+			DynamicTests.MemberAccess(a | b);
+			DynamicTests.MemberAccess(a | 1);
+			DynamicTests.MemberAccess(a | null);
+			DynamicTests.MemberAccess(a ^ b);
+			DynamicTests.MemberAccess(a ^ 1);
+			DynamicTests.MemberAccess(a ^ null);
+			DynamicTests.MemberAccess(a << b);
+			DynamicTests.MemberAccess(a << 1);
+			DynamicTests.MemberAccess(a >> b);
+			DynamicTests.MemberAccess(a >> 1);
+		}
+
 		private static void RelationalOperators(dynamic a, dynamic b)
 		{
 			DynamicTests.MemberAccess(a == b);

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4540,6 +4540,8 @@ namespace ICSharpCode.Decompiler.CSharp
 					return CreateUnaryOperator(UnaryOperatorType.Minus, isChecked: true);
 				case ExpressionType.UnaryPlus:
 					return CreateUnaryOperator(UnaryOperatorType.Plus, isChecked: inst.BinderFlags.HasFlag(CSharpBinderFlags.CheckedContext));
+				case ExpressionType.OnesComplement:
+					return CreateUnaryOperator(UnaryOperatorType.BitNot);
 				case ExpressionType.IsTrue:
 					var operand = TranslateDynamicArgument(inst.Operand, inst.OperandArgumentInfo);
 					Expression expr;


### PR DESCRIPTION
Fixes #3820.

`~` (one's-complement) on a `dynamic` operand decompiled to
`(object)/*OpCode not supported: DynamicUnaryOperatorInstruction*/`, which does
not compile (CS1525). `VisitDynamicUnaryOperatorInstruction` handled `!`, `-`,
`+`, `++`, `--`, and `IsTrue`/`IsFalse`, but not `ExpressionType.OnesComplement`,
so it fell through to the unsupported-opcode error expression.

This maps `OnesComplement` to `UnaryOperatorType.BitNot`, matching the sibling
cases.

### Test

`UnaryOperators` in the `Pretty/DynamicTests` fixture now also exercises `~a`
(alongside the existing `-a` and `+a`).

Verified against a build with this change by decompiling a minimal assembly:
`static object M(dynamic x) => ~x;` now decompiles to `return ~x;` (previously
the unsupported-opcode placeholder).
