### PR TITLE
Fix #3892: preserve unsafe for pointer constructors

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
@@ -24,6 +24,14 @@ using System.Runtime.InteropServices;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	[StructLayout(LayoutKind.Sequential, Size = 1)]
+	internal struct PointerConstructor
+	{
+		public unsafe PointerConstructor(void* pointer)
+		{
+		}
+	}
+
 	internal class SizeofTest
 	{
 		private struct StructWithStaticField
@@ -682,5 +690,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				*ptr = null;
 			}
 		}
+	}
+
+	internal static class UnsafeObjectCreation
+	{
+		private unsafe static readonly PointerConstructor pointerConstructor = new PointerConstructor(null);
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceUnsafeModifier.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceUnsafeModifier.cs
@@ -192,6 +192,14 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			return result;
 		}
 
+		public override bool VisitObjectCreateExpression(ObjectCreateExpression objectCreateExpression)
+		{
+			bool result = base.VisitObjectCreateExpression(objectCreateExpression);
+			if (HasUnsafeResolveResult(objectCreateExpression))
+				return true;
+			return result;
+		}
+
 		public override bool VisitFixedVariableInitializer(FixedVariableInitializer fixedVariableInitializer)
 		{
 			base.VisitFixedVariableInitializer(fixedVariableInitializer);


### PR DESCRIPTION
Fixes #3892.

### Problem

`IntroduceUnsafeModifier` detects pointer parameters on ordinary invocation expressions, but not
on object creation expressions.

If the constructor argument itself contains no pointer syntax, such as `new NativeBuffer(null)`,
the required unsafe context is therefore lost. A field that originally had an `unsafe` modifier
is emitted without one, and the output fails to recompile with CS0214.

### Solution

Apply the existing `HasUnsafeResolveResult` check to `ObjectCreateExpression`, matching the
handling already used for `InvocationExpression`.

This uses the selected constructor's resolved parameter types, so it remains general and does
not depend on a particular struct or argument shape.

### Tests

Added a Pretty regression case where a static field constructs a value through a `void*`
constructor while passing `null`.

Validation:

- `UnsafeCode` Pretty matrix: 20 passed
- Release solution build: 0 warnings, 0 errors
- Full solution test suite: 4,885 passed, 15 existing skips

- [x] At least one test covering the code changed
