### PR TITLE
Show hover tooltips for dynamic member accesses

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Output/CSharpAmbienceTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Output/CSharpAmbienceTests.cs
@@ -355,6 +355,25 @@ namespace ICSharpCode.Decompiler.Tests.Output
 			ambience.ConversionFlags = ConversionFlags.All & ~(ConversionFlags.ShowBody | ConversionFlags.PlaceReturnTypeAfterParameterList);
 			Assert.That(ambience.ConvertSymbol(method), Is.EqualTo("public dynamic dynamic.Compute(int, string, dynamic)"));
 		}
+		[Test]
+		public void DynamicIndexer()
+		{
+			// The shape ExpressionBuilder synthesizes for a[b]: an indexer with dynamic return, index
+			// parameters typed from the callsite delegate, declared on the dynamic type. It carries no
+			// accessors, which the ambience renders cleanly (no empty { } artifact).
+			var indexer = new FakeProperty(compilation) {
+				Name = "Item",
+				IsIndexer = true,
+				ReturnType = SpecialType.Dynamic,
+				DeclaringType = SpecialType.Dynamic,
+				Parameters = new IParameter[] { new DefaultParameter(compilation.FindType(KnownTypeCode.Int32), string.Empty) },
+			};
+			ambience.ConversionFlags = ConversionFlags.ShowReturnType | ConversionFlags.ShowParameterList;
+			Assert.That(ambience.ConvertSymbol(indexer), Is.EqualTo("dynamic this[int]"));
+
+			ambience.ConversionFlags = ConversionFlags.All & ~(ConversionFlags.ShowBody | ConversionFlags.PlaceReturnTypeAfterParameterList);
+			Assert.That(ambience.ConvertSymbol(indexer), Is.EqualTo("public dynamic dynamic.this[int]"));
+		}
 		#endregion
 
 		#region Test types

--- a/ICSharpCode.Decompiler.Tests/Output/CSharpAmbienceTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Output/CSharpAmbienceTests.cs
@@ -323,6 +323,40 @@ namespace ICSharpCode.Decompiler.Tests.Output
 		}
 		#endregion
 
+		#region Dynamic (synthesized member) tests
+		[Test]
+		public void DynamicType()
+		{
+			ambience.ConversionFlags = ConversionFlags.None;
+			Assert.That(ambience.ConvertType(SpecialType.Dynamic), Is.EqualTo("dynamic"));
+		}
+
+		[Test]
+		public void DynamicInvokeMember()
+		{
+			// The shape ExpressionBuilder synthesizes for a.Compute(1, "two", d): dynamic return,
+			// per-argument types from the callsite delegate (constants keep their compile-time type),
+			// declared on the dynamic type.
+			var method = new FakeMethod(compilation, SymbolKind.Method) {
+				Name = "Compute",
+				ReturnType = SpecialType.Dynamic,
+				DeclaringType = SpecialType.Dynamic,
+				Parameters = new IParameter[] {
+					new DefaultParameter(compilation.FindType(KnownTypeCode.Int32), string.Empty),
+					new DefaultParameter(compilation.FindType(KnownTypeCode.String), string.Empty),
+					new DefaultParameter(SpecialType.Dynamic, string.Empty),
+				},
+			};
+			ambience.ConversionFlags = ConversionFlags.ShowReturnType | ConversionFlags.ShowParameterList;
+			Assert.That(ambience.ConvertSymbol(method), Is.EqualTo("dynamic Compute(int, string, dynamic)"));
+
+			// The same member as DecompilerTextView.BuildHoverContent renders it (full hover form): the
+			// unnamed synthetic parameters collapse to their types, so there is no dangling-name artifact.
+			ambience.ConversionFlags = ConversionFlags.All & ~(ConversionFlags.ShowBody | ConversionFlags.PlaceReturnTypeAfterParameterList);
+			Assert.That(ambience.ConvertSymbol(method), Is.EqualTo("public dynamic dynamic.Compute(int, string, dynamic)"));
+		}
+		#endregion
+
 		#region Test types
 #pragma warning disable 169, 67
 

--- a/ICSharpCode.Decompiler.Tests/Output/TextTokenWriterTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Output/TextTokenWriterTests.cs
@@ -102,7 +102,7 @@ namespace ICSharpCode.Decompiler.Tests.Output
 					MemberReferences.Add((text, member));
 			}
 
-			public void WriteLocalReference(string text, object reference, bool isDefinition = false)
+			public void WriteLocalReference(string text, object reference, bool isDefinition = false, bool isHoverOnly = false)
 			{
 				LocalReferences.Add((text, reference, isDefinition));
 			}

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4356,7 +4356,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			var target = TranslateDynamicTarget(inst.Target, inst.TargetArgumentInfo);
 			return new MemberReferenceExpression(target, inst.Name!)
 				.WithILInstruction(inst)
-				.WithRR(new DynamicMemberResolveResult(target.ResolveResult, inst.Name));
+				.WithRR(new DynamicMemberResolveResult(target.ResolveResult, inst.Name, CreateDynamicMemberSymbol(inst.Name!, inst.TargetArgumentInfo)));
 		}
 
 		protected internal override TranslatedExpression VisitDynamicInvokeConstructorInstruction(DynamicInvokeConstructorInstruction inst, TranslationContext context)
@@ -4385,7 +4385,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			var arguments = TranslateDynamicArguments(inst.Arguments.Skip(1), inst.ArgumentInfo.Skip(1)).ToList();
 			return new InvocationExpression(targetExpr, arguments.Select(a => a.Expression))
 				.WithILInstruction(inst)
-				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Invocation, arguments.Select(a => a.ResolveResult).ToArray()));
+				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Invocation, arguments.Select(a => a.ResolveResult).ToArray(), symbol: CreateDynamicInvokeMemberSymbol(inst.Name, inst.ArgumentInfo[0], inst.ArgumentInfo.Skip(1).ToArray())));
 		}
 
 		protected internal override TranslatedExpression VisitDynamicInvokeInstruction(DynamicInvokeInstruction inst, TranslationContext context)
@@ -4424,6 +4424,57 @@ namespace ICSharpCode.Decompiler.CSharp
 			}
 
 			return translatedTarget;
+		}
+
+		/// <summary>
+		/// The type to show for a dynamic callsite argument: its recorded compile-time type when the runtime
+		/// binder was told to use it (statically-typed or constant arguments), otherwise <c>dynamic</c>.
+		/// </summary>
+		static IType DynamicArgumentType(CSharpArgumentInfo info)
+		{
+			if ((info.HasFlag(CSharpArgumentInfoFlags.UseCompileTimeType) || info.HasFlag(CSharpArgumentInfoFlags.Constant))
+				&& info.CompileTimeType != null)
+			{
+				return info.CompileTimeType;
+			}
+			return SpecialType.Dynamic;
+		}
+
+		/// <summary>
+		/// Synthesizes a member on the target type for a dynamic member access (a.Member), so the member
+		/// reference carries a navigable symbol / hover tooltip. Since the real member is unknown, this is a
+		/// <c>dynamic</c>-typed field named after the accessed member, declared on the target's compile-time type.
+		/// </summary>
+		IMember CreateDynamicMemberSymbol(string name, CSharpArgumentInfo targetInfo)
+		{
+			return new FakeField(compilation) {
+				Name = name,
+				ReturnType = SpecialType.Dynamic,
+				DeclaringType = DynamicArgumentType(targetInfo),
+			};
+		}
+
+		/// <summary>
+		/// Synthesizes a member on the target type for a dynamic member invocation (a.Method(b)): a
+		/// <c>dynamic</c>-returning method named after the invoked member, with one parameter per argument
+		/// typed by <see cref="DynamicArgumentType"/>, so the member reference carries a navigable symbol /
+		/// hover tooltip.
+		/// </summary>
+		IMember CreateDynamicInvokeMemberSymbol(string name, CSharpArgumentInfo targetInfo, IReadOnlyList<CSharpArgumentInfo> argumentInfo)
+		{
+			var method = new FakeMethod(compilation, SymbolKind.Method) {
+				Name = name,
+				ReturnType = SpecialType.Dynamic,
+				DeclaringType = DynamicArgumentType(targetInfo),
+			};
+			if (argumentInfo.Count > 0)
+			{
+				var parameters = new IParameter[argumentInfo.Count];
+				for (int i = 0; i < argumentInfo.Count; i++)
+					parameters[i] = new DefaultParameter(DynamicArgumentType(argumentInfo[i]), argumentInfo[i].Name ?? string.Empty);
+				method.Parameters = parameters;
+			}
+			return method;
 		}
 
 		IEnumerable<TranslatedExpression> TranslateDynamicArguments(IEnumerable<ILInstruction> arguments, IEnumerable<CSharpArgumentInfo> argumentInfo)
@@ -4502,7 +4553,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			var value = TranslateDynamicArgument(inst.Value, inst.ValueArgumentInfo);
 			var member = new MemberReferenceExpression(target, inst.Name!)
 				.WithoutILInstruction()
-				.WithRR(new DynamicMemberResolveResult(target.ResolveResult, inst.Name));
+				.WithRR(new DynamicMemberResolveResult(target.ResolveResult, inst.Name, CreateDynamicMemberSymbol(inst.Name!, inst.TargetArgumentInfo)));
 			return Assignment(member, value).WithILInstruction(inst);
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4348,7 +4348,8 @@ namespace ICSharpCode.Decompiler.CSharp
 			var arguments = TranslateDynamicArguments(inst.Arguments.Skip(1), inst.ArgumentInfo.Skip(1)).ToList();
 			return new IndexerExpression(target, arguments.Select(a => a.Expression))
 				.WithILInstruction(inst)
-				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Indexing, arguments.Select(a => a.ResolveResult).ToArray()));
+				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Indexing, arguments.Select(a => a.ResolveResult).ToArray(),
+					symbol: CreateDynamicIndexerSymbol(DynamicArgumentType(inst.ArgumentInfo[0]), inst.ArgumentInfo.Skip(1).ToArray())));
 		}
 
 		protected internal override TranslatedExpression VisitDynamicGetMemberInstruction(DynamicGetMemberInstruction inst, TranslationContext context)
@@ -4509,6 +4510,24 @@ namespace ICSharpCode.Decompiler.CSharp
 			return constructor;
 		}
 
+		/// <summary>
+		/// Synthesizes the indexer for a dynamic index access (a[b]): an indexer on the target type whose
+		/// parameters are typed from the callsite delegate, so the brackets carry a hover tooltip.
+		/// </summary>
+		IMember CreateDynamicIndexerSymbol(IType declaringType, IReadOnlyList<CSharpArgumentInfo> argumentInfo)
+		{
+			var parameters = new IParameter[argumentInfo.Count];
+			for (int i = 0; i < argumentInfo.Count; i++)
+				parameters[i] = new DefaultParameter(DynamicArgumentType(argumentInfo[i]), argumentInfo[i].Name ?? string.Empty);
+			return new FakeProperty(compilation) {
+				Name = "Item",
+				IsIndexer = true,
+				ReturnType = SpecialType.Dynamic,
+				DeclaringType = declaringType,
+				Parameters = parameters,
+			};
+		}
+
 		IEnumerable<TranslatedExpression> TranslateDynamicArguments(IEnumerable<ILInstruction> arguments, IEnumerable<CSharpArgumentInfo> argumentInfo)
 		{
 			foreach (var (argument, info) in arguments.Zip(argumentInfo))
@@ -4575,7 +4594,8 @@ namespace ICSharpCode.Decompiler.CSharp
 			var value = new TranslatedExpression(arguments.Last());
 			var indexer = new IndexerExpression(target, arguments.SkipLast(1).Select(a => a.Expression))
 				.WithoutILInstruction()
-				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Indexing, arguments.SkipLast(1).Select(a => a.ResolveResult).ToArray()));
+				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Indexing, arguments.SkipLast(1).Select(a => a.ResolveResult).ToArray(),
+					symbol: CreateDynamicIndexerSymbol(DynamicArgumentType(inst.ArgumentInfo[0]), inst.ArgumentInfo.Skip(1).Take(inst.ArgumentInfo.Count - 2).ToArray())));
 			return Assignment(indexer, value).WithILInstruction(inst);
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4364,9 +4364,10 @@ namespace ICSharpCode.Decompiler.CSharp
 			if (!(inst.ArgumentInfo[0].HasFlag(CSharpArgumentInfoFlags.IsStaticType) && IL.Transforms.TransformExpressionTrees.MatchGetTypeFromHandle(inst.Arguments[0], out var constructorType)))
 				return ErrorExpression("Could not detect static type for DynamicInvokeConstructorInstruction");
 			var arguments = TranslateDynamicArguments(inst.Arguments.Skip(1), inst.ArgumentInfo.Skip(1)).ToList();
-			//var names = inst.ArgumentInfo.Skip(1).Select(a => a.Name).ToArray();
+			var constructor = CreateDynamicConstructorSymbol(constructorType, inst.ArgumentInfo.Skip(1).ToArray());
 			return new ObjectCreateExpression(ConvertType(constructorType), arguments.Select(a => a.Expression))
-				.WithILInstruction(inst).WithRR(new ResolveResult(constructorType));
+				.WithILInstruction(inst)
+				.WithRR(new CSharpInvocationResolveResult(new ResolveResult(constructorType), constructor, arguments.Select(a => a.ResolveResult).ToArray()));
 		}
 
 		protected internal override TranslatedExpression VisitDynamicInvokeMemberInstruction(DynamicInvokeMemberInstruction inst, TranslationContext context)
@@ -4475,6 +4476,28 @@ namespace ICSharpCode.Decompiler.CSharp
 				method.Parameters = parameters;
 			}
 			return method;
+		}
+
+		/// <summary>
+		/// Synthesizes the constructor for a dynamic object creation (<c>new T(b)</c> where an argument is
+		/// dynamic): a constructor on the created type with one parameter per argument typed by
+		/// <see cref="DynamicArgumentType"/>, so the type name and parentheses carry a hover tooltip.
+		/// </summary>
+		IMethod CreateDynamicConstructorSymbol(IType declaringType, IReadOnlyList<CSharpArgumentInfo> argumentInfo)
+		{
+			var constructor = new FakeMethod(compilation, SymbolKind.Constructor) {
+				Name = ".ctor",
+				DeclaringType = declaringType,
+				ReturnType = compilation.FindType(KnownTypeCode.Void),
+			};
+			if (argumentInfo.Count > 0)
+			{
+				var parameters = new IParameter[argumentInfo.Count];
+				for (int i = 0; i < argumentInfo.Count; i++)
+					parameters[i] = new DefaultParameter(DynamicArgumentType(argumentInfo[i]), argumentInfo[i].Name ?? string.Empty);
+				constructor.Parameters = parameters;
+			}
+			return constructor;
 		}
 
 		IEnumerable<TranslatedExpression> TranslateDynamicArguments(IEnumerable<ILInstruction> arguments, IEnumerable<CSharpArgumentInfo> argumentInfo)

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4386,7 +4386,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			var arguments = TranslateDynamicArguments(inst.Arguments.Skip(1), inst.ArgumentInfo.Skip(1)).ToList();
 			return new InvocationExpression(targetExpr, arguments.Select(a => a.Expression))
 				.WithILInstruction(inst)
-				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Invocation, arguments.Select(a => a.ResolveResult).ToArray(), symbol: CreateDynamicInvokeMemberSymbol(inst.Name, inst.ArgumentInfo[0], inst.ArgumentInfo.Skip(1).ToArray())));
+				.WithRR(new DynamicInvocationResolveResult(target.ResolveResult, DynamicInvocationType.Invocation, arguments.Select(a => a.ResolveResult).ToArray(), symbol: CreateDynamicInvokeMemberSymbol(inst.Name, inst.ArgumentInfo[0], inst.ArgumentInfo.Skip(1).ToArray(), inst.TypeArguments)));
 		}
 
 		protected internal override TranslatedExpression VisitDynamicInvokeInstruction(DynamicInvokeInstruction inst, TranslationContext context)
@@ -4461,7 +4461,7 @@ namespace ICSharpCode.Decompiler.CSharp
 		/// typed by <see cref="DynamicArgumentType"/>, so the member reference carries a navigable symbol /
 		/// hover tooltip.
 		/// </summary>
-		IMember CreateDynamicInvokeMemberSymbol(string name, CSharpArgumentInfo targetInfo, IReadOnlyList<CSharpArgumentInfo> argumentInfo)
+		IMember CreateDynamicInvokeMemberSymbol(string name, CSharpArgumentInfo targetInfo, IReadOnlyList<CSharpArgumentInfo> argumentInfo, IReadOnlyList<IType> typeArguments)
 		{
 			var method = new FakeMethod(compilation, SymbolKind.Method) {
 				Name = name,
@@ -4475,7 +4475,16 @@ namespace ICSharpCode.Decompiler.CSharp
 					parameters[i] = new DefaultParameter(DynamicArgumentType(argumentInfo[i]), argumentInfo[i].Name ?? string.Empty);
 				method.Parameters = parameters;
 			}
-			return method;
+			if (typeArguments.Count == 0)
+				return method;
+			// Explicit type arguments (a.Method<int>()): give the fake a matching set of type parameters,
+			// conventionally named T, T2, ..., and specialize it with the actual arguments like a real
+			// generic call would.
+			var typeParameters = new ITypeParameter[typeArguments.Count];
+			for (int i = 0; i < typeArguments.Count; i++)
+				typeParameters[i] = new DefaultTypeParameter(method, i, i == 0 ? "T" : "T" + (i + 1));
+			method.TypeParameters = typeParameters;
+			return SpecializedMethod.Create(method, new TypeParameterSubstitution(null, typeArguments));
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/CSharp/Resolver/DynamicInvocationResolveResult.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/DynamicInvocationResolveResult.cs
@@ -72,12 +72,20 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 		/// </summary>
 		public readonly IList<ResolveResult> InitializerStatements;
 
-		public DynamicInvocationResolveResult(ResolveResult target, DynamicInvocationType invocationType, IList<ResolveResult> arguments, IList<ResolveResult> initializerStatements = null) : base(SpecialType.Dynamic)
+		/// <summary>
+		/// Synthesized member (a <c>dynamic</c> method on the <c>dynamic</c> type) representing the invoked
+		/// member, so the member reference carries a navigable symbol / hover tooltip. Only set for an
+		/// invoke-member (<c>a.Method(b)</c>); null for a plain invoke or an indexer. May be null.
+		/// </summary>
+		public readonly IMember Symbol;
+
+		public DynamicInvocationResolveResult(ResolveResult target, DynamicInvocationType invocationType, IList<ResolveResult> arguments, IList<ResolveResult> initializerStatements = null, IMember symbol = null) : base(SpecialType.Dynamic)
 		{
 			this.Target = target;
 			this.InvocationType = invocationType;
 			this.Arguments = arguments ?? EmptyList<ResolveResult>.Instance;
 			this.InitializerStatements = initializerStatements ?? EmptyList<ResolveResult>.Instance;
+			this.Symbol = symbol;
 		}
 
 		public override string ToString()

--- a/ICSharpCode.Decompiler/CSharp/Resolver/DynamicMemberResolveResult.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/DynamicMemberResolveResult.cs
@@ -39,10 +39,17 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 		/// </summary>
 		public readonly string Member;
 
-		public DynamicMemberResolveResult(ResolveResult target, string member) : base(SpecialType.Dynamic)
+		/// <summary>
+		/// Synthesized member (a <c>dynamic</c> field on the <c>dynamic</c> type) representing the accessed
+		/// member, so the member reference carries a navigable symbol / hover tooltip. May be null.
+		/// </summary>
+		public readonly IMember Symbol;
+
+		public DynamicMemberResolveResult(ResolveResult target, string member, IMember symbol = null) : base(SpecialType.Dynamic)
 		{
 			this.Target = target;
 			this.Member = member;
+			this.Symbol = symbol;
 		}
 
 		public override string ToString()

--- a/ICSharpCode.Decompiler/Output/ITextOutput.cs
+++ b/ICSharpCode.Decompiler/Output/ITextOutput.cs
@@ -36,7 +36,7 @@ namespace ICSharpCode.Decompiler
 		void WriteReference(MetadataFile metadata, Handle handle, string text, string protocol = "decompile", bool isDefinition = false);
 		void WriteReference(IType type, string text, bool isDefinition = false);
 		void WriteReference(IMember member, string text, bool isDefinition = false);
-		void WriteLocalReference(string text, object reference, bool isDefinition = false);
+		void WriteLocalReference(string text, object reference, bool isDefinition = false, bool isHoverOnly = false);
 
 		void MarkFoldStart(string collapsedText = "...", bool defaultCollapsed = false, bool isDefinition = false);
 		void MarkFoldEnd();

--- a/ICSharpCode.Decompiler/Output/PlainTextOutput.cs
+++ b/ICSharpCode.Decompiler/Output/PlainTextOutput.cs
@@ -147,7 +147,7 @@ namespace ICSharpCode.Decompiler
 			Write(text);
 		}
 
-		public void WriteLocalReference(string text, object reference, bool isDefinition = false)
+		public void WriteLocalReference(string text, object reference, bool isDefinition = false, bool isHoverOnly = false)
 		{
 			Write(text);
 		}
@@ -224,7 +224,7 @@ namespace ICSharpCode.Decompiler
 			actions.Add(target => target.WriteLine());
 		}
 
-		public void WriteLocalReference(string text, object reference, bool isDefinition = false)
+		public void WriteLocalReference(string text, object reference, bool isDefinition = false, bool isHoverOnly = false)
 		{
 			actions.Add(target => target.WriteLocalReference(text, reference, isDefinition));
 		}

--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -159,6 +159,10 @@ namespace ICSharpCode.Decompiler
 		{
 			if (node.Annotation<ResolveResult>() is CSharp.Resolver.DynamicMemberResolveResult)
 				return true;
+			// The node itself is a dynamic invocation/indexing (a.Method(b), a[b]): its parentheses/brackets
+			// carry the synthesized member.
+			if (node.Annotation<ResolveResult>() is CSharp.Resolver.DynamicInvocationResolveResult)
+				return true;
 			if (node.Slot?.Kind == Slots.TargetExpression && node.Parent is InvocationExpression
 				&& node.Parent.Annotation<ResolveResult>() is CSharp.Resolver.DynamicInvocationResolveResult)
 				return true;

--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -161,6 +161,12 @@ namespace ICSharpCode.Decompiler
 			if (node.Slot?.Kind == Slots.TargetExpression && node.Parent is InvocationExpression
 				&& node.Parent.Annotation<ResolveResult>() is CSharp.Resolver.DynamicInvocationResolveResult)
 				return true;
+			// new T(dynamicArg): the object creation (or its type-name slot) is backed by a dynamic newobj,
+			// whose synthesized constructor has no metadata to navigate to.
+			if (node.Annotation<IL.DynamicInvokeConstructorInstruction>() != null)
+				return true;
+			if (node.Slot?.Kind == Slots.Type && node.Parent?.Annotation<IL.DynamicInvokeConstructorInstruction>() != null)
+				return true;
 			return false;
 		}
 
@@ -343,7 +349,10 @@ namespace ICSharpCode.Decompiler
 								output.WriteReference(t, token, false);
 								return;
 							case IMember m:
-								output.WriteReference(m, token, false);
+								if (IsDynamicMemberReference(node))
+									output.WriteLocalReference(token, m);
+								else
+									output.WriteReference(m, token, false);
 								return;
 						}
 					}

--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -81,8 +81,9 @@ namespace ICSharpCode.Decompiler
 					if (IsDynamicMemberReference(nodeStack.Peek()))
 					{
 						// A member synthesized for a dynamic access: show its signature on hover, but do not
-						// make it a navigation target (there is no real member to jump to) - like a local.
-						output.WriteLocalReference(name, m);
+						// make it a navigation target (there is no real member to jump to), and no occurrence
+						// highlight either - it is a distinct synthetic member at every use.
+						output.WriteLocalReference(name, m, isHoverOnly: true);
 					}
 					else
 					{
@@ -350,7 +351,7 @@ namespace ICSharpCode.Decompiler
 								return;
 							case IMember m:
 								if (IsDynamicMemberReference(node))
-									output.WriteLocalReference(token, m);
+									output.WriteLocalReference(token, m, isHoverOnly: true);
 								else
 									output.WriteReference(m, token, false);
 								return;
@@ -457,8 +458,8 @@ namespace ICSharpCode.Decompiler
 					break;
 				case "dynamic":
 					// dynamic has no metadata type definition; emit it as a hover-only reference (no navigation
-					// target) so it can carry a tooltip, like a local.
-					output.WriteLocalReference(type, SpecialType.Dynamic);
+					// target, no occurrence highlight) so it can still carry a tooltip.
+					output.WriteLocalReference(type, SpecialType.Dynamic, isHoverOnly: true);
 					return;
 				case "bool":
 				case "byte":

--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -446,6 +446,11 @@ namespace ICSharpCode.Decompiler
 					output.Write(type);
 					output.Write("()");
 					break;
+				case "dynamic":
+					// dynamic has no metadata type definition; emit it as a hover-only reference (no navigation
+					// target) so it can carry a tooltip, like a local.
+					output.WriteLocalReference(type, SpecialType.Dynamic);
+					return;
 				case "bool":
 				case "byte":
 				case "sbyte":

--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -78,7 +78,16 @@ namespace ICSharpCode.Decompiler
 					output.WriteReference(t, name, false);
 					return;
 				case IMember m:
-					output.WriteReference(m, name, false);
+					if (IsDynamicMemberReference(nodeStack.Peek()))
+					{
+						// A member synthesized for a dynamic access: show its signature on hover, but do not
+						// make it a navigation target (there is no real member to jump to) - like a local.
+						output.WriteLocalReference(name, m);
+					}
+					else
+					{
+						output.WriteReference(m, name, false);
+					}
 					return;
 			}
 
@@ -138,6 +147,21 @@ namespace ICSharpCode.Decompiler
 				return null;
 
 			return symbol;
+		}
+
+		/// <summary>
+		/// True if the member reference at this node was synthesized for a dynamic member access/invocation.
+		/// Such members carry a hover tooltip but must not be navigation targets, since they do not exist in
+		/// metadata.
+		/// </summary>
+		static bool IsDynamicMemberReference(AstNode node)
+		{
+			if (node.Annotation<ResolveResult>() is CSharp.Resolver.DynamicMemberResolveResult)
+				return true;
+			if (node.Slot?.Kind == Slots.TargetExpression && node.Parent is InvocationExpression
+				&& node.Parent.Annotation<ResolveResult>() is CSharp.Resolver.DynamicInvocationResolveResult)
+				return true;
+			return false;
 		}
 
 		object GetCurrentLocalReference()

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -732,6 +732,14 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			{
 				return ((ConversionResolveResult)rr).Input.GetSymbol();
 			}
+			else if (rr is CSharp.Resolver.DynamicMemberResolveResult dynamicMember)
+			{
+				return dynamicMember.Symbol;
+			}
+			else if (rr is CSharp.Resolver.DynamicInvocationResolveResult dynamicInvocation)
+			{
+				return dynamicInvocation.Symbol;
+			}
 
 			return null;
 		}

--- a/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunLanguage.cs
@@ -82,7 +82,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		{
 		}
 
-		public void WriteLocalReference(string text, object reference, bool isDefinition = false)
+		public void WriteLocalReference(string text, object reference, bool isDefinition = false, bool isHoverOnly = false)
 		{
 		}
 

--- a/ILSpy.Tests/Editor/CaretHighlightAdornerTests.cs
+++ b/ILSpy.Tests/Editor/CaretHighlightAdornerTests.cs
@@ -98,7 +98,7 @@ public class CaretHighlightAdornerTests
 		generator.References.Should().NotBeNull(
 			"DecompilerTextView assigns the live References collection on every ApplyDocument");
 		var memberDef = generator.References!
-			.FirstOrDefault(s => s.IsDefinition && !s.IsLocal && s.Reference != null);
+			.FirstOrDefault(s => s.IsDefinition && s.Kind == ReferenceMode.Link && s.Reference != null);
 		((object?)memberDef).Should().NotBeNull(
 			"the decompiled Enumerable class contains at least one member-definition reference");
 

--- a/ILSpy.Tests/Editor/HoverOnlyReferenceTests.cs
+++ b/ILSpy.Tests/Editor/HoverOnlyReferenceTests.cs
@@ -24,7 +24,6 @@ using Avalonia.VisualTree;
 
 using AwesomeAssertions;
 
-using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.TreeNodes;
 
@@ -33,51 +32,48 @@ using NUnit.Framework;
 namespace ICSharpCode.ILSpy.Tests.TextView;
 
 /// <summary>
-/// Sample type decompiled by <see cref="LocalReferenceHighlightTests"/>: a generic local
-/// function inside a generic method, so that every use site carries a specialized method
-/// instance while the declaration carries the unspecialized one (issue #2078).
+/// Sample type decompiled by <see cref="HoverOnlyReferenceTests"/>: a dynamic member access, whose
+/// synthesized member the decompiler renders as a hover-only reference.
 /// </summary>
-public class GenericLocalFunctionSample
+public class DynamicMemberSample
 {
-	public T Run<T>(T t)
+	public object Get(dynamic d)
 	{
-		return Echo(Echo(t));
-
-		static T2 Echo<T2>(T2 value) => value;
+		return d.Property;
 	}
 }
 
 /// <summary>
-/// Pins the local-reference highlighting for local functions: clicking any occurrence of a
-/// generic local function must paint the definition and every use site as one group.
+/// Pins the third reference mode. A member synthesized for a dynamic access shows a hover tooltip but
+/// is not a navigation target and, unlike a local variable, clicking it does not highlight occurrences
+/// (it is a distinct synthetic member at every use).
 /// </summary>
 [TestFixture]
-public class LocalReferenceHighlightTests
+public class HoverOnlyReferenceTests
 {
 	[AvaloniaTest]
-	public async Task Clicking_A_Generic_Local_Function_Use_Highlights_Definition_And_All_Uses()
+	public async Task Dynamic_Member_Is_HoverOnly_And_A_Click_Neither_Navigates_Nor_Highlights()
 	{
 		var (window, vm) = await TestHarness.BootAsync();
-		await vm.OpenAssemblyAsync(typeof(GenericLocalFunctionSample).Assembly.Location);
+		await vm.OpenAssemblyAsync(typeof(DynamicMemberSample).Assembly.Location);
 		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
 			"ILSpy.Tests",
 			"ICSharpCode.ILSpy.Tests.TextView",
-			"ICSharpCode.ILSpy.Tests.TextView.GenericLocalFunctionSample");
+			"ICSharpCode.ILSpy.Tests.TextView.DynamicMemberSample");
 		vm.AssemblyTreeModel.SelectNode(typeNode);
 		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
 		var view = window.GetVisualDescendants().OfType<DecompilerTextView>().First();
 
-		var localFunctionSegments = tab.References!
-			.Where(r => r.Kind == ReferenceMode.LocalHighlight && r.Reference is IMethod { IsLocalFunction: true })
+		var hoverOnly = tab.References!
+			.Where(r => r.Kind == ReferenceMode.HoverOnly)
 			.ToList();
-		localFunctionSegments.Should().HaveCount(3, "the local function has one definition and two calls");
-		localFunctionSegments.Count(r => r.IsDefinition).Should().Be(1);
+		hoverOnly.Should().NotBeEmpty("the dynamic member access 'd.Property' is a hover-only reference");
 
-		var use = localFunctionSegments.First(r => !r.IsDefinition);
-		view.OnReferenceClicked(use);
+		var navigated = false;
+		tab.NavigateRequested += _ => navigated = true;
+		view.OnReferenceClicked(hoverOnly.First());
 
-		view.LocalReferenceMarks.Select(m => m.StartOffset).Should().BeEquivalentTo(
-			localFunctionSegments.Select(s => s.StartOffset),
-			"clicking a use must highlight the definition and every use");
+		navigated.Should().BeFalse("clicking a hover-only reference must not navigate");
+		view.LocalReferenceMarks.Should().BeEmpty("a hover-only reference must not highlight occurrences");
 	}
 }

--- a/ILSpy.Tests/Editor/HoverOnlyReferenceTests.cs
+++ b/ILSpy.Tests/Editor/HoverOnlyReferenceTests.cs
@@ -49,6 +49,11 @@ public class DynamicMemberSample
 	{
 		return d.Compute(1, "two", d);
 	}
+
+	public object Index(dynamic d)
+	{
+		return d[0];
+	}
 }
 
 /// <summary>
@@ -110,5 +115,27 @@ public class HoverOnlyReferenceTests
 			"dynamic Compute(int, string, dynamic)",
 			"each argument is typed from the callsite: the constants keep their compile-time type, "
 			+ "the dynamic argument stays dynamic");
+	}
+
+	[AvaloniaTest]
+	public async Task Dynamic_Index_Access_Is_A_HoverOnly_Indexer()
+	{
+		var (_, vm) = await TestHarness.BootAsync();
+		await vm.OpenAssemblyAsync(typeof(DynamicMemberSample).Assembly.Location);
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"ILSpy.Tests",
+			"ICSharpCode.ILSpy.Tests.TextView",
+			"ICSharpCode.ILSpy.Tests.TextView.DynamicMemberSample");
+		vm.AssemblyTreeModel.SelectNode(typeNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		// The brackets of d[0] carry a synthesized indexer.
+		var bracket = tab.References!.First(r => r.Reference is IProperty { IsIndexer: true });
+		bracket.Kind.Should().Be(ReferenceMode.HoverOnly, "the synthesized indexer has no metadata to jump to");
+
+		var ambience = new CSharpAmbience {
+			ConversionFlags = ConversionFlags.ShowReturnType | ConversionFlags.ShowParameterList,
+		};
+		ambience.ConvertSymbol((IProperty)bracket.Reference!).Should().Be("dynamic this[int]");
 	}
 }

--- a/ILSpy.Tests/Editor/HoverOnlyReferenceTests.cs
+++ b/ILSpy.Tests/Editor/HoverOnlyReferenceTests.cs
@@ -24,6 +24,9 @@ using Avalonia.VisualTree;
 
 using AwesomeAssertions;
 
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.Output;
+using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.TreeNodes;
 
@@ -40,6 +43,11 @@ public class DynamicMemberSample
 	public object Get(dynamic d)
 	{
 		return d.Property;
+	}
+
+	public object Call(dynamic d)
+	{
+		return d.Compute(1, "two", d);
 	}
 }
 
@@ -75,5 +83,32 @@ public class HoverOnlyReferenceTests
 
 		navigated.Should().BeFalse("clicking a hover-only reference must not navigate");
 		view.LocalReferenceMarks.Should().BeEmpty("a hover-only reference must not highlight occurrences");
+	}
+
+	[AvaloniaTest]
+	public async Task Dynamic_Invoke_Member_Hover_Renders_Its_Synthesized_Signature()
+	{
+		var (_, vm) = await TestHarness.BootAsync();
+		await vm.OpenAssemblyAsync(typeof(DynamicMemberSample).Assembly.Location);
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"ILSpy.Tests",
+			"ICSharpCode.ILSpy.Tests.TextView",
+			"ICSharpCode.ILSpy.Tests.TextView.DynamicMemberSample");
+		vm.AssemblyTreeModel.SelectNode(typeNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+
+		// The 'Compute' hover target is the member synthesized for the dynamic call d.Compute(1, "two", d).
+		var compute = tab.References!
+			.Select(r => r.Reference)
+			.OfType<IMethod>()
+			.First(m => m.Name == "Compute");
+
+		var ambience = new CSharpAmbience {
+			ConversionFlags = ConversionFlags.ShowReturnType | ConversionFlags.ShowParameterList,
+		};
+		ambience.ConvertSymbol(compute).Should().Be(
+			"dynamic Compute(int, string, dynamic)",
+			"each argument is typed from the callsite: the constants keep their compile-time type, "
+			+ "the dynamic argument stays dynamic");
 	}
 }

--- a/ILSpy.Tests/Editor/ReferenceClickTests.cs
+++ b/ILSpy.Tests/Editor/ReferenceClickTests.cs
@@ -72,7 +72,7 @@ public class ReferenceClickTests
 	{
 		var textView = view.Editor.TextArea.TextView;
 		var segment = tab.References!
-			.First(r => r.Reference != null && !r.IsLocal && !r.IsDefinition);
+			.First(r => r.Reference != null && r.Kind == ReferenceMode.Link && !r.IsDefinition);
 		var line = view.Editor.Document.GetLineByOffset(segment.StartOffset);
 		view.Editor.ScrollTo(line.LineNumber, segment.StartOffset - line.Offset + 1);
 		window.UpdateLayout();

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -288,6 +288,17 @@ namespace ICSharpCode.ILSpy.Languages
 			return new RichText(text, model);
 		}
 
+		public override RichText GetRichText(IType type)
+		{
+			ArgumentNullException.ThrowIfNull(type);
+			var output = new StringWriter();
+			var decoratedWriter = new TextWriterTokenWriter(output);
+			var writer = new CSharpHighlightingTokenWriter(TokenWriter.InsertRequiredSpaces(decoratedWriter), locatable: decoratedWriter);
+			var astBuilder = new TypeSystemAstBuilder { AlwaysUseShortTypeNames = true };
+			astBuilder.ConvertType(type).AcceptVisitor(new CSharpOutputVisitor(writer, FormattingOptionsFactory.CreateAllman()));
+			return new RichText(output.ToString(), writer.HighlightingModel);
+		}
+
 		static void EmboldenTypeNames(string text, RichTextModel model)
 		{
 			var highlighting = HighlightingManager.Instance.GetDefinition("C#");

--- a/ILSpy/Languages/Language.cs
+++ b/ILSpy/Languages/Language.cs
@@ -188,6 +188,12 @@ namespace ICSharpCode.ILSpy.Languages
 		public virtual RichText GetRichText(IEntity entity, ConversionFlags conversionFlags, bool boldTypeNames = false)
 			=> new(EntityToString(entity, conversionFlags));
 
+		/// <summary>
+		/// Renders a bare type (e.g. a local variable's type, or <c>dynamic</c>) as rich text for a hover.
+		/// </summary>
+		public virtual RichText GetRichText(IType type)
+			=> new(TypeToString(type));
+
 		public virtual void DecompileType(ITypeDefinition type, ITextOutput output, DecompilationOptions options)
 		{
 			WriteCommentLine(output, TypeToString(type));

--- a/ILSpy/TextView/AvaloniaEditTextOutput.cs
+++ b/ILSpy/TextView/AvaloniaEditTextOutput.cs
@@ -226,18 +226,18 @@ namespace ICSharpCode.ILSpy.TextView
 		}
 
 		public void WriteReference(MetadataFile metadata, Handle handle, string text, string protocol = "decompile", bool isDefinition = false)
-			=> AddReference(text, new EntityReference(metadata, handle, protocol), local: false, isDefinition);
+			=> AddReference(text, new EntityReference(metadata, handle, protocol), ReferenceMode.Link, isDefinition);
 
 		public void WriteReference(IType type, string text, bool isDefinition = false)
-			=> AddReference(text, type, local: false, isDefinition);
+			=> AddReference(text, type, ReferenceMode.Link, isDefinition);
 
 		public void WriteReference(IMember member, string text, bool isDefinition = false)
-			=> AddReference(text, member, local: false, isDefinition);
+			=> AddReference(text, member, ReferenceMode.Link, isDefinition);
 
-		public void WriteLocalReference(string text, object reference, bool isDefinition = false)
-			=> AddReference(text, reference, local: true, isDefinition);
+		public void WriteLocalReference(string text, object reference, bool isDefinition = false, bool isHoverOnly = false)
+			=> AddReference(text, reference, isHoverOnly ? ReferenceMode.HoverOnly : ReferenceMode.LocalHighlight, isDefinition);
 
-		void AddReference(string text, object reference, bool local, bool isDefinition)
+		void AddReference(string text, object reference, ReferenceMode kind, bool isDefinition)
 		{
 			WriteIndentIfNeeded();
 			int start = builder.Length;
@@ -249,7 +249,7 @@ namespace ICSharpCode.ILSpy.TextView
 				StartOffset = start,
 				EndOffset = end,
 				Reference = reference,
-				IsLocal = local,
+				Kind = kind,
 				IsDefinition = isDefinition,
 			});
 		}

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -1479,6 +1479,13 @@ namespace ICSharpCode.ILSpy.TextView
 				localRenderer.AddSignatureBlock(new RichText($"({kind}) ") + language.GetRichText(variable.Type) + new RichText($" {variable.Name}"));
 				return new HoverContent(localRenderer.CreateView(), IsRich: true);
 			}
+			if (segment.Reference is IType { Kind: TypeKind.Dynamic } dynamicType && language != null)
+			{
+				// dynamic has no metadata entity; render the keyword as its own hover.
+				var dynamicRenderer = CreateTooltipRenderer();
+				dynamicRenderer.AddSignatureBlock(language.GetRichText(dynamicType));
+				return new HoverContent(dynamicRenderer.CreateView(), IsRich: true);
+			}
 			var resolved = ResolveEntity(model, segment.Reference);
 			switch (resolved)
 			{

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -1471,6 +1471,14 @@ namespace ICSharpCode.ILSpy.TextView
 		internal HoverContent? BuildHoverContent(DecompilerTabPageModel model, ReferenceSegment segment)
 		{
 			var language = model.Language;
+			if (segment.Reference is Decompiler.IL.ILVariable variable && language != null)
+			{
+				// Local variables have no metadata symbol, so render the declared type and name directly.
+				string kind = variable.Kind == Decompiler.IL.VariableKind.Parameter ? "parameter" : "local variable";
+				var localRenderer = CreateTooltipRenderer();
+				localRenderer.AddSignatureBlock(new RichText($"({kind}) ") + language.GetRichText(variable.Type) + new RichText($" {variable.Name}"));
+				return new HoverContent(localRenderer.CreateView(), IsRich: true);
+			}
 			var resolved = ResolveEntity(model, segment.Reference);
 			switch (resolved)
 			{

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -1202,10 +1202,15 @@ namespace ICSharpCode.ILSpy.TextView
 			if (DataContext is not DecompilerTabPageModel model || segment.Reference == null)
 				return;
 
+			// Hover-only references (synthesized dynamic members, the dynamic keyword) carry a tooltip
+			// but are neither navigable nor highlightable — a click does nothing.
+			if (segment.Kind == ReferenceMode.HoverOnly)
+				return;
+
 			// Local references stay inside this document — paint every match and let the user
 			// scrub through them. Cross-document references clear any existing marks since the
 			// view is about to refresh anyway.
-			if (segment.IsLocal)
+			if (segment.Kind == ReferenceMode.LocalHighlight)
 			{
 				HighlightLocalReferences(model, segment.Reference);
 				return;

--- a/ILSpy/TextView/ReferenceSegment.cs
+++ b/ILSpy/TextView/ReferenceSegment.cs
@@ -21,14 +21,30 @@ using AvaloniaEdit.Document;
 namespace ICSharpCode.ILSpy.TextView
 {
 	/// <summary>
-	/// A clickable region in the decompiled text. <see cref="Reference"/> identifies the target;
-	/// <see cref="IsLocal"/> distinguishes local-variable references (highlight-only) from
-	/// cross-document ones; <see cref="IsDefinition"/> marks the spot where the entity is declared.
+	/// How a <see cref="ReferenceSegment"/> behaves when the user interacts with it.
+	/// </summary>
+	public enum ReferenceMode
+	{
+		/// <summary>A navigable reference (real members/types): hand cursor, click navigates.</summary>
+		Link,
+		/// <summary>A local-variable reference: arrow cursor, click highlights all its occurrences.</summary>
+		LocalHighlight,
+		/// <summary>
+		/// A reference that only shows a hover tooltip (synthesized dynamic members, the dynamic keyword):
+		/// arrow cursor, click does nothing, no occurrence highlight. It has no metadata to navigate to.
+		/// </summary>
+		HoverOnly,
+	}
+
+	/// <summary>
+	/// A region in the decompiled text with hover/interaction behavior. <see cref="Reference"/> identifies
+	/// the target; <see cref="Kind"/> selects the interaction mode; <see cref="IsDefinition"/> marks the
+	/// spot where the entity is declared.
 	/// </summary>
 	public sealed class ReferenceSegment : TextSegment
 	{
 		public object? Reference;
-		public bool IsLocal;
+		public ReferenceMode Kind;
 		public bool IsDefinition;
 	}
 }

--- a/ILSpy/TextView/VisualLineReferenceText.cs
+++ b/ILSpy/TextView/VisualLineReferenceText.cs
@@ -49,9 +49,9 @@ namespace ICSharpCode.ILSpy.TextView
 		{
 			if (e.Source is InputElement inputElement)
 			{
-				inputElement.Cursor = new Cursor(referenceSegment.IsLocal
-					? StandardCursorType.Arrow
-					: StandardCursorType.Hand);
+				inputElement.Cursor = new Cursor(referenceSegment.Kind == ReferenceMode.Link
+					? StandardCursorType.Hand
+					: StandardCursorType.Arrow);
 			}
 			// Do NOT set e.Handled = true — AvaloniaEdit's TextView.OnPointerMoved invokes
 			// OnQueryCursor with the live PointerEventArgs, and marking it handled there


### PR DESCRIPTION
Dynamic member accesses (`d.Property`, `d.Method(...)`, `d[index]`, `new T(dynamicArg)`) previously produced no tooltip at all in the text view, because there is no metadata entity behind them. This PR gives them proper hovers by synthesizing a symbol from the encoded callsite:

- `DynamicMemberResolveResult`/`DynamicInvocationResolveResult` gain a `Symbol`, populated in `ExpressionBuilder` with a synthesized `FakeField`/`FakeMethod`/`FakeProperty` (member get/set, invoke-member incl. generic type parameters, get/set index, constructor). Parameter/return types come from `CSharpArgumentInfo.CompileTimeType` where the compiler recorded a static type, else `dynamic`.
- A third reference mode is introduced: `ReferenceSegment.IsLocal` becomes `ReferenceMode { Link, LocalHighlight, HoverOnly }`. Synthesized dynamic members are `HoverOnly` — tooltip, arrow cursor, but no navigation and no occurrence highlight, since there is no real member to jump to. Local variables keep the highlight behavior.
- The `dynamic` keyword itself and local variables/parameters also get hovers.

The decompiled text output is unchanged; only reference/tooltip metadata is affected. Covered by new `HoverOnlyReferenceTests` (end-to-end through the headless UI), `CSharpAmbienceTests` rendering cases, and the existing dynamic pretty tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)