### PR TITLE
Fix async void exception handling in command execute methods

### DIFF
--- a/ILSpy/Commands/FileCommands.cs
+++ b/ILSpy/Commands/FileCommands.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.ILSpy.Commands
 	[method: ImportingConstructor]
 	sealed class OpenCommand(AssemblyTreeModel assemblyTreeModel) : SimpleCommand
 	{
-		public override async void Execute(object? parameter)
+		public override void Execute(object? parameter)
 		{
 			// Tests / scripted callers can pass paths directly and bypass the file picker.
 			if (parameter is string singlePath)
@@ -59,6 +59,11 @@ namespace ICSharpCode.ILSpy.Commands
 				return;
 			}
 
+			ExecuteAsync().HandleExceptions();
+		}
+
+		async Task ExecuteAsync()
+		{
 			var owner = UiContext.MainWindow;
 			if (owner == null)
 				return;
@@ -236,7 +241,12 @@ namespace ICSharpCode.ILSpy.Commands
 		public override bool CanExecute(object? parameter)
 			=> assemblyTreeModel.SelectedItem is ILSpyTreeNode;
 
-		public override async void Execute(object? parameter)
+		public override void Execute(object? parameter)
+		{
+			ExecuteAsync().HandleExceptions();
+		}
+
+		async Task ExecuteAsync()
 		{
 			// Several selected assemblies export a Visual Studio solution (one project each),
 			// matching the Save Code context-menu entry.

--- a/ILSpy/TreeNodes/AssemblyTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyTreeNode.cs
@@ -675,7 +675,12 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 			public bool IsEnabled(TextViewContext context) => true;
 
-			public async void Execute(TextViewContext context)
+			public void Execute(TextViewContext context)
+			{
+				ExecuteAsync(context).HandleExceptions();
+			}
+
+			async Task ExecuteAsync(TextViewContext context)
 			{
 				if (context.SelectedTreeNodes == null)
 					return;


### PR DESCRIPTION
Fixes critical exception handling issues in command `Execute` methods where `async void` was used, causing unhandled exceptions that could crash the application.

## Changes

  - **FileCommands.cs**: Fixed `OpenCommand.Execute` and `SaveCommand.Execute`
  - **AssemblyTreeNode.cs**: Fixed `LoadDependencies.Execute`

### What was fixed?

Previously, these methods used `async void` which:
  - Cannot be awaited by callers
  - Swallows exceptions (causes application crashes)
  - Makes testing difficult

Now they use the project's standard fire-and-forget pattern:
  - Synchronous `void Execute` (maintains interface compatibility)
  -  Async logic extracted to `Task ExecuteAsync`
  -  Uses `HandleExceptions()` to route errors to `GlobalExceptionHandler`
  -  Matches 30+ existing usages throughout the project