### PR TITLE
Fix #3894: keep lambda parameter typing consistent

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AnonymousTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AnonymousTypes.cs
@@ -174,5 +174,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return null;
 		}
+#if ROSLYN
+		private static TValue GetOrCreate<TKey, TValue>(TKey key, Func<TKey, int, TValue> factory)
+		{
+			return factory(key, 1);
+		}
+
+		private static int MixedLambdaParameters()
+		{
+			return GetOrCreate(new {
+				Value = 1
+			}, (item, context) => item.Value + context);
+		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2775,6 +2775,8 @@ namespace ICSharpCode.Decompiler.CSharp
 		IEnumerable<ParameterDeclaration> MakeParameters(IReadOnlyList<IParameter> parameters, ILFunction function)
 		{
 			var variables = function.Variables.Where(v => v.Kind == VariableKind.Parameter).ToDictionary(v => v.Index!.Value);
+			var result = new List<ParameterDeclaration>(parameters.Count);
+			bool anyAnonymousType = false;
 			int i = 0;
 			foreach (var parameter in parameters)
 			{
@@ -2790,10 +2792,21 @@ namespace ICSharpCode.Decompiler.CSharp
 					pd.Name = "P_" + i;
 				}
 				if (settings.AnonymousTypes && parameter.Type.ContainsAnonymousType())
-					pd.Type = null;
-				yield return pd;
+					anyAnonymousType = true;
+				result.Add(pd);
 				i++;
 			}
+			// An anonymous type cannot be named, so a lambda with such a parameter must be implicitly typed.
+			// C# also requires all lambda parameters to use the same form (CS0748). Drop every type when the
+			// remaining parameter syntax permits it; otherwise keep the converted declarations as a
+			// best-effort fallback for an unrepresentable signature.
+			if (anyAnonymousType && result.All(p => p.ParameterModifier == ReferenceKind.None
+				&& !p.IsParams && !p.IsScopedRef && p.Attributes.Count == 0 && p.DefaultExpression is null))
+			{
+				foreach (var pd in result)
+					pd.Type = null;
+			}
+			return result;
 		}
 
 		protected internal override TranslatedExpression VisitBlockContainer(BlockContainer container, TranslationContext context)

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2791,17 +2791,19 @@ namespace ICSharpCode.Decompiler.CSharp
 					// needs to be consistent with logic in ILReader.CreateILVariable
 					pd.Name = "P_" + i;
 				}
+
 				if (settings.AnonymousTypes && parameter.Type.ContainsAnonymousType())
 					anyAnonymousType = true;
+
 				result.Add(pd);
 				i++;
 			}
+
 			// An anonymous type cannot be named, so a lambda with such a parameter must be implicitly typed.
 			// C# also requires all lambda parameters to use the same form (CS0748). Drop every type when the
 			// remaining parameter syntax permits it; otherwise keep the converted declarations as a
 			// best-effort fallback for an unrepresentable signature.
-			if (anyAnonymousType && result.All(p => p.ParameterModifier == ReferenceKind.None
-				&& !p.IsParams && !p.IsScopedRef && p.Attributes.Count == 0 && p.DefaultExpression is null))
+			if (anyAnonymousType && result.All(p => p is { ParameterModifier: ReferenceKind.None, IsParams: false, IsScopedRef: false, Attributes.Count: 0, DefaultExpression: null }))
 			{
 				foreach (var pd in result)
 					pd.Type = null;


### PR DESCRIPTION
Fixes #3894.

### Problem

When a lambda parameter has an anonymous type, ILSpy omits that unnameable type but leaves
sibling parameter types explicit. The resulting mixed form, such as
`(item, int context) => ...`, is rejected with CS0748.

Any source lambda with an anonymous-typed parameter must have used implicit typing for its
whole parameter list, because the anonymous type cannot be written explicitly.

### Solution

Build the parameter list first, detect whether any parameter contains an anonymous type, and
then remove every parameter type when the remaining parameter syntax permits implicit typing.

This keeps the emitted syntax and `DecompiledLambdaResolveResult.IsImplicitlyTyped` consistent,
while leaving unrepresentable modifier/attribute combinations as a conservative fallback.

### Tests

Added a Roslyn Pretty regression using a generic delegate whose first parameter becomes an
anonymous type and whose second parameter is `int`.

Validation:

- Release solution build: 0 warnings, 0 errors
- Full solution test suite

- [x] At least one test covering the code changed
