### PR TITLE
Fix #3821: keep ref-struct conditional as if/return, not ?. / ?? (CS8978)

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/NullPropagation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/NullPropagation.cs
@@ -7,6 +7,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		static void Main()
 		{
 			new NullPropagation().TestNotCoalescing();
+#if CS72
+			new NullPropagation().TestRefStructNotCoalescing();
+#endif
 		}
 
 		class MyClass
@@ -25,5 +28,36 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		{
 			return c != null ? c.Text : "Hello";
 		}
+
+#if CS72
+		ref struct ByRefLikeStruct
+		{
+			public int Value;
+		}
+
+		class RefStructHolder
+		{
+			public ByRefLikeStruct Get()
+			{
+				ByRefLikeStruct result = default(ByRefLikeStruct);
+				result.Value = 42;
+				return result;
+			}
+		}
+
+		void TestRefStructNotCoalescing()
+		{
+			Console.WriteLine("TestRefStructNotCoalescing:");
+			Console.WriteLine(RefStructNotCoalescing(null).Value);
+			Console.WriteLine(RefStructNotCoalescing(new RefStructHolder()).Value);
+		}
+
+		// A by-ref-like return type cannot be turned into a ?. / ?? null-propagation: a ref struct
+		// cannot be wrapped in Nullable<T>, so that form does not compile.
+		ByRefLikeStruct RefStructNotCoalescing(RefStructHolder holder)
+		{
+			return holder != null ? holder.Get() : default(ByRefLikeStruct);
+		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/NullPropagationTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/NullPropagationTransform.cs
@@ -140,12 +140,14 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				IntroduceUnwrap(testedVar, varLoad, mode);
 				return new NullableRewrap(nonNullInst);
 			}
-			else if (!removedRewrapOrNullableCtor && NullableType.IsNonNullableValueType(returnType))
+			else if (!removedRewrapOrNullableCtor && NullableType.IsNonNullableValueType(returnType)
+				&& !returnType.IsByRefLike)
 			{
 				context.Step($"Null propagation (mode={mode}, output=null coalescing)", nonNullInst);
 				// testedVar != null ? testedVar.AccessChain : nullInst
 				// => testedVar?.AccessChain ?? nullInst
-				// (only valid if AccessChain returns a non-nullable value)
+				// (only valid if AccessChain returns a non-nullable value; a by-ref-like type such as
+				// Span<T> is excluded because it cannot be wrapped in Nullable<T> for the ?. / ?? form)
 				IntroduceUnwrap(testedVar, varLoad, mode);
 				return new NullCoalescingInstruction(
 					NullCoalescingKind.NullableWithValueFallback,


### PR DESCRIPTION
Fixes #3821.

`NullPropagationTransform` rewrote `testedVar != null ? testedVar.AccessChain : default`
to `testedVar?.AccessChain ?? default` whenever the access-chain result was a
non-nullable value type. For a by-ref-like type (a ref struct such as `Span<T>`)
this does not compile: a ref struct cannot be wrapped in `Nullable<T>` (CS8978).

This excludes by-ref-like return types from the null-coalescing rewrite, leaving
the conditional as an `if`/return, which compiles.

### Test

A `Correctness/NullPropagation` case returns a ref struct from a
`holder != null ? holder.Get() : default` conditional (guarded `#if CS72`).
Without the fix the decompiled `holder?.Get() ?? default` fails to recompile
(CS8978); with it the decompiled output recompiles and behaves identically.

Verified against a build with this change by decompiling a minimal assembly:
`h != null ? h.GetSpan() : default` now decompiles to an `if`/return instead of
`h?.GetSpan() ?? default(Span<byte>)`.
