### PR TITLE
Fix doubled index on macro opcodes in the IL view

### DIFF
--- a/ILSpy.Tests/TextView/OpCodeReferenceTests.cs
+++ b/ILSpy.Tests/TextView/OpCodeReferenceTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Reflection.Metadata;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler.Disassembler;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.ILSpy.TextView;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// The IL view renders a macro opcode such as "ldarg.0" by writing the mnemonic as an opcode
+/// reference with the index omitted, then writing the index as a separate clickable local or
+/// parameter reference. The omitSuffix path must keep the mnemonic up to the dot ("ldarg.") so the
+/// index is written exactly once; otherwise the opcode reads "ldarg.00".
+/// </summary>
+[TestFixture]
+public class OpCodeReferenceTests
+{
+	static OpCodeInfo MacroOpCode(ILOpCode opCode) => new(opCode, opCode.GetDisplayName());
+
+	[Test]
+	public void WriteReference_OmitSuffix_Keeps_The_Mnemonic_Up_To_The_Dot()
+	{
+		var output = new AvaloniaEditTextOutput();
+
+		output.WriteReference(MacroOpCode(ILOpCode.Ldarg_0), omitSuffix: true);
+
+		output.GetText().Should().Be("ldarg.");
+	}
+
+	[Test]
+	public void WriteReference_Without_OmitSuffix_Writes_The_Full_Opcode()
+	{
+		var output = new AvaloniaEditTextOutput();
+
+		output.WriteReference(MacroOpCode(ILOpCode.Ldarg_0));
+
+		output.GetText().Should().Be("ldarg.0");
+	}
+
+	[Test]
+	public void Macro_Opcode_Renders_Its_Index_Exactly_Once()
+	{
+		// Mirrors MethodBodyDisassembler.WriteOpCode for a macro opcode: the mnemonic (index omitted)
+		// followed by the index as a local/parameter reference.
+		var output = new AvaloniaEditTextOutput();
+
+		output.WriteReference(MacroOpCode(ILOpCode.Ldarg_0), omitSuffix: true);
+		output.WriteLocalReference("0", "param_0");
+
+		output.GetText().Should().Be("ldarg.0");
+	}
+}

--- a/ILSpy/TextView/AvaloniaEditTextOutput.cs
+++ b/ILSpy/TextView/AvaloniaEditTextOutput.cs
@@ -180,7 +180,13 @@ namespace ICSharpCode.ILSpy.TextView
 		{
 			WriteIndentIfNeeded();
 			int start = builder.Length;
-			var name = omitSuffix ? opCode.Name.TrimEnd('.') : opCode.Name;
+			string name = opCode.Name;
+			if (omitSuffix)
+			{
+				int lastDot = name.LastIndexOf('.');
+				if (lastDot > 0)
+					name = name.Remove(lastDot + 1);
+			}
 			builder.Append(name);
 			References.Add(new ReferenceSegment {
 				StartOffset = start,


### PR DESCRIPTION
### Problem

In the **IL view** the macro load/store opcodes render their index twice: `ldarg.0` shows as `ldarg.00`, `ldloc.1` as `ldloc.11`, `stloc.0` as `stloc.00`, and so on. This only affects the ILSpy UI; `ilspycmd -il` and the disassembler tests are unaffected.

### Cause

`MethodBodyDisassembler.WriteOpCode` splits these opcodes so the index can be a clickable local/parameter reference: it writes the mnemonic via `WriteReference(opCode, omitSuffix: true)` and then writes the index via `WriteLocalReference`.

`AvaloniaEditTextOutput.WriteReference` implemented `omitSuffix` as `opCode.Name.TrimEnd('.')`. The name ends in the index digit, not a dot, so that is a no-op: the full `ldarg.0` is written and the index `0` is then appended again → `ldarg.00`.

`PlainTextOutput` and the WPF `AvalonEditTextOutput` instead keep the mnemonic up to and including the last dot (`Name.Remove(lastDot + 1)`); the Avalonia port regressed this. This restores that behavior and adds a regression test for `AvaloniaEditTextOutput`.

---
🤖 This PR was prepared by Claude Code (claude-opus-4-8) on behalf of @siegfriedpammer.
