### PR TITLE
Fix #3895: keep byref-like ToString in string concatenation

### DIFF
--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -339,6 +339,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task StringConcatenation([ValueSource(nameof(roslyn3OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task Async([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StringConcatenation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StringConcatenation.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Sebastien Lebreton
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public static class StringConcatenation
+	{
+		public static string WithSpan(Span<char> value)
+		{
+			return "prefix" + value.ToString();
+		}
+
+		public static string WithReadOnlySpan(ReadOnlySpan<char> value)
+		{
+			return "prefix" + value.ToString();
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/Transforms/ReplaceMethodCallsWithOperators.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/ReplaceMethodCallsWithOperators.cs
@@ -366,6 +366,11 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			var toStringMethod = m.Get<Expression>("call").Single().GetSymbol() as IMethod;
 			var target = m.Get<Expression>("target").Single();
 			var type = target.GetResolveResult().Type;
+			if (type.IsByRefLike)
+			{
+				// ref structs cannot be converted to object for use with +
+				return expr;
+			}
 			if (!(isLastArgument || ToStringIsKnownEffectFree(type)))
 			{
 				// ToString() order of evaluation matters, see CheckArgumentsForStringConcat().


### PR DESCRIPTION
Fixes #3895.

### Problem

String-concatenation reconstruction removes explicit `ToString()` calls when the C# compiler
would normally reproduce an equivalent call through the built-in `+` operator.

That assumption does not hold for byref-like values. `Span<T>` and `ReadOnlySpan<T>` cannot be
converted to `object`, so removing the call from `"prefix" + span.ToString()` produces
`"prefix" + span`, which fails with CS0019.

### Solution

Keep the explicit `ToString()` call when its target is byref-like.

The surrounding `string.Concat` reconstruction still proceeds, so the result remains the
natural and compilable `"prefix" + span.ToString()` form.

### Tests

Added a Roslyn 3+ Pretty fixture covering both `Span<char>` and `ReadOnlySpan<char>`.

Validation:

- `StringConcatenation` Pretty matrix: 6 passed
- Release solution build: 0 warnings, 0 errors
- Full solution test suite: 4,891 passed, 15 existing skips

- [x] At least one test covering the code changed
