### PR TITLE
Add support for C# 15 closed hierarchies

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -575,7 +575,16 @@ namespace System.Runtime.CompilerServices
 			{
 				string depSourcePath = Path.GetFullPath(Path.Combine(
 					Path.GetDirectoryName(sourceFileName), match.Groups[1].Value));
-				var depResults = await CompileCSharp(depSourcePath, flags | CompilerOptions.Library).ConfigureAwait(false);
+				// Compile the dependency next to the main output, so that the assembly resolver
+				// finds it when the main assembly is decompiled.
+				string depOutputFileName = null;
+				if (outputFileName != null)
+				{
+					depOutputFileName = Path.Combine(
+						Path.GetDirectoryName(Path.GetFullPath(outputFileName)),
+						Path.GetFileNameWithoutExtension(depSourcePath) + GetSuffix(flags | CompilerOptions.Library) + ".dll");
+				}
+				var depResults = await CompileCSharp(depSourcePath, flags | CompilerOptions.Library, depOutputFileName).ConfigureAwait(false);
 				dependencyAssemblies.Add(Path.GetFullPath(depResults.PathToAssembly));
 			}
 

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -221,6 +221,12 @@
     <None Include="TestCases\ILPretty\Unsafe.cs" />
     <Compile Remove="TestCases\ILPretty\WeirdEnums.cs" />
     <None Include="TestCases\ILPretty\WeirdEnums.cs" />
+    <Compile Remove="TestCases\Pretty\ClosedHierarchies.cs" />
+    <None Include="TestCases\Pretty\ClosedHierarchies.cs" />
+    <Compile Remove="TestCases\Pretty\ClosedHierarchiesCrossAssembly.cs" />
+    <None Include="TestCases\Pretty\ClosedHierarchiesCrossAssembly.cs" />
+    <Compile Remove="TestCases\Pretty\ClosedHierarchiesCrossAssembly.dep.cs" />
+    <None Include="TestCases\Pretty\ClosedHierarchiesCrossAssembly.dep.cs" />
     <Compile Remove="TestCases\Pretty\IndexRangeTest.cs" />
     <None Include="TestCases\Pretty\IndexRangeTest.cs" />
     <Compile Remove="TestCases\Pretty\MetadataAttributes.cs" />

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -664,6 +664,18 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task ClosedHierarchies([ValueSource(nameof(roslyn5OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions | CompilerOptions.Preview);
+		}
+
+		[Test]
+		public async Task ClosedHierarchiesCrossAssembly([ValueSource(nameof(roslyn5OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions | CompilerOptions.Preview);
+		}
+
+		[Test]
 		public async Task NullPropagation([ValueSource(nameof(roslynOnlyOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ClosedHierarchies.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ClosedHierarchies.cs
@@ -1,0 +1,74 @@
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class ClosedHierarchies
+	{
+		public closed class Animal
+		{
+			public string Name { get; }
+
+			protected Animal()
+			{
+				Name = "unnamed";
+			}
+
+			protected Animal(string name)
+			{
+				Name = name;
+			}
+		}
+
+		public class Cat : Animal
+		{
+		}
+
+		public sealed class Dog : Animal
+		{
+			public Dog()
+				: base("Dog")
+			{
+			}
+		}
+
+		public closed class Job
+		{
+			public required string Title { get; set; }
+		}
+
+		public sealed class CompileJob : Job
+		{
+		}
+
+		public closed class Tree<T>
+		{
+		}
+
+		public sealed class Leaf<U> : Tree<U>
+		{
+		}
+
+		public sealed class ArrayLeaf<V> : Tree<V[]>
+		{
+		}
+	}
+	public closed record JobStatus;
+	internal record JobStatusCanceled : JobStatus;
+	public record JobStatusQueued : JobStatus;
+	public record JobStatusRunning(int PercentComplete) : JobStatus;
+	internal closed class State
+	{
+	}
+	internal sealed class StateActive : State
+	{
+	}
+}
+#if !EXPECTED_OUTPUT
+// The .NET 11 preview 5 BCL does not ship ClosedAttribute yet; the compiler requires
+// every assembly using the 'closed' modifier to declare it (matched by full name).
+namespace System.Runtime.CompilerServices
+{
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+	internal sealed class ClosedAttribute : Attribute
+	{
+	}
+}
+#endif

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ClosedHierarchiesCrossAssembly.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ClosedHierarchiesCrossAssembly.cs
@@ -1,0 +1,9 @@
+// #dependency ClosedHierarchiesCrossAssembly.dep.cs
+using CrossAssemblyClosed;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public closed record LocalMessage;
+	public record LocalTextMessage(string Text) : LocalMessage;
+	public record Sedan(int Doors) : Car(Doors);
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ClosedHierarchiesCrossAssembly.dep.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ClosedHierarchiesCrossAssembly.dep.cs
@@ -1,0 +1,17 @@
+namespace CrossAssemblyClosed
+{
+	public closed record Vehicle;
+	public record Car(int Doors) : Vehicle;
+	public sealed record Truck(double PayloadTons) : Vehicle;
+}
+
+// Public so that the main test assembly can use the 'closed' modifier without
+// declaring its own copy of the attribute (the shape the BCL will provide once
+// ClosedAttribute ships).
+namespace System.Runtime.CompilerServices
+{
+	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+	public sealed class ClosedAttribute : Attribute
+	{
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3684.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3684.cs
@@ -15,7 +15,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			T IInterface.Convert<T>(T input)
 			{
-				return ((BaseClass)this).Convert<T>(input);
+				return Convert(input);
 			}
 		}
 	}

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1703,6 +1703,12 @@ namespace ICSharpCode.Decompiler.CSharp
 				{
 					RemoveAttribute(typeDecl, KnownAttribute.Required);
 				}
+				if (settings.ClosedHierarchies && RemoveAttribute(typeDecl, KnownAttribute.Closed))
+				{
+					// closed classes are implicitly abstract
+					typeDecl.Modifiers |= Modifiers.Closed;
+					typeDecl.Modifiers &= ~Modifiers.Abstract;
+				}
 				if (typeDecl.ClassType == ClassType.Enum)
 				{
 					Debug.Assert(typeDef.Kind == TypeKind.Enum);
@@ -2006,6 +2012,10 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (method.IsConstructor && settings.RequiredMembers && RemoveCompilerFeatureRequiredAttribute(methodDecl, "RequiredMembers"))
 				{
 					RemoveObsoleteAttribute(methodDecl, "Constructors of types with required members are not supported in this version of your compiler.");
+				}
+				if (method.IsConstructor && settings.ClosedHierarchies)
+				{
+					RemoveCompilerFeatureRequiredAttribute(methodDecl, "ClosedClasses");
 				}
 				return methodDecl;
 

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/ProjectFileWriterDefault.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/ProjectFileWriterDefault.cs
@@ -97,7 +97,10 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 				}
 
 				w.WriteElementString("OutputType", outputType);
-				w.WriteElementString("LangVersion", project.LanguageVersion.ToString().Replace("CSharp", "").Replace('_', '.'));
+				// C# 15 is still in preview; the compiler only accepts -langversion:preview for it.
+				w.WriteElementString("LangVersion", project.LanguageVersion >= LanguageVersion.CSharp15_0
+					? "preview"
+					: project.LanguageVersion.ToString().Replace("CSharp", "").Replace('_', '.'));
 				w.WriteElementString("CheckForOverflowUnderflow", project.CheckForOverflowUnderflow ? "true" : "false");
 
 				w.WriteElementString("AssemblyName", module.Name);

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/ProjectFileWriterSdkStyle.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/ProjectFileWriterSdkStyle.cs
@@ -190,7 +190,10 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 		static void WriteProjectInfo(XmlTextWriter xml, IProjectInfoProvider project)
 		{
-			xml.WriteElementString("LangVersion", project.LanguageVersion.ToString().Replace("CSharp", "").Replace('_', '.'));
+			// C# 15 is still in preview; the compiler only accepts -langversion:preview for it.
+			xml.WriteElementString("LangVersion", project.LanguageVersion >= LanguageVersion.CSharp15_0
+				? "preview"
+				: project.LanguageVersion.ToString().Replace("CSharp", "").Replace('_', '.'));
 			xml.WriteElementString("AllowUnsafeBlocks", TrueString);
 			xml.WriteElementString("CheckForOverflowUnderflow", project.CheckForOverflowUnderflow ? TrueString : FalseString);
 

--- a/ICSharpCode.Decompiler/CSharp/RecordDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/RecordDecompiler.cs
@@ -200,7 +200,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				IMethod? chainedCtor = (IMethod?)FindChainedCtor(body)?.MemberDefinition;
 				ctorChainMap[method] = chainedCtor;
 
-				if (chainedCtor != null && chainedCtor.DeclaringTypeDefinition!.Equals(recordTypeDef))
+				if (chainedCtor != null && recordTypeDef.Equals(chainedCtor.DeclaringTypeDefinition))
 				{
 					continue;
 				}
@@ -233,7 +233,7 @@ namespace ICSharpCode.Decompiler.CSharp
 					// follow this rule.
 					// we don't have to check the full chain, because the C# compiler enforces that
 					// there are no loops in the ctor call graph.
-					if (target == null || !target.DeclaringTypeDefinition!.Equals(recordTypeDef))
+					if (target == null || !recordTypeDef.Equals(target.DeclaringTypeDefinition))
 					{
 						guessedPrimaryCtor = null;
 						break;
@@ -522,6 +522,12 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				case "System.Runtime.CompilerServices.CompilerGeneratedAttribute":
 					return true;
+				case "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute":
+					// closed records carry CompilerFeatureRequired("ClosedClasses") on all constructors
+					return settings.ClosedHierarchies
+						&& attribute.FixedArguments.Length == 1
+						&& attribute.FixedArguments[0].Value is string feature
+						&& feature == "ClosedClasses";
 				default:
 					return false;
 			}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Modifiers.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Modifiers.cs
@@ -59,6 +59,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		Async = 0x10000,
 		Ref = 0x20000,
 		Required = 0x40000,
+		Closed = 0x80000,
 
 		VisibilityMask = Private | Internal | Protected | Public,
 
@@ -76,7 +77,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			Modifiers.Public, Modifiers.Private, Modifiers.Protected, Modifiers.Internal,
 			Modifiers.New,
 			Modifiers.Unsafe,
-			Modifiers.Static, Modifiers.Abstract, Modifiers.Virtual, Modifiers.Sealed, Modifiers.Override,
+			Modifiers.Static, Modifiers.Abstract, Modifiers.Virtual, Modifiers.Sealed, Modifiers.Closed, Modifiers.Override,
 			Modifiers.Required, Modifiers.Readonly, Modifiers.Volatile,
 			Modifiers.Ref,
 			Modifiers.Extern, Modifiers.Partial, Modifiers.Const,
@@ -126,6 +127,8 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 					return "ref";
 				case Modifiers.Required:
 					return "required";
+				case Modifiers.Closed:
+					return "closed";
 				case Modifiers.Any:
 					// even though it's used for pattern matching only, 'any' needs to be in this list to be usable in the AST
 					return "any";

--- a/ICSharpCode.Decompiler/CSharp/Transforms/EscapeInvalidIdentifiers.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/EscapeInvalidIdentifiers.cs
@@ -186,6 +186,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			"System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
 			"System.Runtime.CompilerServices.RequiredMemberAttribute",
 			"System.Runtime.CompilerServices.IsExternalInit",
+			"System.Runtime.CompilerServices.ClosedAttribute",
 		};
 
 		public override void VisitTypeDeclaration(TypeDeclaration typeDeclaration)

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -177,10 +177,16 @@ namespace ICSharpCode.Decompiler
 				extensionMembers = false;
 				firstClassSpanTypes = false;
 			}
+			if (languageVersion < CSharp.LanguageVersion.CSharp15_0)
+			{
+				closedHierarchies = false;
+			}
 		}
 
 		public CSharp.LanguageVersion GetMinimumRequiredVersion()
 		{
+			if (closedHierarchies)
+				return CSharp.LanguageVersion.CSharp15_0;
 			if (extensionMembers || firstClassSpanTypes)
 				return CSharp.LanguageVersion.CSharp14_0;
 			if (paramsCollections)
@@ -2189,6 +2195,24 @@ namespace ICSharpCode.Decompiler
 				if (extensionMembers != value)
 				{
 					extensionMembers = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool closedHierarchies = true;
+
+		/// <summary>
+		/// Gets/Sets whether the closed modifier should be reconstructed on closed hierarchies.
+		/// </summary>
+		[Category("C# 15.0 / VS 2026")]
+		[Description("DecompilerSettings.ClosedHierarchies")]
+		public bool ClosedHierarchies {
+			get { return closedHierarchies; }
+			set {
+				if (closedHierarchies != value)
+				{
+					closedHierarchies = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -120,11 +120,14 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		// C# 14 attributes:
 		ExtensionMarker,
+
+		// C# 15 attributes:
+		Closed,
 	}
 
 	public static class KnownAttributes
 	{
-		internal const int Count = (int)KnownAttribute.ExtensionMarker + 1;
+		internal const int Count = (int)KnownAttribute.Closed + 1;
 
 		static readonly TopLevelTypeName[] typeNames = new TopLevelTypeName[Count]{
 			default,
@@ -200,6 +203,8 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			new TopLevelTypeName("System.Runtime.CompilerServices", "InlineArrayAttribute"),
 			// C# 14 attributes:
 			new TopLevelTypeName("System.Runtime.CompilerServices", "ExtensionMarkerAttribute"),
+			// C# 15 attributes:
+			new TopLevelTypeName("System.Runtime.CompilerServices", "ClosedAttribute"),
 		};
 
 		public static ref readonly TopLevelTypeName GetTypeName(this KnownAttribute attr)

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -360,6 +360,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.CheckedOperators" xml:space="preserve">
     <value>User-defined checked operators</value>
   </data>
+  <data name="DecompilerSettings.ClosedHierarchies" xml:space="preserve">
+    <value>Use the closed modifier on closed hierarchies</value>
+  </data>
   <data name="DecompilerSettings.CovariantReturns" xml:space="preserve">
     <value>Covariant return types</value>
   </data>


### PR DESCRIPTION
## What this adds

C# 15 (shipping with .NET 11, currently preview 5) introduces [closed hierarchies](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-15#closed-hierarchies): a `closed` modifier on classes/records that restricts direct derivation to the declaring assembly, enabling exhaustive `switch` expressions without a default arm ([keyword reference](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/closed), [feature spec](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/closed-hierarchies)).

The preview 5 compiler encodes the modifier as (verified against the shipped Roslyn binary and the red-test diff; the older spec text still says `IsClosedTypeAttribute`, which is *not* what is emitted):

- `System.Runtime.CompilerServices.ClosedAttribute` on the type,
- `[CompilerFeatureRequired("ClosedClasses")]` on **every** constructor, including the synthesized copy constructor of records (no paired `[Obsolete]`, unlike required members),
- the `abstract` flag on the type (`closed` is implicitly abstract).

The BCL does not ship `ClosedAttribute` yet, so every assembly using `closed` declares its own copy (or references one from another assembly); the compiler matches it by full name.

Previously ILSpy showed the raw encoding (`[Closed] public abstract class ...` with `[CompilerFeatureRequired]` on constructors); now it prints `public closed class ...` again.

## Implementation

Mirrors the `required`-members pipeline end to end, gated on a new `DecompilerSettings.ClosedHierarchies` toggle (default on, disabled for language versions below C# 15):

| Area | Change |
|---|---|
| `KnownAttributes` | new `KnownAttribute.Closed` -> `S.R.CS.ClosedAttribute` |
| `Modifiers` | new `Modifiers.Closed`, printed after `sealed` in the modifier order |
| `CSharpDecompiler` | type level: remove `[Closed]`, set `Modifiers.Closed`, clear the implicit `Modifiers.Abstract`; constructor level: strip `CompilerFeatureRequired("ClosedClasses")` (composes with the existing `RequiredMembers` stripper when both features are used on one type) |
| `RecordDecompiler` | `IsAllowedAttribute` now accepts `CompilerFeatureRequired("ClosedClasses")`, so the synthesized copy constructor of a closed record is still recognized as compiler-generated and hidden |
| `DecompilerSettings` | new C# 15 gate in `SetLanguageVersion`/`GetMinimumRequiredVersion` |
| project export | `ProjectFileWriterDefault`/`ProjectFileWriterSdkStyle` emit `<LangVersion>preview</LangVersion>` for C# 15, because csc does not accept `-langversion:15.0` yet (and `LanguageVersion.CSharp15_0`/`Preview` share the enum value 1500, making `ToString()` ambiguous) |
| test harness | `RemoveEmbeddedAttributes` also strips a source-declared `S.R.CS.ClosedAttribute` polyfill class from decompiled output |
| ILSpy UI | resource string for the new setting |

## Tests

Two new Pretty fixtures on `roslyn5OrNewerOptions` + `CompilerOptions.Preview` (the pinned Roslyn `5.8.0-1.26302.115` / net11 preview 5 ref pack; same shape as `ExtensionEverything`):

- **`ClosedHierarchies.cs`** - minimum covering set for the definition side: plain `closed class` with multiple constructors (attribute stripping on each), `closed record` with positional record descendants, an **internal** descendant of a public closed record, an **internal** closed class, a nested closed class, a generic `closed class Tree<T>` with `Leaf<U> : Tree<U>` and `ArrayLeaf<V> : Tree<V[]>`, and a closed class with a `required` member so both `CompilerFeatureRequired` values land on one constructor. The `ClosedAttribute` polyfill is declared under `#if !EXPECTED_OUTPUT`.
- **`ClosedHierarchiesCrossAssembly.cs` + `.dep.cs`** - cross-assembly dimension via the `// #dependency` mechanism: the attribute *and* a closed hierarchy live in the referenced assembly; the decompiled assembly declares its own closed record using the dep-provided attribute (the shape everything will have once the BCL ships it) and derives a record from the dep's non-closed descendant (the legal cross-assembly derivation).

Deliberately **not** covered: consuming-side exhaustive switch expressions. Exhaustiveness is compile-time knowledge only - the IL of a switch over a closed hierarchy is identical to one over an open hierarchy, so there is nothing for a decompiler test to observe.

The fixtures were written and shown red first (TDD): the red diff doubled as the authoritative probe of what preview 5 actually emits.

## Changes to existing decompilation behavior

- **`Issue3684.cs` expected output changed** from `((BaseClass)this).Convert<T>(input)` to `Convert(input)`. This falls out of the harness fix below: the fixture's dependency assembly is now resolvable while decompiling, so ILSpy can prove the simple-name call binds to the base method and no longer emits the defensive cast + explicit type arguments. The calls are semantically identical, and the point of that test (removal of compiler-generated interface accessor helpers) is unaffected.
- **Whole-project export now writes `<LangVersion>preview</LangVersion>`** whenever the effective minimum language version is C# 15 - which it is by default, since the new setting defaults to on (the same convention as every previous default-on language feature setting).

## Pre-existing issues surfaced by the new tests

- **`#dependency` assemblies were never resolvable at decompile time.** `Tester.CompileCSharp` compiled them to a random temp file (`CompilerResults.PathToAssembly` falls back to `GetTempFileName()`), so the `UniversalAssemblyResolver` could not find them next to the main test assembly. `Issue3684` never noticed because plain classes decompile fine with an unresolved base type. Dependencies now compile to `<depName><config-suffix>.dll` next to the main output.
- **Latent NRE in `RecordDecompiler`.** `DetectPrimaryConstructor` dereferenced `chainedCtor.DeclaringTypeDefinition!` (and the same for the ctor-chain check), which is null when a record's base type lives in an assembly that cannot be resolved - crashing decompilation of such records anywhere, not just in tests. Both checks now use null-safe comparisons and degrade gracefully.

## Verification

- New tests: 4/4 green (both fixtures, optimized and non-optimized).
- Full `PrettyTestRunner`: 1854 test cases green.
- Whole `ICSharpCode.Decompiler.Tests` project: 3666 passed, 0 failed (12 pre-existing skips: mono/known bugs/ILSpy-tests submodule not checked out).
- `ILSpy.Tests` + `ILSpy.Tests.Windows`: 1091 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
