### PR TITLE
Set OpenSSL SHA1 flag in build scripts

### DIFF
--- a/BuildTools/format.ps1
+++ b/BuildTools/format.ps1
@@ -2,6 +2,7 @@
 # Trigger the commit hook's formatter against the working tree without committing,
 # applying the same formatting the pre-commit hook enforces.
 $ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 Push-Location (Join-Path $PSScriptRoot '..')
 try {
     bash BuildTools/pre-commit --format

--- a/BuildTools/pre-commit
+++ b/BuildTools/pre-commit
@@ -8,6 +8,7 @@ set -eu
 
 DOTNET_FORMAT_VERSION=10.0.100-rtm.25531.102
 DOTNET_FORMAT_SOURCE="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json"
+export OPENSSL_ENABLE_SHA1_SIGNATURES=1
 
 # Per-OS tool cache location + binary suffix. Windows uses %LOCALAPPDATA% and a .exe
 # suffix; Unix-likes follow the XDG basedir spec (falling back to ~/.local/share) and

--- a/build.ps1
+++ b/build.ps1
@@ -6,4 +6,5 @@ param(
     [string]$Configuration = 'Debug'
 )
 $ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 dotnet build ILSpy.sln -c $Configuration "-p:Platform=Any CPU" @args

--- a/clean.ps1
+++ b/clean.ps1
@@ -1,5 +1,6 @@
 #!/usr/bin/env pwsh
 # Clean the Debug and Release build outputs of ILSpy.sln.
 $ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 dotnet clean ILSpy.sln -c Debug "-p:Platform=Any CPU" @args
 dotnet clean ILSpy.sln -c Release "-p:Platform=Any CPU" @args

--- a/publish.ps1
+++ b/publish.ps1
@@ -13,6 +13,7 @@ param(
     [string]$Platform = 'windows'
 )
 $ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 
 $base = "./ILSpy/bin/$Configuration/net10.0"
 

--- a/publishlocaldev.ps1
+++ b/publishlocaldev.ps1
@@ -1,5 +1,8 @@
 # For local development of the VSIX package - build and publish (VS2022 also needs arm64)
 
+$ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
+
 $configuration = "Debug"
 
 dotnet build ./ILSpy.sln -c $configuration

--- a/restore.ps1
+++ b/restore.ps1
@@ -2,4 +2,5 @@
 # Restore all NuGet packages for ILSpy.sln, honouring the committed packages.lock.json files.
 # Use updatedeps.ps1 instead when you have changed a PackageVersion and need to refresh the locks.
 $ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 dotnet restore ILSpy.sln -p:RestoreEnablePackagePruning=false @args

--- a/updatedeps.ps1
+++ b/updatedeps.ps1
@@ -3,4 +3,5 @@
 # Run this after changing a PackageVersion in Directory.Packages.props (or adding a package),
 # then commit the updated lock files.
 $ErrorActionPreference = 'Stop'
+$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 dotnet restore ILSpy.sln --force-evaluate -p:RestoreEnablePackagePruning=false @args


### PR DESCRIPTION
## Summary
- Set OPENSSL_ENABLE_SHA1_SIGNATURES=1 directly in restore, build, update-deps, clean, publish, local publish, and format scripts before they invoke dotnet or the formatter hook.
- Export the same variable in the pre-commit formatter hook for direct hook usage.

## Verification
- env -u OPENSSL_ENABLE_SHA1_SIGNATURES pwsh ./build.ps1 -Configuration Debug --no-restore
- env -u OPENSSL_ENABLE_SHA1_SIGNATURES pwsh ./BuildTools/format.ps1
- git diff --check origin/master...HEAD