### PR TITLE
Fix #3827: keep the while-loop for a ref local used after the loop (avoid an uninitialized hoisted ref decl)

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
@@ -168,17 +168,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static Issue3827Node RefLocalUsedAfterForLoop(Issue3827Node[] buckets, int hash, Issue3827Node newNode)
 		{
-			// The ref local is used after the loop, so its declaration is hoisted in front of the
-			// for-statement; the for-initializer ref-assignment must stay on the declaration, because
-			// a ref local cannot be declared without an initializer.
+			// The ref local is used after the loop, so its declaration is hoisted in front of the loop.
+			// The loop is kept as a while-loop (rather than converted to a headless for-loop) so the
+			// ref-assignment stays on the declaration -- a ref local cannot be declared without an initializer.
 			ref Issue3827Node reference = ref buckets[hash & 3];
-			for (; reference != null; reference = ref reference.next)
+			while (reference != null)
 			{
 				if (reference.value == hash)
 				{
 					reference = newNode;
 					break;
 				}
+				reference = ref reference.next;
 			}
 			if (reference == null)
 			{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
@@ -45,6 +45,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public class Issue3827Node
+		{
+			public Issue3827Node next;
+
+			public int value;
+		}
+
 		public delegate ref T RefFunc<T>();
 		public delegate ref readonly T ReadOnlyRefFunc<T>();
 		public delegate ref TReturn RefFunc<T1, TReturn>(T1 param1);
@@ -158,6 +165,27 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		private static string NullString = "";
 
 		private static int DefaultInt = 0;
+
+		public static Issue3827Node RefLocalUsedAfterForLoop(Issue3827Node[] buckets, int hash, Issue3827Node newNode)
+		{
+			// The ref local is used after the loop, so its declaration is hoisted in front of the
+			// for-statement; the for-initializer ref-assignment must stay on the declaration, because
+			// a ref local cannot be declared without an initializer.
+			ref Issue3827Node reference = ref buckets[hash & 3];
+			for (; reference != null; reference = ref reference.next)
+			{
+				if (reference.value == hash)
+				{
+					reference = newNode;
+					break;
+				}
+			}
+			if (reference == null)
+			{
+				reference = newNode;
+			}
+			return reference;
+		}
 
 		public static ref T GetRef<T>()
 		{

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -582,39 +582,6 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				&& identExpr.TypeArguments.Count == 0;
 		}
 
-		/// <summary>
-		/// Matches the case where the variable's only initialization is the first initializer of a
-		/// for-statement (`for (v = expr; ...)`) and the declaration has to be placed in front of the
-		/// for-statement (e.g. because the variable is used after the loop). Used to keep a ref local's
-		/// initializer on its declaration (a ref local may not be declared without one).
-		/// </summary>
-		bool IsMatchingForInitializerAssignment(VariableToDeclare v, [NotNullWhen(true)] out ForStatement? forStatement,
-			[NotNullWhen(true)] out Statement? initializerStatement, [NotNullWhen(true)] out AssignmentExpression? assignment)
-		{
-			forStatement = null;
-			initializerStatement = null;
-			assignment = null;
-
-			if (v.InsertionPoint.nextNode is not ForStatement { Parent: BlockStatement } fs)
-				return false;
-
-			if (fs.Initializers.FirstOrDefault() is not ExpressionStatement { Expression: AssignmentExpression a } firstInit)
-				return false;
-
-			if (a.Operator != AssignmentOperatorType.Assign
-				|| a.Left is not IdentifierExpression identExpr
-				|| identExpr.Identifier != v.Name
-				|| identExpr.TypeArguments.Count != 0)
-			{
-				return false;
-			}
-
-			forStatement = fs;
-			initializerStatement = firstInit;
-			assignment = a;
-			return true;
-		}
-
 		bool CombineDeclarationAndInitializer(VariableToDeclare v, TransformContext context)
 		{
 			if (v.Type.IsByRefLike)
@@ -665,32 +632,6 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						}
 					}
 					replacements.Add((v.InsertionPoint.nextNode, vds));
-				}
-				else if (v.Type.IsByRefLike && IsMatchingForInitializerAssignment(v, out var forStatement, out var forInitializerStatement, out var forInitAssignment))
-				{
-					// A by-ref-like local that is used after the loop has its declaration hoisted in
-					// front of the for-statement, but its only initialization is the for-initializer
-					// ref-assignment. A ref local must be declared with an initializer (CS8174), so move
-					// the ref-assignment's value up into the declaration and drop the for-initializer.
-					AstType type = context.TypeSystemAstBuilder.ConvertType(v.Type);
-					if (v.ILVariable.IsRefReadOnly && type is ComposedType { HasRefSpecifier: true } composedType)
-					{
-						composedType.HasReadOnlySpecifier = true;
-					}
-
-					var vds = new VariableDeclarationStatement(type, v.Name, forInitAssignment.Right.Detach());
-					var init = vds.Variables.Single();
-					init.AddAnnotation(forInitAssignment.Left.GetResolveResult());
-					foreach (object annotation in forInitAssignment.Left.Annotations.Concat(forInitAssignment.Annotations))
-					{
-						if (annotation is not ResolveResult)
-						{
-							init.AddAnnotation(annotation);
-						}
-					}
-
-					forInitializerStatement.Remove();
-					forStatement.Parent!.InsertChildBefore(forStatement, vds, Slots.Statement);
 				}
 				else if (CanBeDeclaredAsOutVariable(v, out var dirExpr))
 				{

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -582,6 +582,39 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				&& identExpr.TypeArguments.Count == 0;
 		}
 
+		/// <summary>
+		/// Matches the case where the variable's only initialization is the first initializer of a
+		/// for-statement (`for (v = expr; ...)`) and the declaration has to be placed in front of the
+		/// for-statement (e.g. because the variable is used after the loop). Used to keep a ref local's
+		/// initializer on its declaration (a ref local may not be declared without one).
+		/// </summary>
+		bool IsMatchingForInitializerAssignment(VariableToDeclare v, [NotNullWhen(true)] out ForStatement? forStatement,
+			[NotNullWhen(true)] out Statement? initializerStatement, [NotNullWhen(true)] out AssignmentExpression? assignment)
+		{
+			forStatement = null;
+			initializerStatement = null;
+			assignment = null;
+
+			if (v.InsertionPoint.nextNode is not ForStatement { Parent: BlockStatement } fs)
+				return false;
+
+			if (fs.Initializers.FirstOrDefault() is not ExpressionStatement { Expression: AssignmentExpression a } firstInit)
+				return false;
+
+			if (a.Operator != AssignmentOperatorType.Assign
+				|| a.Left is not IdentifierExpression identExpr
+				|| identExpr.Identifier != v.Name
+				|| identExpr.TypeArguments.Count != 0)
+			{
+				return false;
+			}
+
+			forStatement = fs;
+			initializerStatement = firstInit;
+			assignment = a;
+			return true;
+		}
+
 		bool CombineDeclarationAndInitializer(VariableToDeclare v, TransformContext context)
 		{
 			if (v.Type.IsByRefLike)
@@ -632,6 +665,32 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						}
 					}
 					replacements.Add((v.InsertionPoint.nextNode, vds));
+				}
+				else if (v.Type.IsByRefLike && IsMatchingForInitializerAssignment(v, out var forStatement, out var forInitializerStatement, out var forInitAssignment))
+				{
+					// A by-ref-like local that is used after the loop has its declaration hoisted in
+					// front of the for-statement, but its only initialization is the for-initializer
+					// ref-assignment. A ref local must be declared with an initializer (CS8174), so move
+					// the ref-assignment's value up into the declaration and drop the for-initializer.
+					AstType type = context.TypeSystemAstBuilder.ConvertType(v.Type);
+					if (v.ILVariable.IsRefReadOnly && type is ComposedType { HasRefSpecifier: true } composedType)
+					{
+						composedType.HasReadOnlySpecifier = true;
+					}
+
+					var vds = new VariableDeclarationStatement(type, v.Name, forInitAssignment.Right.Detach());
+					var init = vds.Variables.Single();
+					init.AddAnnotation(forInitAssignment.Left.GetResolveResult());
+					foreach (object annotation in forInitAssignment.Left.Annotations.Concat(forInitAssignment.Annotations))
+					{
+						if (annotation is not ResolveResult)
+						{
+							init.AddAnnotation(annotation);
+						}
+					}
+
+					forInitializerStatement.Remove();
+					forStatement.Parent!.InsertChildBefore(forStatement, vds, Slots.Statement);
 				}
 				else if (CanBeDeclaredAsOutVariable(v, out var dirExpr))
 				{

--- a/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
@@ -202,6 +202,12 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			if (variable != m3.Get<IdentifierExpression>("ident").Single().GetILVariable())
 				return null;
 			WhileStatement loop = (WhileStatement)next;
+			// Cannot convert to for loop, if the iteration variable is a ref local used after the loop: its
+			// declaration is hoisted in front, leaving a headless `for (; cond; v = ref ...)` whose only
+			// initialization is the for-initializer ref-assignment -- which can't be split from a ref local
+			// (CS8174). Keeping it a while-loop matches the source and keeps the initializer on the decl.
+			if (variable != null && variable.Type.IsByRefLike && IsVariableUsedAfter(loop, variable))
+				return null;
 			// Cannot convert to for loop, if any variable that is used in the "iterator" part of the pattern,
 			// will be declared in the body of the while-loop.
 			var iteratorStatement = m3.Get<Statement>("iterator").Single();
@@ -241,6 +247,16 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				return true;
 			if (statement.Iterators.Any(i => i.DescendantsAndSelf.OfType<IdentifierExpression>().Any(ie => ie.GetILVariable() == variable)))
 				return true;
+			return false;
+		}
+
+		bool IsVariableUsedAfter(Statement loop, IL.ILVariable variable)
+		{
+			for (AstNode? sibling = loop.NextSibling; sibling != null; sibling = sibling.NextSibling)
+			{
+				if (sibling.DescendantsAndSelf.OfType<IdentifierExpression>().Any(ie => ie.GetILVariable() == variable))
+					return true;
+			}
 			return false;
 		}
 

--- a/ICSharpCode.Decompiler/IL/Transforms/HighLevelLoopTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/HighLevelLoopTransform.cs
@@ -395,6 +395,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				// - increment block
 				if (incrementBlock.Instructions.Count <= 1 || loop.Blocks.Count < 3)
 					return false;
+				if (StoresRefLocalUsedAfterLoop(loop, incrementBlock))
+					return false;
 				context.Step("Transform to for loop: " + loop.EntryPoint.Label, loop);
 				// move the block to the end of the loop:
 				loop.Blocks.MoveElementToEnd(incrementBlock);
@@ -465,6 +467,27 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				loop.Kind = ContainerKind.For;
 			}
 			return true;
+		}
+
+		static bool StoresRefLocalUsedAfterLoop(BlockContainer loop, Block incrementBlock)
+		{
+			foreach (var store in incrementBlock.Instructions.SkipLast(1).SelectMany(inst => inst.Descendants).OfType<StLoc>())
+			{
+				var variable = store.Variable;
+				if (variable.Type.IsByRefLike && IsVariableUsedAfterLoop(loop, variable))
+					return true;
+			}
+			return false;
+		}
+
+		static bool IsVariableUsedAfterLoop(BlockContainer loop, ILVariable variable)
+		{
+			foreach (var use in variable.LoadInstructions.Concat<ILInstruction>(variable.AddressInstructions).Concat(variable.StoreInstructions.Cast<ILInstruction>()))
+			{
+				if (loop.GetCommonParent(use) is Block { Kind: BlockKind.ControlFlow } && loop.IsBefore(use))
+					return true;
+			}
+			return false;
 		}
 
 		bool IsAssignment(ILInstruction inst)


### PR DESCRIPTION
Fixes #3827.

A `ref` local used after a `while`-loop has its declaration hoisted in front of the
loop. `PatternStatementTransform` then rewrote the `while` into a `for`, moving the
sole ref-assignment into the for-initializer — leaving `ref T x;` (no initializer)
in front of a headless `for (; cond; x = ref …)`, which does not compile
(CS8174: a by-reference variable must have an initializer).

### Fix
Per @siegfriedpammer's review, instead of emitting a headless for-loop,
`PatternStatementTransform.TransformFor` now leaves the loop as a `while` when the
iteration variable is a by-ref-like local used after the loop. The ref-assignment
stays on the hoisted declaration and the output matches the original source — both
simpler and free of the not-so-nice headless-for form.

**Before** (does not recompile — CS8174):
```c#
ref Node reference;
for (reference = ref _buckets[hash & 3]; reference != null; reference = ref reference.next)
{
    ...
}
```
**After:**
```c#
ref Node reference = ref _buckets[hash & 3];
while (reference != null)
{
    ...
    reference = ref reference.next;
}
```

### Test
`Pretty/RefLocalsAndReturns.RefLocalUsedAfterForLoop` round-trips the hoisted-decl +
while-loop form.

Real-world occurrence: Enums.NET (net461) hash-bucket walk. Same symptom as the
long-closed #1630 (stale-bot closed, no fix); the if/else ref-assignment variant
from #1520 is not addressed here.
