### PR TITLE
Model scoped and UnscopedRef lifetimes in the type system

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemLoaderTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemLoaderTests.cs
@@ -197,6 +197,87 @@ namespace ICSharpCode.Decompiler.Tests.TypeSystem
 		}
 
 		[Test]
+		public void LifetimeAnnotations()
+		{
+			ITypeDefinition type = GetTypeDefinition(typeof(LifetimeAnnotationTests));
+
+			IParameter explicitScopedRef = type.Methods.Single(m => m.Name == "ExplicitScopedRef").Parameters.Single();
+			Assert.That(explicitScopedRef.Lifetime.DeclaredScope, Is.EqualTo(ScopedKind.ScopedRef));
+			Assert.That(explicitScopedRef.GetEffectiveScope(), Is.EqualTo(ScopedKind.ScopedRef));
+			Assert.That(explicitScopedRef.Lifetime.HasUnscopedRefAttribute, Is.False);
+			Assert.That(explicitScopedRef.Lifetime.ScopedRef, Is.True);
+
+			IParameter explicitScopedValue = type.Methods.Single(m => m.Name == "ExplicitScopedValue").Parameters.Single();
+			Assert.That(explicitScopedValue.Lifetime.DeclaredScope, Is.EqualTo(ScopedKind.ScopedValue));
+			Assert.That(explicitScopedValue.GetEffectiveScope(), Is.EqualTo(ScopedKind.ScopedValue));
+			Assert.That(explicitScopedValue.Lifetime.HasUnscopedRefAttribute, Is.False);
+			Assert.That(explicitScopedValue.Lifetime.ScopedRef, Is.True);
+
+			IParameter implicitScopedRef = type.Methods.Single(m => m.Name == "ImplicitScopedRef").Parameters.Single();
+			Assert.That(implicitScopedRef.Lifetime.DeclaredScope, Is.EqualTo(ScopedKind.None));
+			Assert.That(implicitScopedRef.GetEffectiveScope(), Is.EqualTo(ScopedKind.ScopedRef));
+			Assert.That(implicitScopedRef.Lifetime.HasUnscopedRefAttribute, Is.False);
+			Assert.That(implicitScopedRef.Lifetime.ScopedRef, Is.False);
+
+			IParameter unscopedRef = type.Methods.Single(m => m.Name == "UnscopedRef").Parameters.Single();
+			Assert.That(unscopedRef.Lifetime.DeclaredScope, Is.EqualTo(ScopedKind.None));
+			Assert.That(unscopedRef.GetEffectiveScope(), Is.EqualTo(ScopedKind.None));
+			Assert.That(unscopedRef.Lifetime.HasUnscopedRefAttribute, Is.True);
+			Assert.That(unscopedRef.GetAttributes().Any(a =>
+				a.AttributeType.FullName == "System.Diagnostics.CodeAnalysis.UnscopedRefAttribute"), Is.True);
+
+			var paramsRefStruct = new DefaultParameter(type, "values", isParams: true);
+			Assert.That(paramsRefStruct.GetEffectiveScope(), Is.EqualTo(ScopedKind.ScopedValue));
+
+			IMethod instanceMethod = type.Methods.Single(m => m.Name == "InstanceMethod");
+			Assert.That(instanceMethod.GetThisParameterScope(), Is.EqualTo(ScopedKind.ScopedRef));
+			Assert.That(instanceMethod.HasAttribute(KnownAttribute.UnscopedRef), Is.False);
+
+			IMethod unscopedMethod = type.Methods.Single(m => m.Name == "UnscopedMethod");
+			Assert.That(unscopedMethod.GetThisParameterScope(), Is.EqualTo(ScopedKind.None));
+			Assert.That(unscopedMethod.HasAttribute(KnownAttribute.UnscopedRef), Is.True);
+
+			IProperty unscopedProperty = type.Properties.Single(p => p.Name == "UnscopedProperty");
+			Assert.That(unscopedProperty.Getter.GetThisParameterScope(), Is.EqualTo(ScopedKind.None));
+			Assert.That(unscopedProperty.HasAttribute(KnownAttribute.UnscopedRef), Is.True);
+
+			IProperty accessorUnscopedProperty = type.Properties.Single(p => p.Name == "AccessorUnscopedProperty");
+			Assert.That(accessorUnscopedProperty.Getter.GetThisParameterScope(), Is.EqualTo(ScopedKind.None));
+			Assert.That(accessorUnscopedProperty.Getter.HasAttribute(KnownAttribute.UnscopedRef), Is.True);
+
+			IMethod staticMethod = type.Methods.Single(m => m.Name == "ExplicitScopedRef");
+			Assert.That(staticMethod.GetThisParameterScope(), Is.EqualTo(ScopedKind.None));
+
+			IMethod classMethod = GetTypeDefinition(typeof(SimplePublicClass)).Methods.Single(m => m.Name == "Method");
+			Assert.That(classMethod.GetThisParameterScope(), Is.EqualTo(ScopedKind.None));
+
+			// The legacy mscorlib fixture has no RefSafetyRulesAttribute, so out is not implicitly scoped.
+			ITypeDefinition int32 = compilation.FindType(KnownTypeCode.Int32).GetDefinition();
+			IMethod legacyTryParse = int32.Methods.Single(m => m.Name == "TryParse"
+				&& m.Parameters.Count == 2
+				&& m.Parameters[1].ReferenceKind == ReferenceKind.Out);
+			Assert.That(legacyTryParse.Parameters[1].GetEffectiveScope(), Is.EqualTo(ScopedKind.None));
+		}
+
+		[Test]
+		public void LifetimeAnnotationsCanBeDisabled()
+		{
+			var compilationWithoutLifetimeAnnotations = new SimpleCompilation(
+				TestAssembly.WithOptions(TypeSystemOptions.Default & ~TypeSystemOptions.ScopedRef),
+				Mscorlib.WithOptions(TypeSystemOptions.Default | TypeSystemOptions.OnlyPublicAPI));
+			ITypeDefinition type = compilationWithoutLifetimeAnnotations.FindType(typeof(LifetimeAnnotationTests)).GetDefinition();
+
+			IParameter explicitScopedRef = type.Methods.Single(m => m.Name == "ExplicitScopedRef").Parameters.Single();
+			Assert.That(explicitScopedRef.Lifetime.DeclaredScope, Is.EqualTo(ScopedKind.None));
+			Assert.That(explicitScopedRef.GetEffectiveScope(), Is.EqualTo(ScopedKind.None));
+			Assert.That(explicitScopedRef.GetAttributes().Any(a =>
+				a.AttributeType.FullName == "System.Runtime.CompilerServices.ScopedRefAttribute"), Is.True);
+
+			IMethod instanceMethod = type.Methods.Single(m => m.Name == "InstanceMethod");
+			Assert.That(instanceMethod.GetThisParameterScope(), Is.EqualTo(ScopedKind.None));
+		}
+
+		[Test]
 		public void AssemblyAttribute()
 		{
 			var attributes = compilation.MainModule.GetAssemblyAttributes().ToList();

--- a/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
+++ b/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -218,6 +219,34 @@ namespace ICSharpCode.Decompiler.Tests.TypeSystem
 		public void MethodWithOptionalNullableLongParameter(long? x = 1) { }
 		public void MethodWithOptionalDecimalParameter(decimal x = 1) { }
 		public void VarArgsMethod(__arglist) { }
+	}
+
+	public ref struct LifetimeAnnotationTests
+	{
+		private int value;
+
+		public static void ExplicitScopedRef(scoped ref int value) { }
+		public static void ExplicitScopedValue(scoped LifetimeAnnotationTests value) { }
+		public static void ImplicitScopedRef(out int value) { value = 0; }
+		public static void UnscopedRef([UnscopedRef] out int value) { value = 0; }
+
+		public void InstanceMethod() { }
+
+		[UnscopedRef]
+		public ref int UnscopedMethod()
+		{
+			return ref value;
+		}
+
+		[UnscopedRef]
+		public ref int UnscopedProperty => ref value;
+
+		public ref int AccessorUnscopedProperty {
+			[UnscopedRef]
+			get {
+				return ref value;
+			}
+		}
 	}
 
 	public class VarArgsCtor

--- a/ICSharpCode.Decompiler/TypeSystem/IParameter.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/IParameter.cs
@@ -18,7 +18,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -52,23 +51,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// Gets or sets the scope explicitly encoded by <c>ScopedRefAttribute</c>.
 		/// Implicit and redundant scopedness is excluded.
 		/// </summary>
-		public ScopedKind DeclaredScope {
-			get {
-#pragma warning disable 618
-				if (ValueScoped)
-					return ScopedKind.ScopedValue;
-				if (RefScoped)
-					return ScopedKind.ScopedRef;
-#pragma warning restore 618
-				return ScopedKind.None;
-			}
-			set {
-#pragma warning disable 618
-				RefScoped = value != ScopedKind.None;
-				ValueScoped = value == ScopedKind.ScopedValue;
-#pragma warning restore 618
-			}
-		}
+		public ScopedKind DeclaredScope { get; set; }
 
 		/// <summary>
 		/// C# 11 scoped annotation: "scoped ref" (ScopedRefAttribute)
@@ -77,12 +60,6 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			get { return DeclaredScope != ScopedKind.None; }
 			set { DeclaredScope = value ? ScopedKind.ScopedRef : ScopedKind.None; }
 		}
-
-		[Obsolete("Use ScopedRef property instead of directly accessing this field")]
-		public bool RefScoped;
-
-		[Obsolete("C# 11 preview: \"ref scoped\" no longer supported")]
-		public bool ValueScoped;
 
 		/// <summary>
 		/// Gets or sets whether <c>UnscopedRefAttribute</c> is present.

--- a/ICSharpCode.Decompiler/TypeSystem/IParameter.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/IParameter.cs
@@ -36,16 +36,46 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		RefReadOnly,
 	}
 
+	/// <summary>
+	/// Describes which part of a parameter or local is restricted to the current scope.
+	/// </summary>
+	public enum ScopedKind : byte
+	{
+		None,
+		ScopedRef,
+		ScopedValue,
+	}
+
 	public struct LifetimeAnnotation
 	{
+		/// <summary>
+		/// Gets or sets the scope explicitly encoded by <c>ScopedRefAttribute</c>.
+		/// Implicit and redundant scopedness is excluded.
+		/// </summary>
+		public ScopedKind DeclaredScope {
+			get {
+#pragma warning disable 618
+				if (ValueScoped)
+					return ScopedKind.ScopedValue;
+				if (RefScoped)
+					return ScopedKind.ScopedRef;
+#pragma warning restore 618
+				return ScopedKind.None;
+			}
+			set {
+#pragma warning disable 618
+				RefScoped = value != ScopedKind.None;
+				ValueScoped = value == ScopedKind.ScopedValue;
+#pragma warning restore 618
+			}
+		}
+
 		/// <summary>
 		/// C# 11 scoped annotation: "scoped ref" (ScopedRefAttribute)
 		/// </summary>
 		public bool ScopedRef {
-#pragma warning disable 618
-			get { return RefScoped; }
-			set { RefScoped = value; }
-#pragma warning restore 618
+			get { return DeclaredScope != ScopedKind.None; }
+			set { DeclaredScope = value ? ScopedKind.ScopedRef : ScopedKind.None; }
 		}
 
 		[Obsolete("Use ScopedRef property instead of directly accessing this field")]
@@ -53,6 +83,11 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		[Obsolete("C# 11 preview: \"ref scoped\" no longer supported")]
 		public bool ValueScoped;
+
+		/// <summary>
+		/// Gets or sets whether <c>UnscopedRefAttribute</c> is present.
+		/// </summary>
+		public bool HasUnscopedRefAttribute { get; set; }
 	}
 
 	public interface IParameter : IVariable

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -114,21 +114,19 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		// C# 11 attributes:
 		Required,
+		UnscopedRef,
+		RefSafetyRules,
 
 		// C# 12 attributes:
 		InlineArray,
 
 		// C# 14 attributes:
 		ExtensionMarker,
-
-		// Lifetime attributes:
-		UnscopedRef,
-		RefSafetyRules,
 	}
 
 	public static class KnownAttributes
 	{
-		internal const int Count = (int)KnownAttribute.RefSafetyRules + 1;
+		internal const int Count = (int)KnownAttribute.ExtensionMarker + 1;
 
 		static readonly TopLevelTypeName[] typeNames = new TopLevelTypeName[Count]{
 			default,
@@ -200,13 +198,12 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			new TopLevelTypeName("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute"),
 			// C# 11 attributes:
 			new TopLevelTypeName("System.Runtime.CompilerServices", "RequiredMemberAttribute"),
+			new TopLevelTypeName("System.Diagnostics.CodeAnalysis", "UnscopedRefAttribute"),
+			new TopLevelTypeName("System.Runtime.CompilerServices", "RefSafetyRulesAttribute"),
 			// C# 12 attributes:
 			new TopLevelTypeName("System.Runtime.CompilerServices", "InlineArrayAttribute"),
 			// C# 14 attributes:
 			new TopLevelTypeName("System.Runtime.CompilerServices", "ExtensionMarkerAttribute"),
-			// Lifetime attributes:
-			new TopLevelTypeName("System.Diagnostics.CodeAnalysis", "UnscopedRefAttribute"),
-			new TopLevelTypeName("System.Runtime.CompilerServices", "RefSafetyRulesAttribute"),
 		};
 
 		public static ref readonly TopLevelTypeName GetTypeName(this KnownAttribute attr)

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/KnownAttributes.cs
@@ -120,11 +120,15 @@ namespace ICSharpCode.Decompiler.TypeSystem
 
 		// C# 14 attributes:
 		ExtensionMarker,
+
+		// Lifetime attributes:
+		UnscopedRef,
+		RefSafetyRules,
 	}
 
 	public static class KnownAttributes
 	{
-		internal const int Count = (int)KnownAttribute.ExtensionMarker + 1;
+		internal const int Count = (int)KnownAttribute.RefSafetyRules + 1;
 
 		static readonly TopLevelTypeName[] typeNames = new TopLevelTypeName[Count]{
 			default,
@@ -200,6 +204,9 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			new TopLevelTypeName("System.Runtime.CompilerServices", "InlineArrayAttribute"),
 			// C# 14 attributes:
 			new TopLevelTypeName("System.Runtime.CompilerServices", "ExtensionMarkerAttribute"),
+			// Lifetime attributes:
+			new TopLevelTypeName("System.Diagnostics.CodeAnalysis", "UnscopedRefAttribute"),
+			new TopLevelTypeName("System.Runtime.CompilerServices", "RefSafetyRulesAttribute"),
 		};
 
 		public static ref readonly TopLevelTypeName GetTypeName(this KnownAttribute attr)

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataParameter.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataParameter.cs
@@ -125,17 +125,29 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 
 				var metadata = module.metadata;
 				var parameterDef = metadata.GetParameter(handle);
-				if ((module.TypeSystemOptions & TypeSystemOptions.ParamsCollections) != 0
-					&& parameterDef.GetCustomAttributes().HasKnownAttribute(metadata, KnownAttribute.ParamCollection))
+				var attributes = parameterDef.GetCustomAttributes();
+				bool hasUnscopedRefAttribute = attributes.HasKnownAttribute(metadata, KnownAttribute.UnscopedRef);
+				bool isParamsCollection = (module.TypeSystemOptions & TypeSystemOptions.ParamsCollections) != 0
+					&& attributes.HasKnownAttribute(metadata, KnownAttribute.ParamCollection);
+				ScopedKind declaredScope = ScopedKind.None;
+				if (!hasUnscopedRefAttribute
+					&& !isParamsCollection
+					&& attributes.HasKnownAttribute(metadata, KnownAttribute.ScopedRef))
 				{
-					// params collections are implicitly scoped
-					return default;
+					if (ReferenceKind != ReferenceKind.None)
+					{
+						declaredScope = ScopedKind.ScopedRef;
+					}
+					else if (Type.IsRefLikeOrAllowsRefLikeType())
+					{
+						declaredScope = ScopedKind.ScopedValue;
+					}
 				}
-				if (parameterDef.GetCustomAttributes().HasKnownAttribute(metadata, KnownAttribute.ScopedRef))
-				{
-					return new LifetimeAnnotation { ScopedRef = true };
-				}
-				return default;
+
+				return new LifetimeAnnotation {
+					DeclaredScope = declaredScope,
+					HasUnscopedRefAttribute = hasUnscopedRefAttribute
+				};
 			}
 		}
 

--- a/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/MetadataModule.cs
@@ -91,6 +91,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			var customAttrs = metadata.GetModuleDefinition().GetCustomAttributes();
 			this.NullableContext = customAttrs.GetNullableContext(metadata) ?? Nullability.Oblivious;
 			this.minAccessibilityForNRT = FindMinimumAccessibilityForNRT(metadata, customAttrs);
+			this.UseUpdatedEscapeRules = HasRefSafetyRulesVersion(customAttrs, 11);
 			this.rootNamespace = new MetadataNamespace(this, null, string.Empty, metadata.GetNamespaceDefinitionRoot());
 
 			if (!options.HasFlag(TypeSystemOptions.Uncached))
@@ -111,6 +112,43 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		public TypeSystemOptions TypeSystemOptions => options;
+
+		/// <summary>
+		/// Gets whether the module declares the C# 11 ref-safety rules.
+		/// </summary>
+		internal bool UseUpdatedEscapeRules { get; }
+
+		bool HasRefSafetyRulesVersion(CustomAttributeHandleCollection attributes, int expectedVersion)
+		{
+			foreach (var attributeHandle in attributes)
+			{
+				var attribute = metadata.GetCustomAttribute(attributeHandle);
+				if (!attribute.IsKnownAttribute(metadata, KnownAttribute.RefSafetyRules))
+					continue;
+
+				CustomAttributeValue<IType> value;
+				try
+				{
+					value = attribute.DecodeValue(Metadata.MetadataExtensions.MinimalAttributeTypeProvider);
+				}
+				catch (BadImageFormatException)
+				{
+					continue;
+				}
+				catch (Metadata.EnumUnderlyingTypeResolveException)
+				{
+					continue;
+				}
+				if (value.FixedArguments.Length == 1
+					&& value.FixedArguments[0].Value is int version)
+				{
+					// Roslyn recognizes exactly version 11; missing and unknown versions use legacy rules.
+					return version == expectedVersion;
+				}
+			}
+
+			return false;
+		}
 
 		#region IModule interface
 		public MetadataFile MetadataFile { get; }

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -692,6 +692,65 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 		#endregion
 
+		#region Lifetime annotations
+		internal static bool IsRefLikeOrAllowsRefLikeType(this IType type)
+		{
+			return type.IsByRefLike
+				|| type is ITypeParameter { AllowsRefLikeType: true };
+		}
+
+		/// <summary>
+		/// Gets the parameter's effective scope after applying implicit scope rules and
+		/// <c>UnscopedRefAttribute</c>.
+		/// </summary>
+		internal static ScopedKind GetEffectiveScope(this IParameter parameter)
+		{
+			LifetimeAnnotation lifetime = parameter.Lifetime;
+			if (lifetime.HasUnscopedRefAttribute)
+				return ScopedKind.None;
+
+			if (lifetime.DeclaredScope != ScopedKind.None)
+				return lifetime.DeclaredScope;
+
+			if (parameter.Owner?.ParentModule is MetadataModule module)
+			{
+				if ((module.TypeSystemOptions & TypeSystemOptions.ScopedRef) == 0)
+					return ScopedKind.None;
+
+				if (module.UseUpdatedEscapeRules && parameter.ReferenceKind == ReferenceKind.Out)
+					return ScopedKind.ScopedRef;
+			}
+
+			if (parameter.IsParams && parameter.Type.IsRefLikeOrAllowsRefLikeType())
+				return ScopedKind.ScopedValue;
+
+			return ScopedKind.None;
+		}
+
+		/// <summary>
+		/// Gets the effective scope of the implicit <c>this</c> parameter.
+		/// </summary>
+		internal static ScopedKind GetThisParameterScope(this IMethod method)
+		{
+			if (method.IsStatic || method.DeclaringTypeDefinition?.Kind != TypeKind.Struct)
+				return ScopedKind.None;
+
+			if (method.ParentModule is MetadataModule module)
+			{
+				if ((module.TypeSystemOptions & TypeSystemOptions.ScopedRef) == 0)
+					return ScopedKind.None;
+
+				bool hasUnscopedRefAttribute = method.HasAttribute(KnownAttribute.UnscopedRef)
+					|| method.AccessorOwner is IProperty property
+						&& property.HasAttribute(KnownAttribute.UnscopedRef);
+				if (hasUnscopedRefAttribute && module.UseUpdatedEscapeRules)
+					return ScopedKind.None;
+			}
+
+			return ScopedKind.ScopedRef;
+		}
+		#endregion
+
 		#region IParameter.IsDefaultValueAssignmentAllowed
 		/// <summary>
 		/// Checks if the parameter is allowed to be assigned a default value.


### PR DESCRIPTION
Related to #3853. This is the type-system prerequisite requested during review of #3854.

tl;dr: ILSpy currently treats `ScopedRefAttribute` as a single boolean and has no semantic
model for `UnscopedRefAttribute`, implicit scopes, or the module's ref-safety rules. This PR
aligns the type system with Roslyn without changing decompiler output. A separate follow-up
will use this model to recover erased `scoped` local modifiers.

### Problem

`LifetimeAnnotation.ScopedRef` only reports whether a parameter has
`ScopedRefAttribute`. That is sufficient to print the explicit `scoped` keyword, but not to
reason about effective lifetimes:

- `ScopedRefAttribute` represents `ScopedRef` on a by-ref parameter and `ScopedValue` on a
  by-value ref-like parameter.
- `out` is implicitly `ScopedRef` only for modules using
  `[module: RefSafetyRules(11)]`.
- ref-like `params` collections are implicitly `ScopedValue`, while their compiler-emitted
  `ScopedRefAttribute` is redundant and must not be printed.
- `UnscopedRefAttribute` can remove an implicit scope.
- a struct receiver is implicitly `ScopedRef`; `UnscopedRefAttribute` may be placed on the
  method, property, or accessor.

Without these distinctions, a local-lifetime analysis cannot tell whether an argument may be
captured by a call.

### Solution

- Add `ScopedKind` with `None`, `ScopedRef`, and `ScopedValue`.
- Extend `LifetimeAnnotation` with the explicit attribute-encoded scope and
  `HasUnscopedRefAttribute`, while preserving the current `ScopedRef` API.
  `ScopedKind` replaces the obsolete preview-era `RefScoped` and `ValueScoped` fields.
- Recognize `System.Diagnostics.CodeAnalysis.UnscopedRefAttribute` and
  `System.Runtime.CompilerServices.RefSafetyRulesAttribute`.
- Decode `ScopedRefAttribute` according to parameter ref-ness and ref-like type semantics.
  Conflicting or malformed annotations degrade to no explicit scope.
- Read exactly `RefSafetyRules(11)` from the module, matching Roslyn's old/new escape-rule
  selection.
- Add internal helpers for effective parameter scope and implicit struct-receiver scope,
  including method/property/accessor `UnscopedRefAttribute`.

The display path continues to use only the explicit scope. Implicit `out`, `this`, and
ref-like `params` scopes therefore do not introduce redundant `scoped` keywords, and
`UnscopedRefAttribute` remains visible as a normal attribute.

### Tests

- explicit `scoped ref` and `scoped` ref-struct parameters
- implicit new-rules `out`
- `[UnscopedRef] out`
- legacy `out` from a module without `RefSafetyRules(11)`
- struct, class, static, method, property, and accessor receiver scopes
- ref-like `params` effective scope
- `ScopedRef` option disabled, including preservation of the raw attribute
- existing `RefFields` and `ParamsCollections` Pretty matrices remain byte-identical

Validation:

- Debug and Release solution builds: 0 warnings, 0 errors
- full Pretty suite: 1906 passed, 5 existing skips
- full solution test suite: 4887 passed, 15 existing skips

### Review focus

The main review points are the public `LifetimeAnnotation` shape and the exact mapping of
Roslyn's declared versus effective scope rules.

- [x] At least one test covering the code changed