### PR TITLE
Fix #3475: Emit 'true ? null : new { ... }' for null of anonymous type

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AnonymousTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AnonymousTypes.cs
@@ -133,5 +133,46 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				Renamed = v.Minor
 			};
 		}
+
+		private void NullOfAnonymousType()
+		{
+			Identify(true ? null : new {
+				X = default(int),
+				Y = default(int)
+			});
+			Identify(true ? null : new {
+				N = default(int),
+				S = (string)null
+			});
+			Identify(true ? null : new {
+				Inner = new {
+					X = default(int)
+				}
+			});
+		}
+
+		private void NullOfAnonymousTypeNonGenericCall()
+		{
+#if OPT
+			MakeAction(new {
+				X = 0
+			})(null);
+#else
+			var action = MakeAction(new {
+				X = 0
+			});
+			action(null);
+#endif
+		}
+
+		private static void Identify<T>(T t)
+		{
+			Console.WriteLine(typeof(T).FullName);
+		}
+
+		private static Action<T> MakeAction<T>(T template)
+		{
+			return null;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -1201,9 +1201,22 @@ namespace ICSharpCode.Decompiler.CSharp
 				// if necessary.
 				if (!CanInferTypeArgumentsFromArguments(method, argumentList, expressionBuilder.typeInference))
 				{
-					requireTypeArguments = true;
-					typeArguments = method.TypeArguments.ToArray();
-					appliedRequireTypeArgumentsShortcut = true;
+					if (settings.AnonymousTypes
+						&& method.TypeArguments.Any(a => a.ContainsAnonymousType())
+						&& PinTypesOfNullArguments(argumentList)
+						&& CanInferTypeArgumentsFromArguments(method, argumentList, expressionBuilder.typeInference))
+					{
+						// Anonymous types cannot be written as explicit type arguments; instead the
+						// null arguments were rewritten so that all type arguments are inferable.
+						requireTypeArguments = false;
+						typeArguments = Empty<IType>.Array;
+					}
+					else
+					{
+						requireTypeArguments = true;
+						typeArguments = method.TypeArguments.ToArray();
+						appliedRequireTypeArgumentsShortcut = true;
+					}
 				}
 				else
 				{
@@ -1376,6 +1389,58 @@ namespace ICSharpCode.Decompiler.CSharp
 				argumentList.Arguments.SelectReadOnlyArray(a => a.ResolveResult), paramTypesInArgumentOrder,
 				out bool success);
 			return success;
+		}
+
+		/// <summary>
+		/// C# has no syntax to spell out an anonymous type, so a null literal cannot be given such
+		/// a type with a cast. The minimal expression that produces a null value of an anonymous
+		/// type is a conditional expression whose never-taken branch creates an instance of the
+		/// type: <c>true ? null : new { A = default(int) }</c>.
+		/// Replaces null-literal arguments of an anonymous type with such an expression, so that
+		/// type arguments involving anonymous types (which cannot be written explicitly either)
+		/// become inferable from the arguments.
+		/// Returns true, if at least one argument was replaced.
+		/// </summary>
+		private bool PinTypesOfNullArguments(ArgumentList argumentList)
+		{
+			bool anyArgumentReplaced = false;
+			for (int i = 0; i < argumentList.Length; i++)
+			{
+				IType expectedType = argumentList.ExpectedParameters[i].Type;
+				if (argumentList.Arguments[i].Expression is not NullReferenceExpression)
+					continue;
+				if (!expectedType.IsAnonymousType() || NewAnonymousTypeInstance(expectedType) is not NewObj newObj)
+					continue;
+				var nullLiteral = argumentList.Arguments[i];
+				argumentList.Arguments[i] = new ConditionalExpression(new PrimitiveExpression(true),
+						nullLiteral.Expression.Detach(), expressionBuilder.Translate(newObj, expectedType))
+					.WithILInstruction(nullLiteral.ILInstructions)
+					.WithRR(new ResolveResult(expectedType));
+				anyArgumentReplaced = true;
+			}
+			return anyArgumentReplaced;
+		}
+
+		/// <summary>
+		/// Builds a 'newobj' instruction creating an instance of the anonymous type
+		/// <paramref name="type"/> with default property values; translating it yields
+		/// object-initializer syntax, the only way to name the type in source code. Returns null
+		/// if a property type involves an anonymous type other than by direct nesting (e.g. an
+		/// array of anonymous type), because its default value expression would have to name it.
+		/// </summary>
+		private NewObj? NewAnonymousTypeInstance(IType type)
+		{
+			var newObj = new NewObj(type.GetConstructors().Single());
+			foreach (var parameter in newObj.Method.Parameters)
+			{
+				ILInstruction? argument = parameter.Type.IsAnonymousType()
+					? NewAnonymousTypeInstance(parameter.Type)
+					: parameter.Type.ContainsAnonymousType() ? null : new DefaultValue(parameter.Type);
+				if (argument == null)
+					return null;
+				newObj.Arguments.Add(argument);
+			}
+			return newObj;
 		}
 
 		private void CastArguments(IList<TranslatedExpression> arguments, IList<IParameter> expectedParameters)


### PR DESCRIPTION
Fixes #3475.

**Problem**: `Test(true ? null : new { A = 1, B = 2 })` compiles to a bare `ldnull` passed to `Test<<>f__AnonymousType0<int, int>>`. The type argument cannot be written explicitly (anonymous types cannot be named), so ILSpy silently dropped the type argument list and emitted `Test(null)`, which no longer compiles (CS0411).

**Approach**: when type inference fails and the type arguments contain anonymous types, `CallBuilder` now rewrites null-literal arguments of anonymous type as `true ? null : new { A = default(int), B = default(int) }` -- a conditional expression whose never-taken branch creates an instance of the anonymous type. This is the minimal C# expression that produces a null value of an anonymous type, and it makes the type arguments inferable again. Roslyn folds the constant conditional back to `ldnull`, so the output round-trips.

The instance expression is not assembled by hand: a synthesized `newobj` instruction with `default.value` arguments (nested `newobj` for directly nested anonymous types) is run through the existing translation pipeline, which already renders anonymous-type creations as object-initializer syntax with exactly-typed values (`default(int)`, `(string)null`, ...). Exact types matter because anonymous-type property types are inferred from the initializer values. The original property values are not recoverable (the IL contains only `ldnull`) and are never evaluated.

Anonymous types that occur inside other constructed types (e.g. `List<T>` or arrays of an anonymous type) cannot be expressed without naming the type; those keep the previous output.

**Verification**: new round-trip cases in the `AnonymousTypes` pretty test, covering the plain, string-property, and nested cases (green in all 12 configurations runnable on Linux; mcs/legacy-csc configurations need Windows CI); full decompiler suite passes; the issue's exact reproduction decompiles to compilable code that prints the same anonymous type name at runtime as the original assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
