### PR TITLE
Fix #3853: infer scoped locals from ref safety

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
@@ -3,6 +3,45 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	internal struct Buffer
+	{
+		private int value;
+
+		[UnscopedRef]
+		public ref int GetRef()
+		{
+			return ref value;
+		}
+	}
+
+	internal ref struct Holder
+	{
+		public Span<int> Inner;
+
+		public void Set(Span<int> inner)
+		{
+			Inner = inner;
+		}
+
+		public readonly void ReadonlyUse(Span<int> inner)
+		{
+			_ = inner.Length;
+		}
+	}
+
+	internal static class HolderExtensions
+	{
+		public static void SetExtension(this ref Holder holder, Span<int> inner)
+		{
+			holder.Inner = inner;
+		}
+
+		public static void ReadonlyExtension(this in Holder holder, Span<int> inner)
+		{
+			_ = inner.Length;
+		}
+	}
+
 	internal class LifetimeTests
 	{
 		private static int staticField;
@@ -35,14 +74,276 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			span = default(Span<int>);
 		}
 
+		public Span<int> CaptureOut([UnscopedRef] out int value)
+		{
+			value = 0;
+			return new Span<int>(ref value);
+		}
+
+		public Span<int> NoCaptureOut(out int value)
+		{
+			value = 0;
+			return default(Span<int>);
+		}
+
+		public Span<int> Identity(Span<int> span)
+		{
+			return span;
+		}
+
 		public void Calls()
 		{
 			int value = 0;
-			Span<int> span = CreateWithoutCapture(ref value);
-			//span = CreateAndCapture(ref value); -- would need scoped local, not yet implemented
+			scoped Span<int> span = CreateWithoutCapture(ref value);
+			span = CreateAndCapture(ref value);
 			span = ScopedRefSpan(ref span);
 			span = ScopedSpan(span);
 			OutSpan(out span);
+		}
+
+		public int ReassignScopedRefToLocal(bool b, ref int x)
+		{
+			int num = 42;
+			scoped ref int reference = ref x;
+			if (b)
+			{
+				reference = ref num;
+			}
+			return reference;
+		}
+
+		public int ReassignScopedSpanFromOut(bool b)
+		{
+			int value = 0;
+			scoped Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = CaptureOut(out value);
+			}
+			return span[0] + value;
+		}
+
+		public int ImplicitScopedOutDoesNotCapture()
+		{
+			Span<int> span = default(Span<int>);
+			span = NoCaptureOut(out var value);
+			Console.WriteLine(span.Length);
+			return span.Length + value;
+		}
+
+		public int ReassignScopedSpanFromReceiver(bool b)
+		{
+			UnscopedRefStruct unscopedRefStruct = default(UnscopedRefStruct);
+			scoped Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = unscopedRefStruct.AsSpan();
+			}
+			return span[0];
+		}
+
+		public int ReassignScopedSpanFromRefParameter(bool b, ref int value)
+		{
+			scoped Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = CreateAndCapture(ref value);
+			}
+			return span[0];
+		}
+
+		public int ReassignScopedSpanFromStackAlloc(bool b)
+		{
+			scoped Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = stackalloc int[1];
+			}
+			return span[0];
+		}
+
+		public int ReassignScopedSpanFromScopedValue(bool b, scoped Span<int> value)
+		{
+			scoped Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = value;
+			}
+			return span[0];
+		}
+
+		public int ReassignScopedSpanFromNestedCall(bool b)
+		{
+			int value = 0;
+			scoped Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = Identity(CreateAndCapture(ref value));
+			}
+			return span[0];
+		}
+
+		public int ReassignScopedSpanFromLocalCopy(bool b)
+		{
+			Span<int> span = stackalloc int[1];
+			scoped Span<int> span2 = default(Span<int>);
+			if (b)
+			{
+				span2 = span;
+			}
+			return span2[0];
+		}
+
+		public int ReassignScopedSpanFromScopedRefValue(bool b)
+		{
+			Span<int> span = stackalloc int[1];
+			scoped Span<int> span2 = default(Span<int>);
+			if (b)
+			{
+				span2 = ScopedRefSpan(ref span);
+			}
+			return span2[0];
+		}
+
+		public int NarrowInitializerDoesNotNeedScoped(bool b)
+		{
+			int num = 1;
+			int num2 = 2;
+			ref int reference = ref num;
+			if (b)
+			{
+				reference = ref num2;
+			}
+			return reference;
+		}
+
+		public int NarrowThenWideDoesNotNeedScoped(bool b, ref int value)
+		{
+			int num = 1;
+			ref int reference = ref num;
+			if (b)
+			{
+				reference = ref value;
+			}
+			return reference;
+		}
+
+		public int ClassParameterReceiverDoesNotNarrow(SpanProvider provider, bool b)
+		{
+			Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = provider.GetBuffer();
+			}
+			return span.Length;
+		}
+
+		public int ClassLocalReceiverDoesNotNarrow(bool b)
+		{
+			SpanProvider spanProvider = new SpanProvider();
+			Span<int> span = default(Span<int>);
+			if (b)
+			{
+				span = spanProvider.GetBuffer();
+			}
+			return span.Length;
+		}
+
+		public ref int PlainStructReceiverDoesNotForceScoped(bool b, ref Buffer buffer, ref int other)
+		{
+			ref int result = ref buffer.GetRef();
+			if (b)
+			{
+				result = ref other;
+			}
+			return ref result;
+		}
+
+		public int FieldStoreRequiresScoped()
+		{
+			scoped Holder holder = default(Holder);
+			Span<int> inner = stackalloc int[4];
+			holder.Inner = inner;
+			return holder.Inner.Length;
+		}
+
+		public int ReceiverCallRequiresScoped()
+		{
+			scoped Holder holder = default(Holder);
+			Span<int> inner = stackalloc int[4];
+			holder.Set(inner);
+			return holder.Inner.Length;
+		}
+
+		public int ExtensionReceiverCallRequiresScoped()
+		{
+			scoped Holder holder = default(Holder);
+			Span<int> inner = stackalloc int[4];
+			holder.SetExtension(inner);
+			return holder.Inner.Length;
+		}
+
+		public Holder ReadonlyReceiverDoesNotRequireScoped(bool b)
+		{
+			Holder result = default(Holder);
+			if (b)
+			{
+				Span<int> inner = stackalloc int[4];
+				result.ReadonlyUse(inner);
+			}
+			return result;
+		}
+
+		public Holder ReadonlyExtensionReceiverDoesNotRequireScoped(bool b)
+		{
+			Holder holder = default(Holder);
+			if (b)
+			{
+				Span<int> inner = stackalloc int[4];
+				holder.ReadonlyExtension(inner);
+			}
+			return holder;
+		}
+
+		public ReadOnlyHolder ReadonlyRefStructReceiverDoesNotRequireScoped(bool b, Span<int> wide)
+		{
+			ReadOnlyHolder result = new ReadOnlyHolder(wide);
+			if (b)
+			{
+				Span<int> other = stackalloc int[1];
+				result.Compare(other);
+			}
+			return result;
+		}
+
+		public int TryInitThenReassign(bool condition, Span<int> wide)
+		{
+			scoped Span<int> span;
+			try
+			{
+				span = stackalloc int[4];
+			}
+			finally
+			{
+				Console.WriteLine("cleanup");
+			}
+			if (condition)
+			{
+				span = wide;
+			}
+			return span[0];
+		}
+
+	}
+
+	internal readonly ref struct ReadOnlyHolder(Span<int> inner)
+	{
+		private readonly Span<int> inner = inner;
+
+		public void Compare(Span<int> other)
+		{
+			_ = inner.Length;
+			_ = other.Length;
 		}
 	}
 
@@ -86,6 +387,14 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 	}
 
+	internal sealed class SpanProvider
+	{
+		public Span<int> GetBuffer()
+		{
+			return default(Span<int>);
+		}
+	}
+
 	internal ref struct UnscopedRefStruct
 	{
 		private int val;
@@ -97,6 +406,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public ref int ByRefAccess()
 		{
 			return ref val;
+		}
+
+		[UnscopedRef]
+		public Span<int> AsSpan()
+		{
+			return new Span<int>(ref val);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
@@ -74,6 +74,28 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			span = default(Span<int>);
 		}
 
+		public void CaptureIntoRef(ref Holder holder, Span<int> inner)
+		{
+			holder.Inner = inner;
+		}
+
+		public void CaptureIntoOut(out Holder holder, Span<int> inner)
+		{
+			holder = default(Holder);
+			holder.Inner = inner;
+		}
+
+		public void CaptureRefIntoOut(out Holder holder, ref int value)
+		{
+			holder = default(Holder);
+			holder.Inner = new Span<int>(ref value);
+		}
+
+		public ref Holder Identity(ref Holder holder)
+		{
+			return ref holder;
+		}
+
 		public Span<int> CaptureOut([UnscopedRef] out int value)
 		{
 			value = 0;
@@ -281,6 +303,59 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Span<int> inner = stackalloc int[4];
 			holder.SetExtension(inner);
 			return holder.Inner.Length;
+		}
+
+		public int RefArgumentCallRequiresScoped()
+		{
+			scoped Holder holder = default(Holder);
+			Span<int> inner = stackalloc int[4];
+			CaptureIntoRef(ref holder, inner);
+			return holder.Inner.Length;
+		}
+
+		public int OutArgumentCallRequiresScoped()
+		{
+			scoped Holder holder = default(Holder);
+			Span<int> inner = stackalloc int[4];
+			CaptureIntoOut(out holder, inner);
+			return holder.Inner.Length;
+		}
+
+		public int OutArgumentCapturesRefRequiresScoped()
+		{
+			int value = 0;
+			scoped Holder holder = default(Holder);
+			CaptureRefIntoOut(out holder, ref value);
+			return holder.Inner[0];
+		}
+
+		public Holder RefArgumentWideValueDoesNotRequireScoped(Span<int> wide)
+		{
+			Holder holder = default(Holder);
+			CaptureIntoRef(ref holder, wide);
+			return holder;
+		}
+
+		public Holder OutArgumentWideValueDoesNotRequireScoped(Span<int> wide)
+		{
+			Holder holder = default(Holder);
+			CaptureIntoOut(out holder, wide);
+			return holder;
+		}
+
+		public int RefReturnFieldStoreRequiresScoped()
+		{
+			scoped Holder holder = default(Holder);
+			Span<int> inner = stackalloc int[4];
+			Identity(ref holder).Inner = inner;
+			return holder.Inner.Length;
+		}
+
+		public Holder RefReturnFieldStoreWideValueDoesNotRequireScoped(Span<int> wide)
+		{
+			Holder holder = default(Holder);
+			Identity(ref holder).Inner = wide;
+			return holder;
 		}
 
 		public Holder ReadonlyReceiverDoesNotRequireScoped(bool b)

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -173,6 +173,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				new RemoveRedundantReturn(),
 				new IntroduceDynamicTypeOnLocals(),
 				new IntroduceNativeIntTypeOnLocals(),
+				new IntroduceScopedModifierOnLocals(),
 				new AssignVariableNames(),
 			};
 		}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Modifiers.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Modifiers.cs
@@ -59,6 +59,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		Async = 0x10000,
 		Ref = 0x20000,
 		Required = 0x40000,
+		Scoped = 0x80000,
 
 		VisibilityMask = Private | Internal | Protected | Public,
 
@@ -78,6 +79,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			Modifiers.Unsafe,
 			Modifiers.Static, Modifiers.Abstract, Modifiers.Virtual, Modifiers.Sealed, Modifiers.Override,
 			Modifiers.Required, Modifiers.Readonly, Modifiers.Volatile,
+			Modifiers.Scoped,
 			Modifiers.Ref,
 			Modifiers.Extern, Modifiers.Partial, Modifiers.Const,
 			Modifiers.Async,
@@ -124,6 +126,8 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 					return "async";
 				case Modifiers.Ref:
 					return "ref";
+				case Modifiers.Scoped:
+					return "scoped";
 				case Modifiers.Required:
 					return "required";
 				case Modifiers.Any:

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -649,6 +649,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 								init.AddAnnotation(annotation);
 							}
 						}
+						if (context.Settings.ScopedRef && v.ILVariable.IsScoped)
+						{
+							vds.Modifiers |= Modifiers.Scoped;
+						}
 						return vds;
 					}, "Combine variable declaration with initializer"));
 				}
@@ -707,6 +711,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						initializer = new DefaultValueExpression(type.Clone());
 					}
 					var vds = new VariableDeclarationStatement(type, v.Name, initializer);
+					if (context.Settings.ScopedRef && v.ILVariable.IsScopedWithoutInitializer)
+					{
+						vds.Modifiers |= Modifiers.Scoped;
+					}
 					vds.Variables.Single().AddAnnotation(new ILVariableResolveResult(ilVariable));
 					context.Step("Insert variable declaration", v.InsertionPoint.nextNode);
 					if (v.InsertionPoint.nextNode.Parent is LambdaExpression lambda)

--- a/ICSharpCode.Decompiler/IL/ILVariable.cs
+++ b/ICSharpCode.Decompiler/IL/ILVariable.cs
@@ -155,6 +155,16 @@ namespace ICSharpCode.Decompiler.IL
 		public bool IsRefReadOnly { get; internal set; }
 
 		/// <summary>
+		/// This variable must be declared with the C# <c>scoped</c> modifier.
+		/// </summary>
+		public bool IsScoped { get; internal set; }
+
+		/// <summary>
+		/// This variable must be declared with <c>scoped</c> when its declaration has no initializer.
+		/// </summary>
+		internal bool IsScopedWithoutInitializer { get; set; }
+
+		/// <summary>
 		/// The index of the local variable or parameter (depending on Kind)
 		/// 
 		/// For VariableKinds with "Local" in the name:
@@ -477,6 +487,10 @@ namespace ICSharpCode.Decompiler.IL
 
 		internal void WriteDefinitionTo(ITextOutput output)
 		{
+			if (IsScoped)
+			{
+				output.Write("scoped ");
+			}
 			if (IsRefReadOnly)
 			{
 				output.Write("readonly ");

--- a/ICSharpCode.Decompiler/IL/Transforms/IntroduceScopedModifierOnLocals.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/IntroduceScopedModifierOnLocals.cs
@@ -1,0 +1,670 @@
+// Copyright (c) 2026 Sebastien Lebreton
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+using ICSharpCode.Decompiler.IL.Transforms;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ICSharpCode.Decompiler.IL
+{
+	/// <summary>
+	/// Infers the C# <c>scoped</c> modifier on locals whose initializer has a wider
+	/// ref-safety context than a later assignment.
+	/// </summary>
+	/// <remarks>
+	/// The modifier is erased from IL and PDBs, so recovery compares the ref-safe-context
+	/// (for ref locals) or safe-context (for ref-struct locals) of the declaration initializer
+	/// with each later store. The three contexts are ordered from narrowest to widest:
+	/// current method, return-only, calling method. A narrower later store proves that the
+	/// original declaration required <c>scoped</c>.
+	/// </remarks>
+	class IntroduceScopedModifierOnLocals : IILTransform
+	{
+		public void Run(ILFunction function, ILTransformContext context)
+		{
+			if (!context.Settings.ScopedRef)
+				return;
+
+			foreach (var nestedFunction in function.Descendants.OfType<ILFunction>())
+			{
+				if (nestedFunction.Method is not {
+					ParentModule: MetadataModule { UseUpdatedEscapeRules: true }
+				} method)
+				{
+					continue;
+				}
+
+				new Analyzer(nestedFunction, method, context).Run();
+			}
+		}
+
+		enum SafeContext : byte
+		{
+			CurrentMethod,
+			ReturnOnly,
+			CallingMethod,
+		}
+
+		readonly struct LocalScopes(
+			SafeContext? refEscape,
+			SafeContext? valEscape,
+			bool isScoped,
+			bool isScopedWithoutInitializer)
+		{
+			public SafeContext? RefEscape { get; } = refEscape;
+			public SafeContext? ValEscape { get; } = valEscape;
+			public bool IsScoped { get; } = isScoped;
+			public bool IsScopedWithoutInitializer { get; } = isScopedWithoutInitializer;
+		}
+
+		sealed class Analyzer(ILFunction function, IMethod method, ILTransformContext context)
+		{
+			readonly Dictionary<ILVariable, StLoc[]> _stores = [];
+			readonly Dictionary<ILVariable, List<StObj>> _fieldStores = [];
+			readonly Dictionary<ILVariable, List<CallInstruction>> _receiverCalls = [];
+			Dictionary<ILVariable, LocalScopes> _scopes = [];
+
+			public void Run()
+			{
+				foreach (var variable in function.Variables)
+				{
+					variable.IsScoped = false;
+					variable.IsScopedWithoutInitializer = false;
+					if (variable.Kind is not (VariableKind.Local or VariableKind.StackSlot)
+						|| !variable.Type.IsRefLikeOrAllowsRefLikeType()
+						|| variable.UsesInitialValue)
+					{
+						continue;
+					}
+
+					var stores = variable.StoreInstructions.OfType<StLoc>().ToArray();
+					if (stores.Length == 0 || stores.Any(store => store.Parent == null))
+						continue;
+
+					_stores.Add(variable, stores);
+					_scopes.Add(variable, default);
+				}
+
+				foreach (var store in function.Descendants.OfType<StObj>())
+				{
+					if (!TryGetStorageRoot(store.Target, out var variable)
+						|| !_stores.ContainsKey(variable))
+					{
+						continue;
+					}
+
+					if (!_fieldStores.TryGetValue(variable, out var stores))
+					{
+						stores = [];
+						_fieldStores.Add(variable, stores);
+					}
+					stores.Add(store);
+				}
+
+				foreach (var call in function.Descendants.OfType<CallInstruction>())
+				{
+					bool isRefStructReceiver = call.IsInstanceCall
+						&& call.Method.DeclaringType.IsRefLikeOrAllowsRefLikeType()
+						&& !call.Method.ThisIsRefReadOnly;
+					if (!(isRefStructReceiver || IsRefStructExtensionReceiver(call))
+						|| call.Arguments.Count == 0
+						|| !TryGetStorageRoot(call.Arguments[0], out var variable)
+						|| !_stores.ContainsKey(variable))
+					{
+						continue;
+					}
+
+					if (!_receiverCalls.TryGetValue(variable, out var calls))
+					{
+						calls = [];
+						_receiverCalls.Add(variable, calls);
+					}
+					calls.Add(call);
+				}
+
+				for (int iteration = 0; iteration <= _stores.Count * 3; iteration++)
+				{
+					context.CancellationToken.ThrowIfCancellationRequested();
+					bool changed = false;
+					var nextScopes = new Dictionary<ILVariable, LocalScopes>(_scopes);
+					foreach (var pair in _stores)
+					{
+						ILVariable variable = pair.Key;
+						StLoc[] stores = pair.Value;
+						var initializer = GetFirstStore(stores);
+						LocalScopes scopes = CalculateLocalScopes(variable, initializer, stores);
+						LocalScopes previous = _scopes[variable];
+						if (scopes.RefEscape != previous.RefEscape
+							|| scopes.ValEscape != previous.ValEscape
+							|| scopes.IsScoped != previous.IsScoped
+							|| scopes.IsScopedWithoutInitializer != previous.IsScopedWithoutInitializer)
+						{
+							nextScopes[variable] = scopes;
+							changed = true;
+						}
+					}
+
+					_scopes = nextScopes;
+					if (!changed)
+						break;
+				}
+
+				foreach (var pair in _scopes)
+				{
+					pair.Key.IsScoped = pair.Value.IsScoped;
+					pair.Key.IsScopedWithoutInitializer = pair.Value.IsScopedWithoutInitializer;
+				}
+			}
+
+			LocalScopes CalculateLocalScopes(ILVariable variable, StLoc initializer, IReadOnlyList<StLoc> stores)
+			{
+				bool isRefLocal = variable.Type.Kind == TypeKind.ByReference;
+				SafeContext? initializerRefEscape = isRefLocal
+					? GetRefEscape(initializer.Value)
+					: SafeContext.CurrentMethod;
+				SafeContext? initializerValEscape = GetVariableValueType(variable).IsRefLikeOrAllowsRefLikeType()
+					? GetValEscape(initializer.Value)
+					: SafeContext.CallingMethod;
+
+				if (initializerRefEscape == null || initializerValEscape == null)
+					return default;
+
+				bool requiresScoped = false;
+				SafeContext initializerEscape = isRefLocal
+					? initializerRefEscape.Value
+					: initializerValEscape.Value;
+				bool requiresScopedWithoutInitializer = initializerEscape < SafeContext.CallingMethod;
+				foreach (var store in stores)
+				{
+					if (store == initializer)
+						continue;
+
+					SafeContext? storeEscape = isRefLocal
+						? GetRefEscape(store.Value)
+						: GetValEscape(store.Value);
+					if (storeEscape is not { } scope)
+						continue;
+
+					if (scope < SafeContext.CallingMethod)
+						requiresScopedWithoutInitializer = true;
+					if (scope < initializerEscape)
+					{
+						requiresScoped = true;
+					}
+				}
+
+				if (!requiresScoped && _fieldStores.TryGetValue(variable, out var fieldStores))
+				{
+					foreach (var store in fieldStores)
+					{
+						if (!initializer.IsBefore(store))
+							continue;
+
+						SafeContext? storeEscape = store.Type.Kind == TypeKind.ByReference
+							? GetRefEscape(store.Value)
+							: GetValEscape(store.Value);
+						if (storeEscape is not { } scope)
+							continue;
+
+						if (scope < SafeContext.CallingMethod)
+							requiresScopedWithoutInitializer = true;
+						if (scope < initializerValEscape.Value)
+						{
+							requiresScoped = true;
+						}
+					}
+				}
+
+				if (!requiresScoped && _receiverCalls.TryGetValue(variable, out var receiverCalls))
+				{
+					foreach (var call in receiverCalls)
+					{
+						if (!initializer.IsBefore(call))
+							continue;
+
+						SafeContext? callEscape = GetInvocationEscapeToReceiver(call);
+						if (callEscape is not { } scope)
+							continue;
+
+						if (scope < SafeContext.CallingMethod)
+							requiresScopedWithoutInitializer = true;
+						if (scope < initializerValEscape.Value)
+						{
+							requiresScoped = true;
+						}
+					}
+				}
+
+				if (!requiresScoped)
+				{
+					return new LocalScopes(
+						initializerRefEscape,
+						initializerValEscape,
+						isScoped: false,
+						isScopedWithoutInitializer: requiresScopedWithoutInitializer);
+				}
+
+				return isRefLocal
+					? new LocalScopes(
+						SafeContext.CurrentMethod,
+						SafeContext.CallingMethod,
+						isScoped: true,
+						isScopedWithoutInitializer: true)
+					: new LocalScopes(
+						SafeContext.CurrentMethod,
+						SafeContext.CurrentMethod,
+						isScoped: true,
+						isScopedWithoutInitializer: true);
+			}
+
+			/// <summary>
+			/// Gets the declaration-initializer candidate: the first assignment in the final
+			/// ILAst traversal order.
+			/// </summary>
+			static StLoc GetFirstStore(IReadOnlyList<StLoc> stores)
+			{
+				StLoc first = stores[0];
+				for (int i = 1; i < stores.Count; i++)
+				{
+					if (stores[i].IsBefore(first))
+						first = stores[i];
+				}
+
+				return first;
+			}
+
+			static bool IsRefStructExtensionReceiver(CallInstruction call)
+			{
+				if (!call.Method.IsExtensionMethod || call.Arguments.Count == 0)
+					return false;
+
+				IParameter? receiver = call.GetParameter(0);
+				return receiver is { ReferenceKind: ReferenceKind.Ref }
+					&& GetValueType(receiver.Type).IsRefLikeOrAllowsRefLikeType();
+			}
+
+			static bool TryGetStorageRoot(ILInstruction target, out ILVariable variable)
+			{
+				while (target is LdFlda fieldAddress)
+				{
+					target = fieldAddress.Target;
+				}
+
+				if (target is LdLoca ldloca)
+				{
+					variable = ldloca.Variable;
+					return true;
+				}
+
+				variable = null!;
+				return false;
+			}
+
+			SafeContext? GetRefEscape(ILInstruction value)
+			{
+				switch (value)
+				{
+					case LdLoc ldloc:
+						return GetVariableScopes(ldloc.Variable).RefEscape;
+					case LdLoca:
+					case LocAlloc:
+					case LocAllocSpan:
+						return SafeContext.CurrentMethod;
+					case LdsFlda:
+					case LdElema:
+						return SafeContext.CallingMethod;
+					case LdElemaInlineArray inlineArray:
+						return GetRefEscape(inlineArray.Array);
+					case LdFlda fieldAddress:
+						return GetFieldRefEscape(fieldAddress);
+					case LdObjIfRef load:
+						return GetRefEscape(load.Target);
+					case CallInstruction call:
+						return GetInvocationEscape(call, isRefEscape: true);
+					case IfInstruction conditional:
+						return Intersect(GetRefEscape(conditional.TrueInst), GetRefEscape(conditional.FalseInst));
+					case NullCoalescingInstruction coalescing:
+						return Intersect(GetRefEscape(coalescing.ValueInst), GetRefEscape(coalescing.FallbackInst));
+					case Block block:
+						return block.Kind == BlockKind.StackAllocInitializer
+							? SafeContext.CurrentMethod
+							: GetRefEscape(block.FinalInstruction);
+					default:
+						return null;
+				}
+			}
+
+			SafeContext? GetValEscape(ILInstruction value)
+			{
+				switch (value)
+				{
+					case DefaultValue:
+					case LdNull:
+					case NewArr:
+						return SafeContext.CallingMethod;
+					case LocAlloc:
+					case LocAllocSpan:
+						return SafeContext.CurrentMethod;
+					case LdLoc ldloc:
+						return GetVariableScopes(ldloc.Variable).ValEscape;
+					case LdLoca ldloca:
+						return GetVariableScopes(ldloca.Variable).ValEscape;
+					case LdsFlda:
+					case LdElema:
+						return SafeContext.CallingMethod;
+					case LdElemaInlineArray inlineArray:
+						return GetValEscape(inlineArray.Array);
+					case LdFlda fieldAddress:
+						return GetFieldValEscape(fieldAddress);
+					case LdObj load:
+						return GetValEscape(load.Target);
+					case LdObjIfRef load:
+						return GetValEscape(load.Target);
+					case CallInstruction call:
+						return GetInvocationEscape(call, isRefEscape: false);
+					case IfInstruction conditional:
+						return Intersect(GetValEscape(conditional.TrueInst), GetValEscape(conditional.FalseInst));
+					case NullCoalescingInstruction coalescing:
+						return Intersect(GetValEscape(coalescing.ValueInst), GetValEscape(coalescing.FallbackInst));
+					case Block block:
+						return block.Kind == BlockKind.StackAllocInitializer
+							? SafeContext.CurrentMethod
+							: GetValEscape(block.FinalInstruction);
+					default:
+						return null;
+				}
+			}
+
+			SafeContext? GetFieldRefEscape(LdFlda fieldAddress)
+			{
+				if (fieldAddress.Field.IsStatic || fieldAddress.Field.DeclaringType.IsReferenceType == true)
+					return SafeContext.CallingMethod;
+
+				if (fieldAddress.Field.ReturnType.Kind == TypeKind.ByReference)
+					return GetValEscape(fieldAddress.Target);
+
+				return GetRefEscape(fieldAddress.Target);
+			}
+
+			SafeContext? GetFieldValEscape(LdFlda fieldAddress)
+			{
+				if (fieldAddress.Field.IsStatic
+					|| !fieldAddress.Field.DeclaringType.IsRefLikeOrAllowsRefLikeType())
+				{
+					return SafeContext.CallingMethod;
+				}
+
+				return GetValEscape(fieldAddress.Target);
+			}
+
+			SafeContext? GetInvocationEscape(CallInstruction call, bool isRefEscape)
+			{
+				IType returnType = call is NewObj ? call.Method.DeclaringType : call.Method.ReturnType;
+				bool hasRefLikeReturn = GetValueType(returnType).IsRefLikeOrAllowsRefLikeType();
+				if (!isRefEscape && !hasRefLikeReturn)
+					return SafeContext.CallingMethod;
+
+				if (returnType.Kind == TypeKind.Unknown)
+					return null;
+
+				if (call.Method.ParentModule is not MetadataModule module)
+					return null;
+
+				return module.UseUpdatedEscapeRules
+					? GetInvocationEscapeWithUpdatedRules(call, isRefEscape, returnType)
+					: GetInvocationEscapeWithOldRules(call, isRefEscape);
+			}
+
+			SafeContext? GetInvocationEscapeWithUpdatedRules(
+				CallInstruction call, bool isRefEscape, IType returnType)
+			{
+				SafeContext? result = SafeContext.CallingMethod;
+				bool returnsRefToRefStruct = returnType is ByReferenceType { ElementType: var elementType }
+					&& elementType.IsRefLikeOrAllowsRefLikeType();
+
+				for (int i = 0; i < call.Arguments.Count; i++)
+				{
+					if (i == 0 && call.IsInstanceCall)
+					{
+						IType receiverType = call.Method.DeclaringType;
+						if (receiverType.IsRefLikeOrAllowsRefLikeType())
+						{
+							result = AddInvocationEscape(
+								result, GetValEscape(call.Arguments[i]), false,
+								isRefEscape, returnsRefToRefStruct, isRefToRefStruct: true);
+						}
+
+						if (receiverType.IsReferenceType == false
+							&& call.Method.GetThisParameterScope() != ScopedKind.ScopedRef)
+						{
+							result = AddInvocationEscape(
+								result, GetRefEscape(call.Arguments[i]), true,
+								isRefEscape, returnsRefToRefStruct,
+								isRefToRefStruct: receiverType.IsRefLikeOrAllowsRefLikeType());
+						}
+						continue;
+					}
+
+					IParameter? parameter = call.GetParameter(i);
+					if (parameter == null)
+						return null;
+
+					IType parameterType = GetValueType(parameter.Type);
+					bool isRefToRefStruct = parameter.ReferenceKind != ReferenceKind.None
+						&& parameterType.IsRefLikeOrAllowsRefLikeType();
+					if (parameterType.IsRefLikeOrAllowsRefLikeType()
+						&& parameter.ReferenceKind != ReferenceKind.Out
+						&& GetParameterValEscape(parameter) != SafeContext.CurrentMethod)
+					{
+						result = AddInvocationEscape(
+							result, GetValEscape(call.Arguments[i]), false,
+							isRefEscape, returnsRefToRefStruct, isRefToRefStruct);
+					}
+
+					if (parameter.ReferenceKind != ReferenceKind.None
+						&& GetParameterRefEscape(parameter) != SafeContext.CurrentMethod)
+					{
+						result = AddInvocationEscape(
+							result, GetRefEscape(call.Arguments[i]), true,
+							isRefEscape, returnsRefToRefStruct, isRefToRefStruct);
+					}
+				}
+
+				return result;
+			}
+
+			SafeContext? GetInvocationEscapeWithOldRules(CallInstruction call, bool isRefEscape)
+			{
+				SafeContext? result = SafeContext.CallingMethod;
+				for (int i = 0; i < call.Arguments.Count; i++)
+				{
+					if (i == 0 && call.IsInstanceCall)
+					{
+						if (call.Method.DeclaringType.IsRefLikeOrAllowsRefLikeType())
+							result = Intersect(result, GetValEscape(call.Arguments[i]));
+						continue;
+					}
+
+					IParameter? parameter = call.GetParameter(i);
+					if (parameter == null)
+						return null;
+
+					if (!isRefEscape && GetValueType(parameter.Type).IsRefLikeOrAllowsRefLikeType())
+						result = Intersect(result, GetValEscape(call.Arguments[i]));
+
+					if (isRefEscape && parameter.ReferenceKind != ReferenceKind.None)
+						result = Intersect(result, GetRefEscape(call.Arguments[i]));
+				}
+
+				return result;
+			}
+
+			SafeContext? GetInvocationEscapeToReceiver(CallInstruction call)
+			{
+				if (call.Method.ParentModule is not MetadataModule { UseUpdatedEscapeRules: true })
+					return null;
+
+				SafeContext? result = SafeContext.CallingMethod;
+				for (int i = 1; i < call.Arguments.Count; i++)
+				{
+					IParameter? parameter = call.GetParameter(i);
+					if (parameter == null)
+						return null;
+
+					IType parameterType = GetValueType(parameter.Type);
+					if (parameterType.IsRefLikeOrAllowsRefLikeType()
+						&& parameter.ReferenceKind != ReferenceKind.Out
+						&& GetParameterValEscape(parameter) == SafeContext.CallingMethod)
+					{
+						result = Intersect(result, GetValEscape(call.Arguments[i]));
+					}
+
+					if (parameter.ReferenceKind != ReferenceKind.None
+						&& GetParameterRefEscape(parameter) == SafeContext.CallingMethod)
+					{
+						result = Intersect(result, GetRefEscape(call.Arguments[i]));
+					}
+				}
+
+				return result;
+			}
+
+			static SafeContext? AddInvocationEscape(
+				SafeContext? current,
+				SafeContext? argument,
+				bool argumentIsRefEscape,
+				bool invocationIsRefEscape,
+				bool returnsRefToRefStruct,
+				bool isRefToRefStruct)
+			{
+				if (returnsRefToRefStruct
+					&& (!isRefToRefStruct || argumentIsRefEscape != invocationIsRefEscape))
+				{
+					return current;
+				}
+
+				return Intersect(current, argument);
+			}
+
+			LocalScopes GetVariableScopes(ILVariable variable)
+			{
+				if (_scopes.TryGetValue(variable, out var scopes))
+					return scopes;
+
+				if (variable.Kind != VariableKind.Parameter)
+					return default;
+
+				if (variable.Index is not int index)
+					return default;
+
+				if (index < 0)
+					return GetThisParameterScopes();
+
+				if (index >= method.Parameters.Count)
+					return default;
+
+				IParameter parameter = method.Parameters[index];
+				return new LocalScopes(
+					GetParameterRefEscape(parameter),
+					GetParameterValEscape(parameter),
+					isScoped: false,
+					isScopedWithoutInitializer: false);
+			}
+
+			LocalScopes GetThisParameterScopes()
+			{
+				if (method.DeclaringTypeDefinition?.Kind != TypeKind.Struct)
+				{
+					return new LocalScopes(
+						SafeContext.CallingMethod,
+						SafeContext.CallingMethod,
+						isScoped: false,
+						isScopedWithoutInitializer: false);
+				}
+
+				SafeContext refEscape = method.GetThisParameterScope() == ScopedKind.ScopedRef
+					? SafeContext.CurrentMethod
+					: SafeContext.ReturnOnly;
+				SafeContext valEscape = method.IsConstructor
+					? SafeContext.ReturnOnly
+					: SafeContext.CallingMethod;
+				return new LocalScopes(
+					refEscape,
+					valEscape,
+					isScoped: false,
+					isScopedWithoutInitializer: false);
+			}
+
+			static SafeContext GetParameterRefEscape(IParameter parameter)
+			{
+				if (parameter.ReferenceKind == ReferenceKind.None)
+					return SafeContext.CurrentMethod;
+				if (parameter.GetEffectiveScope() == ScopedKind.ScopedRef)
+					return SafeContext.CurrentMethod;
+
+				bool useUpdatedEscapeRules = parameter.Owner?.ParentModule is MetadataModule {
+					UseUpdatedEscapeRules: true
+				};
+				if (parameter.Lifetime.HasUnscopedRefAttribute
+					&& useUpdatedEscapeRules
+					&& parameter.ReferenceKind == ReferenceKind.Out)
+				{
+					return SafeContext.ReturnOnly;
+				}
+				if (parameter.Lifetime.HasUnscopedRefAttribute && useUpdatedEscapeRules)
+					return SafeContext.CallingMethod;
+
+				return SafeContext.ReturnOnly;
+			}
+
+			static SafeContext GetParameterValEscape(IParameter parameter)
+			{
+				if (parameter.GetEffectiveScope() == ScopedKind.ScopedValue)
+					return SafeContext.CurrentMethod;
+				if (parameter.ReferenceKind == ReferenceKind.Out
+					&& parameter.Owner?.ParentModule is MetadataModule { UseUpdatedEscapeRules: true })
+				{
+					return SafeContext.ReturnOnly;
+				}
+
+				return SafeContext.CallingMethod;
+			}
+
+			static IType GetVariableValueType(ILVariable variable)
+			{
+				return GetValueType(variable.Type);
+			}
+
+			static IType GetValueType(IType type)
+			{
+				return type is ByReferenceType byReference ? byReference.ElementType : type;
+			}
+
+			static SafeContext? Intersect(SafeContext? left, SafeContext? right)
+			{
+				if (left == null || right == null)
+					return null;
+				return left < right ? left : right;
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/IntroduceScopedModifierOnLocals.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/IntroduceScopedModifierOnLocals.cs
@@ -19,6 +19,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using ICSharpCode.Decompiler.IL.Transforms;
@@ -34,8 +35,8 @@ namespace ICSharpCode.Decompiler.IL
 	/// The modifier is erased from IL and PDBs, so recovery compares the ref-safe-context
 	/// (for ref locals) or safe-context (for ref-struct locals) of the declaration initializer
 	/// with each later store. The three contexts are ordered from narrowest to widest:
-	/// current method, return-only, calling method. A narrower later store proves that the
-	/// original declaration required <c>scoped</c>.
+	/// function-member (current method), return-only, caller-context (calling method).
+	/// A narrower later store proves that the original declaration required <c>scoped</c>.
 	/// </remarks>
 	class IntroduceScopedModifierOnLocals : IILTransform
 	{
@@ -59,9 +60,9 @@ namespace ICSharpCode.Decompiler.IL
 
 		enum SafeContext : byte
 		{
-			CurrentMethod,
-			ReturnOnly,
-			CallingMethod,
+			CurrentMethod, // function-member
+			ReturnOnly, // return-only
+			CallingMethod, // caller-context
 		}
 
 		readonly struct LocalScopes(
@@ -80,7 +81,7 @@ namespace ICSharpCode.Decompiler.IL
 		{
 			readonly Dictionary<ILVariable, StLoc[]> _stores = [];
 			readonly Dictionary<ILVariable, List<StObj>> _fieldStores = [];
-			readonly Dictionary<ILVariable, List<CallInstruction>> _receiverCalls = [];
+			readonly Dictionary<ILVariable, List<(CallInstruction Call, int ArgumentIndex)>> _callCaptures = [];
 			Dictionary<ILVariable, LocalScopes> _scopes = [];
 
 			public void Run()
@@ -97,8 +98,9 @@ namespace ICSharpCode.Decompiler.IL
 					}
 
 					var stores = variable.StoreInstructions.OfType<StLoc>().ToArray();
-					if (stores.Length == 0 || stores.Any(store => store.Parent == null))
+					if (stores.Length == 0)
 						continue;
+					Debug.Assert(stores.All(store => store.Parent != null));
 
 					_stores.Add(variable, stores);
 					_scopes.Add(variable, default);
@@ -106,39 +108,40 @@ namespace ICSharpCode.Decompiler.IL
 
 				foreach (var store in function.Descendants.OfType<StObj>())
 				{
-					if (!TryGetStorageRoot(store.Target, out var variable)
-						|| !_stores.ContainsKey(variable))
+					foreach (var variable in GetStorageRoots(store.Target).Distinct())
 					{
-						continue;
-					}
+						if (!_stores.ContainsKey(variable))
+							continue;
 
-					if (!_fieldStores.TryGetValue(variable, out var stores))
-					{
-						stores = [];
-						_fieldStores.Add(variable, stores);
+						if (!_fieldStores.TryGetValue(variable, out var stores))
+						{
+							stores = [];
+							_fieldStores.Add(variable, stores);
+						}
+						stores.Add(store);
 					}
-					stores.Add(store);
 				}
 
 				foreach (var call in function.Descendants.OfType<CallInstruction>())
 				{
-					bool isRefStructReceiver = call.IsInstanceCall
-						&& call.Method.DeclaringType.IsRefLikeOrAllowsRefLikeType()
-						&& !call.Method.ThisIsRefReadOnly;
-					if (!(isRefStructReceiver || IsRefStructExtensionReceiver(call))
-						|| call.Arguments.Count == 0
-						|| !TryGetStorageRoot(call.Arguments[0], out var variable)
-						|| !_stores.ContainsKey(variable))
+					for (int argumentIndex = 0; argumentIndex < call.Arguments.Count; argumentIndex++)
 					{
-						continue;
-					}
+						if (!IsWritableRefStructArgument(call, argumentIndex))
+							continue;
 
-					if (!_receiverCalls.TryGetValue(variable, out var calls))
-					{
-						calls = [];
-						_receiverCalls.Add(variable, calls);
+						foreach (var variable in GetStorageRoots(call.Arguments[argumentIndex]).Distinct())
+						{
+							if (!_stores.ContainsKey(variable))
+								continue;
+
+							if (!_callCaptures.TryGetValue(variable, out var captures))
+							{
+								captures = [];
+								_callCaptures.Add(variable, captures);
+							}
+							captures.Add((call, argumentIndex));
+						}
 					}
-					calls.Add(call);
 				}
 
 				for (int iteration = 0; iteration <= _stores.Count * 3; iteration++)
@@ -234,14 +237,14 @@ namespace ICSharpCode.Decompiler.IL
 					}
 				}
 
-				if (!requiresScoped && _receiverCalls.TryGetValue(variable, out var receiverCalls))
+				if (!requiresScoped && _callCaptures.TryGetValue(variable, out var callCaptures))
 				{
-					foreach (var call in receiverCalls)
+					foreach (var (call, argumentIndex) in callCaptures)
 					{
 						if (!initializer.IsBefore(call))
 							continue;
 
-						SafeContext? callEscape = GetInvocationEscapeToReceiver(call);
+						SafeContext? callEscape = GetInvocationEscapeToWritableArgument(call, argumentIndex);
 						if (callEscape is not { } scope)
 							continue;
 
@@ -292,31 +295,70 @@ namespace ICSharpCode.Decompiler.IL
 				return first;
 			}
 
-			static bool IsRefStructExtensionReceiver(CallInstruction call)
+			static bool IsWritableRefStructArgument(CallInstruction call, int argumentIndex)
 			{
-				if (!call.Method.IsExtensionMethod || call.Arguments.Count == 0)
-					return false;
+				if (argumentIndex == 0 && call.IsInstanceCall)
+				{
+					return call.Method.DeclaringType.IsRefLikeOrAllowsRefLikeType()
+						&& !call.Method.ThisIsRefReadOnly;
+				}
 
-				IParameter? receiver = call.GetParameter(0);
-				return receiver is { ReferenceKind: ReferenceKind.Ref }
-					&& GetValueType(receiver.Type).IsRefLikeOrAllowsRefLikeType();
+				IParameter? parameter = call.GetParameter(argumentIndex);
+				return parameter is { ReferenceKind: ReferenceKind.Ref or ReferenceKind.Out }
+					&& GetValueType(parameter.Type).IsRefLikeOrAllowsRefLikeType();
 			}
 
-			static bool TryGetStorageRoot(ILInstruction target, out ILVariable variable)
+			/// <summary>
+			/// Gets the locals whose storage may be reached through an address expression.
+			/// A ref-return call may alias any eligible ref argument, so every such argument is followed.
+			/// </summary>
+			IEnumerable<ILVariable> GetStorageRoots(ILInstruction target)
 			{
-				while (target is LdFlda fieldAddress)
+				switch (target)
 				{
-					target = fieldAddress.Target;
+					case LdFlda fieldAddress:
+						return GetStorageRoots(fieldAddress.Target);
+					case LdElemaInlineArray inlineArray:
+						return GetStorageRoots(inlineArray.Array);
+					case LdLoca ldloca:
+						return [ldloca.Variable];
+					case CallInstruction call:
+						return GetRefReturnStorageArguments(call)
+							.SelectMany(argumentIndex => GetStorageRoots(call.Arguments[argumentIndex]));
+					default:
+						return [];
+				}
+			}
+
+			IEnumerable<int> GetRefReturnStorageArguments(CallInstruction call)
+			{
+				if (call.Method.ReturnType is not ByReferenceType { ElementType: var elementType }
+					|| !elementType.IsRefLikeOrAllowsRefLikeType())
+				{
+					yield break;
 				}
 
-				if (target is LdLoca ldloca)
+				for (int argumentIndex = 0; argumentIndex < call.Arguments.Count; argumentIndex++)
 				{
-					variable = ldloca.Variable;
-					return true;
-				}
+					if (argumentIndex == 0 && call.IsInstanceCall)
+					{
+						if (call.Method.DeclaringType.IsRefLikeOrAllowsRefLikeType()
+							&& !call.Method.ThisIsRefReadOnly
+							&& call.Method.GetThisParameterScope() != ScopedKind.ScopedRef)
+						{
+							yield return argumentIndex;
+						}
+						continue;
+					}
 
-				variable = null!;
-				return false;
+					IParameter? parameter = call.GetParameter(argumentIndex);
+					if (parameter is { ReferenceKind: ReferenceKind.Ref or ReferenceKind.Out }
+						&& GetValueType(parameter.Type).IsRefLikeOrAllowsRefLikeType()
+						&& GetParameterRefEscape(parameter) != SafeContext.CurrentMethod)
+					{
+						yield return argumentIndex;
+					}
+				}
 			}
 
 			SafeContext? GetRefEscape(ILInstruction value)
@@ -518,14 +560,56 @@ namespace ICSharpCode.Decompiler.IL
 				return result;
 			}
 
-			SafeContext? GetInvocationEscapeToReceiver(CallInstruction call)
+			SafeContext? GetInvocationEscapeToWritableArgument(CallInstruction call, int writableArgumentIndex)
 			{
 				if (call.Method.ParentModule is not MetadataModule { UseUpdatedEscapeRules: true })
 					return null;
 
-				SafeContext? result = SafeContext.CallingMethod;
-				for (int i = 1; i < call.Arguments.Count; i++)
+				// The destination context determines which arguments the callee can legally capture into it.
+				SafeContext destinationValEscape;
+				if (writableArgumentIndex == 0 && call.IsInstanceCall)
 				{
+					destinationValEscape = call.Method.IsConstructor
+						? SafeContext.ReturnOnly
+						: SafeContext.CallingMethod;
+				}
+				else
+				{
+					IParameter? writableParameter = call.GetParameter(writableArgumentIndex);
+					if (writableParameter == null)
+						return null;
+					destinationValEscape = GetParameterValEscape(writableParameter);
+				}
+
+				SafeContext? result = SafeContext.CallingMethod;
+				for (int i = 0; i < call.Arguments.Count; i++)
+				{
+					if (i == writableArgumentIndex)
+						continue;
+
+					if (i == 0 && call.IsInstanceCall)
+					{
+						IType receiverType = call.Method.DeclaringType;
+						SafeContext receiverValEscape = call.Method.IsConstructor
+							? SafeContext.ReturnOnly
+							: SafeContext.CallingMethod;
+						if (receiverType.IsRefLikeOrAllowsRefLikeType()
+							&& receiverValEscape >= destinationValEscape)
+						{
+							result = Intersect(result, GetValEscape(call.Arguments[i]));
+						}
+
+						SafeContext receiverRefEscape = call.Method.GetThisParameterScope() == ScopedKind.ScopedRef
+							? SafeContext.CurrentMethod
+							: SafeContext.ReturnOnly;
+						if (receiverType.IsReferenceType == false
+							&& receiverRefEscape >= destinationValEscape)
+						{
+							result = Intersect(result, GetRefEscape(call.Arguments[i]));
+						}
+						continue;
+					}
+
 					IParameter? parameter = call.GetParameter(i);
 					if (parameter == null)
 						return null;
@@ -533,13 +617,13 @@ namespace ICSharpCode.Decompiler.IL
 					IType parameterType = GetValueType(parameter.Type);
 					if (parameterType.IsRefLikeOrAllowsRefLikeType()
 						&& parameter.ReferenceKind != ReferenceKind.Out
-						&& GetParameterValEscape(parameter) == SafeContext.CallingMethod)
+						&& GetParameterValEscape(parameter) >= destinationValEscape)
 					{
 						result = Intersect(result, GetValEscape(call.Arguments[i]));
 					}
 
 					if (parameter.ReferenceKind != ReferenceKind.None
-						&& GetParameterRefEscape(parameter) == SafeContext.CallingMethod)
+						&& GetParameterRefEscape(parameter) >= destinationValEscape)
 					{
 						result = Intersect(result, GetRefEscape(call.Arguments[i]));
 					}


### PR DESCRIPTION
Fixes #3853. Supersedes #3854. Depends on #3887.

tl;dr: `scoped` on a local is erased from IL and PDBs, so type-system support cannot recover
the modifier directly. This PR adds a late ILAst ref-safety analysis that emits `scoped` only
when a later assignment or mutation is strictly narrower than the declaration initializer.

### Problem

A local's `scoped` modifier has no metadata representation. Dropping it produces invalid C#
when a wide initializer is followed by a narrower operation:

- ref reassignment to method-local storage, CS8374
- a ref-struct result that captures a local/ref/out argument, CS8347/CS8352/CS9077
- `stackalloc`, CS8353
- propagation through nested calls or other ref-struct locals
- storing a narrow value into a ref-struct field
- passing a narrow value to a method that may capture it into a writable ref-struct receiver

A shape-only check is not sufficient. It can both miss required modifiers and add redundant
ones when the initializer is already narrow.

### Solution

Add `IntroduceScopedModifierOnLocals`, a late `IILTransform` that mirrors Roslyn's ref-safety
model:

- track separate ref-escape and value-escape contexts
- use the ordered contexts current method, return-only, and calling method
- infer each local's contexts from its declaration initializer
- iterate to a fixpoint for local-to-local propagation
- apply Roslyn's updated and legacy invocation argument filtering
- account for scoped and unscoped parameters, `out`, struct receivers, ref-to-ref-struct
  returns, fields, conditionals, null coalescing, and unknown signatures
- account for later `StLoc` assignments, field stores, and captures into writable instance or
  classic ref extension receivers
- handle bare declarations separately from declarations combined with an initializer
- treat unknown shapes conservatively, so they cannot cause a false `scoped`

The transform records the result on `ILVariable.IsScoped`. `DeclareVariables` only renders the
modifier, following the existing `IntroduceRefReadOnlyModifierOnLocals` pattern.

### Tests

The `Pretty/RefFields` Roslyn 4+ matrix covers:

- ref-local and ref-struct positive cases
- local, ref-parameter, out-parameter, receiver, stackalloc, nested-call, and local-copy
  propagation
- scoped-ref ref-struct value propagation
- field stores and captures into instance/ref-extension receivers
- class, readonly, in/ref-readonly, readonly-ref-struct, and plain-struct receivers that must
  not cause `scoped`
- narrow initializer followed by narrow or wider stores, which must not over-apply

Validation:

- Debug and Release solution builds: 0 warnings, 0 errors
- full Pretty suite: 1906 passed, 5 existing skips
- full solution test suite: 4887 passed, 15 existing skips

### Review focus

The main review area is the transfer logic in `IntroduceScopedModifierOnLocals`, especially
invocation escape and receiver-capture rules.

- [x] At least one test covering the code changed