### PR TITLE
Don't undo the compiler's &&-to-& optimization

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ShortCircuit.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ShortCircuit.cs
@@ -326,13 +326,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 #endif
 
-		public void PreferLogicalToBitwise(bool a, bool b, int i, float f)
+		public void BitwiseBooleanOperators(bool a, bool b, int i, float f)
 		{
-			B(a && b);
+			B(a & b);
+			B(a & (i == 1));
+			B((i == 1) & a);
+			B((i > i - 3) & a);
+			B((f < 0.1f) & a);
+			B(a | b);
 			B(a && i == 1);
-			B(i == 1 && a);
-			B(i > i - 3 && a);
-			B(f < 0.1f && a);
+			B(a || i == 1);
+		}
+
+		public bool BitwiseOrWithComparisons(char c)
+		{
+			return (c == 'a') | (c == 'b');
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Switch.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Switch.cs
@@ -1282,7 +1282,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if ROSLYN || OPT
 		public static void SingleIf1(int i, bool a)
 		{
-			if (i == 1 || (i == 2 && a))
+			if (i == 1 || ((i == 2) & a))
 			{
 				Console.WriteLine(1);
 			}
@@ -1292,7 +1292,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void SingleIf2(int i, bool a, bool b)
 		{
-			if (i == 1 || (i == 2 && a) || (i == 3 && b))
+			if (i == 1 || ((i == 2) & a) || ((i == 3) & b))
 			{
 				Console.WriteLine(1);
 			}
@@ -1301,7 +1301,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void SingleIf3(int i, bool a, bool b)
 		{
-			if (a || i == 1 || (i == 2 && b))
+			if (a || i == 1 || ((i == 2) & b))
 			{
 				Console.WriteLine(1);
 			}
@@ -1310,7 +1310,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void SingleIf4(int i, bool a)
 		{
-			if (i == 1 || i == 2 || (i != 3 && a) || i != 4)
+			if (i == 1 || i == 2 || ((i != 3) & a) || i != 4)
 			{
 				Console.WriteLine(1);
 			}

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -1650,22 +1650,6 @@ namespace ICSharpCode.Decompiler.CSharp
 						right.ResolveResult));
 				}
 			}
-			if (op.IsBitwise()
-				&& left.Type.IsKnownType(KnownTypeCode.Boolean)
-				&& right.Type.IsKnownType(KnownTypeCode.Boolean)
-				&& SemanticHelper.IsPure(inst.Right.Flags))
-			{
-				// Undo the C# compiler's optimization of "a && b" to "a & b".
-				if (op == BinaryOperatorType.BitwiseAnd)
-				{
-					op = BinaryOperatorType.ConditionalAnd;
-				}
-				else if (op == BinaryOperatorType.BitwiseOr)
-				{
-					op = BinaryOperatorType.ConditionalOr;
-				}
-			}
-
 			if (op.IsBitwise() && (left.Type.Kind == TypeKind.Enum || right.Type.Kind == TypeKind.Enum))
 			{
 				left = AdjustConstantExpressionToType(left, right.Type);


### PR DESCRIPTION
Closes #1924; implements option (c) from the discussion in #1545 (remove the de-optimization, stay close to the IL).

`ExpressionBuilder.HandleBinaryNumeric` printed bitwise `&`/`|` on booleans as `&&`/`||` whenever the right-hand side was side-effect-free. Roslyn's forward optimization is much narrower: `LocalRewriter.MakeBinaryOperator` lowers `&&`/`||` to `&`/`|` only when the lowered right operand is `BoundKind.Local` or `BoundKind.Parameter` (unchanged since 2014, applies in Debug and Release alike, expression-tree lambdas exempt). So for shapes like `(c == 'a') | (c == 'b')` the IL can only originate from a bitwise source operator, yet ILSpy showed it as short-circuiting -- the #1924 report.

Per the maintainer position in both threads, the reversal is removed entirely rather than narrowed: the decompiled code now shows the operator the IL actually uses.

Consequences:
- `(c == 'a') | (c == 'b')` (the #1924 repro) round-trips as `|`.
- Genuine short-circuit IL still decompiles to `&&`/`||` (e.g. `a && i == 1`, which Roslyn never optimizes to `and`).
- Roslyn-compiled `a && b` (bare local/parameter RHS) now decompiles to `a & b` -- the deliberate trade-off of option (c); both forms compile back to identical IL.

Test changes: `ShortCircuit.PreferLogicalToBitwise` is reworked into `BitwiseBooleanOperators` plus a `BitwiseOrWithComparisons` method with the #1924 repro (shown failing before the code change); four `&& local` conditions in `Switch.cs` "Overagressive Switch Use" flip to the `&` form (for Roslyn the IL is identical either way). Bitwise `&`/`|` on bools compiles to `and`/`or` under every supported compiler, so the fixture expectations stay uniform across the matrix without `#if` splits. Full XPlat suite green on Linux (2404 tests, 32 pre-existing skips); the legacy csc/mcs configs only run on Windows CI.

This PR was authored by an AI agent (Claude Code) operated by @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)