### PR TITLE
Beautify enum declarations by referencing previously declared members

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/EnumTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/EnumTests.cs
@@ -51,7 +51,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Item0 = 0,
 			Item1 = 1,
 			Item2A = 2,
-			Item2B = 2
+			Item2B = Item2A
 		}
 
 		public enum LongBasedEnum : long
@@ -88,7 +88,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Item1 = 1,
 			Item2 = 2,
 			Item3 = 4,
-			All = 7
+			All = Item1 | Item2 | Item3
+		}
+
+		[Flags]
+		public enum SelfReferentialEnum
+		{
+			None = 0,
+			Item1 = 1,
+			Item2 = Item1,
+			Item3 = 3
 		}
 
 		[Flags]
@@ -100,6 +109,78 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public enum NegativeValueWithoutFlags
 		{
 			Value = -2147483647
+		}
+
+		public enum NonFlagsDuplicateItems
+		{
+			OK = 200,
+			Default = OK,
+			NoContent = 204
+		}
+
+		public enum ZeroDuplicateItems
+		{
+			Unknown = 0,
+			Default = Unknown
+		}
+
+		[Flags]
+		public enum ZeroDuplicateFlags
+		{
+			None = 0,
+			Default = 0,
+			Item1 = 1
+		}
+
+		[Flags]
+		public enum MaskFamilyFlags
+		{
+			VisibilityMask = 7,
+			NotPublic = 0,
+			Public = 1,
+			NestedPublic = 2,
+			NestedPrivate = 3,
+			LayoutMask = 0x18,
+			AutoLayout = 0,
+			SequentialLayout = 8,
+			ExplicitLayout = 0x10
+		}
+
+		[Flags]
+		public enum UnsignedFlags : uint
+		{
+			None = 0u,
+			Item1 = 1u,
+			Item2 = 2u,
+			Item3 = 4u,
+			All = uint.MaxValue,
+			NotItem1 = ~Item1
+		}
+
+		[Flags]
+		public enum ByteFlags : byte
+		{
+			None = 0,
+			Item1 = 1,
+			Item2 = 2,
+			NotItem2 = 0xFD
+		}
+
+		[Flags]
+		public enum ShortFlags : short
+		{
+			None = 0,
+			Item1 = 1,
+			NotItem1 = ~Item1
+		}
+
+		[Flags]
+		public enum FlagsWithNegation
+		{
+			None = 0,
+			Item1 = 1,
+			Item2 = 2,
+			NotItem1 = ~Item1
 		}
 
 		public AttributeTargets SingleEnumValue()
@@ -140,6 +221,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public object PreservingTypeWhenBoxedTwoEnum()
 		{
 			return AttributeTargets.Class | AttributeTargets.Delegate;
+		}
+
+		public SimpleFlagsEnum SignedEnumComplement()
+		{
+			return ~SimpleFlagsEnum.Item1;
+		}
+
+		public UnsignedFlags UnsignedEnumComplement()
+		{
+			return ~UnsignedFlags.Item2;
+		}
+
+		public ByteFlags ByteEnumComplement()
+		{
+			return ~ByteFlags.Item1;
 		}
 
 		public void EnumInNotZeroCheck(SimpleEnum value, NoZero value2)

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -2369,7 +2369,18 @@ namespace ICSharpCode.Decompiler.CSharp
 					object? constantValue = field.GetConstantValue();
 					if (constantValue != null)
 					{
-						enumDec.Initializer = typeSystemAstBuilder.ConvertConstantValue(decompilationContext.CurrentTypeDefinition.EnumUnderlyingType!, constantValue);
+						TypeCode underlyingTypeCode = ReflectionHelper.GetTypeCode(decompilationContext.CurrentTypeDefinition.EnumUnderlyingType);
+						if (underlyingTypeCode is >= TypeCode.SByte and <= TypeCode.UInt64)
+						{
+							long initValue = (long)CSharpPrimitiveCast.Cast(TypeCode.Int64, constantValue, false);
+							enumDec.Initializer = typeSystemAstBuilder.ConvertEnumValue(decompilationContext.CurrentTypeDefinition, initValue, field);
+						}
+						else
+						{
+							// Unusual underlying types (bool, native int, ...) cannot be losslessly
+							// squeezed through the long-based member-reference beautification.
+							enumDec.Initializer = typeSystemAstBuilder.ConvertConstantValue(decompilationContext.CurrentTypeDefinition.EnumUnderlyingType!, constantValue);
+						}
 					}
 					enumDec.Attributes.AddRange(field.GetAttributes().Select(a => new AttributeSection(typeSystemAstBuilder.ConvertAttribute(a))));
 					enumDec.AddAnnotation(new MemberResolveResult(null, field));

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -23,6 +23,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 
 using ICSharpCode.Decompiler.CSharp.Resolver;
@@ -1293,26 +1294,47 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			return type.HasAttribute(KnownAttribute.Flags);
 		}
 
-		Expression ConvertEnumValue(IType type, long val)
+		/// <summary>
+		/// Converts a numeric enum value into its enum member representation, if possible.
+		/// Uses a series of enum members concatenated by <c>|</c>, if necessary.
+		/// Returns <c>(EnumType)value</c> (or the plain numeric value, if <paramref name="declaringEnumMember"/> is set), if it fails.
+		/// <para>
+		/// If <paramref name="declaringEnumMember"/> is set to a non-<see langword="null"/> value,
+		/// unqualified references are used and self references are avoided. Also, casts to EnumType are dropped.
+		/// </para>
+		/// </summary>
+		internal Expression ConvertEnumValue(IType type, long val, IField? declaringEnumMember = null)
 		{
 			ITypeDefinition enumDefinition = type.GetDefinition()!;
 			TypeCode enumBaseTypeCode = ReflectionHelper.GetTypeCode(enumDefinition.EnumUnderlyingType);
+			bool isFlags = IsFlagsEnum(enumDefinition);
 			var fields = enumDefinition.Fields
 				.Select(PrepareConstant)
-				.Where(f => f.field != null)
+				.WhereNotNull()
 				.ToArray();
-			foreach (var (value, field) in fields)
+			int declaringTokenRowNumber = declaringEnumMember == null ? int.MaxValue : MetadataTokens.GetRowNumber(declaringEnumMember.MetadataToken);
+			foreach (var (value, field, weight) in fields)
 			{
-				if (value == val)
+				// In a [Flags] enum declaration, only reference single-bit members directly:
+				// combined values are built from their flag components below (so that
+				// e.g. All = Item1 | Item2 | Item3), and zero members stay numeric, because
+				// mask-style enums routinely contain several unrelated zero members
+				// (e.g. MethodAttributes.PrivateScope/ReuseSlot).
+				if (value == val && (declaringEnumMember == null || !isFlags || weight == 1))
 				{
-					var mre = new MemberReferenceExpression(new TypeReferenceExpression(ConvertType(type)), field.Name);
-					if (AddResolveResultAnnotations)
-						mre.AddAnnotation(new MemberResolveResult(mre.Target.GetResolveResult(), field));
-					return mre;
+					if (field == declaringEnumMember || (declaringTokenRowNumber < MetadataTokens.GetRowNumber(field.MetadataToken)))
+					{
+						return ConvertConstantValue(enumDefinition.EnumUnderlyingType!, CSharpPrimitiveCast.Cast(enumBaseTypeCode, val, false));
+					}
+					return MakeEnumMemberReference(field);
 				}
 			}
-			if (IsFlagsEnum(enumDefinition))
+			if (isFlags)
 			{
+				// The complement of a byte- or ushort-based enum member is computed in int and
+				// therefore negative, which an enum member initializer cannot implicitly convert
+				// back to the underlying type -- the ~X form would not compile there.
+				bool complementCompiles = declaringEnumMember == null || enumBaseTypeCode is not (TypeCode.Byte or TypeCode.UInt16);
 				long enumValue = val;
 				Expression? expr = null;
 				long negatedEnumValue = ~val;
@@ -1333,14 +1355,17 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 						break;
 				}
 				Expression? negatedExpr = null;
-				foreach (var (fieldValue, field) in fields.OrderByDescending(f => CalculateHammingWeight(unchecked((ulong)f.value))))
+				foreach (var (fieldValue, field, weight) in fields.OrderByDescending(f => f.weight))
 				{
-					if (fieldValue == 0)
+					if (fieldValue == 0 || field == declaringEnumMember)
 						continue;   // skip None enum value
+
+					if (declaringTokenRowNumber < MetadataTokens.GetRowNumber(field.MetadataToken))
+						continue;
 
 					if ((fieldValue & enumValue) == fieldValue)
 					{
-						var fieldExpression = new MemberReferenceExpression(new TypeReferenceExpression(ConvertType(type)), field.Name);
+						var fieldExpression = MakeEnumMemberReference(field);
 						if (expr == null)
 							expr = fieldExpression;
 						else
@@ -1348,9 +1373,9 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 						enumValue &= ~fieldValue;
 					}
-					if ((fieldValue & negatedEnumValue) == fieldValue)
+					if (complementCompiles && (fieldValue & negatedEnumValue) == fieldValue)
 					{
-						var fieldExpression = new MemberReferenceExpression(new TypeReferenceExpression(ConvertType(type)), field.Name);
+						var fieldExpression = MakeEnumMemberReference(field);
 						if (negatedExpr == null)
 							negatedExpr = fieldExpression;
 						else
@@ -1359,28 +1384,43 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 						negatedEnumValue &= ~fieldValue;
 					}
 				}
-				if (enumValue == 0 && expr != null)
+				// A multi-bit value that lies entirely within a larger, previously declared member
+				// is usually a field encoding inside that mask (e.g. TypeAttributes.NestedPrivate
+				// within VisibilityMask), not a union of independent flags; keep it numeric.
+				bool isEncodedInEarlierMask = declaringEnumMember != null && fields.Any(
+					f => f.field != declaringEnumMember
+						&& MetadataTokens.GetRowNumber(f.field.MetadataToken) < declaringTokenRowNumber
+						&& (f.value & val) == val && f.value != val);
+				if (enumValue == 0 && expr != null && !isEncodedInEarlierMask)
 				{
 					if (!(negatedEnumValue == 0 && negatedExpr != null && negatedExpr.Descendants.Count() < expr.Descendants.Count()))
 					{
 						return expr;
 					}
 				}
-				if (negatedEnumValue == 0 && negatedExpr != null)
+				if (complementCompiles && negatedEnumValue == 0 && negatedExpr != null)
 				{
 					return new UnaryOperatorExpression(UnaryOperatorType.BitNot, negatedExpr);
 				}
 			}
-			return new CastExpression(ConvertType(type), new PrimitiveExpression(CSharpPrimitiveCast.Cast(enumBaseTypeCode, val, false)));
 
-			(long value, IField field) PrepareConstant(IField field)
+			var numericExpression = ConvertConstantValue(enumDefinition.EnumUnderlyingType!, CSharpPrimitiveCast.Cast(enumBaseTypeCode, val, false));
+			if (declaringEnumMember != null)
+			{
+				return numericExpression;
+			}
+			return new CastExpression(ConvertType(type), numericExpression);
+
+			(long value, IField field, int weight)? PrepareConstant(IField field)
 			{
 				if (!field.IsConst)
-					return (-1, null!);
+					return null;
 				object? constantValue = field.GetConstantValue();
 				if (constantValue == null)
-					return (-1, null!);
-				return ((long)CSharpPrimitiveCast.Cast(TypeCode.Int64, constantValue, checkForOverflow: false), field);
+					return null;
+				var value = (long)CSharpPrimitiveCast.Cast(TypeCode.Int64, constantValue, checkForOverflow: false);
+				var weight = CalculateHammingWeight(unchecked((ulong)value));
+				return (value, field, weight);
 			}
 
 			// see https://en.wikipedia.org/wiki/Hamming_weight
@@ -1394,6 +1434,24 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				x = (x & m2) + ((x >> 2) & m2); //put count of each 4 bits into those 4 bits 
 				x = (x + (x >> 4)) & m4;        //put count of each 8 bits into those 8 bits 
 				return unchecked((int)((x * h01) >> 56));  //returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ... 
+			}
+
+			Expression MakeEnumMemberReference(IField field)
+			{
+				if (declaringEnumMember == null)
+				{
+					var mre = new MemberReferenceExpression(new TypeReferenceExpression(ConvertType(type)), field.Name);
+					if (AddResolveResultAnnotations)
+						mre.AddAnnotation(new MemberResolveResult(mre.Target.GetResolveResult(), field));
+					return mre;
+				}
+				else
+				{
+					var ie = new IdentifierExpression(field.Name);
+					if (AddResolveResultAnnotations)
+						ie.AddAnnotation(new MemberResolveResult(null, field));
+					return ie;
+				}
 			}
 		}
 

--- a/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
+++ b/ICSharpCode.Decompiler/Util/CollectionExtensions.cs
@@ -254,6 +254,30 @@ namespace ICSharpCode.Decompiler.Util
 		}
 
 		/// <summary>
+		/// Filters out null elements, narrowing the element type to non-nullable.
+		/// </summary>
+		public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class
+		{
+			foreach (var item in source)
+			{
+				if (item != null)
+					yield return item;
+			}
+		}
+
+		/// <summary>
+		/// Filters out null elements and unwraps the remaining values.
+		/// </summary>
+		public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : struct
+		{
+			foreach (var item in source)
+			{
+				if (item.HasValue)
+					yield return item.GetValueOrDefault();
+			}
+		}
+
+		/// <summary>
 		/// The merge step of merge sort.
 		/// </summary>
 		public static IEnumerable<T> Merge<T>(this IEnumerable<T> input1, IEnumerable<T> input2, Comparison<T> comparison)


### PR DESCRIPTION
### Problem

Enum declarations are decompiled with every member shown as a bare number, even when the original source referenced other members: `All = 7` instead of `All = Item1 | Item2 | Item3`, `Item2B = 2` instead of `Item2B = Item2A`. (No open issue; this revives and completes the old `stash/beautify-enum-member-declarations` experiment.)

### Solution

Enum member initializers that duplicate an earlier member now reference it, and combined `[Flags]` values are shown as a union of their earlier single-bit members or as a complement:

```csharp
[Flags]
public enum SimpleFlagsEnum
{
	None = 0,
	Item1 = 1,
	Item2 = 2,
	Item3 = 4,
	All = Item1 | Item2 | Item3   // was: All = 7
}

public enum EnumDuplicateItemTest
{
	Item0 = 0,
	Item1 = 1,
	Item2A = 2,
	Item2B = Item2A               // was: Item2B = 2
}
```

Guardrails keep the output faithful to how such enums are written by hand:

* Only previously declared members are referenced (field row order), so forward references never appear and the output always compiles.
* A multi-bit value lying entirely within a larger, earlier-declared member is treated as a field encoding inside that mask rather than a flag union and stays numeric; zero-valued members of `[Flags]` enums stay numeric too (mask-style enums routinely have several unrelated zero members, e.g. `MethodAttributes.PrivateScope`/`ReuseSlot`).
* The `~X` complement form is suppressed in byte/ushort enum declarations, where the initializer constant folds in `int` and would not compile (CS0031); expression contexts keep it for every underlying type.
* Enums with unusual underlying types (bool, native int) keep the plain constant conversion.

With these rules, decompiling System.Private.CoreLib reproduces the hand-written declarations of `TypeAttributes`, `MethodAttributes`, `FileAttributes` and `AttributeTargets` (including `All = Assembly | Module | ... | GenericParameter`) almost verbatim: numeric exactly where the original sources are numeric, while unambiguous aliases such as `NewSlot = VtableLayoutMask` are referenced.

Most in need of attention: the two output-policy heuristics (mask-encoding suppression and numeric zeros in `[Flags]` declarations) are aesthetic trade-offs; the fixtures pin the chosen behavior.

* [x] At least one test covering the code changed — new Pretty fixtures in `EnumTests` cover mask-family enums, unsigned/byte/short flags, complements at declaration and usage sites, and zero/non-flags duplicates; full suite green (all non-Correctness tests 2171 passed, Correctness 197 passed).

The code and this description were largely written by an AI agent (Claude Code), reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)