### PR TITLE
Fix #3908: use the async iterator element type for yield

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncStreams.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncStreams.cs
@@ -6,6 +6,12 @@ using System.Threading.Tasks;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	public enum AsyncStreamColor
+	{
+		Red,
+		Green
+	}
+
 	public class AsyncStreams
 	{
 		public static async IAsyncEnumerable<int> CountTo(int until)
@@ -85,6 +91,33 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				await Task.Yield();
 			}
 		}
+
+		public static async IAsyncEnumerable<IAsyncStreamEntry> ConstrainedGenericYield<T>(IAsyncEnumerable<T> items) where T : IAsyncStreamEntry
+		{
+			await foreach (T item in items)
+			{
+				yield return item;
+			}
+		}
+
+		public static IEnumerable<object> BoxedValues()
+		{
+			yield return true;
+			yield return 'a';
+			yield return AsyncStreamColor.Green;
+		}
+
+		public static async IAsyncEnumerable<object> BoxedValuesAsync()
+		{
+			yield return true;
+			await Task.Yield();
+			yield return 'a';
+			yield return AsyncStreamColor.Green;
+		}
+	}
+
+	public interface IAsyncStreamEntry
+	{
 	}
 
 	public struct TestStruct

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -433,7 +433,8 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		protected internal override TranslatedStatement VisitYieldReturn(YieldReturn inst)
 		{
-			var elementType = currentFunction.ReturnType.GetElementTypeFromIEnumerable(typeSystem, true, out var isGeneric);
+			var elementType = currentFunction.AsyncReturnType
+				?? currentFunction.ReturnType.GetElementTypeFromIEnumerable(typeSystem, true, out _);
 			var expr = exprBuilder.Translate(inst.Value, typeHint: elementType)
 				.ConvertTo(elementType, exprBuilder, allowImplicitConversion: true);
 			return new YieldReturnStatement {


### PR DESCRIPTION
Fixes #3908.

### Problem

`StatementBuilder.VisitYieldReturn` derives the target element type from `IEnumerable<T>` /
`IEnumerator<T>`. For an async iterator, that lookup returns an unknown type even though
`AsyncAwaitDecompiler` has already recovered the element type.

Without the target type, the compiler-generated `box T` used to store a constrained generic value
in the async iterator's current field remains visible as `(object)value`. The resulting
`yield return` fails with CS0266 when the iterator returns an interface constraint.

### Solution

Use `ILFunction.AsyncReturnType` as the element type for async iterators, falling back to the
existing synchronous enumerable lookup.

The existing expression conversion logic can then remove compiler boxing when an implicit
conversion to the recovered element type exists. No async-state-machine-specific cast rewrite is
needed.

### Tests

Extended the `AsyncStreams` Pretty fixture with:

- a constrained generic async iterator returning its interface constraint;
- synchronous and asynchronous object iterators yielding boxed `bool`, `char`, and enum values,
  ensuring their source values remain intact.

Validation:

- `AsyncStreams` Pretty matrix: 6 passed
- runtime-async `AsyncStreams` matrix: 2 passed
- full Pretty suite: 1,913 passed, 5 existing skips
- Release solution build: 0 warnings, 0 errors
- full solution test suite: 4,921 passed, 15 existing skips

- [x] At least one test covering the code changed
