### PR TITLE
Assign a text location to comment-only empty statements

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -163,6 +163,7 @@
 
   <ItemGroup>
     <None Include="TestCases\PdbGen\*.cs" />
+    <None Include="TestCases\PdbGen\PinnedRegionWarning.il" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PdbGenerationTestRunner.cs
@@ -5,8 +5,11 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 
 using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.CSharp.Syntax;
 using ICSharpCode.Decompiler.DebugInfo;
 using ICSharpCode.Decompiler.Metadata;
 using ICSharpCode.Decompiler.Tests.Helpers;
@@ -294,6 +297,43 @@ namespace ICSharpCode.Decompiler.Tests
 			}
 
 			Assert.That(lastFilesWritten, Is.EqualTo(totalFiles));
+		}
+
+		[Test]
+		public async Task PinnedRegionWarning()
+		{
+			// Decompiling this fixture makes DetectPinnedRegions duplicate a block shared by a pinned
+			// region and record a warning. The warning is emitted as an EmptyStatement that carries
+			// only a comment, so it prints no semicolon. Such a statement must still be assigned a text
+			// location, otherwise SequencePointBuilder crashes on the empty location while generating
+			// sequence points for the PDB.
+			string ilFile = Path.Combine(TestCasePath, nameof(PinnedRegionWarning) + ".il");
+			string peFileName = await Tester.AssembleIL(ilFile, AssemblerOptions.Library);
+
+			var module = new PEFile(peFileName);
+			var resolver = new UniversalAssemblyResolver(peFileName, false,
+				module.Metadata.DetectTargetFrameworkId(), null, PEStreamOptions.PrefetchEntireImage);
+			var settings = new DecompilerSettings();
+			var decompiler = new CSharpDecompiler(module, resolver, settings);
+
+			var syntaxTree = decompiler.DecompileType(new Decompiler.TypeSystem.FullTypeName("C"));
+
+			// Locations are recorded while printing, so the tree has to be run through the output
+			// visitor first - exactly as PortablePdbWriter does before calling CreateSequencePoints.
+			var output = new StringWriter();
+			TokenWriter tokenWriter = new TextWriterTokenWriter(output);
+			tokenWriter = TokenWriter.WrapInWriterThatSetsLocationsInAST(tokenWriter);
+			syntaxTree.AcceptVisitor(new CSharpOutputVisitor(tokenWriter, settings.CSharpFormattingOptions));
+
+			var warningStatement = syntaxTree.Descendants.OfType<EmptyStatement>().SingleOrDefault();
+			Assert.That(warningStatement, Is.Not.Null,
+				"the fixture must produce the warning-carrying EmptyStatement it is testing");
+			var comment = warningStatement.LeadingTrivia.Concat(warningStatement.TrailingTrivia).FirstOrDefault();
+			Assert.That(comment, Is.Not.Null, "the warning statement must carry a comment");
+			Assert.That(comment.StartLocation.IsEmpty, Is.False, "the carried comment must have been printed");
+			Assert.That(warningStatement.StartLocation, Is.EqualTo(comment.StartLocation),
+				"a comment-only EmptyStatement should take the location of the comment it carries");
+			Assert.DoesNotThrow(() => decompiler.CreateSequencePoints(syntaxTree));
 		}
 
 		private class TestProgressReporter : IProgress<DecompilationProgress>

--- a/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/PinnedRegionWarning.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/PdbGen/PinnedRegionWarning.il
@@ -1,0 +1,50 @@
+// A C++/CLI-style pinned pointer whose pinned region is reachable both inside and outside the
+// `fixed` statement. Decompiling it makes DetectPinnedRegions duplicate the shared block and
+// record a warning, which is emitted as a comment-carrying EmptyStatement at the top of the
+// method body. That statement has no text location, which used to crash PDB generation in
+// SequencePointBuilder. Regression fixture for that crash.
+.assembly extern System.Runtime { }
+.assembly PinnedRegionWarning { }
+.module PinnedRegionWarning.dll
+
+.class public auto ansi beforefieldinit C extends [System.Runtime]System.Object
+{
+  .method public hidebysig instance void PinPtrTest(int32[] a, int32[] b) cil managed
+  {
+    .maxstack 3
+    .locals (
+      [0] int32& pinned p
+    )
+    IL_0000: ldarg.1
+    IL_0001: ldc.i4.0
+    IL_0002: ldelema [System.Runtime]System.Int32
+    IL_0007: stloc.0
+    IL_0008: ldloc.0
+    IL_0009: ldind.i4
+    IL_000a: ldc.i4.0
+    IL_000b: ble.s IL_0016
+
+    IL_000d: ldarg.2
+    IL_000e: ldloc.0
+    IL_000f: ldind.i4
+    IL_0010: ldelema [System.Runtime]System.Int32
+    IL_0015: stloc.0
+
+    IL_0016: ldloc.0
+    IL_0017: ldc.i4.4
+    IL_0018: ldc.i4.0
+    IL_0019: mul
+    IL_001a: add
+    IL_001b: ldc.i4.1
+    IL_001c: stind.i4
+    IL_001d: ret
+  }
+
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+  {
+    .maxstack 1
+    ldarg.0
+    call instance void [System.Runtime]System.Object::.ctor()
+    ret
+  }
+}

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertMissingTokensDecorator.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertMissingTokensDecorator.cs
@@ -87,7 +87,20 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			{
 				// A node that printed no tokens of its own collapses to a zero-width span here.
 				if (nodesAwaitingStartLocation.Remove(node))
+				{
 					node.StorePrintStart(lastTokenEnd);
+					// EmptyStatement derives StartLocation/EndLocation from its own Location field, which
+					// is otherwise only set when the semicolon token is written. A comment-only empty
+					// statement (e.g. the carrier for a decompiler warning) prints no semicolon, so point
+					// its location at the comment it carries -- already printed by now, so the statement
+					// lines up with the text the reader sees -- rather than leaving it empty.
+					if (node is EmptyStatement emptyStatement)
+					{
+						var trivia = emptyStatement.LeadingTrivia.Concat(emptyStatement.TrailingTrivia)
+							.FirstOrDefault(t => !t.StartLocation.IsEmpty);
+						emptyStatement.Location = trivia != null ? trivia.StartLocation : lastTokenEnd;
+					}
+				}
 				node.StorePrintEnd(lastTokenEnd);
 				System.Diagnostics.Debug.Assert(currentList != null);
 				foreach (var child in currentList)


### PR DESCRIPTION
## Problem

Generating a portable PDB for an assembly whose decompilation emits a warning aborted in `SequencePointBuilder` with a `missing startLocation` assertion (Debug), or would emit no/incorrect sequence points (Release). Reproduces on real assemblies such as `System.Net.Requests.dll`, surfaced while testing #3754.

## Root cause

Decompiler warnings (`ILFunction.Warnings`, e.g. the `DetectPinnedRegions` block-duplication notice) are surfaced as an `EmptyStatement` carrying only a comment. `VisitEmptyStatement` prints no semicolon for such a statement, and `EmptyStatement.StartLocation`/`EndLocation` derive from its `Location` field — which is only assigned when that semicolon token is written. The statement was therefore left without a text location, and `SequencePointBuilder` asserted on the empty start location.

## Fix

Assign the collapsed location to the `EmptyStatement` in the token-location decorator (`InsertMissingTokensDecorator`), reusing the same `lastTokenEnd` fallback already applied to the generic start location of a node that prints no tokens. Every printed node then has a location, so `SequencePointBuilder`'s location invariant holds without special-casing — the assertion stays a genuine guard rather than being relaxed.

Verified separately that "every `ILInstruction` has a non-empty `ILRange`" is **not** an invariant (~32% of non-container instructions — `Nop`, and transform-synthesized `IfInstruction`/`Comp`/`Await`/`delayex` field accesses, etc. — legitimately have empty ranges), so the comment-only `EmptyStatement` is handled at the location layer rather than by tightening IL-range expectations.

## Test

Adds `TestCases/PdbGen/PinnedRegionWarning.il` — a C++/CLI-style pinned pointer whose pinned region is reachable both inside and outside the `fixed` statement, which reliably produces the block-duplication warning — and a `PdbGenerationTestRunner.PinnedRegionWarning` test that decompiles it, asserts the warning-carrying `EmptyStatement` now has a non-empty text location, and that `CreateSequencePoints` no longer throws. Fails before the fix, passes after; the full PdbGen fixture stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)