### PR TITLE
Fix #3860: Avoid 'out var' if the variable recurs in the argument list

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
@@ -92,5 +92,24 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value2);
 			Console.WriteLine(value2);
 		}
+
+		private static void GetTwo(out int a, out int b)
+		{
+			a = 1;
+			b = 2;
+		}
+
+		public static void SameVariableUsedForTwoOutParameters()
+		{
+			// The declaration must use the explicit type: referencing an implicitly-typed
+			// out variable in another argument of the declaring call is an error (CS8196).
+			GetTwo(out int a, out a);
+		}
+
+		public static int SameVariableUsedForTwoOutParametersAndRead()
+		{
+			GetTwo(out int a, out a);
+			return a;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
@@ -111,5 +111,24 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			GetTwo(out int a, out a);
 			return a;
 		}
+
+		private static void OutAndValue(out int a, int b)
+		{
+			a = b;
+		}
+
+		private static int UseAndReturn(out int a)
+		{
+			a = 1;
+			return a;
+		}
+
+		public static void SameVariableUsedInNestedCallArgument()
+		{
+			// CS8196 also applies when the second reference is nested within
+			// another argument of the declaring call.
+			OutAndValue(out int a, UseAndReturn(out a));
+			Console.WriteLine(a);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -651,7 +651,8 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						type = new SimpleType("var");
 						isOutVar = true;
 					}
-					else if (dirExpr.Annotation<UseImplicitlyTypedOutAnnotation>() != null)
+					else if (dirExpr.Annotation<UseImplicitlyTypedOutAnnotation>() != null
+						&& !IsReferencedWithinDeclaringCall(dirExpr, v))
 					{
 						type = new SimpleType("var");
 						isOutVar = true;
@@ -786,6 +787,45 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				oldNode.ReplaceWith(newNode);
 				context.EndStep(newNode);
 			}
+		}
+
+		/// <summary>
+		/// Gets whether the variable declared by <paramref name="dirExpr"/> is referenced again within
+		/// another argument of the call containing the declaration. In that case the declaration must use
+		/// the explicit type: referencing an implicitly-typed out variable is not permitted until overload
+		/// resolution of the declaring call has inferred its type (CS8196).
+		/// </summary>
+		bool IsReferencedWithinDeclaringCall(DirectionExpression dirExpr, VariableToDeclare v)
+		{
+			AstNode? call = dirExpr.Parent;
+			if (call == null)
+				return false;
+			for (AstNode? argument = call.FirstChild; argument != null; argument = argument.NextSibling)
+			{
+				if (argument == dirExpr)
+					continue;
+				foreach (AstNode node in argument.DescendantsAndSelf)
+				{
+					if (node is IdentifierExpression identifier && ResolveVariableToDeclare(identifier.GetILVariable()) == v)
+						return true;
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Maps an ILVariable to the variable declaration it will end up in, following merges
+		/// performed by ResolveCollisions.
+		/// </summary>
+		VariableToDeclare? ResolveVariableToDeclare(ILVariable? variable)
+		{
+			if (variable == null || !variableDict.TryGetValue(variable, out VariableToDeclare? v))
+				return null;
+			while (v.ReplacementDueToCollision is { } replacement)
+			{
+				v = replacement;
+			}
+			return v;
 		}
 
 		private bool CanBeDeclaredAsOutVariable(VariableToDeclare v, [NotNullWhen(true)] out DirectionExpression? dirExpr)


### PR DESCRIPTION
Fixes #3860.

When the same local is passed as multiple out arguments of one call, DeclareVariables turned the first use into an implicitly-typed declaration, producing `f(out var x, out x)`, which fails to recompile with CS8196: referencing an implicitly-typed out variable in another argument of the declaring call is not permitted, because its type is only inferred once overload resolution of that call has completed. The explicitly-typed form `f(out int x, out x)` is valid C#, so the transform now falls back to the explicit type when the variable is referenced again within the declaring call (resolving identifiers through collision-merged variables).

New Pretty fixture methods in `OutVariables.cs` reproduce the issue (previously decompiled as `out var a, out a` in all compiler configurations); full Pretty/Ugly/ILPretty/VBPretty runs pass.

This PR was authored by an AI agent on behalf of @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)