### PR TITLE
Fix #3804: decompile foreach over inline array

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InlineArrayTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InlineArrayTests.cs
@@ -99,6 +99,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return array[GetIndex()] = (array[GetIndex() + 1] = value);
 		}
 
+		public int SumForeach(Byte16 b)
+		{
+			int num = 0;
+			foreach (byte b2 in b)
+			{
+				num += b2;
+			}
+			return num;
+		}
+
 		public void OverloadResolution()
 		{
 			Receiver(GetByte16());

--- a/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
@@ -95,6 +95,9 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			AstNode? result = TransformForeachOnArray(forStatement);
 			if (result != null)
 				return result;
+			result = TransformForeachOnInlineArray(forStatement);
+			if (result != null)
+				return result;
 			return base.VisitForStatement(forStatement);
 		}
 
@@ -381,6 +384,112 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			// Add the variable annotation for highlighting (TokenTextWriter expects it directly on the ForeachStatement).
 			foreachStmt.VariableDesignation.AddAnnotation(new ILVariableResolveResult(itemVariable, itemVariable.Type));
 			// TODO : add ForeachAnnotation
+			forStatement.ReplaceWith(foreachStmt);
+			context.EndStep(foreachStmt);
+			return foreachStmt;
+		}
+
+		static readonly ForStatement forOnInlineArrayPattern = new ForStatement {
+			Initializers = {
+				new ExpressionStatement(
+				new AssignmentExpression(
+					new NamedNode("indexVariable", new IdentifierExpression(Pattern.AnyString)),
+					new PrimitiveExpression(0)
+				))
+			},
+			Condition = new BinaryOperatorExpression(
+				new IdentifierExpressionBackreference("indexVariable"),
+				BinaryOperatorType.LessThan,
+				new NamedNode("length", new PrimitiveExpression(PrimitiveExpression.AnyValue))
+			),
+			Iterators = {
+				new ExpressionStatement(
+				new AssignmentExpression(
+					new IdentifierExpressionBackreference("indexVariable"),
+					new BinaryOperatorExpression(new IdentifierExpressionBackreference("indexVariable"), BinaryOperatorType.Add, new PrimitiveExpression(1))
+				))
+			},
+			EmbeddedStatement = new BlockStatement {
+				Statements = {
+					new ExpressionStatement(new AssignmentExpression(
+						new NamedNode("itemVariable", new IdentifierExpression(Pattern.AnyString)),
+						new NamedNode("elementAccess", new AnyNode())
+					)),
+					new Repeat(new AnyNode("statements"))
+				}
+			}
+		};
+
+		/// <summary>
+		/// Reconstructs a <c>foreach</c> over an inline array from the <c>for</c> loop the compiler
+		/// lowers it to: <c>for (i = 0; i &lt; N; i++) { item = &lt;PrivateImplementationDetails&gt;.InlineArrayElementRef(ref buffer, i); ... }</c>.
+		/// The rewrite is only sound because the loop bound <c>N</c> equals the inline array length,
+		/// which proves the index is always in range: <c>InlineArrayElementRef</c> is the compiler's
+		/// unchecked element accessor, whereas the C# inline-array indexer <c>buffer[i]</c> is
+		/// bounds-checked, so the two only agree when the index is provably in-bounds. A loop that
+		/// does not match this exact shape keeps the (unnameable but faithful) helper call.
+		/// </summary>
+		Statement? TransformForeachOnInlineArray(ForStatement forStatement)
+		{
+			if (!context.Settings.ForEachStatement || !context.Settings.InlineArrays)
+				return null;
+			Match m = forOnInlineArrayPattern.Match(forStatement);
+			if (!m.Success)
+				return null;
+			var itemVariable = m.Get<IdentifierExpression>("itemVariable").Single().GetILVariable();
+			var indexVariable = m.Get<IdentifierExpression>("indexVariable").Single().GetILVariable();
+			if (itemVariable == null || indexVariable == null)
+				return null;
+
+			// The loop body must start with `item = InlineArrayElementRef(ref buffer, index)`.
+			if (m.Get<Expression>("elementAccess").Single() is not InvocationExpression elementAccess)
+				return null;
+			if (elementAccess.GetSymbol() is not IMethod { DeclaringType.FullName: "<PrivateImplementationDetails>" } helper)
+				return null;
+			if (helper.Name is not ("InlineArrayElementRef" or "InlineArrayElementRefReadOnly"))
+				return null;
+			if (elementAccess.Arguments.Count != 2)
+				return null;
+			// arg0: `ref buffer`, arg1: the loop index.
+			if (elementAccess.Arguments.First() is not DirectionExpression { Expression: IdentifierExpression bufferIdentifier })
+				return null;
+			var bufferVariable = bufferIdentifier.GetILVariable();
+			if (bufferVariable == null)
+				return null;
+			if (elementAccess.Arguments.Last() is not IdentifierExpression indexIdentifier
+				|| indexIdentifier.GetILVariable() != indexVariable)
+				return null;
+
+			// Soundness: the loop counts 0..length-1 over exactly the inline array's length, so the
+			// index is provably in range. Any other bound (or a non-inline-array buffer) is rejected.
+			if (bufferVariable.Type.GetInlineArrayLength() is not int arrayLength)
+				return null;
+			if (m.Get<PrimitiveExpression>("length").Single().Value is not int loopBound || loopBound != arrayLength)
+				return null;
+
+			if (!VariableCanBeUsedAsForeachLocal(itemVariable, forStatement))
+				return null;
+			// The index is a pure counter: stored at init + increment, loaded at the condition,
+			// the increment, and the element access; never captured by address.
+			if (indexVariable.StoreCount != 2 || indexVariable.LoadCount != 3 || indexVariable.AddressCount != 0)
+				return null;
+
+			context.Step("Introduce foreach over inline array", forStatement);
+			// Take the buffer reference for the `in` expression before dropping the element access.
+			var inExpression = bufferIdentifier.Detach();
+			// Reuse the loop body (preserving its annotations) after removing its leading
+			// `item = <PrivateImplementationDetails>.InlineArrayElementRef(ref buffer, i)` statement.
+			var body = (BlockStatement)forStatement.EmbeddedStatement;
+			body.Statements.First().Remove();
+			var foreachStmt = new ForeachStatement {
+				VariableType = context.Settings.AnonymousTypes && itemVariable.Type.ContainsAnonymousType() ? new SimpleType("var") : context.TypeSystemAstBuilder.ConvertType(itemVariable.Type),
+				VariableDesignation = new SingleVariableDesignation { Identifier = itemVariable.Name! },
+				InExpression = inExpression,
+				EmbeddedStatement = body.Detach()
+			};
+			foreachStmt.CopyAnnotationsFrom(forStatement);
+			itemVariable.Kind = IL.VariableKind.ForeachLocal;
+			foreachStmt.VariableDesignation.AddAnnotation(new ILVariableResolveResult(itemVariable, itemVariable.Type));
 			forStatement.ReplaceWith(foreachStmt);
 			context.EndStep(foreachStmt);
 			return foreachStmt;


### PR DESCRIPTION
Fixes #3804.

## Problem

Decompiling a `foreach` over an inline-array value emitted a `for` loop whose body called the compiler-internal `<PrivateImplementationDetails>.InlineArrayElementRef(ref b, i)` helper. That type name contains angle brackets and cannot be written in C#, so the output did not compile.

## Approach

The earlier version of this PR relaxed the IL matcher to rewrite `InlineArrayElementRef` to the inline-array indexer `b[i]` for any index. As @dgrunwald pointed out, that is unsound: `InlineArrayElementRef` is the compiler's **unchecked** element accessor, whereas the C# indexer `b[i]` (variable index) lowers to a **bounds-checked** span access, so the two only agree when the index is provably in-bounds.

This version reconstructs the `foreach` at the AST level instead, in `PatternStatementTransform`, alongside the existing `TransformForeachOnArray`. It matches the exact shape the compiler emits:

```
for (i = 0; i < N; i++) { item = <PrivateImplementationDetails>.InlineArrayElementRef(ref buffer, i); ... }
```

and only fires when the loop bound `N` equals `buffer`'s inline-array length. That equality is the in-bounds proof: `0 <= i < length`. The `InlineArrayElementRef` helper call is left untouched in the IL, so a loop that does not match this shape keeps the faithful (if unnameable) helper call rather than silently gaining a bounds check. This is sound in all cases, including hand-crafted IL.

Output:

```csharp
public int Sum(Byte16 b)
{
    int num = 0;
    foreach (byte b2 in b)
    {
        num += b2;
    }
    return num;
}
```

Verified that the checked span path (`b[i]` with a variable index), a partial-range loop (`i < 8`), and a genuine `for` loop reusing the index are all left unchanged.

## Test

Adds a `SumForeach` method to the `InlineArrayTests` Pretty fixture; it round-trips exactly (no `EXPECTED_OUTPUT` needed) across all `roslyn4OrNewerOptions` configs. Confirmed red without the transform (all 4 configs fail) and green with it; the full Pretty suite (1189 tests) stays green.

This PR was authored by an AI agent (Claude Code) operated by @siegfriedpammer and reviewed and manually verified by him.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
