### PR TITLE
Add test coverage for untested corners of implemented language features

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Documentation/XmlDocTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Documentation/XmlDocTests.cs
@@ -1,0 +1,291 @@
+// Copyright (c) 2026 AlphaSierraPapa for the SharpDevelop Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+using ICSharpCode.Decompiler.Documentation;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.Tests.Helpers;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.Decompiler.TypeSystem.Implementation;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.Decompiler.Tests.Documentation
+{
+	[TestFixture]
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
+		Justification = "The PEFile is disposed by the OneTimeTearDown method.")]
+	public class XmlDocTests
+	{
+		// Compiled by Tester.CompileCSharp with CompilerOptions.ProcessXmlDoc, so the member
+		// ID strings in the documentation file come from the compiler itself. Looking an
+		// entity's documentation up therefore checks IdStringProvider.GetIdString against
+		// the compiler-generated ID for the same member.
+		const string SampleCode = """
+			using System;
+
+			namespace XmlDocSamples
+			{
+				/// <summary>Documentation for the sample class.</summary>
+				public class Sample
+				{
+					/// <summary>Documentation for the field.</summary>
+					public int Field;
+
+					/// <summary>Documentation for the event.</summary>
+					public event EventHandler Event;
+
+					/// <summary>Documentation for the constructor.</summary>
+					public Sample(int x)
+					{
+					}
+
+					/// <summary>Documentation for the indexer.</summary>
+					public string this[int index] => null;
+
+					/// <summary>Documentation for ref/out parameters.</summary>
+					public void MethodWithRefOutParams(ref int x, out string y)
+					{
+						y = null;
+					}
+
+					/// <summary>Documentation for params.</summary>
+					public void MethodWithParamsArray(params object[] args)
+					{
+					}
+
+					/// <summary>Documentation for pointers.</summary>
+					public unsafe void MethodWithPointer(int* p)
+					{
+					}
+
+					/// <summary>Documentation for arrays.</summary>
+					public void MethodWithArrays(int[] a, string[,] b, int[][] c)
+					{
+					}
+
+					/// <summary>Documentation for the addition operator.</summary>
+					public static Sample operator +(Sample a, Sample b)
+					{
+						return a;
+					}
+
+					/// <summary>Documentation for the implicit conversion.</summary>
+					public static implicit operator int(Sample a)
+					{
+						return 0;
+					}
+
+					/// <summary>Documentation for the explicit conversion.</summary>
+					public static explicit operator Sample(int a)
+					{
+						return null;
+					}
+				}
+
+				/// <summary>Documentation for the generic sample class.</summary>
+				public class GenericSample<A, B>
+				{
+					/// <summary>Documentation for the nested generic class.</summary>
+					public class Nested<C>
+					{
+						/// <summary>Documentation for the nested method.</summary>
+						public void NestedMethod(A a, C c)
+						{
+						}
+					}
+
+					/// <summary>Documentation for the method using class type parameters.</summary>
+					public void Method(A a, B b)
+					{
+					}
+
+					/// <summary>Documentation for the generic method.</summary>
+					public C GenericMethod<C>(C input, A other)
+					{
+						return input;
+					}
+				}
+			}
+			""";
+
+		const string NS = "XmlDocSamples";
+
+		string sourceFile;
+		CompilerResults results;
+		PEFile peFile;
+		ICompilation compilation;
+		XmlDocumentationProvider documentation;
+
+		[OneTimeSetUp]
+		public async Task CompileSample()
+		{
+			sourceFile = Path.Combine(Path.GetTempPath(), $"XmlDocSamples-{Guid.NewGuid():N}.cs");
+			File.WriteAllText(sourceFile, SampleCode);
+			results = await Tester.CompileCSharp(sourceFile,
+				CompilerOptions.UseRoslynLatest | CompilerOptions.Optimize | CompilerOptions.Library | CompilerOptions.ProcessXmlDoc);
+			peFile = new PEFile(results.PathToAssembly,
+				new FileStream(results.PathToAssembly, FileMode.Open, FileAccess.Read));
+			compilation = new SimpleCompilation(peFile.WithOptions(TypeSystemOptions.Default), MinimalCorlib.Instance);
+			documentation = new XmlDocumentationProvider(Path.ChangeExtension(results.PathToAssembly, ".xml"));
+		}
+
+		[OneTimeTearDown]
+		public void Cleanup()
+		{
+			peFile?.Dispose();
+			if (results != null)
+			{
+				string xmlFile = Path.ChangeExtension(results.PathToAssembly, ".xml");
+				results.DeleteTempFiles();
+				if (File.Exists(xmlFile))
+					File.Delete(xmlFile);
+			}
+			if (sourceFile != null && File.Exists(sourceFile))
+				File.Delete(sourceFile);
+		}
+
+		ITypeDefinition GetTypeDefinition(string reflectionName)
+		{
+			var typeDef = compilation.FindType(new FullTypeName(reflectionName)).GetDefinition();
+			Assert.That(typeDef, Is.Not.Null, $"Could not resolve {reflectionName}");
+			return typeDef;
+		}
+
+		void AssertIdStringRoundTrip(IEntity entity, string expectedIdString)
+		{
+			Assert.That(entity.GetIdString(), Is.EqualTo(expectedIdString));
+			var found = IdStringProvider.FindEntity(expectedIdString, new SimpleTypeResolveContext(compilation));
+			Assert.That(found, Is.EqualTo(entity), $"FindEntity did not round-trip {expectedIdString}");
+		}
+
+		void AssertDocumentation(IEntity entity, string expectedText)
+		{
+			Assert.That(documentation.GetDocumentation(entity), Does.Contain(expectedText),
+				$"Documentation not found for {entity.GetIdString()}");
+		}
+
+		[Test]
+		public void TypeIdStrings()
+		{
+			AssertIdStringRoundTrip(GetTypeDefinition($"{NS}.Sample"),
+				$"T:{NS}.Sample");
+			AssertIdStringRoundTrip(GetTypeDefinition($"{NS}.GenericSample`2"),
+				$"T:{NS}.GenericSample`2");
+			AssertIdStringRoundTrip(GetTypeDefinition($"{NS}.GenericSample`2+Nested`1"),
+				$"T:{NS}.GenericSample`2.Nested`1");
+		}
+
+		[Test]
+		public void FieldEventAndConstructorIdStrings()
+		{
+			var sample = GetTypeDefinition($"{NS}.Sample");
+			AssertIdStringRoundTrip(sample.Fields.Single(f => f.Name == "Field"),
+				$"F:{NS}.Sample.Field");
+			AssertIdStringRoundTrip(sample.Events.Single(),
+				$"E:{NS}.Sample.Event");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.IsConstructor),
+				$"M:{NS}.Sample.#ctor(System.Int32)");
+		}
+
+		[Test]
+		public void MethodIdStrings()
+		{
+			var sample = GetTypeDefinition($"{NS}.Sample");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "MethodWithRefOutParams"),
+				$"M:{NS}.Sample.MethodWithRefOutParams(System.Int32@,System.String@)");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "MethodWithParamsArray"),
+				$"M:{NS}.Sample.MethodWithParamsArray(System.Object[])");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "MethodWithPointer"),
+				$"M:{NS}.Sample.MethodWithPointer(System.Int32*)");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "MethodWithArrays"),
+				$"M:{NS}.Sample.MethodWithArrays(System.Int32[],System.String[0:,0:],System.Int32[][])");
+		}
+
+		[Test]
+		public void IndexerIdString()
+		{
+			var sample = GetTypeDefinition($"{NS}.Sample");
+			AssertIdStringRoundTrip(sample.Properties.Single(p => p.IsIndexer),
+				$"P:{NS}.Sample.Item(System.Int32)");
+		}
+
+		[Test]
+		public void OperatorIdStrings()
+		{
+			var sample = GetTypeDefinition($"{NS}.Sample");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "op_Addition"),
+				$"M:{NS}.Sample.op_Addition({NS}.Sample,{NS}.Sample)");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "op_Implicit"),
+				$"M:{NS}.Sample.op_Implicit({NS}.Sample)~System.Int32");
+			AssertIdStringRoundTrip(sample.Methods.Single(m => m.Name == "op_Explicit"),
+				$"M:{NS}.Sample.op_Explicit(System.Int32)~{NS}.Sample");
+		}
+
+		[Test]
+		public void GenericMemberIdStrings()
+		{
+			var generic = GetTypeDefinition($"{NS}.GenericSample`2");
+			AssertIdStringRoundTrip(generic.Methods.Single(m => m.Name == "Method"),
+				$"M:{NS}.GenericSample`2.Method(`0,`1)");
+			AssertIdStringRoundTrip(generic.Methods.Single(m => m.Name == "GenericMethod"),
+				$"M:{NS}.GenericSample`2.GenericMethod``1(``0,`0)");
+			var nested = GetTypeDefinition($"{NS}.GenericSample`2+Nested`1");
+			AssertIdStringRoundTrip(nested.Methods.Single(m => m.Name == "NestedMethod"),
+				$"M:{NS}.GenericSample`2.Nested`1.NestedMethod(`0,`2)");
+		}
+
+		[Test]
+		public void LookupByIdString()
+		{
+			Assert.That(documentation.GetDocumentation($"T:{NS}.Sample"),
+				Does.Contain("Documentation for the sample class."));
+			Assert.That(documentation.GetDocumentation($"T:{NS}.DoesNotExist"), Is.Null);
+		}
+
+		[Test]
+		public void LookupByEntityMatchesCompilerGeneratedIds()
+		{
+			var sample = GetTypeDefinition($"{NS}.Sample");
+			AssertDocumentation(sample, "Documentation for the sample class.");
+			AssertDocumentation(sample.Fields.Single(f => f.Name == "Field"), "Documentation for the field.");
+			AssertDocumentation(sample.Events.Single(), "Documentation for the event.");
+			AssertDocumentation(sample.Methods.Single(m => m.IsConstructor), "Documentation for the constructor.");
+			AssertDocumentation(sample.Properties.Single(p => p.IsIndexer), "Documentation for the indexer.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "MethodWithRefOutParams"), "Documentation for ref/out parameters.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "MethodWithParamsArray"), "Documentation for params.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "MethodWithPointer"), "Documentation for pointers.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "MethodWithArrays"), "Documentation for arrays.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "op_Addition"), "Documentation for the addition operator.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "op_Implicit"), "Documentation for the implicit conversion.");
+			AssertDocumentation(sample.Methods.Single(m => m.Name == "op_Explicit"), "Documentation for the explicit conversion.");
+
+			var generic = GetTypeDefinition($"{NS}.GenericSample`2");
+			AssertDocumentation(generic, "Documentation for the generic sample class.");
+			AssertDocumentation(generic.Methods.Single(m => m.Name == "Method"), "Documentation for the method using class type parameters.");
+			AssertDocumentation(generic.Methods.Single(m => m.Name == "GenericMethod"), "Documentation for the generic method.");
+			var nested = GetTypeDefinition($"{NS}.GenericSample`2+Nested`1");
+			AssertDocumentation(nested, "Documentation for the nested generic class.");
+			AssertDocumentation(nested.Methods.Single(m => m.Name == "NestedMethod"), "Documentation for the nested method.");
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -927,6 +927,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task Variance([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task StaticAbstractInterfaceMembers([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AnonymousTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AnonymousTypes.cs
@@ -110,5 +110,28 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			v = init;
 		}
+
+		private static string NestedAnonymousTypeMembers()
+		{
+			var anon = new {
+				Outer = new {
+					Inner = 1
+				},
+				Arr = new[] {
+					new {
+						X = 1
+					}
+				}
+			};
+			return anon.Outer.Inner + anon.ToString() + anon.Arr[0].X;
+		}
+
+		private static object MemberProjection(Version v)
+		{
+			return new {
+				Major = v.Major,
+				Renamed = v.Minor
+			};
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Async.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Async.cs
@@ -583,6 +583,39 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 #endif
+
+#if ROSLYN
+		// The legacy csc lowering of await inside the null-coalescing operator is not
+		// reconstructed; the raw awaiter state machine leaks into the output.
+		public static async Task<int> AwaitInCoalesce(Task<int?> t, Task<int> u)
+		{
+			return (await t) ?? (await u);
+		}
+#endif
+
+		public static async Task DoWhileAwaitCondition(Func<Task<bool>> t)
+		{
+			do
+			{
+				Console.WriteLine("body");
+			} while (await t());
+		}
+
+#if CS70 && !NET40
+		// The legacy csc and Roslyn 1.x configurations compile against the legacy
+		// .NET Framework reference assemblies, which have no ValueTask.
+		public static async Task<int> AwaitValueTask(ValueTask<int> t)
+		{
+			return await t + 1;
+		}
+#endif
+
+#if CS100 && !NET40
+		public static async Task<string> AwaitInInterpolationHole(Task<int> t)
+		{
+			return $"val={await t,5:x} end";
+		}
+#endif
 	}
 
 	public struct AsyncInStruct

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncForeach.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncForeach.cs
@@ -51,5 +51,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 			return max;
 		}
+
+		public async Task<int> SumWithConfigureAwait(IAsyncEnumerable<int> items)
+		{
+			int sum = 0;
+			await foreach (int item in items.ConfigureAwait(continueOnCapturedContext: false))
+			{
+				sum += item;
+			}
+			return sum;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncStreams.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncStreams.cs
@@ -62,6 +62,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			await Task.Delay(100, cancellationToken);
 			yield return 2;
 		}
+
+		public static async IAsyncEnumerable<int> CountToWithConfigureAwait(int until)
+		{
+			for (int i = 0; i < until; i++)
+			{
+				yield return i;
+				await Task.Delay(10).ConfigureAwait(continueOnCapturedContext: false);
+			}
+		}
 	}
 
 	public struct TestStruct

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AutoProperties.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AutoProperties.cs
@@ -2,6 +2,12 @@ using System;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	internal class AsymmetricAccessibility
+	{
+		public int PrivateSetter { get; private set; }
+
+		public int ProtectedSetter { get; protected set; }
+	}
 	internal class AutoProperties
 	{
 #if CS110
@@ -38,10 +44,40 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #endif
 		}
 	}
+	internal class AutoPropertiesBase
+	{
+		public virtual int VirtualProperty { get; set; }
+
+		public virtual int VirtualGetterOnly { get; }
+	}
+	internal class AutoPropertiesDerived : AutoPropertiesBase
+	{
+		public override int VirtualProperty { get; set; }
+
+		public sealed override int VirtualGetterOnly { get; }
+	}
+	internal class AutoPropertyExplicitImpl : IAutoProperty
+	{
+		int IAutoProperty.Property { get; set; }
+	}
+	internal class AutoPropertyImplicitImpl : IAutoProperty
+	{
+		public int Property { get; set; }
+	}
+	internal interface IAutoProperty
+	{
+		int Property { get; set; }
+	}
 #if !NET70
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 	internal sealed class RequiredMemberAttribute : Attribute
 	{
 	}
 #endif
+	internal struct StructAutoProperties
+	{
+		public int Property { get; set; }
+
+		public int GetterOnly { get; }
+	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AutoProperties.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AutoProperties.cs
@@ -1,4 +1,7 @@
 using System;
+#if CS110 && NET70
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
@@ -68,6 +71,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 	{
 		int Property { get; set; }
 	}
+#if CS110 && NET70
+	internal class RequiredMembersBase
+	{
+		public required int A { get; set; }
+
+		public RequiredMembersBase()
+		{
+		}
+
+		[SetsRequiredMembers]
+		public RequiredMembersBase(int seed)
+		{
+			A = seed;
+		}
+	}
+	internal class RequiredMembersDerived : RequiredMembersBase
+	{
+		public required int B { get; init; }
+	}
+	internal abstract class RequiredMembersGeneric<T>
+	{
+		public required T Value { get; set; }
+	}
+#endif
 #if !NET70
 	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 	internal sealed class RequiredMemberAttribute : Attribute

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CustomAttributes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CustomAttributes.cs
@@ -170,6 +170,13 @@ namespace CustomAttributes
 		public static void UseGenericAttributeWithArg()
 		{
 		}
+		[Generic<List<int>>]
+		[Generic<Dictionary<string, List<int>>>]
+		[Generic<int[]>]
+		[Generic<StringComparison>(StringComparison.Ordinal)]
+		public static void UseGenericAttributeWithComplexTypes()
+		{
+		}
 #endif
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
@@ -576,6 +576,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return ref o;
 		}
 #endif
+
+		private static void WhileDynamic(dynamic a)
+		{
+			while (a)
+			{
+				Console.WriteLine("x");
+			}
+		}
+
+#if CS60
+		private static void NullConditionalInvocation(dynamic a)
+		{
+			a?.Call();
+		}
+#endif
 	}
 
 	internal static class Extension

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExceptionHandling.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExceptionHandling.cs
@@ -501,5 +501,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 #endif
+
+		public static void ContinueInCatchInForeach(int[] arr)
+		{
+			foreach (int value in arr)
+			{
+				try
+				{
+					Console.WriteLine(value);
+				}
+				catch (Exception)
+				{
+					continue;
+				}
+				Console.WriteLine("after");
+			}
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExceptionHandling.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExceptionHandling.cs
@@ -500,6 +500,25 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #pragma warning restore CA2200 // Rethrow to preserve stack details
 			}
 		}
+
+		private static bool FilterWithSideEffect(Exception e, ref int log)
+		{
+			log++;
+			return e.Message.Length > 0;
+		}
+
+		public static void SideEffectingFilter()
+		{
+			int log = 0;
+			try
+			{
+				Console.WriteLine("try");
+			}
+			catch (Exception e) when (FilterWithSideEffect(e, ref log))
+			{
+				Console.WriteLine(log);
+			}
+		}
 #endif
 
 		public static void ContinueInCatchInForeach(int[] arr)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
@@ -944,6 +944,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			ToCode(null, (int? a) => a & (int?)2);
 			ToCode(null, (int? a) => a & a);
 		}
+
+		public void CheckedArithmetic()
+		{
+			checked
+			{
+				ToCode(null, (int a, int b) => a + b);
+				ToCode(null, (int a, int b) => a - b);
+				ToCode(null, (int a, int b) => a * b);
+				ToCode(null, (int a) => (short)a);
+			}
+		}
 	}
 
 	internal static class Extensions

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Generics.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Generics.cs
@@ -20,6 +20,27 @@ using System.Collections.Generic;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	internal class DerivedFromGenericBase : GenericBase<string>
+	{
+		public override string Get()
+		{
+			return "x";
+		}
+
+		public override void Set(string value)
+		{
+		}
+	}
+
+	internal abstract class GenericBase<T>
+	{
+		public abstract T Get();
+
+		public virtual void Set(T value)
+		{
+		}
+	}
+
 	internal class Generics
 	{
 		private class GenericClass<T>
@@ -357,4 +378,5 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		//#endif
 #endif
 	}
+
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -1257,6 +1257,14 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 		}
 
 #if CS60
+		public static void RealDictionaryIndexInitializer()
+		{
+			X(Y(), new Dictionary<string, int> {
+				["a"] = 1,
+				["b"] = GetInt()
+			});
+		}
+
 		public static void SimpleDictInitializer()
 		{
 			X(Y(), new Data {

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -458,6 +458,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 #if CS110 && !NET40
 		public static ReadOnlySpan<byte> UTF8Literal => "Hello, world!"u8;
 		public static ReadOnlySpan<byte> UTF8LiteralWithNullTerminator => "Hello, world!\0"u8;
+		public static ReadOnlySpan<byte> UTF8LiteralEmpty => ""u8;
+		public static ReadOnlySpan<byte> UTF8LiteralWithEscapeSequences => "line1\nline2\t\"quoted\"\\"u8;
 #endif
 		#endregion
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InterfaceTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InterfaceTests.cs
@@ -104,6 +104,32 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public interface IB
 		{
 		}
+#if CS80 && !NET40
+		public interface IProtectedMembers
+		{
+			protected void ProtectedMethod();
+
+			protected internal void ProtectedInternalMethod()
+			{
+				ProtectedMethod();
+			}
+		}
+		public interface IStaticMembers
+		{
+			static int StaticProperty { get; set; }
+
+			static event EventHandler StaticEvent;
+		}
+		public interface IGenericWithDefaultImpl<T>
+		{
+			T Value { get; }
+
+			T DefaultGet<U>(U key) where U : T
+			{
+				return Value;
+			}
+		}
+#endif
 		public class C : IA2, IA, IB
 		{
 			int IA.Property1 {

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LiftedOperators.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LiftedOperators.cs
@@ -937,6 +937,26 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 	}
 
+	internal class T04_LiftedCompoundAssignAndBoxing
+	{
+		public static int? CompoundAssign(int? x, int? y)
+		{
+			x += y;
+			x <<= 2;
+			return x;
+		}
+
+		public static object Box(int? x)
+		{
+			return x;
+		}
+
+		public static int? Unbox(object o)
+		{
+			return (int?)o;
+		}
+	}
+
 	// dummy structure for testing custom operators
 	[StructLayout(LayoutKind.Sequential, Size = 1)]
 	public struct TS

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -21,6 +21,7 @@ using System.Linq;
 #if CS90
 using System.Runtime.InteropServices;
 #endif
+using System.Threading.Tasks;
 
 namespace LocalFunctions
 {
@@ -667,6 +668,32 @@ namespace LocalFunctions
 				{
 					yield return i;
 				}
+			}
+		}
+
+		public static async Task<int> AsyncLocalFunction()
+		{
+			return await GetValueAsync() + await GetValueAsync();
+
+#if CS80
+			static async Task<int> GetValueAsync()
+#else
+			async Task<int> GetValueAsync()
+#endif
+			{
+				await Task.Yield();
+				return 1;
+			}
+		}
+
+		public static async Task<int> AsyncLocalFunctionWithCapture(int n)
+		{
+			return await AddAsync();
+
+			async Task<int> AddAsync()
+			{
+				await Task.Yield();
+				return n + 1;
 			}
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullableRefTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullableRefTypes.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
@@ -182,6 +183,29 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		void IEnumerator.Reset()
 		{
 			throw new NotImplementedException();
+		}
+	}
+
+	public class T08_NullablePostconditionAttributes
+	{
+		public bool TryGet(string key, [MaybeNullWhen(false)] out string value)
+		{
+			value = null;
+			return false;
+		}
+
+		public static void ThrowIfNull([NotNull] object? o)
+		{
+			if (o == null)
+			{
+				throw new ArgumentNullException("o");
+			}
+		}
+
+		[return: MaybeNull]
+		public T FirstOrDefault<T>(IEnumerable<T> source)
+		{
+			return default(T);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Operators.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Operators.cs
@@ -294,5 +294,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #endif
 			a = num;
 		}
+#if CS110
+		public void CheckedCompoundAssign()
+		{
+			a += b;
+			a -= b;
+			checked
+			{
+				a += b;
+				a -= b;
+				a *= b;
+				a /= b;
+			}
+			// force end of checked block:
+			++a;
+		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -204,6 +204,14 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				   select (x);
 		}
 
+		public object SelectIntoContinuation()
+		{
+			return from c in customers
+				   select c.Name into n
+				   where n.Length > 3
+				   select n.ToUpper();
+		}
+
 #if CS60
 		private List<string> Issue2545(List<string> arglist)
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Records.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Records.cs
@@ -1,6 +1,7 @@
 using System;
 #if CS100
 using System.Runtime.InteropServices;
+using System.Text;
 #endif
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
@@ -247,6 +248,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if CS100
 	internal class RecordStructs
 	{
+		public readonly record struct ReadonlyPoint(int X, int Y);
+
 		public record struct Base(string A);
 
 		public record CopyCtor(string A)
@@ -442,6 +445,26 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				: this(42, B)
 			{
 				C = 1.41;
+			}
+		}
+	}
+
+	internal class RecordsWithCustomSynthesizedMembers
+	{
+		public record WithCustomToString(int A)
+		{
+			public sealed override string ToString()
+			{
+				return "custom";
+			}
+		}
+
+		public record WithCustomPrintMembers(int A)
+		{
+			protected virtual bool PrintMembers(StringBuilder builder)
+			{
+				builder.Append("X");
+				return true;
 			}
 		}
 	}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
@@ -82,6 +83,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Field1 = ref v;
 			Field2 = ref v;
 			Field3 = ref v;
+		}
+	}
+
+	internal ref struct UnscopedRefStruct
+	{
+		private int val;
+
+		[UnscopedRef]
+		public ref int ByRefProperty => ref val;
+
+		[UnscopedRef]
+		public ref int ByRefAccess()
+		{
+			return ref val;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StaticAbstractInterfaceMembers.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StaticAbstractInterfaceMembers.cs
@@ -223,4 +223,38 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.StaticAbstractInterfaceM
 			++t;
 		}
 	}
+
+#if CS110
+	internal class ZZCheckedAndShiftOperatorTest
+	{
+		public interface IShifty<T> where T : IShifty<T>
+		{
+			static abstract T operator +(T l, T r);
+
+			static abstract T operator checked +(T l, T r);
+
+			static abstract T operator >>>(T l, int r);
+		}
+
+		public static T Add<T>(T a, T b) where T : IShifty<T>
+		{
+			return a + b;
+		}
+
+		public static T AddChecked<T>(T a, T b) where T : IShifty<T>
+		{
+			return checked(a + b);
+		}
+
+		public static T Shift<T>(T a) where T : IShifty<T>
+		{
+			return a >>> 3;
+		}
+
+		public static int UsePropertiesAsRValue<T>() where T : IAmSimple
+		{
+			return T.Capacity + T.Count;
+		}
+	}
+#endif
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
@@ -668,5 +668,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			UseArrayOfPointers(null);
 		}
+
+		public unsafe static int* PointerToPointer(int** pp)
+		{
+			*pp = null;
+			return pp[3] = *pp;
+		}
+
+		public unsafe static void FixedPointerToPointer(int*[] arr)
+		{
+			fixed (int** ptr = &arr[0])
+			{
+				*ptr = null;
+			}
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UsingVariables.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UsingVariables.cs
@@ -17,12 +17,25 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Runtime.InteropServices;
 #if !NET40
 using System.Threading.Tasks;
 #endif
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	[StructLayout(LayoutKind.Sequential, Size = 1)]
+	internal ref struct RefStructWithDispose
+	{
+		public void Use()
+		{
+		}
+
+		public void Dispose()
+		{
+		}
+	}
+
 	public class UsingVariables
 	{
 		public IDisposable GetDisposable()
@@ -96,5 +109,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Use(asyncDisposable);
 		}
 #endif
+
+		public void UsingVarPatternBasedDispose()
+		{
+			Console.WriteLine("before using");
+			using RefStructWithDispose refStructWithDispose = default(RefStructWithDispose);
+			Console.WriteLine("inside using");
+			refStructWithDispose.Use();
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Variance.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Variance.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public class ExplicitVariantImpl : IVariant<object, string>
+	{
+		string IVariant<object, string>.Convert(object value)
+		{
+			return null;
+		}
+	}
+
+	public interface IConstrainedCovariant<out T> where T : class
+	{
+		T Get();
+	}
+
+	public interface IContravariant<in T>
+	{
+		void Set(T value);
+	}
+
+	public interface ICovariant<out T>
+	{
+		T Get();
+	}
+
+	public interface IVariant<in TIn, out TOut>
+	{
+		TOut Convert(TIn value);
+	}
+
+	public static class VarianceConversions
+	{
+		public static IEnumerable<object> Widen(IEnumerable<string> xs)
+		{
+			return xs;
+		}
+
+		public static Action<string> Narrow(Action<object> a)
+		{
+			return a;
+		}
+
+		public static Func<object> ToObjectFunc(Func<string> f)
+		{
+			return f;
+		}
+
+		public static ICovariant<object> WidenInterface(ICovariant<string> c)
+		{
+			return c;
+		}
+
+		public static IContravariant<string> NarrowInterface(IContravariant<object> c)
+		{
+			return c;
+		}
+
+		public static VariantFunc<string, object> ConvertDelegate(VariantFunc<object, string> f)
+		{
+			return f;
+		}
+
+		public static void ArgumentConversion(ICovariant<string> c, IContravariant<object> c2)
+		{
+			UseCovariant(c);
+			UseContravariant(c2);
+		}
+
+		private static void UseCovariant(ICovariant<object> c)
+		{
+		}
+
+		private static void UseContravariant(IContravariant<string> c)
+		{
+		}
+	}
+
+	public delegate TResult VariantFunc<in TArg, out TResult>(TArg arg);
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/YieldReturn.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/YieldReturn.cs
@@ -441,5 +441,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				yield return i;
 			}
 		}
+
+		internal static IEnumerable<T> GenericRepeat<T>(T value, int count)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				yield return value;
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR was written by an AI agent (Claude Code), driven and reviewed by @siegfriedpammer.

An audit of the language features marked as implemented in #829 and on the wiki Language-Feature-Roadmap, compared against the existing Pretty fixtures, found a number of constructs that decompile correctly today but had no test pinning them. This PR adds green tests only, one commit per feature (27 commits, 26 files, +791 lines, no production code changes).

Highlights:

- **Generic co-/contravariance had zero coverage**: no `out T`/`in T` declaration or variance conversion anywhere in the suite. New `Variance` fixture + runner method.
- **The XmlDoc subsystem (`ICSharpCode.Decompiler/Documentation/`) had zero tests**: new unit tests pin `IdStringProvider` round-trips (nested generics, `` `0``/`` ``0`` references, `@`/pointer/array forms incl. `[0:,0:]`, conversion-operator `~ReturnType` suffixes, indexers, `#ctor`) and `XmlDocumentationProvider` lookup.
- First coverage for: `[SetsRequiredMembers]` and required-member inheritance, `[UnscopedRef]` members, static abstract `checked`/`>>>` operators, generic attributes with constructed/array/enum type arguments, nullable postcondition attributes (`MaybeNullWhen` etc.), `ConfigureAwait(false)` in async iterators, `await` in an interpolated-string hole, pattern-based `Dispose` of a ref struct, protected/static/generic default interface members, readonly record structs and records with user-declared `ToString`/`PrintMembers`, async local functions, checked compound assignment, lifted compound assignment and `Nullable<T>` boxing, pointer-to-pointer shapes, dictionary index initializers, UTF-8 literal edge cases, select-into continuations, nested anonymous-type members, generic iterators, exception filters with side effects, and `continue` inside a catch within a loop (pins the fixed behavior from #2829, which can be closed).

All added tests pass on the Linux configuration subset (Roslyn 3.11 / 4.14 / latest, plus/minus Optimize and net40 where the fixture's group includes it): 303/303 including the pre-existing cases of the touched fixtures. Legacy csc/mcs configurations run on Windows CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)