### PR TITLE
Fix #3909: emit nullable override disambiguators

### DIFF
--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -664,6 +664,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task Issue3909([ValueSource(nameof(roslyn3OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions | CompilerOptions.NullableEnable);
+		}
+
+		[Test]
 		public async Task Issue3452([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions | CompilerOptions.NullableEnable);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
@@ -1,0 +1,105 @@
+#nullable enable
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class Issue3909
+	{
+		public abstract class Base
+		{
+			public virtual T? Unconstrained<T>(T? value)
+			{
+				return value;
+			}
+
+			public virtual T? ReferenceType<T>(T? value) where T : class
+			{
+				return value;
+			}
+
+			public virtual T? ReferenceTypeNullable<T>(T? value) where T : class?
+			{
+				return value;
+			}
+
+			public virtual T? NotNull<T>(T? value) where T : notnull
+			{
+				return value;
+			}
+
+			public virtual T? ValueType<T>(T? value) where T : struct
+			{
+				return value;
+			}
+
+			public virtual U? ReturnOnly<U>()
+			{
+				return default(U);
+			}
+
+			public virtual T?[] Nested<T>(T?[] values)
+			{
+				return values;
+			}
+
+			public virtual T Identity<T>(T value)
+			{
+				return value;
+			}
+		}
+
+		public sealed class Derived : Base
+		{
+			public override T? Unconstrained<T>(T? value) where T : default
+			{
+				return value;
+			}
+
+			public override T? ReferenceType<T>(T? value) where T : class
+			{
+				return value;
+			}
+
+			public override T? ReferenceTypeNullable<T>(T? value) where T : class
+			{
+				return value;
+			}
+
+			public override T? NotNull<T>(T? value) where T : default
+			{
+				return value;
+			}
+
+			public override T? ValueType<T>(T? value)
+			{
+				return value;
+			}
+
+			public override U? ReturnOnly<U>() where U : default
+			{
+				return default(U);
+			}
+
+			public override T?[] Nested<T>(T?[] values) where T : default
+			{
+				return values;
+			}
+
+			public override T Identity<T>(T value)
+			{
+				return value;
+			}
+		}
+
+		public interface IRoundTrip
+		{
+			T? RoundTrip<T>(T? value);
+		}
+
+		public class ExplicitImpl : IRoundTrip
+		{
+			T? IRoundTrip.RoundTrip<T>(T? value) where T : default
+			{
+				return value;
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
@@ -207,6 +207,32 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public abstract class MethodChainBase
+		{
+			public virtual T? DependentOnClassConstrained<T, U>(T? value, U other) where T : U where U : class
+			{
+				return value;
+			}
+
+			public virtual T? DependentOnClassType<T, U>(T? value, U other) where T : U where U : Node
+			{
+				return value;
+			}
+		}
+
+		public sealed class MethodChainDerived : MethodChainBase
+		{
+			public override T? DependentOnClassConstrained<T, U>(T? value, U other) where T : default
+			{
+				return value;
+			}
+
+			public override T? DependentOnClassType<T, U>(T? value, U other) where T : class
+			{
+				return value;
+			}
+		}
+
 		public class ContainerBase<TOuter> where TOuter : class
 		{
 			public virtual TOuter? Pick<TItem>(TItem item)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 #nullable enable
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
@@ -99,6 +102,124 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			T? IRoundTrip.RoundTrip<T>(T? value) where T : default
 			{
 				return value;
+			}
+		}
+
+		public class Node
+		{
+		}
+
+		public abstract class ConstrainedBase
+		{
+			public virtual T? ClassType<T>(T? value) where T : Node
+			{
+				return value;
+			}
+
+			public virtual T? DelegateType<T>(T? value) where T : Delegate
+			{
+				return value;
+			}
+
+			public virtual T? EnumType<T>(T? value) where T : Enum
+			{
+				return value;
+			}
+
+			public virtual T? InterfaceType<T>(T? value) where T : IDisposable
+			{
+				return value;
+			}
+
+			public virtual List<T?> NestedGeneric<T>(List<T?> values)
+			{
+				return values;
+			}
+
+			public virtual TItem? PartiallyAnnotated<TItem, TOther>(TItem? value, TOther other)
+			{
+				return value;
+			}
+		}
+
+		public sealed class ConstrainedDerived : ConstrainedBase
+		{
+			public override T? ClassType<T>(T? value) where T : class
+			{
+				return value;
+			}
+
+			public override T? DelegateType<T>(T? value) where T : class
+			{
+				return value;
+			}
+
+			public override T? EnumType<T>(T? value) where T : default
+			{
+				return value;
+			}
+
+			public override T? InterfaceType<T>(T? value) where T : default
+			{
+				return value;
+			}
+
+			public override List<T?> NestedGeneric<T>(List<T?> values) where T : default
+			{
+				return values;
+			}
+
+			public override TItem? PartiallyAnnotated<TItem, TOther>(TItem? value, TOther other) where TItem : default
+			{
+				return value;
+			}
+		}
+
+		public class ClassTypeChainBase<TOuter> where TOuter : Node
+		{
+			public virtual T? Chained<T>(T? value) where T : TOuter
+			{
+				return value;
+			}
+		}
+
+		public sealed class ClassTypeChainDerived<TOuter> : ClassTypeChainBase<TOuter> where TOuter : Node
+		{
+			public override T? Chained<T>(T? value) where T : class
+			{
+				return value;
+			}
+		}
+
+		public class ReferenceTypeChainBase<TOuter> where TOuter : class
+		{
+			public virtual T? Chained<T>(T? value) where T : TOuter
+			{
+				return value;
+			}
+		}
+
+		public sealed class ReferenceTypeChainDerived<TOuter> : ReferenceTypeChainBase<TOuter> where TOuter : class
+		{
+			public override T? Chained<T>(T? value) where T : default
+			{
+				return value;
+			}
+		}
+
+		public class ContainerBase<TOuter> where TOuter : class
+		{
+			public virtual TOuter? Pick<TItem>(TItem item)
+			{
+				return null;
+			}
+		}
+
+		public sealed class ContainerDerived<TOuter> : ContainerBase<TOuter> where TOuter : class
+		{
+			public override TOuter? Pick<TItem>(TItem item)
+			{
+				return null;
 			}
 		}
 	}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
@@ -222,5 +222,28 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				return null;
 			}
 		}
+#if CS130
+		public class BaseWithAllowsRefStruct
+		{
+			public virtual void Annotated<T>(T? value) where T : allows ref struct
+			{
+			}
+
+			public virtual void Plain<T>(T value) where T : allows ref struct
+			{
+			}
+		}
+
+		public class DerivedWithAllowsRefStruct : BaseWithAllowsRefStruct
+		{
+			public override void Annotated<T>(T? value) where T : default
+			{
+			}
+
+			public override void Plain<T>(T value)
+			{
+			}
+		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -2336,13 +2336,24 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			if (method.IsExtensionMethod && method.ReducedFrom == null && decl.Parameters.Any())
 				decl.Parameters.First().HasThisModifier = true;
 
-			if (this.ShowTypeParameters && this.ShowTypeParameterConstraints && !method.IsOverride && !method.IsExplicitInterfaceImplementation)
+			if (this.ShowTypeParameters && this.ShowTypeParameterConstraints)
 			{
-				foreach (ITypeParameter tp in method.TypeParameters)
+				if (method.IsOverride || method.IsExplicitInterfaceImplementation)
 				{
-					var constraint = ConvertTypeParameterConstraint(tp);
-					if (constraint != null)
-						decl.Constraints.Add(constraint);
+					// C# inherits the constraints of an override or explicit interface
+					// implementation from the base member and forbids restating them, with a
+					// single exception: a 'class', 'struct', or 'default' constraint may be given
+					// to disambiguate whether 'T?' denotes a nullable annotation or Nullable<T>.
+					AddNullabilityDisambiguatingConstraints(decl, method);
+				}
+				else
+				{
+					foreach (ITypeParameter tp in method.TypeParameters)
+					{
+						var constraint = ConvertTypeParameterConstraint(tp);
+						if (constraint != null)
+							decl.Constraints.Add(constraint);
+					}
 				}
 			}
 			decl.Body = GenerateBodyBlock();
@@ -2600,6 +2611,54 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				c.BaseTypes.Add(new PrimitiveType("allows ref struct"));
 			}
 			return c;
+		}
+
+		// The compiler records the inherited class/struct constraint flags on an override or
+		// explicit interface implementation in metadata, even though the source does not restate
+		// them, so the disambiguator can be derived from the method's own type parameters without
+		// resolving the base member. A disambiguator is required only where the type parameter
+		// itself carries a nullable annotation ('T?') in the signature: without it the compiler
+		// reads 'T?' as Nullable<T>. A struct-constrained parameter uses Nullable<T> rather than a
+		// nullable annotation, so it neither needs nor permits one.
+		void AddNullabilityDisambiguatingConstraints(MethodDeclaration decl, IMethod method)
+		{
+			if (method.TypeParameters.Count == 0)
+				return;
+			NullableTypeParameterCollector collector = new();
+			method.ReturnType.AcceptVisitor(collector);
+			foreach (IParameter p in method.Parameters)
+				p.Type.AcceptVisitor(collector);
+			if (collector.MethodTypeParameterIndices.Count == 0)
+				return;
+			foreach (ITypeParameter tp in method.TypeParameters)
+			{
+				if (!collector.MethodTypeParameterIndices.Contains(tp.Index) || tp.HasValueTypeConstraint)
+					continue;
+				Constraint c = new();
+				c.TypeParameter = MakeSimpleType(tp.Name);
+				// C# accepts only plain 'class' here, never 'class?'; the constraint's own
+				// nullability is inherited from the base member regardless.
+				c.BaseTypes.Add(new PrimitiveType(tp.HasReferenceTypeConstraint ? "class" : "default"));
+				decl.Constraints.Add(c);
+			}
+		}
+
+		// Collects the indices of a method's own type parameters that appear with a nullable
+		// annotation ('T?') anywhere in a visited type, including nested positions such as
+		// List<T?> or T?[].
+		sealed class NullableTypeParameterCollector : TypeVisitor
+		{
+			public readonly HashSet<int> MethodTypeParameterIndices = [];
+
+			public override IType VisitNullabilityAnnotatedType(NullabilityAnnotatedType type)
+			{
+				if (type is NullabilityAnnotatedTypeParameter { Nullability: Nullability.Nullable } natp
+					&& natp.OriginalTypeParameter.OwnerType == SymbolKind.Method)
+				{
+					MethodTypeParameterIndices.Add(natp.OriginalTypeParameter.Index);
+				}
+				return base.VisitNullabilityAnnotatedType(type);
+			}
 		}
 
 		static bool IsObjectOrValueType(IType type)

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -2613,49 +2613,57 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			return c;
 		}
 
-		// The compiler records the inherited class/struct constraint flags on an override or
-		// explicit interface implementation in metadata, even though the source does not restate
-		// them, so the disambiguator can be derived from the method's own type parameters without
-		// resolving the base member. A disambiguator is required only where the type parameter
-		// itself carries a nullable annotation ('T?') in the signature: without it the compiler
-		// reads 'T?' as Nullable<T>. A struct-constrained parameter uses Nullable<T> rather than a
-		// nullable annotation, so it neither needs nor permits one.
+		// A disambiguator is required only where the type parameter itself carries a nullable
+		// annotation ('T?') in the signature: without it the compiler reads 'T?' as Nullable<T>.
+		// Which one is legal follows from whether the inherited constraints make the type
+		// parameter a reference type, a value type, or neither:
+		//   - a value type uses Nullable<T> rather than a nullable annotation, so it neither
+		//     needs nor permits a disambiguator;
+		//   - a reference type requires 'class';
+		//   - anything else requires 'default'.
+		// The inherited constraints are re-emitted on the override's own type parameters in
+		// metadata, so this classification does not depend on resolving the base member. The
+		// restated disambiguator itself is not, hence it must be derived rather than read back.
 		void AddNullabilityDisambiguatingConstraints(MethodDeclaration decl, IMethod method)
 		{
 			if (method.TypeParameters.Count == 0)
 				return;
-			NullableTypeParameterCollector collector = new();
+			NullableTypeParameterCollector collector = new(method.TypeParameters);
 			method.ReturnType.AcceptVisitor(collector);
 			foreach (IParameter p in method.Parameters)
 				p.Type.AcceptVisitor(collector);
-			if (collector.MethodTypeParameterIndices.Count == 0)
+			if (collector.NullableTypeParameters.Count == 0)
 				return;
 			foreach (ITypeParameter tp in method.TypeParameters)
 			{
-				if (!collector.MethodTypeParameterIndices.Contains(tp.Index) || tp.HasValueTypeConstraint)
+				if (!collector.NullableTypeParameters.Contains(tp))
+					continue;
+				bool? isReferenceType = tp.IsReferenceType;
+				if (isReferenceType == false)
 					continue;
 				Constraint c = new();
 				c.TypeParameter = MakeSimpleType(tp.Name);
 				// C# accepts only plain 'class' here, never 'class?'; the constraint's own
 				// nullability is inherited from the base member regardless.
-				c.BaseTypes.Add(new PrimitiveType(tp.HasReferenceTypeConstraint ? "class" : "default"));
+				c.BaseTypes.Add(new PrimitiveType(isReferenceType == true ? "class" : "default"));
 				decl.Constraints.Add(c);
 			}
 		}
 
-		// Collects the indices of a method's own type parameters that appear with a nullable
-		// annotation ('T?') anywhere in a visited type, including nested positions such as
-		// List<T?> or T?[].
-		sealed class NullableTypeParameterCollector : TypeVisitor
+		// Collects the type parameters of one method that appear with a nullable annotation ('T?')
+		// anywhere in a visited type, including nested positions such as List<T?> or T?[]. Type
+		// parameters of any other owner are ignored: a specialized signature can substitute a
+		// foreign type parameter that happens to share an index with one of this method's own.
+		sealed class NullableTypeParameterCollector(IReadOnlyList<ITypeParameter> typeParameters) : TypeVisitor
 		{
-			public readonly HashSet<int> MethodTypeParameterIndices = [];
+			public readonly HashSet<ITypeParameter> NullableTypeParameters = [];
 
 			public override IType VisitNullabilityAnnotatedType(NullabilityAnnotatedType type)
 			{
 				if (type is NullabilityAnnotatedTypeParameter { Nullability: Nullability.Nullable } natp
-					&& natp.OriginalTypeParameter.OwnerType == SymbolKind.Method)
+					&& typeParameters.Contains(natp.OriginalTypeParameter))
 				{
-					MethodTypeParameterIndices.Add(natp.OriginalTypeParameter.Index);
+					NullableTypeParameters.Add(natp.OriginalTypeParameter);
 				}
 				return base.VisitNullabilityAnnotatedType(type);
 			}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -2615,15 +2615,10 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		// A disambiguator is required only where the type parameter itself carries a nullable
 		// annotation ('T?') in the signature: without it the compiler reads 'T?' as Nullable<T>.
-		// Which one is legal follows from whether the inherited constraints make the type
-		// parameter a reference type, a value type, or neither:
-		//   - a value type uses Nullable<T> rather than a nullable annotation, so it neither
-		//     needs nor permits a disambiguator;
-		//   - a reference type requires 'class';
-		//   - anything else requires 'default'.
 		// The inherited constraints are re-emitted on the override's own type parameters in
-		// metadata, so this classification does not depend on resolving the base member. The
-		// restated disambiguator itself is not, hence it must be derived rather than read back.
+		// metadata, so which disambiguator is legal follows from them without resolving the base
+		// member. The restated disambiguator leaves no metadata trace of its own, hence it must be
+		// derived rather than read back.
 		void AddNullabilityDisambiguatingConstraints(MethodDeclaration decl, IMethod method)
 		{
 			if (method.TypeParameters.Count == 0)
@@ -2636,19 +2631,27 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				return;
 			foreach (ITypeParameter tp in method.TypeParameters)
 			{
-				if (!collector.NullableTypeParameters.Contains(tp))
-					continue;
-				bool? isReferenceType = tp.IsReferenceType;
-				if (isReferenceType == false)
+				if (!collector.NullableTypeParameters.Contains(tp) || GetNullabilityDisambiguator(tp) is not string keyword)
 					continue;
 				Constraint c = new();
 				c.TypeParameter = MakeSimpleType(tp.Name);
-				// C# accepts only plain 'class' here, never 'class?'; the constraint's own
-				// nullability is inherited from the base member regardless.
-				c.BaseTypes.Add(new PrimitiveType(isReferenceType == true ? "class" : "default"));
+				c.BaseTypes.Add(new PrimitiveType(keyword));
 				decl.Constraints.Add(c);
 			}
 		}
+
+		// Returns the constraint that keeps 'T?' meaning a nullable annotation on an override or
+		// explicit interface implementation, or null where the type parameter neither needs nor
+		// permits one.
+		static string? GetNullabilityDisambiguator(ITypeParameter tp) => tp.IsReferenceType switch {
+			// C# accepts only plain 'class' here, never 'class?'; the constraint's own nullability
+			// is inherited from the base member regardless.
+			true => "class",
+			// Constrained to neither a reference type nor a value type.
+			null => "default",
+			// A value type uses Nullable<T> rather than a nullable annotation.
+			false => null
+		};
 
 		// Collects the type parameters of one method that appear with a nullable annotation ('T?')
 		// anywhere in a visited type, including nested positions such as List<T?> or T?[]. Type

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -2619,6 +2619,9 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		// metadata, so which disambiguator is legal follows from them without resolving the base
 		// member. The restated disambiguator leaves no metadata trace of its own, hence it must be
 		// derived rather than read back.
+		// The clause is built here rather than through ConvertTypeParameterConstraint, which also
+		// prints 'allows ref struct' from the byreflike flag. That flag is re-emitted on the
+		// override's own type parameter as well, and restating it is CS0460.
 		void AddNullabilityDisambiguatingConstraints(MethodDeclaration decl, IMethod method)
 		{
 			if (method.TypeParameters.Count == 0)


### PR DESCRIPTION
Fixes #3909.

### Problem

C# normally inherits generic constraints on overrides and explicit interface implementations, so
ILSpy correctly avoids restating them. Nullable annotations introduce one exception: when a
method type parameter appears as `T?`, C# requires `class`, `struct`, or `default` to distinguish
a nullable annotation from `Nullable<T>`.

Omitting that discriminator can change the signature and produce CS0115 / CS0453.

### Solution

For overrides and explicit interface implementations:

- collect method type parameters that appear with a nullable annotation anywhere in the return or
  parameter types;
- skip value-type-constrained parameters, where `T?` already means `Nullable<T>`;
- emit `class` for an inherited reference-type constraint, otherwise emit `default`.

Roslyn records the inherited reference/value constraint flags on the implementation method's own
type parameters, so this remains exact even when the base assembly cannot be resolved. Other
inherited constraints remain omitted, as required by C#.

### Tests

Added a Roslyn 3+ Pretty fixture covering:

- unconstrained and `notnull` parameters requiring `default`;
- `class` and `class?` contracts requiring plain `class`;
- `struct` and non-nullable-signature controls;
- return-only and nested-array nullable annotations;
- an explicit interface implementation.

Validation:

- `Issue3909` Pretty matrix: 6 passed
- related generic / nullable Pretty matrices: 26 passed
- full Pretty suite: 1,919 passed, 5 existing skips
- type-system unit tests: 174 passed
- Release solution build: 0 warnings, 0 errors
- full solution test suite: 4,927 passed, 15 existing skips

- [x] At least one test covering the code changed
