### PR TITLE
Fix #3825: reconstruct async iterators with [EnumeratorCancellation] and await in finally

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncStreams.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncStreams.cs
@@ -71,6 +71,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				await Task.Delay(10).ConfigureAwait(continueOnCapturedContext: false);
 			}
 		}
+
+		public static async IAsyncEnumerable<int> AwaitInFinallyWithCancellation([EnumeratorCancellation] CancellationToken cancellationToken)
+		{
+			await Task.Yield();
+			try
+			{
+				yield return 1;
+				await Task.Delay(10, cancellationToken);
+			}
+			finally
+			{
+				await Task.Yield();
+			}
+		}
 	}
 
 	public struct TestStruct

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -911,6 +911,11 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			finalStateKnown = true;
 			pos++;
 
+			// [optional] stfld <>u__N(ldloc this, ldnull)
+			// The hoisted-local cleanup may appear either before or after the combined-tokens disposal
+			// (the latter is present for async iterators with an [EnumeratorCancellation] token).
+			MatchHoistedLocalCleanup(block, ref pos);
+
 			if (pos + 2 == block.Instructions.Count && block.MatchIfAtEndOfBlock(out var condition, out var trueInst, out var falseInst))
 			{
 				if (MatchDisposeCombinedTokens(blockContainer, condition, trueInst, falseInst, blocksAnalyzed, out var setResultAndExitBlock))
@@ -1088,6 +1093,12 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 				finalState = newState;
 				finalStateKnown = true;
 			}
+
+			// [optional] stfld <>u__N(ldloc this, ldnull)
+			// The hoisted-local cleanup may appear either before or after the combined-tokens disposal
+			// (the latter is present for async iterators with an [EnumeratorCancellation] token).
+			MatchHoistedLocalCleanup(catchBlock, ref pos);
+
 			if (pos + 2 == catchBlock.Instructions.Count && catchBlock.MatchIfAtEndOfBlock(out var condition, out var trueInst, out var falseInst))
 			{
 				if (MatchDisposeCombinedTokens(handlerContainer, condition, trueInst, falseInst, blocksAnalyzed, out var setResultAndExitBlock))


### PR DESCRIPTION
Fixes #3825.

An `async IAsyncEnumerable<T>` iterator that has both an `[EnumeratorCancellation]`
cancellation-token parameter and an `await` inside a `finally` was not
reconstructed: the decompiler emitted the raw compiler-generated state machine
(`catch (object)`, `goto case`, `<>1__state`, ...), which does not compile.

### Root cause
For such an iterator, the hoisted-local cleanup (`stfld <>u__N(this, null)`) is
emitted before the combined `CancellationTokenSource` disposal in both the
set-result block and the catch block. `CheckSetResultReturnBlock` and
`ValidateCatchBlock` only consumed that cleanup after the disposal, so the
`pos + 2 == count` test missed the dispose pattern, the symbolic analysis failed,
and `AsyncAwaitDecompiler` left the raw state machine.

### Fix
Allow the hoisted-local cleanup to appear before the combined-tokens disposal as
well (one extra `MatchHoistedLocalCleanup` call in each of the two methods).

### Test
`Pretty/AsyncStreams.AwaitInFinallyWithCancellation` combines
`[EnumeratorCancellation]` with an `await` in a `finally`; it now round-trips.

Real-world occurrence: Renci.SshNet `SftpClient.ListDirectoryAsync` (net462).
