### PR TITLE
Generate version-info files with CRLF on all platforms

### DIFF
--- a/BuildTools/update-assemblyinfo.ps1
+++ b/BuildTools/update-assemblyinfo.ps1
@@ -158,7 +158,9 @@ try {
 	}
     
 	foreach ($file in $templateFiles) {
-		[string]$in = (Get-Content $file.Input) -Join [System.Environment]::NewLine;
+		# Force CRLF regardless of platform: the repo's .cs files are CRLF, and the format
+		# hook flags the generated file on every run if it is written with LF on Linux.
+		[string]$in = (Get-Content $file.Input) -Join "`r`n";
 
 		$out = $in.Replace('$INSERTVERSION$', $fullVersionNumber);
 		$out = $out.Replace('$INSERTMAJORVERSION$', $major);
@@ -173,7 +175,7 @@ try {
 		$out = $out.Replace('$INSERTVERSIONNAMEPOSTFIX$', $postfixVersionName);
 		$out = $out.Replace('$INSERTBUILDCONFIG$', $buildConfig);
 
-		if ((-not (Test-File $file.Output)) -or (((Get-Content $file.Output) -Join [System.Environment]::NewLine) -ne $out)) {
+		if ((-not (Test-File $file.Output)) -or (((Get-Content $file.Output) -Join "`r`n") -ne $out)) {
 			$utf8NoBom = New-Object System.Text.UTF8Encoding($false);
 			[System.IO.File]::WriteAllText($file.Output, $out, $utf8NoBom);
 		}


### PR DESCRIPTION
update-assemblyinfo.ps1 joins the template lines with `Environment.NewLine`, so on Linux the generated `DecompilerVersionInfo.cs` is written with LF. The repo's `.cs` files are CRLF, so the pre-commit format hook re-flags every line of the generated file on each commit made on a Linux machine ("Formatted 1 of N files" on every run).

Write the generated file with CRLF regardless of platform, and use the same separator in the up-to-date comparison so the change detection stays consistent. After the fix the hook reports "Formatted 0 of 1697 files" on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)