### PR TITLE
Upload TestCases folder as artifact when CI tests fail

### DIFF
--- a/.github/workflows/build-ilspy.yml
+++ b/.github/workflows/build-ilspy.yml
@@ -90,6 +90,7 @@ jobs:
       run: dotnet-format whitespace --verify-no-changes --verbosity detailed ILSpy.sln
 
     - name: Execute unit tests
+      id: unit-tests
       run: >
         dotnet test --solution ilspy.sln
         --configuration ${{ matrix.configuration }}
@@ -102,6 +103,14 @@ jobs:
       with:
         name: test-results-${{ matrix.configuration }}
         path: 'test-results/${{ matrix.configuration }}/*.trx'
+
+    - name: Upload TestCases on test failure
+      uses: actions/upload-artifact@v7
+      if: failure() && steps.unit-tests.outcome == 'failure'
+      with:
+        name: testcases-${{ matrix.configuration }}
+        path: ICSharpCode.Decompiler.Tests/TestCases
+        compression-level: 9
 
     - name: Create Test Report
       uses: test-summary/action@v2
@@ -324,6 +333,7 @@ jobs:
         --results-directory test-results
 
     - name: Execute decompiler tests
+      id: decompiler-tests
       run: >
         dotnet test --project ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
         --configuration Release
@@ -336,6 +346,14 @@ jobs:
       with:
         name: test-results-${{ matrix.platform }}
         path: 'test-results/*.trx'
+
+    - name: Upload TestCases on test failure
+      uses: actions/upload-artifact@v7
+      if: failure() && steps.decompiler-tests.outcome == 'failure'
+      with:
+        name: testcases-${{ matrix.platform }}
+        path: ICSharpCode.Decompiler.Tests/TestCases
+        compression-level: 9
 
     - name: Create Test Report
       uses: test-summary/action@v2


### PR DESCRIPTION
When tests fail in CI, the generated fixtures under `ICSharpCode.Decompiler.Tests/TestCases` (compiled test assemblies, generated IL, diff inputs) are lost with the runner. This uploads that folder as a maximum-compression artifact whenever the test step fails, to make CI-only failures diagnosable.

- Windows `Build` job: added `id: unit-tests` to "Execute unit tests" and a new "Upload TestCases on test failure" step right after "Upload Test Logs", gated on `failure() && steps.unit-tests.outcome == 'failure'` (artifact `testcases-Debug` / `testcases-Release`)
- Linux/macOS `Desktop` job: same pattern keyed to "Execute decompiler tests" via `id: decompiler-tests` (artifact `testcases-linux` / `testcases-macos`)
- Uses `actions/upload-artifact@v7` with `compression-level: 9` instead of a separate 7z step - the action zips client-side at maximum compression, and `7z` is not reliably available on the macOS runner
- `if-no-files-found` stays at the default `warn` so a run where TestCases was never generated does not mask the original test failure with an artifact error

On green runs the new steps show as skipped; they only execute when their test step failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
