### PR TITLE
Refactor TransformArrayInitializers to split up brain methods

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -279,6 +279,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await Run();
 		}
 
+		[Test]
+		public async Task StackAllocDuplicateStore()
+		{
+			await Run();
+		}
+
 		[Test, Platform("Win")] // UseLegacyAssembler requires the .NET Framework ilasm
 		public async Task Unsafe()
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/StackAllocDuplicateStore.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/StackAllocDuplicateStore.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
+{
+	public static class StackAllocDuplicateStore
+	{
+		public unsafe static int Seq(int a, int b, int c)
+		{
+			byte* num = stackalloc byte[12];
+			*(int*)num = a;
+			*(int*)num = 99;
+			((int*)num)[1] = b;
+			((int*)num)[2] = c;
+			Span<int> span = new Span<int>(num, 3);
+			return span[0] + span[1] + span[2];
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/StackAllocDuplicateStore.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/StackAllocDuplicateStore.il
@@ -1,0 +1,70 @@
+// Metadata version: v4.0.30319
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 9:0:0:0
+}
+.assembly StackAllocDuplicateStore
+{
+  .ver 1:0:0:0
+}
+.module StackAllocDuplicateStore.dll
+.corflags 0x00000001    //  ILONLY
+
+// A stackalloc initializer that writes the first element twice. The sequential-store
+// initializer transform must not fold this into a 'stackalloc int[] { ... }': the earlier
+// store would be dropped, which is observable when its value has side effects.
+
+.class public abstract auto ansi sealed beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.ILPretty.StackAllocDuplicateStore
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static int32  Seq(int32 a,
+                                             int32 b,
+                                             int32 c) cil managed
+  {
+    .maxstack  4
+    .locals init (valuetype [System.Runtime]System.Span`1<int32> V_0)
+    IL_0000:  ldc.i4.s   12
+    IL_0002:  conv.u
+    IL_0003:  localloc
+    IL_0005:  dup
+    IL_0006:  ldarg.0
+    IL_0007:  stind.i4
+    IL_0008:  dup
+    IL_0009:  ldc.i4.s   99
+    IL_000b:  stind.i4
+    IL_000c:  dup
+    IL_000d:  ldc.i4.4
+    IL_000e:  add
+    IL_000f:  ldarg.1
+    IL_0010:  stind.i4
+    IL_0011:  dup
+    IL_0012:  ldc.i4.2
+    IL_0013:  conv.i
+    IL_0014:  ldc.i4.4
+    IL_0015:  mul
+    IL_0016:  add
+    IL_0017:  ldarg.2
+    IL_0018:  stind.i4
+    IL_0019:  ldc.i4.3
+    IL_001a:  newobj     instance void valuetype [System.Runtime]System.Span`1<int32>::.ctor(void*,
+                                                                                             int32)
+    IL_001f:  stloc.0
+    IL_0020:  ldloca.s   V_0
+    IL_0022:  ldc.i4.0
+    IL_0023:  call       instance !0& valuetype [System.Runtime]System.Span`1<int32>::get_Item(int32)
+    IL_0028:  ldind.i4
+    IL_0029:  ldloca.s   V_0
+    IL_002b:  ldc.i4.1
+    IL_002c:  call       instance !0& valuetype [System.Runtime]System.Span`1<int32>::get_Item(int32)
+    IL_0031:  ldind.i4
+    IL_0032:  add
+    IL_0033:  ldloca.s   V_0
+    IL_0035:  ldc.i4.2
+    IL_0036:  call       instance !0& valuetype [System.Runtime]System.Span`1<int32>::get_Item(int32)
+    IL_003b:  ldind.i4
+    IL_003c:  add
+    IL_003d:  ret
+  } // end of method StackAllocDuplicateStore::Seq
+
+} // end of class StackAllocDuplicateStore

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -515,6 +515,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 			X(Y(), new int[5] { a, 0, b, 0, c });
 		}
 
+		public static int[] DuplicateElementAssignment()
+		{
+			// A second store to an element that was already written must stop the array-initializer
+			// transform from folding these stores into a 'new int[] { ... }'. Doing so would drop the
+			// earlier store, which is a visible change when its value has side effects.
+			int[] array = new int[3];
+			array[0] = 1;
+			array[0] = 2;
+			array[1] = 3;
+			array[2] = 4;
+			return array;
+		}
+
 		public static void NestedArray(int a, int b, int c)
 		{
 			X(Y(), new int[3][] {

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -93,11 +93,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					if (HandleJaggedArrayInitializer(body, pos + 1, v, elementType, arrayLength[0], out ILVariable finalStore, out values, out instructionsToRemove))
 					{
 						context.Step("HandleJaggedArrayInitializer: single-dim", inst);
-						var block = new Block(BlockKind.ArrayInitializer);
 						var tempStore = context.Function.RegisterVariable(VariableKind.InitializerTarget, v.Type);
-						block.Instructions.Add(new StLoc(tempStore, new NewArr(elementType, arrayLength.Select(l => new LdcI4(l)).ToArray())));
-						block.Instructions.AddRange(values.SelectWithIndex((i, value) => StElem(new LdLoc(tempStore), new[] { new LdcI4(i) }, value, elementType)));
-						block.FinalInstruction = new LdLoc(tempStore);
+						var block = BuildSimpleArrayInitializerBlock(tempStore, elementType, arrayLength,
+							values.SelectWithIndex((i, value) => (new ILInstruction[] { new LdcI4(i) }, value)).ToArray());
 						var newStore = new StLoc(finalStore, block);
 						body.Instructions[pos] = newStore;
 						body.Instructions.RemoveRange(pos + 1, instructionsToRemove);

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -518,6 +518,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					return;
 				if (!MatchGetStaticFieldAddress(src, out var field))
 					return;
+				if (field.MetadataToken.IsNil)
+					return;
 				var fd = context.PEFile.Metadata.GetFieldDefinition((FieldDefinitionHandle)field.MetadataToken);
 				if (!fd.HasFlag(System.Reflection.FieldAttributes.HasFieldRVA))
 					return;

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -428,10 +428,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 			BlobReader blob = default;
 
-			if (lengthInstruction.MatchLdcI(out long byteCount)
-				&& !TryHandleLocAllocInitializerPrefix(block, ref pos, store, byteCount, ref blob, ref instructionsToRemove))
+			if (lengthInstruction.MatchLdcI(out long byteCount))
 			{
-				return false;
+				// An initblk/cpblk that does not fit the expected shape is left in place;
+				// the per-element stobj scan below then fails to match it and rejects the
+				// transform on its own.
+				HandleLocAllocInitializerPrefix(block, ref pos, store, byteCount, ref blob, ref instructionsToRemove);
 			}
 
 			for (int i = pos; i < block.Instructions.Count; i++)
@@ -499,34 +501,32 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return elementCount <= values.Length;
 		}
 
-		bool TryHandleLocAllocInitializerPrefix(Block block, ref int pos, ILVariable store, long byteCount, ref BlobReader blob, ref int instructionsToRemove)
+		void HandleLocAllocInitializerPrefix(Block block, ref int pos, ILVariable store, long byteCount, ref BlobReader blob, ref int instructionsToRemove)
 		{
 			// initblk(ldloc store, value, byteCount)
 			if (block.Instructions[pos].MatchInitblk(out var dest, out _, out var size))
 			{
 				if (!dest.MatchLdLoc(store) || !size.MatchLdcI(byteCount))
-					return false;
+					return;
 				instructionsToRemove++;
 				pos++;
-				return true;
+				return;
 			}
 
 			// cpblk(ldloc store, ldsflda/call get_Item(CreateSpan(field)) data, byteCount)
 			if (block.Instructions[pos].MatchCpblk(out dest, out var src, out size))
 			{
 				if (!dest.MatchLdLoc(store) || !size.MatchLdcI(byteCount))
-					return false;
+					return;
 				if (!MatchGetStaticFieldAddress(src, out var field))
-					return false;
+					return;
 				var fd = context.PEFile.Metadata.GetFieldDefinition((FieldDefinitionHandle)field.MetadataToken);
 				if (!fd.HasFlag(System.Reflection.FieldAttributes.HasFieldRVA))
-					return false;
+					return;
 				blob = fd.GetInitialValue(context.PEFile, context.TypeSystem);
 				instructionsToRemove++;
 				pos++;
 			}
-
-			return true;
 		}
 
 		static bool TryGetSequentialStoreOffset(ILInstruction target, ILVariable store, IType elementType, long minExpectedOffset, out long offset, out bool abortTransform)

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -81,18 +81,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					if (HandleSimpleArrayInitializer(function, body, pos + 1, v, arrayLength, out var arrayValues, out var instructionsToRemove))
 					{
 						context.Step("HandleSimpleArrayInitializer: single-dim", inst);
-						var block = new Block(BlockKind.ArrayInitializer);
 						var tempStore = context.Function.RegisterVariable(VariableKind.InitializerTarget, v.Type);
-						block.Instructions.Add(new StLoc(tempStore, new NewArr(elementType, arrayLength.Select(l => new LdcI4(l)).ToArray())));
-						block.Instructions.AddRange(arrayValues.Select(
-							t => {
-								var (indices, value) = t;
-								if (value == null)
-									value = GetNullExpression(elementType);
-								return StElem(new LdLoc(tempStore), indices, value, elementType);
-							}
-						));
-						block.FinalInstruction = new LdLoc(tempStore);
+						var block = BuildSimpleArrayInitializerBlock(tempStore, elementType, arrayLength, arrayValues);
 						var newStore = new StLoc(v, block);
 						body.Instructions[pos] = newStore;
 						body.Instructions.RemoveRange(pos + 1, instructionsToRemove);
@@ -266,18 +256,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				if (HandleSimpleArrayInitializer(function, body, pos + 1, v, length, out var arrayValues, out var instructionsToRemove))
 				{
 					context.Step("HandleSimpleArrayInitializer: multi-dim", inst);
-					var block = new Block(BlockKind.ArrayInitializer);
 					var tempStore = context.Function.RegisterVariable(VariableKind.InitializerTarget, v.Type);
-					block.Instructions.Add(new StLoc(tempStore, new NewArr(elementType, length.Select(l => new LdcI4(l)).ToArray())));
-					block.Instructions.AddRange(arrayValues.Select(
-						t => {
-							var (indices, value) = t;
-							if (value == null)
-								value = GetNullExpression(elementType);
-							return StElem(new LdLoc(tempStore), indices, value, elementType);
-						}
-					));
-					block.FinalInstruction = new LdLoc(tempStore);
+					var block = BuildSimpleArrayInitializerBlock(tempStore, elementType, length, arrayValues);
 					var newStore = new StLoc(v, block);
 					body.Instructions[pos] = newStore;
 					body.Instructions.RemoveRange(pos + 1, instructionsToRemove);
@@ -826,6 +806,18 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 				block.Instructions.Add(StElem(new LdLoc(v), indices.ToArray(), value, elementType));
 				indices.Clear();
+			}
+			block.FinalInstruction = new LdLoc(v);
+			return block;
+		}
+
+		static Block BuildSimpleArrayInitializerBlock(ILVariable v, IType elementType, int[] arrayLength, (ILInstruction[] Indices, ILInstruction Value)[] values)
+		{
+			var block = new Block(BlockKind.ArrayInitializer);
+			block.Instructions.Add(new StLoc(v, new NewArr(elementType, arrayLength.SelectArray(l => new LdcI4(l)))));
+			foreach (var (indices, value) in values)
+			{
+				block.Instructions.Add(StElem(new LdLoc(v), indices, value ?? GetNullExpression(elementType), elementType));
 			}
 			block.FinalInstruction = new LdLoc(v);
 			return block;

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -462,13 +462,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				{
 					break;
 				}
-				if (!TryGetSequentialStoreOffset(target, store, elementType, minExpectedOffset, out var offset, out var abortTransform))
-				{
-					if (abortTransform)
-						return false;
+				var match = GetSequentialStoreOffset(target, store, elementType, ref minExpectedOffset);
+				if (match == SequentialStoreMatch.Abort)
+					return false;
+				if (match != SequentialStoreMatch.Matched)
 					break;
-				}
-				minExpectedOffset = offset;
 				if (values == null)
 				{
 					var countInstruction = PointerArithmeticOffset.Detect(lengthInstruction, elementType, checkForOverflow: true);
@@ -529,34 +527,35 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 		}
 
-		static bool TryGetSequentialStoreOffset(ILInstruction target, ILVariable store, IType elementType, long minExpectedOffset, out long offset, out bool abortTransform)
+		enum SequentialStoreMatch
 		{
-			offset = 0;
-			abortTransform = false;
+			// The store belongs to the initializer sequence.
+			Matched,
+			// The store is not part of the sequence; it ends the scan, keeping what was matched.
+			SequenceEnd,
+			// The store's shape is unexpected; reject the whole transform.
+			Abort,
+		}
 
+		static SequentialStoreMatch GetSequentialStoreOffset(ILInstruction target, ILVariable store, IType elementType, ref long minExpectedOffset)
+		{
 			// stobj T(ldloc store, value) writes at the current expected offset, initially 0.
 			if (target.MatchLdLoc(store))
-			{
-				offset = minExpectedOffset;
-				return true;
-			}
+				return SequentialStoreMatch.Matched;
 
 			// stobj T(binary.add(ldloc store, offset), value)
 			// The offset is either sizeof(T) or an element index multiplied by sizeof(T).
 			if (!target.MatchBinaryNumericInstruction(BinaryNumericOperator.Add, out var left, out var right))
-			{
-				abortTransform = true;
-				return false;
-			}
+				return SequentialStoreMatch.Abort;
 			if (!left.MatchLdLoc(store))
-				return false;
+				return SequentialStoreMatch.SequenceEnd;
 			var offsetInst = PointerArithmeticOffset.Detect(right, elementType, ((BinaryNumericInstruction)target).CheckForOverflow);
 			if (offsetInst == null)
-			{
-				abortTransform = true;
-				return false;
-			}
-			return offsetInst.MatchLdcI(out offset) && offset >= 0 && offset >= minExpectedOffset;
+				return SequentialStoreMatch.Abort;
+			if (!offsetInst.MatchLdcI(out long offset) || offset < 0 || offset < minExpectedOffset)
+				return SequentialStoreMatch.SequenceEnd;
+			minExpectedOffset = offset;
+			return SequentialStoreMatch.Matched;
 		}
 
 		ILInstruction RewrapStore(ILVariable target, StObj storeInstruction, IType type)

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -428,28 +428,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 			BlobReader blob = default;
 
-			if (lengthInstruction.MatchLdcI(out long byteCount))
+			if (lengthInstruction.MatchLdcI(out long byteCount)
+				&& !TryHandleLocAllocInitializerPrefix(block, ref pos, store, byteCount, ref blob, ref instructionsToRemove))
 			{
-				if (block.Instructions[pos].MatchInitblk(out var dest, out var value, out var size))
-				{
-					if (!dest.MatchLdLoc(store) || !size.MatchLdcI(byteCount))
-						return false;
-					instructionsToRemove++;
-					pos++;
-				}
-				else if (block.Instructions[pos].MatchCpblk(out dest, out var src, out size))
-				{
-					if (!dest.MatchLdLoc(store) || !size.MatchLdcI(byteCount))
-						return false;
-					if (!MatchGetStaticFieldAddress(src, out var field))
-						return false;
-					var fd = context.PEFile.Metadata.GetFieldDefinition((FieldDefinitionHandle)field.MetadataToken);
-					if (!fd.HasFlag(System.Reflection.FieldAttributes.HasFieldRVA))
-						return false;
-					blob = fd.GetInitialValue(context.PEFile, context.TypeSystem);
-					instructionsToRemove++;
-					pos++;
-				}
+				return false;
 			}
 
 			for (int i = pos; i < block.Instructions.Count; i++)
@@ -480,22 +462,13 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				{
 					break;
 				}
-				// match the target
-				// should be either ldloc store (at offset 0)
-				// or binary.add(ldloc store, offset) where offset is either 'elementSize' or 'i * elementSize'
-				if (!target.MatchLdLoc(store))
+				if (!TryGetSequentialStoreOffset(target, store, elementType, minExpectedOffset, out var offset, out var abortTransform))
 				{
-					if (!target.MatchBinaryNumericInstruction(BinaryNumericOperator.Add, out var left, out var right))
+					if (abortTransform)
 						return false;
-					if (!left.MatchLdLoc(store))
-						break;
-					var offsetInst = PointerArithmeticOffset.Detect(right, elementType, ((BinaryNumericInstruction)target).CheckForOverflow);
-					if (offsetInst == null)
-						return false;
-					if (!offsetInst.MatchLdcI(out long offset) || offset < 0 || offset < minExpectedOffset)
-						break;
-					minExpectedOffset = offset;
+					break;
 				}
+				minExpectedOffset = offset;
 				if (values == null)
 				{
 					var countInstruction = PointerArithmeticOffset.Detect(lengthInstruction, elementType, checkForOverflow: true);
@@ -524,6 +497,66 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			instructionsToRemove += elementCount;
 
 			return elementCount <= values.Length;
+		}
+
+		bool TryHandleLocAllocInitializerPrefix(Block block, ref int pos, ILVariable store, long byteCount, ref BlobReader blob, ref int instructionsToRemove)
+		{
+			// initblk(ldloc store, value, byteCount)
+			if (block.Instructions[pos].MatchInitblk(out var dest, out _, out var size))
+			{
+				if (!dest.MatchLdLoc(store) || !size.MatchLdcI(byteCount))
+					return false;
+				instructionsToRemove++;
+				pos++;
+				return true;
+			}
+
+			// cpblk(ldloc store, ldsflda/call get_Item(CreateSpan(field)) data, byteCount)
+			if (block.Instructions[pos].MatchCpblk(out dest, out var src, out size))
+			{
+				if (!dest.MatchLdLoc(store) || !size.MatchLdcI(byteCount))
+					return false;
+				if (!MatchGetStaticFieldAddress(src, out var field))
+					return false;
+				var fd = context.PEFile.Metadata.GetFieldDefinition((FieldDefinitionHandle)field.MetadataToken);
+				if (!fd.HasFlag(System.Reflection.FieldAttributes.HasFieldRVA))
+					return false;
+				blob = fd.GetInitialValue(context.PEFile, context.TypeSystem);
+				instructionsToRemove++;
+				pos++;
+			}
+
+			return true;
+		}
+
+		static bool TryGetSequentialStoreOffset(ILInstruction target, ILVariable store, IType elementType, long minExpectedOffset, out long offset, out bool abortTransform)
+		{
+			offset = 0;
+			abortTransform = false;
+
+			// stobj T(ldloc store, value) writes at the current expected offset, initially 0.
+			if (target.MatchLdLoc(store))
+			{
+				offset = minExpectedOffset;
+				return true;
+			}
+
+			// stobj T(binary.add(ldloc store, offset), value)
+			// The offset is either sizeof(T) or an element index multiplied by sizeof(T).
+			if (!target.MatchBinaryNumericInstruction(BinaryNumericOperator.Add, out var left, out var right))
+			{
+				abortTransform = true;
+				return false;
+			}
+			if (!left.MatchLdLoc(store))
+				return false;
+			var offsetInst = PointerArithmeticOffset.Detect(right, elementType, ((BinaryNumericInstruction)target).CheckForOverflow);
+			if (offsetInst == null)
+			{
+				abortTransform = true;
+				return false;
+			}
+			return offsetInst.MatchLdcI(out offset) && offset >= 0 && offset >= minExpectedOffset;
 		}
 
 		ILInstruction RewrapStore(ILVariable target, StObj storeInstruction, IType type)


### PR DESCRIPTION
Refactoring to address code-quality regressions flagged by CodeScene ("Brain Method") in `TransformArrayInitializers.cs`. No behavior change intended.

- Extract the repeated `Block(ArrayInitializer)` construction into a shared helper (`BuildSimpleArrayInitializerBlock`) and use it from the single-dim, multi-dim, and jagged-array branches.
- Split `HandleSequentialLocAllocInitializer` into its three concerns: consuming the optional `initblk`/`cpblk` prefix, matching each sequential store's offset, and the scan loop itself.
- Replace the bool-plus-out-flag contract of the store-offset matcher with a three-value enum naming each outcome (matched / sequence ended / reject transform).
- Fix uncovered along the way: the localloc `cpblk` prefix path now rejects nil field tokens instead of throwing in `GetFieldDefinition` (the `HandleCpblkInitializer` path already guarded this); aborting on a missing prefix had also broken plain constant-length `stackalloc` initializers (caught by `CS73_StackAllocInitializers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)