### PR TITLE
Revive NRefactory conversion tests and cover all of C# standard chapter 10

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 using ICSharpCode.Decompiler.CSharp.Resolver;
 using ICSharpCode.Decompiler.Semantics;
@@ -104,6 +105,37 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			IType from2 = compilation.FindType(from).AcceptVisitor(new ReplaceSpecialTypesVisitor());
 			IType to2 = compilation.FindType(to).AcceptVisitor(new ReplaceSpecialTypesVisitor());
 			return conversions.ExplicitConversion(from2, to2);
+		}
+
+		/// <summary>
+		/// Converts a constant expression (e.g. an integer literal) to the target type.
+		/// </summary>
+		Conversion ConstantConversion(object value, Type to)
+		{
+			IType fromType = compilation.FindType(value.GetType());
+			IType to2 = compilation.FindType(to).AcceptVisitor(new ReplaceSpecialTypesVisitor());
+			return conversions.ImplicitConversion(new ConstantResolveResult(fromType, value), to2);
+		}
+
+		/// <summary>
+		/// Builds a MethodGroupResolveResult from all methods named <paramref name="methodName"/>
+		/// in <paramref name="declaringType"/> (as if the expression were "instance.M") and
+		/// converts it to <paramref name="delegateType"/>.
+		/// </summary>
+		Conversion MethodGroupConversion(Type declaringType, string methodName, Type delegateType,
+			ResolveResult targetResult = null, IMethod[] extensionMethods = null)
+		{
+			IType declaring = compilation.FindType(declaringType);
+			var mgrr = new MethodGroupResolveResult(
+				targetResult ?? new ResolveResult(declaring), methodName,
+				new[] { new MethodListWithDeclaringType(declaring, declaring.GetMethods(m => m.Name == methodName)) },
+				null);
+			if (extensionMethods != null)
+			{
+				mgrr.extensionMethods = new List<List<IMethod>> { new List<IMethod>(extensionMethods) };
+			}
+			IType dt = compilation.FindType(delegateType).AcceptVisitor(new ReplaceSpecialTypesVisitor());
+			return conversions.ImplicitConversion(mgrr, dt);
 		}
 
 		[Test]
@@ -688,161 +720,123 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(BetterConversion(typeof(sbyte), typeof(int?), typeof(uint?)), Is.EqualTo(0));
 		}
 
-		/* TODO: we should probably revive these tests somehow
 		[Test]
 		public void ExpansiveInheritance()
 		{
-			var a = new DefaultUnresolvedTypeDefinition(string.Empty, "A");
-			var b = new DefaultUnresolvedTypeDefinition(string.Empty, "B");
-			// interface A<in U>
-			a.Kind = TypeKind.Interface;
-			a.TypeParameters.Add(new DefaultUnresolvedTypeParameter(SymbolKind.TypeDefinition, 0, "U") { Variance = VarianceModifier.Contravariant });
+			// interface A<in U> { }
 			// interface B<X> : A<A<B<X>>> { }
-			b.TypeParameters.Add(new DefaultUnresolvedTypeParameter(SymbolKind.TypeDefinition, 0, "X"));
-			b.BaseTypes.Add(new ParameterizedTypeReference(
-				a, new[] { new ParameterizedTypeReference(
-					a, new [] { new ParameterizedTypeReference(
-						b, new [] { new TypeParameterReference(SymbolKind.TypeDefinition, 0) }
-					) } ) }));
+			// Finding a conversion B<double> -> A<B<string>> must terminate even though
+			// the base-type substitution keeps producing ever-larger types.
+			ITypeDefinition a = compilation.FindType(typeof(ExpansiveInheritanceTestCases.A<>)).GetDefinition();
+			ITypeDefinition b = compilation.FindType(typeof(ExpansiveInheritanceTestCases.B<>)).GetDefinition();
 
-			ICompilation compilation = TypeSystemHelper.CreateCompilation(a, b);
-			ITypeDefinition resolvedA = compilation.MainAssembly.GetTypeDefinition(a.FullTypeName);
-			ITypeDefinition resolvedB = compilation.MainAssembly.GetTypeDefinition(b.FullTypeName);
-
-			IType type1 = new ParameterizedType(resolvedB, new[] { compilation.FindType(KnownTypeCode.Double) });
-			IType type2 = new ParameterizedType(resolvedA, new[] { new ParameterizedType(resolvedB, new[] { compilation.FindType(KnownTypeCode.String) }) });
+			IType type1 = new ParameterizedType(b, ImmutableArray.Create(compilation.FindType(KnownTypeCode.Double)));
+			IType type2 = new ParameterizedType(a, ImmutableArray.Create<IType>(
+				new ParameterizedType(b, ImmutableArray.Create(compilation.FindType(KnownTypeCode.String)))));
 			Assert.That(!conversions.ImplicitConversion(type1, type2).IsValid);
 		}
 
 		[Test]
 		public void ImplicitTypeParameterConversion()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where T : U {
-		U u = $t$;
-	}
-}";
-			Assert.AreEqual(C.BoxingConversion, GetConversion(program));
+			// void M<T, U>(T t) where T : U  =>  "U u = t;" is a boxing conversion
+			// (e.g. T = int, U = object)
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", constraints: new[] { u });
+			Assert.That(conversions.ImplicitConversion(t, u), Is.EqualTo(C.BoxingConversion));
 		}
 
 		[Test]
 		public void InvalidImplicitTypeParameterConversion()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where U : T {
-		U u = $t$;
-	}
-}";
-			Assert.AreEqual(C.None, GetConversion(program));
+			// void M<T, U>(T t) where U : T  =>  "U u = t;" is invalid
+			// (the constraint points the wrong way)
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", constraints: new[] { t });
+			Assert.That(conversions.ImplicitConversion(t, u), Is.EqualTo(C.None));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterArrayConversion()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where T : U {
-		U[] u = $t$;
-	}
-}";
-			// invalid, e.g. T=int[], U=object[]
-			Assert.AreEqual(C.None, GetConversion(program));
+			// void M<T, U>(T[] t) where T : U  =>  "U[] u = t;" is invalid
+			// (e.g. T = int, U = object: int[] is not convertible to object[])
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", constraints: new[] { u });
+			Assert.That(conversions.ImplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.None));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterConversionWithClassConstraint()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where T : class, U where U : class {
-		U u = $t$;
-	}
-}";
-			Assert.AreEqual(C.ImplicitReferenceConversion, GetConversion(program));
+			// void M<T, U>(T t) where T : class, U where U : class  =>  "U u = t;" is a reference conversion
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", hasReferenceTypeConstraint: true);
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasReferenceTypeConstraint: true, constraints: new[] { u });
+			Assert.That(conversions.ImplicitConversion(t, u), Is.EqualTo(C.ImplicitReferenceConversion));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterArrayConversionWithClassConstraint()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where T : class, U where U : class {
-		U[] u = $t$;
-	}
-}";
-			Assert.AreEqual(C.ImplicitReferenceConversion, GetConversion(program));
+			// void M<T, U>(T[] t) where T : class, U where U : class  =>  "U[] u = t;" is a
+			// covariant array conversion (both are known to be reference types)
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", hasReferenceTypeConstraint: true);
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasReferenceTypeConstraint: true, constraints: new[] { u });
+			Assert.That(conversions.ImplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.ImplicitReferenceConversion));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterConversionWithClassConstraintOnlyOnT()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where T : class, U {
-		U u = $t$;
-	}
-}";
-			Assert.AreEqual(C.ImplicitReferenceConversion, GetConversion(program));
+			// void M<T, U>(T t) where T : class, U  =>  "U u = t;" is a reference conversion
+			// (T is known to be a reference type, so no boxing is involved)
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasReferenceTypeConstraint: true, constraints: new[] { u });
+			Assert.That(conversions.ImplicitConversion(t, u), Is.EqualTo(C.ImplicitReferenceConversion));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterArrayConversionWithClassConstraintOnlyOnT()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where T : class, U {
-		U[] u = $t$;
-	}
-}";
-			Assert.AreEqual(C.ImplicitReferenceConversion, GetConversion(program));
+			// void M<T, U>(T[] t) where T : class, U  =>  "U[] u = t;" is a covariant array conversion
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasReferenceTypeConstraint: true, constraints: new[] { u });
+			Assert.That(conversions.ImplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.ImplicitReferenceConversion));
 		}
 
 		[Test]
 		public void MethodGroupConversion_Void()
 		{
-			string program = @"using System;
-delegate void D();
-class Test {
-	D d = $M$;
-	public static void M() {}
-}";
-			var c = GetConversion(program);
+			// delegate void D();
+			// D d = M;  with  public static void M() {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.VoidStatic), "M",
+				typeof(MethodGroupConversionTestCases.DVoid));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 			Assert.That(!c.DelegateCapturesFirstArgument);
-			Assert.IsNotNull(c.Method);
+			Assert.That(c.Method, Is.Not.Null);
 		}
 
 		[Test]
 		public void MethodGroupConversion_Void_InstanceMethod()
 		{
-			string program = @"using System;
-delegate void D();
-class Test {
-	D d;
-	public void M() {
-		d = $M$;
-	}
-}";
-			var c = GetConversion(program);
+			// delegate void D();
+			// D d = M;  with  public void M() {}  (instance method)
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.VoidInstance), "M",
+				typeof(MethodGroupConversionTestCases.DVoid));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 			Assert.That(c.DelegateCapturesFirstArgument);
-			Assert.IsNotNull(c.Method);
+			Assert.That(c.Method, Is.Not.Null);
 		}
 
 		[Test]
 		public void MethodGroupConversion_MatchingSignature()
 		{
-			string program = @"using System;
-delegate object D(int argument);
-class Test {
-	D d = $M$;
-	public static object M(int argument) {}
-}";
-			var c = GetConversion(program);
+			// delegate object D(int argument);
+			// D d = M;  with  public static object M(int argument) {...}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ReturnObjectFromInt), "M",
+				typeof(MethodGroupConversionTestCases.DObjInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
@@ -850,13 +844,12 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_InvalidReturnType()
 		{
-			string program = @"using System;
-delegate object D(int argument);
-class Test {
-	D d = $M$;
-	public static int M(int argument) {}
-}";
-			var c = GetConversion(program);
+			// delegate object D(int argument);
+			// D d = M;  with  public static int M(int argument) {...}
+			// int -> object is a boxing conversion, not an identity/reference conversion,
+			// so the method is not delegate-compatible.
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ReturnIntFromInt), "M",
+				typeof(MethodGroupConversionTestCases.DObjInt));
 			Assert.That(!c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
@@ -864,13 +857,10 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_CovariantReturnType()
 		{
-			string program = @"using System;
-delegate object D(int argument);
-class Test {
-	D d = $M$;
-	public static string M(int argument) {}
-}";
-			var c = GetConversion(program);
+			// delegate object D(int argument);
+			// D d = M;  with  public static string M(int argument) {...}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ReturnStringFromInt), "M",
+				typeof(MethodGroupConversionTestCases.DObjInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
@@ -878,13 +868,10 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_RefArgumentTypesEqual()
 		{
-			string program = @"using System;
-delegate void D(ref object o);
-class Test {
-	D d = $M$;
-	public static void M(ref object o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(ref object o);
+			// D d = M;  with  public static void M(ref object o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.RefObjParam), "M",
+				typeof(MethodGroupConversionTestCases.DRefObj));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
@@ -892,66 +879,54 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_RefArgumentObjectVsDynamic()
 		{
-			string program = @"using System;
-delegate void D(ref object o);
-class Test {
-	D d = $M$;
-	public static void M(ref dynamic o) {}
-}";
-			var c = GetConversion(program);
-			Assert.That(!c.IsValid);
+			// delegate void D(ref object o);
+			// D d = M;  with  public static void M(ref dynamic o) {}
+			// ref parameters require an identity conversion, and object <-> dynamic IS an
+			// identity conversion, so this is valid (Roslyn accepts it; the original
+			// NRefactory test expected invalid, which matched pre-Roslyn csc behavior).
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.RefDynamicParam), "M",
+				typeof(MethodGroupConversionTestCases.DRefObj));
+			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
 
 		[Test]
 		public void MethodGroupConversion_RefVsOut()
 		{
-			string program = @"using System;
-delegate void D(ref object o);
-class Test {
-	D d = $M$;
-	public static void M(out object o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(ref object o);
+			// D d = M;  with  public static void M(out object o) {...}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.OutObjParam), "M",
+				typeof(MethodGroupConversionTestCases.DRefObj));
 			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_RefVsNormal()
 		{
-			string program = @"using System;
-delegate void D(ref object o);
-class Test {
-	D d = $M$;
-	public static void M(object o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(ref object o);
+			// D d = M;  with  public static void M(object o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ObjParam), "M",
+				typeof(MethodGroupConversionTestCases.DRefObj));
 			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_NormalVsOut()
 		{
-			string program = @"using System;
-delegate void D(object o);
-class Test {
-	D d = $M$;
-	public static void M(out object o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(object o);
+			// D d = M;  with  public static void M(out object o) {...}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.OutObjParam), "M",
+				typeof(MethodGroupConversionTestCases.DObj));
 			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_MatchingNormalParameter()
 		{
-			string program = @"using System;
-delegate void D(object o);
-class Test {
-	D d = $M$;
-	public static void M(object o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(object o);
+			// D d = M;  with  public static void M(object o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ObjParam), "M",
+				typeof(MethodGroupConversionTestCases.DObj));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
@@ -959,13 +934,11 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_IdentityConversion()
 		{
-			string program = @"using System;
-delegate void D(object o);
-class Test {
-	D d = $M$;
-	public static void M(dynamic o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(object o);
+			// D d = M;  with  public static void M(dynamic o) {}
+			// object -> dynamic is an identity conversion, so M is delegate-compatible.
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.DynamicParam), "M",
+				typeof(MethodGroupConversionTestCases.DObj));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
@@ -973,95 +946,77 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_Contravariance()
 		{
-			string program = @"using System;
-delegate void D(string o);
-class Test {
-	D d = $M$;
-	public static void M(object o) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(string o);
+			// D d = M;  with  public static void M(object o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ObjParam), "M",
+				typeof(MethodGroupConversionTestCases.DStr));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
-
 		}
 
 		[Test, Ignore("Not sure if this conversion should be valid or not... NR and mcs both accept it as valid, csc treats it as invalid")]
 		public void MethodGroupConversion_NoContravarianceDynamic()
 		{
-			string program = @"using System;
-delegate void D(string o);
-class Test {
-	D d = $M$;
-	public static void M(dynamic o) {}
-}";
-			var c = GetConversion(program);
-			//Assert.IsFrue(c.IsValid);
+			// delegate void D(string o);
+			// D d = M;  with  public static void M(dynamic o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.DynamicParam), "M",
+				typeof(MethodGroupConversionTestCases.DStr));
+			//Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 		}
 
 		[Test]
 		public void MethodGroupConversion_ExactMatchIsBetter()
 		{
-			string program = @"using System;
-class Test {
-	delegate void D(string a);
-	D d = $M$;
-	static void M(object x) {}
-	static void M(string x = null) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(string a);
+			// D d = M;  with  static void M(object x) {}  and  static void M(string x = null) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.OverloadObjectOrOptionalString), "M",
+				typeof(MethodGroupConversionTestCases.DStr));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
-			Assert.AreEqual("System.String", c.Method.Parameters.Single().Type.FullName);
+			Assert.That(c.Method.Parameters.Single().Type.FullName, Is.EqualTo("System.String"));
 		}
 
 		[Test]
 		public void MethodGroupConversion_CannotLeaveOutOptionalParameters()
 		{
-			string program = @"using System;
-class Test {
-	delegate void D(string a);
-	D d = $M$;
-	static void M(object x) {}
-	static void M(string x, string y = null) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(string a);
+			// D d = M;  with  static void M(object x) {}  and  static void M(string x, string y = null) {}
+			// The two-parameter overload cannot bind to a one-parameter delegate.
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.OverloadObjectOrStringPlusOptional), "M",
+				typeof(MethodGroupConversionTestCases.DStr));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
-			Assert.AreEqual("System.Object", c.Method.Parameters.Single().Type.FullName);
+			Assert.That(c.Method.Parameters.Single().Type.FullName, Is.EqualTo("System.Object"));
 		}
 
 		[Test]
 		public void MethodGroupConversion_CannotUseExpandedParams()
 		{
-			string program = @"using System;
-class Test {
-	delegate void D(string a);
-	D d = $M$;
-	static void M(object x) {}
-	static void M(params string[] x) {}
-}";
-			var c = GetConversion(program);
+			// delegate void D(string a);
+			// D d = M;  with  static void M(object x) {}  and  static void M(params string[] x) {}
+			// The params overload only matches in expanded form, which method group
+			// conversions do not use.
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.OverloadObjectOrParamsString), "M",
+				typeof(MethodGroupConversionTestCases.DStr));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
-			Assert.AreEqual("System.Object", c.Method.Parameters.Single().Type.FullName);
+			Assert.That(c.Method.Parameters.Single().Type.FullName, Is.EqualTo("System.Object"));
 		}
 
 		[Test]
 		public void MethodGroupConversion_ExtensionMethod()
 		{
-			string program = @"using System;
-static class Ext {
-	public static void M(this string s, int x) {}
-}
-class Test {
-	delegate void D(int a);
-	void F() {
-		string s = """";
-		D d = $s.M$;
-	}
-}";
-			var c = GetConversion(program);
+			// static class Ext { public static void M(this string s, int x) {} }
+			// delegate void D(int a);
+			// string s = ""; D d = s.M;
+			IType stringType = compilation.FindType(KnownTypeCode.String);
+			IMethod extensionMethod = compilation.FindType(typeof(MethodGroupConversionExt))
+				.GetMethods(m => m.Name == "M").Single();
+			var c = MethodGroupConversion(typeof(string), "M",
+				typeof(MethodGroupConversionTestCases.DInt),
+				targetResult: new ResolveResult(stringType),
+				extensionMethods: new[] { extensionMethod });
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 			Assert.That(c.DelegateCapturesFirstArgument);
@@ -1070,17 +1025,11 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_ExtensionMethodUsedAsStaticMethod()
 		{
-			string program = @"using System;
-static class Ext {
-	public static void M(this string s, int x) {}
-}
-class Test {
-	delegate void D(string s, int a);
-	void F() {
-		D d = $Ext.M$;
-	}
-}";
-			var c = GetConversion(program);
+			// static class Ext { public static void M(this string s, int x) {} }
+			// delegate void D(string s, int a);
+			// D d = Ext.M;
+			var c = MethodGroupConversion(typeof(MethodGroupConversionExt), "M",
+				typeof(MethodGroupConversionTestCases.DStrInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsMethodGroupConversion);
 			Assert.That(!c.DelegateCapturesFirstArgument);
@@ -1089,102 +1038,63 @@ class Test {
 		[Test]
 		public void MethodGroupConversion_ObjectToDynamic()
 		{
-			string program = @"using System;
-class Test {
-	public void F(object o) {}
-	public void M() {
-		Action<dynamic> x = $F$;
-	}
-}";
-			var c = GetConversion(program);
+			// Action<dynamic> x = F;  with  public void F(object o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ObjParamInstance), "F",
+				typeof(Action<dynamic>));
 			Assert.That(c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_ObjectToDynamicGenericArgument()
 		{
-			string program = @"using System;
-using System.Collections.Generic;
-class Test {
-	public void F(List<object> l) {}
-	public void M() {
-		Action<List<dynamic>> x = $F$;
-	}
-}";
-			var c = GetConversion(program);
+			// Action<List<dynamic>> x = F;  with  public void F(List<object> l) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ObjListParamInstance), "F",
+				typeof(Action<List<dynamic>>));
 			Assert.That(c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_ObjectToDynamicReturnValue()
 		{
-			string program = @"using System;
-class Test {
-	public object F() {}
-	public void M() {
-		Func<dynamic> x = $F$;
-	}
-}";
-			var c = GetConversion(program);
+			// Func<dynamic> x = F;  with  public object F() {...}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.ObjReturnInstance), "F",
+				typeof(Func<dynamic>));
 			Assert.That(c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_DynamicToObject()
 		{
-			string program = @"using System;
-class Test {
-	public void F(dynamic o) {}
-	public void M() {
-		Action<object> x = $F$;
-	}
-}";
-			var c = GetConversion(program);
+			// Action<object> x = F;  with  public void F(dynamic o) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.DynamicParamInstance), "F",
+				typeof(Action<object>));
 			Assert.That(c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_DynamicToObjectGenericArgument()
 		{
-			string program = @"using System;
-using System.Collections.Generic;
-class Test {
-	public void F(List<dynamic> l) {}
-	public void M() {
-		Action<List<object>> x = $F$;
-	}
-}";
-			var c = GetConversion(program);
+			// Action<List<object>> x = F;  with  public void F(List<dynamic> l) {}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.DynamicListParamInstance), "F",
+				typeof(Action<List<object>>));
 			Assert.That(c.IsValid);
 		}
 
 		[Test]
 		public void MethodGroupConversion_DynamicToObjectReturnValue()
 		{
-			string program = @"using System;
-class Test {
-	public dynamic F() {}
-	public void M() {
-		Func<object> x = $F$;
-	}
-}";
-			var c = GetConversion(program);
+			// Func<object> x = F;  with  public dynamic F() {...}
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.DynamicReturnInstance), "F",
+				typeof(Func<object>));
 			Assert.That(c.IsValid);
 		}
 
 		[Test]
 		public void UserDefined_IntLiteral_ViaUInt_ToCustomStruct()
 		{
-			string program = @"using System;
-struct T {
-	public static implicit operator T(uint a) { return new T(); }
-}
-class Test {
-	static void M() {
-		T t = $1$;
-	}
-}";
-			var c = GetConversion(program);
+			// struct T { public static implicit operator T(uint a) {...} }
+			// T t = 1;
+			var c = ConstantConversion(1, typeof(UserDefinedConversionTestCases.TFromUInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
 		}
@@ -1192,17 +1102,9 @@ class Test {
 		[Test]
 		public void UserDefined_NullLiteral_ViaString_ToCustomStruct()
 		{
-			string program = @"using System;
-struct T {
-	public static implicit operator T(string a) { return new T(); }
-
-}
-class Test {
-	static void M() {
-		T t = $null$;
-	}
-}";
-			var c = GetConversion(program);
+			// struct T { public static implicit operator T(string a) {...} }
+			// T t = null;
+			var c = ImplicitConversion(typeof(Null), typeof(UserDefinedConversionTestCases.TFromString));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
 		}
@@ -1210,17 +1112,9 @@ class Test {
 		[Test]
 		public void UserDefined_CanUseLiftedEvenIfReturnTypeAlreadyNullable()
 		{
-			string program = @"using System;
-struct S {
-	public static implicit operator short?(S s) { return 0; }
-}
-
-class Test {
-	static void M(S? s) {
-		int? i = $s$;
-	}
-}";
-			var c = GetConversion(program);
+			// struct S { public static implicit operator short?(S s) {...} }
+			// int? i = s;  with s of type S?
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.SToNullableShort?), typeof(int?));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
 			Assert.That(c.IsLifted);
@@ -1229,285 +1123,157 @@ class Test {
 		[Test]
 		public void UserDefinedImplicitConversion_PicksExactSourceTypeIfPossible()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(int i) {return new Convertible(); }
-	public static implicit operator Convertible(short s) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible a = $33$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators from int ("i") and short ("s");
+			// Convertible a = 33;
+			var c = ConstantConversion(33, typeof(UserDefinedConversionTestCases.ConvertibleFromIntOrShort));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("i", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_PicksMostEncompassedSourceType()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(long l) {return new Convertible(); }
-	public static implicit operator Convertible(uint ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible a = $(ushort)33$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators from long ("l") and uint ("ui");
+			// Convertible a = (ushort)33;
+			var c = ConstantConversion((ushort)33, typeof(UserDefinedConversionTestCases.ConvertibleFromLongOrUInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("ui", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_NoMostEncompassedSourceTypeIsInvalid()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(ulong l) {return new Convertible(); }
-	public static implicit operator Convertible(int ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible a = $(ushort)33$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators from ulong and int; neither source type encompasses
+			// the other, so the conversion from ushort is ambiguous.
+			var c = ConstantConversion((ushort)33, typeof(UserDefinedConversionTestCases.ConvertibleFromULongOrInt));
 			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_PicksExactTargetTypeIfPossible()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator int(Convertible i) {return 0; }
-	public static implicit operator short(Convertible s) {return 0; }
-}
-class Test {
-	public void M() {
-		int a = $new Convertible()$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators to int ("i") and short ("s");
+			// int a = new Convertible();
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ConvertibleToIntOrShort), typeof(int));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("i", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_PicksMostEncompassingTargetType()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator int(Convertible i) {return 0; }
-	public static implicit operator ushort(Convertible us) {return 0; }
-}
-class Test {
-	public void M() {
-		ulong a = $new Convertible()$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators to int ("i") and ushort ("us");
+			// ulong a = new Convertible();  -- only ushort converts implicitly to ulong
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ConvertibleToIntOrUShort), typeof(ulong));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("us", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("us"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_NoMostEncompassingTargetTypeIsInvalid()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator uint(Convertible i) {return 0; }
-	public static implicit operator short(Convertible us) {return 0; }
-}
-class Test {
-	public void M() {
-		long a = $new Convertible()$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators to uint and short; neither target type encompasses
+			// the other, so the conversion to long is ambiguous.
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ConvertibleToUIntOrShort), typeof(long));
 			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_AmbiguousIsInvalid()
 		{
-			string program = @"using System;
-class Convertible1 {
-	public static implicit operator Convertible2(Convertible1 c) {return 0; }
-}
-class Convertible2 {
-	public static implicit operator Convertible2(Convertible1 c) {return 0; }
-}
-class Test {
-	public void M() {
-		Convertible2 a = $new Convertible1()$;
-	}
-}";
-			var c = GetConversion(program);
+			// Both AmbiguousA and AmbiguousB declare implicit operator AmbiguousB(AmbiguousA).
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.AmbiguousA), typeof(UserDefinedConversionTestCases.AmbiguousB));
 			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_DefinedNullableTakesPrecedenceOverLifted()
 		{
-			string program = @"using System;
-struct Convertible {
-	public static implicit operator Convertible(int i) {return new Convertible(); }
-	public static implicit operator Convertible?(int? ni) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible? a = $(int?)33$;
-	}
-}";
-			var c = GetConversion(program);
+			// struct Convertible declares operators from int ("i") and from int? ("ni");
+			// Convertible? a = (int?)33;  -- the user-defined nullable operator wins over
+			// the lifted form of the int operator.
+			var c = ImplicitConversion(typeof(int?), typeof(UserDefinedConversionTestCases.NullableConvertible?));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
 			Assert.That(!c.IsLifted);
-			Assert.AreEqual("ni", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ni"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_UIntConstant()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(long l) {return new Convertible(); }
-	public static implicit operator Convertible(uint ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible a = $33$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators from long ("l") and uint ("ui");
+			// Convertible a = 33;  -- the constant 33 converts to uint, which is more specific
+			var c = ConstantConversion(33, typeof(UserDefinedConversionTestCases.ConvertibleFromLongOrUInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("ui", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_NullableUIntConstant()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(long? l) {return new Convertible(); }
-	public static implicit operator Convertible(uint? ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible a = $33$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has operators from long? ("l") and uint? ("ui");
+			// Convertible a = 33;
+			var c = ConstantConversion(33, typeof(UserDefinedConversionTestCases.ConvertibleFromNullableLongOrNullableUInt));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("ui", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_UseShortResult_BecauseNullableCannotBeUnpacked()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator int?(Test i) { return 0; }
-	public static implicit operator short(Test s) { return 0; }
-}
-class Program {
-	public static void Main(string[] args)
-	{
-		int x = $new Test()$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators to int? ("i") and short ("s");
+			// int x = new Test();  -- int? cannot be unpacked to int, so short is used
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ToNullableIntOrShort), typeof(int));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("System.Int16", c.Method.ReturnType.FullName);
+			Assert.That(c.Method.ReturnType.FullName, Is.EqualTo("System.Int16"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_Short_Or_NullableByte_Target()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator short(Test s) { return 0; }
-	public static implicit operator byte?(Test b) { return 0; }
-}
-class Program {
-	public static void Main(string[] args)
-	{
-		int? x = $new Test()$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators to short ("s") and byte? ("b");
+			// int? x = new Test();
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ToShortOrNullableByte), typeof(int?));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("System.Int16", c.Method.ReturnType.FullName);
+			Assert.That(c.Method.ReturnType.FullName, Is.EqualTo("System.Int16"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_Byte_Or_NullableShort_Target()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator byte(Test b) { return 0; }
-	public static implicit operator short?(Test s) { return 0; }
-}
-class Program {
-	public static void Main(string[] args)
-	{
-		int? x = $new Test()$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators to byte ("b") and short? ("s");
+			// int? x = new Test();
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ToByteOrNullableShort), typeof(int?));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("s", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("s"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_Int_Or_NullableLong_Source()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator Test(int i) { return new Test(); }
-	public static implicit operator Test(long? l) { return new Test(); }
-}
-class Program {
-	static void Main() {
-		short s = 0;
-		Test t = $s$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators from int ("i") and long? ("l"); source is short
+			var c = ImplicitConversion(typeof(short), typeof(UserDefinedConversionTestCases.FromIntOrNullableLong));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("i", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedImplicitConversion_NullableInt_Or_Long_Source()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator Test(int? i) { return new Test(); }
-	public static implicit operator Test(long l) { return new Test(); }
-}
-class Program {
-	static void Main() {
-		short s = 0;
-		Test t = $s$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators from int? ("i") and long ("l"); source is short:
+			// neither int? nor long is more specific, so the conversion is ambiguous
+			var c = ImplicitConversion(typeof(short), typeof(UserDefinedConversionTestCases.FromNullableIntOrLong));
 			Assert.That(!c.IsValid);
 			Assert.That(c.IsUserDefined);
 		}
@@ -1515,17 +1281,8 @@ class Program {
 		[Test]
 		public void UserDefinedImplicitConversion_NullableInt_Or_Long_Constant_Source()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator Test(int? i) { return new Test(); }
-	public static implicit operator Test(long l) { return new Test(); }
-}
-class Program {
-	static void Main() {
-		Test t = $1$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators from int? ("i") and long ("l"); source is the constant 1
+			var c = ConstantConversion(1, typeof(UserDefinedConversionTestCases.FromNullableIntOrLong));
 			Assert.That(!c.IsValid);
 			Assert.That(c.IsUserDefined);
 		}
@@ -1533,44 +1290,36 @@ class Program {
 		[Test]
 		public void UserDefinedImplicitConversion_NullableInt_Or_NullableLong_Source()
 		{
-			string program = @"using System;
-class Test {
-	public static implicit operator Test(int? i) { return new Test(); }
-	public static implicit operator Test(long? l) { return new Test(); }
-}
-class Program {
-	static void Main() {
-		short s = 0;
-		Test t = $s$;
-	}
-}";
-			var c = GetConversion(program);
+			// operators from int? ("i") and long? ("l"); source is short
+			var c = ImplicitConversion(typeof(short), typeof(UserDefinedConversionTestCases.FromNullableIntOrNullableLong));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsUserDefined);
-			Assert.AreEqual("i", c.Method.Parameters[0].Name);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void PreferUserDefinedConversionOverReferenceConversion()
 		{
-			// actually this is not because user-defined conversions are better;
-			// but because string is a better conversion target
-			string program = @"
-class AA {
-	public static implicit operator string(AA a) { return null; }
-}
-class Test {
-	static void M(object obj) {}
-	static void M(string str) {}
-	
-	static void Main() {
-		$M(new AA())$;
-	}
-}";
+			// M(new AA()) with overloads M(object) and M(string), where AA has an implicit
+			// conversion to string, picks M(string) -- not because user-defined conversions
+			// are better, but because string is a better conversion target.
+			IMethod MakeM(Type parameterType)
+			{
+				var m = new FakeMethod(compilation, SymbolKind.Method);
+				m.Name = "M";
+				m.Parameters = new[] { new DefaultParameter(compilation.FindType(parameterType), "x", owner: m) };
+				return m;
+			}
 
-			var rr = Resolve<CSharpInvocationResolveResult>(program);
-			Assert.That(!rr.IsError);
-			Assert.AreEqual("str", rr.Member.Parameters[0].Name);
+			var or = new OverloadResolution(compilation, new[] {
+				new ResolveResult(compilation.FindType(typeof(UserDefinedConversionTestCases.ConvertibleToString)))
+			});
+			IMethod mObject = MakeM(typeof(object));
+			IMethod mString = MakeM(typeof(string));
+			Assert.That(or.AddCandidate(mObject), Is.EqualTo(OverloadResolutionErrors.None));
+			Assert.That(or.AddCandidate(mString), Is.EqualTo(OverloadResolutionErrors.None));
+			Assert.That(!or.IsAmbiguous);
+			Assert.That(or.BestCandidate, Is.SameAs(mString));
 		}
 
 		[Test]
@@ -1579,25 +1328,11 @@ class Test {
 			// Ambiguous conversions are a compiler error; but they are not
 			// preventing the overload from being chosen.
 
-			// The user-defined conversion wins because BB is a better conversion target than object.
-			string program = @"
-class AA {
-	public static implicit operator BB(AA a) { return null; }
-}
-class BB {
-	public static implicit operator BB(AA a) { return null; }
-}
-
-class Test {
-	static void M(BB b) {}
-	static void M(object o) {}
-	
-	static void Main() {
-		M($new AA()$);
-	}
-}";
-
-			var c = GetConversion(program);
+			// M(new AmbiguousA()) with overloads M(AmbiguousB) and M(object) picks
+			// M(AmbiguousB) because AmbiguousB is a better conversion target than object,
+			// even though the user-defined conversion itself is ambiguous (declared both
+			// in AmbiguousA and AmbiguousB) and therefore invalid.
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.AmbiguousA), typeof(UserDefinedConversionTestCases.AmbiguousB));
 			Assert.That(c.IsUserDefined);
 			Assert.That(!c.IsValid);
 		}
@@ -1605,17 +1340,8 @@ class Test {
 		[Test]
 		public void UserDefinedImplicitConversion_ConversionBeforeUserDefinedOperatorIsCorrect()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(long l) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		int i = 33;
-		Convertible a = $i$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has an operator from long; converting an int goes int -> long -> Convertible.
+			var c = ImplicitConversion(typeof(int), typeof(UserDefinedConversionTestCases.ConvertibleFromLong));
 			Assert.That(c.IsValid);
 			Assert.That(c.ConversionBeforeUserDefinedOperator.IsImplicit);
 			Assert.That(c.ConversionBeforeUserDefinedOperator.IsNumericConversion);
@@ -1626,16 +1352,8 @@ class Test {
 		[Test]
 		public void UserDefinedImplicitConversion_ConversionAfterUserDefinedOperatorIsCorrect()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator int(Convertible i) {return 0; }
-}
-class Test {
-	public void M() {
-		long a = $new Convertible()$;
-	}
-}";
-			var c = GetConversion(program);
+			// Convertible has an operator to int; converting to long goes Convertible -> int -> long.
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.ConvertibleToInt), typeof(long));
 			Assert.That(c.IsValid);
 			Assert.That(c.ConversionBeforeUserDefinedOperator.IsIdentityConversion);
 			Assert.That(c.ConversionAfterUserDefinedOperator.IsImplicit);
@@ -1647,24 +1365,12 @@ class Test {
 		public void UserDefinedImplicitConversion_IsImplicit()
 		{
 			// Bug icsharpcode/NRefactory#183: conversions from constant expressions were incorrectly marked as explicit
-			string program = @"using System;
-	class Test {
-		void Hello(JsNumber3 x) {
-			Hello($7$);
-		}
-	}
-	public class JsNumber3 {
-		public static implicit operator JsNumber3(int d) {
-			return null;
-		}
-	}";
-			var c = GetConversion(program);
+			var c = ConstantConversion(7, typeof(UserDefinedConversionTestCases.JsNumber));
 			Assert.That(c.IsValid);
 			Assert.That(c.IsImplicit);
 			Assert.That(!c.IsExplicit);
-			Assert.AreEqual(Conversion.IdentityConversion, c.ConversionBeforeUserDefinedOperator);
-			Assert.AreEqual(Conversion.IdentityConversion, c.ConversionAfterUserDefinedOperator);
+			Assert.That(c.ConversionBeforeUserDefinedOperator, Is.EqualTo(C.IdentityConversion));
+			Assert.That(c.ConversionAfterUserDefinedOperator, Is.EqualTo(C.IdentityConversion));
 		}
-		*/
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
@@ -1297,25 +1297,28 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
+		/// <summary>
+		/// Creates a fake method named M with a single parameter of the given type.
+		/// </summary>
+		IMethod MakeUnaryMethod(Type parameterType)
+		{
+			var m = new FakeMethod(compilation, SymbolKind.Method);
+			m.Name = "M";
+			m.Parameters = new[] { new DefaultParameter(compilation.FindType(parameterType), "x", owner: m) };
+			return m;
+		}
+
 		[Test]
 		public void PreferUserDefinedConversionOverReferenceConversion()
 		{
 			// M(new AA()) with overloads M(object) and M(string), where AA has an implicit
 			// conversion to string, picks M(string) -- not because user-defined conversions
 			// are better, but because string is a better conversion target.
-			IMethod MakeM(Type parameterType)
-			{
-				var m = new FakeMethod(compilation, SymbolKind.Method);
-				m.Name = "M";
-				m.Parameters = new[] { new DefaultParameter(compilation.FindType(parameterType), "x", owner: m) };
-				return m;
-			}
-
 			var or = new OverloadResolution(compilation, new[] {
 				new ResolveResult(compilation.FindType(typeof(UserDefinedConversionTestCases.ConvertibleToString)))
 			});
-			IMethod mObject = MakeM(typeof(object));
-			IMethod mString = MakeM(typeof(string));
+			IMethod mObject = MakeUnaryMethod(typeof(object));
+			IMethod mString = MakeUnaryMethod(typeof(string));
 			Assert.That(or.AddCandidate(mObject), Is.EqualTo(OverloadResolutionErrors.None));
 			Assert.That(or.AddCandidate(mString), Is.EqualTo(OverloadResolutionErrors.None));
 			Assert.That(!or.IsAmbiguous);
@@ -1328,13 +1331,22 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			// Ambiguous conversions are a compiler error; but they are not
 			// preventing the overload from being chosen.
 
-			// M(new AmbiguousA()) with overloads M(AmbiguousB) and M(object) picks
-			// M(AmbiguousB) because AmbiguousB is a better conversion target than object,
-			// even though the user-defined conversion itself is ambiguous (declared both
-			// in AmbiguousA and AmbiguousB) and therefore invalid.
+			// The user-defined conversion AmbiguousA -> AmbiguousB is ambiguous (declared
+			// in both classes) and therefore invalid...
 			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.AmbiguousA), typeof(UserDefinedConversionTestCases.AmbiguousB));
 			Assert.That(c.IsUserDefined);
 			Assert.That(!c.IsValid);
+
+			// ...but M(new AmbiguousA()) with overloads M(AmbiguousB) and M(object) still
+			// picks M(AmbiguousB), because AmbiguousB is a better conversion target than object.
+			var or = new OverloadResolution(compilation, new[] {
+				new ResolveResult(compilation.FindType(typeof(UserDefinedConversionTestCases.AmbiguousA)))
+			});
+			IMethod mAmbiguousB = MakeUnaryMethod(typeof(UserDefinedConversionTestCases.AmbiguousB));
+			IMethod mObject = MakeUnaryMethod(typeof(object));
+			or.AddCandidate(mAmbiguousB);
+			or.AddCandidate(mObject);
+			Assert.That(or.BestCandidate, Is.SameAs(mAmbiguousB));
 		}
 
 		[Test]

--- a/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
@@ -123,13 +123,13 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 		/// converts it to <paramref name="delegateType"/>.
 		/// </summary>
 		Conversion MethodGroupConversion(Type declaringType, string methodName, Type delegateType,
-			ResolveResult targetResult = null, IMethod[] extensionMethods = null)
+			ResolveResult targetResult = null, IMethod[] extensionMethods = null, IReadOnlyList<IType> typeArguments = null)
 		{
 			IType declaring = compilation.FindType(declaringType);
 			var mgrr = new MethodGroupResolveResult(
 				targetResult ?? new ResolveResult(declaring), methodName,
 				new[] { new MethodListWithDeclaringType(declaring, declaring.GetMethods(m => m.Name == methodName)) },
-				null);
+				typeArguments);
 			if (extensionMethods != null)
 			{
 				mgrr.extensionMethods = new List<List<IMethod>> { new List<IMethod>(extensionMethods) };
@@ -1383,6 +1383,374 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(!c.IsExplicit);
 			Assert.That(c.ConversionBeforeUserDefinedOperator, Is.EqualTo(C.IdentityConversion));
 			Assert.That(c.ConversionAfterUserDefinedOperator, Is.EqualTo(C.IdentityConversion));
+		}
+
+		[Test]
+		public void TupleIdentityConversionWithUnderlyingValueTuple()
+		{
+			// C# standard 10.2.2: identity conversion between a tuple type and the
+			// corresponding constructed ValueTuple<...> type
+			var intType = compilation.FindType(typeof(int));
+			var stringType = compilation.FindType(typeof(string));
+			IType tupleType = new TupleType(compilation, ImmutableArray.Create(intType, stringType), ImmutableArray.Create("a", "b"));
+			IType valueTupleType = compilation.FindType(typeof(ValueTuple<int, string>));
+			Assert.That(conversions.ImplicitConversion(tupleType, valueTupleType), Is.EqualTo(C.IdentityConversion));
+			Assert.That(conversions.ImplicitConversion(valueTupleType, tupleType), Is.EqualTo(C.IdentityConversion));
+		}
+
+		[Test]
+		public void IdentityConversionNullableReferenceType()
+		{
+			// C# standard 10.2.2: identity conversion between T and T? for any reference type T
+			IType stringType = compilation.FindType(KnownTypeCode.String);
+			IType nullableStringType = stringType.ChangeNullability(Nullability.Nullable);
+			Assert.That(conversions.ImplicitConversion(stringType, nullableStringType), Is.EqualTo(C.IdentityConversion));
+			Assert.That(conversions.ImplicitConversion(nullableStringType, stringType), Is.EqualTo(C.IdentityConversion));
+		}
+
+		[Test]
+		public void NumericConversionMatrix()
+		{
+			// C# standard 10.2.3 (implicit numeric conversions) and 10.3.2 (explicit numeric
+			// conversions). The implicit table below is transcribed from 10.2.3; every other
+			// pair of distinct numeric types must be an explicit numeric conversion.
+			var allNumericTypes = new[] {
+				typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int),
+				typeof(uint), typeof(long), typeof(ulong), typeof(char), typeof(float),
+				typeof(double), typeof(decimal)
+			};
+			var implicitConversions = new Dictionary<Type, Type[]> {
+				[typeof(sbyte)] = new[] { typeof(short), typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(byte)] = new[] { typeof(short), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(short)] = new[] { typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(ushort)] = new[] { typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(int)] = new[] { typeof(long), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(uint)] = new[] { typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(long)] = new[] { typeof(float), typeof(double), typeof(decimal) },
+				[typeof(ulong)] = new[] { typeof(float), typeof(double), typeof(decimal) },
+				[typeof(char)] = new[] { typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) },
+				[typeof(float)] = new[] { typeof(double) },
+				[typeof(double)] = new Type[0],
+				[typeof(decimal)] = new Type[0],
+			};
+			foreach (Type from in allNumericTypes)
+			{
+				foreach (Type to in allNumericTypes)
+				{
+					string pair = from.Name + " -> " + to.Name;
+					if (from == to)
+					{
+						Assert.That(ImplicitConversion(from, to), Is.EqualTo(C.IdentityConversion), pair);
+					}
+					else if (Array.IndexOf(implicitConversions[from], to) >= 0)
+					{
+						Assert.That(ImplicitConversion(from, to), Is.EqualTo(C.ImplicitNumericConversion), pair);
+						Assert.That(ExplicitConversion(from, to), Is.EqualTo(C.ImplicitNumericConversion), pair);
+					}
+					else
+					{
+						Assert.That(ImplicitConversion(from, to), Is.EqualTo(C.None), pair);
+						Assert.That(ExplicitConversion(from, to), Is.EqualTo(C.ExplicitNumericConversion), pair);
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void InterpolatedStringConversion()
+		{
+			// C# standard 10.2.5: an interpolated string expression converts to
+			// System.IFormattable and System.FormattableString
+			var interpolated = new InterpolatedStringResolveResult(compilation.FindType(KnownTypeCode.String),
+				"{0}", new ResolveResult(compilation.FindType(KnownTypeCode.Int32)));
+			Assert.That(conversions.ImplicitConversion(interpolated, compilation.FindType(KnownTypeCode.IFormattable)), Is.EqualTo(C.ImplicitInterpolatedStringConversion));
+			Assert.That(conversions.ImplicitConversion(interpolated, compilation.FindType(KnownTypeCode.FormattableString)), Is.EqualTo(C.ImplicitInterpolatedStringConversion));
+			Assert.That(conversions.ImplicitConversion(interpolated, compilation.FindType(KnownTypeCode.String)), Is.EqualTo(C.IdentityConversion));
+		}
+
+		[Test]
+		public void IdentityDerivedNullableConversion()
+		{
+			// C# standard 10.2.6/10.6.1: nullable conversion derived from the identity conversion
+			Assert.That(ImplicitConversion(typeof(int), typeof(int?)), Is.EqualTo(C.ImplicitNullableConversion));
+		}
+
+		[Test]
+		public void DelegateToSystemDelegateConversions()
+		{
+			// C# standard 10.2.8: from any delegate_type to System.Delegate and the
+			// interfaces it implements
+			Assert.That(ImplicitConversion(typeof(Action), typeof(Delegate)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(Action), typeof(MulticastDelegate)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(Action), typeof(ICloneable)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(Delegate), typeof(Action)), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void ClassToBaseClassConversion()
+		{
+			// C# standard 10.2.8: from any class_type S to any class_type T, provided S is derived from T
+			Assert.That(ImplicitConversion(typeof(UserDefinedExplicitConversionTestCases.DerivedClass), typeof(UserDefinedExplicitConversionTestCases.BaseClass)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(UserDefinedExplicitConversionTestCases.BaseClass), typeof(UserDefinedExplicitConversionTestCases.DerivedClass)), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void ArrayToIReadOnlyListConversion()
+		{
+			// C# standard 10.2.8: from S[] to IReadOnlyList<T> and its base interfaces
+			Assert.That(ImplicitConversion(typeof(string[]), typeof(IReadOnlyList<string>)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(string[]), typeof(IReadOnlyList<object>)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(string[]), typeof(IReadOnlyCollection<string>)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(string[,]), typeof(IReadOnlyList<string>)), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void VarianceConversionWithDynamicTypeArgument()
+		{
+			// C# standard 10.2.8: implicit reference conversion via a variance-convertible
+			// type where the type arguments differ by the object/dynamic identity conversion
+			Assert.That(ImplicitConversion(typeof(IEnumerable<string>), typeof(IEnumerable<dynamic>)), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(ImplicitConversion(typeof(List<string>), typeof(IEnumerable<dynamic>)), Is.EqualTo(C.ImplicitReferenceConversion));
+		}
+
+		[Test]
+		public void BoxingConversions()
+		{
+			// C# standard 10.2.9
+			Assert.That(ImplicitConversion(typeof(int), typeof(object)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(int), typeof(ValueType)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(StringComparison), typeof(Enum)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(int), typeof(IFormattable)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(int), typeof(IComparable<int>)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(int), typeof(IComparable<string>)), Is.EqualTo(C.None));
+			// nullable value types box to the reference types their underlying type boxes to
+			Assert.That(ImplicitConversion(typeof(int?), typeof(object)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(int?), typeof(IFormattable)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(StringComparison?), typeof(Enum)), Is.EqualTo(C.BoxingConversion));
+		}
+
+		[Test]
+		public void BoxingConversionViaVariance()
+		{
+			// C# standard 10.2.9: boxing to an interface that the implemented interface is
+			// variance-convertible to
+			Assert.That(ImplicitConversion(typeof(StructImplementingIEnumerableOfString), typeof(IEnumerable<string>)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(StructImplementingIEnumerableOfString), typeof(IEnumerable<object>)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(StructImplementingIEnumerableOfString), typeof(IEnumerable)), Is.EqualTo(C.BoxingConversion));
+			Assert.That(ImplicitConversion(typeof(StructImplementingIEnumerableOfString), typeof(IEnumerable<int>)), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void ImplicitConstantExpressionConversionToUInt64()
+		{
+			// C# standard 10.2.11: an int constant expression converts to ulong
+			// provided its value is non-negative
+			Assert.That(IntegerLiteralConversion(0, typeof(ulong)));
+			Assert.That(IntegerLiteralConversion(200, typeof(ulong)));
+			Assert.That(!IntegerLiteralConversion(-1, typeof(ulong)));
+		}
+
+		[Test]
+		public void TypeParameterConversionViaVariance()
+		{
+			// C# standard 10.2.12 (last bullet group): conversions from T via a
+			// variance-convertible interface of its effective base class / interface set
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T",
+				constraints: new[] { compilation.FindType(typeof(List<string>)) });
+			Assert.That(conversions.ImplicitConversion(t, compilation.FindType(typeof(IEnumerable<object>))), Is.EqualTo(C.ImplicitReferenceConversion));
+
+			ITypeParameter t2 = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T",
+				constraints: new[] { compilation.FindType(typeof(IEnumerable<string>)) });
+			Assert.That(conversions.ImplicitConversion(t2, compilation.FindType(typeof(IEnumerable<object>))), Is.EqualTo(C.BoxingConversion));
+		}
+
+		[Test]
+		public void TupleLiteralConversions()
+		{
+			// C# standard 10.2.13: implicit conversion from a tuple literal, using the
+			// implicit conversions of the element expressions
+			var intType = compilation.FindType(KnownTypeCode.Int32);
+			var stringType = compilation.FindType(KnownTypeCode.String);
+			var byteType = compilation.FindType(KnownTypeCode.Byte);
+
+			// (2, null) -> (byte, string)
+			var literal = new TupleResolveResult(compilation, ImmutableArray.Create<ResolveResult>(
+				new ConstantResolveResult(intType, 2),
+				new ConstantResolveResult(SpecialType.NullType, null)));
+			Assert.That(conversions.ImplicitConversion(literal, new TupleType(compilation, ImmutableArray.Create(byteType, stringType))),
+				Is.EqualTo(C.TupleConversion(ImmutableArray.Create(C.ImplicitConstantExpressionConversion, C.NullLiteralConversion))));
+
+			// arity mismatch
+			Assert.That(conversions.ImplicitConversion(literal, new TupleType(compilation, ImmutableArray.Create(byteType, stringType, intType))),
+				Is.EqualTo(C.None));
+
+			// (300, null) -> (byte, string): 300 is out of range for byte
+			var literal2 = new TupleResolveResult(compilation, ImmutableArray.Create<ResolveResult>(
+				new ConstantResolveResult(intType, 300),
+				new ConstantResolveResult(SpecialType.NullType, null)));
+			Assert.That(conversions.ImplicitConversion(literal2, new TupleType(compilation, ImmutableArray.Create(byteType, stringType))),
+				Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void UserDefinedImplicitConversion_OperatorDeclaredInBaseClassOfSource()
+		{
+			// C# standard 10.5.4: the set of considered operator declarations includes the
+			// base classes of the source type
+			var c = ImplicitConversion(typeof(UserDefinedConversionTestCases.DerivedFromOperatorInBaseClass), typeof(string));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.DeclaringType.Name, Is.EqualTo("OperatorInBaseClass"));
+		}
+
+		[Test, Ignore("C# standard 10.2.16 is not implemented: CSharpConversions.ImplicitConversion has a TODO for default literal conversions, and no ResolveResult represents a typeless default literal")]
+		public void DefaultLiteralConversions()
+		{
+			// C# standard 10.2.16: an implicit conversion exists from a default_literal to
+			// any type, producing the default value of the inferred type. Once the semantic
+			// model gains a typeless default-literal ResolveResult, this test should assert
+			// that it converts to int, string, int? and type parameters.
+			Assert.Fail("Default literal conversions are not implemented.");
+		}
+
+		[Test, Ignore("C# standard 10.2.18 is not implemented: no ResolveResult represents a switch expression; the decompiler converts each arm separately in ILAst")]
+		public void SwitchExpressionConversion()
+		{
+			// C# standard 10.2.18: an implicit conversion exists from a switch_expression to
+			// every type T to which all arm expressions implicitly convert. Once the semantic
+			// model gains a switch-expression ResolveResult, this test should assert that the
+			// conversion exists iff every arm converts to the target type.
+			Assert.Fail("Switch expression conversions are not implemented.");
+		}
+
+		[Test]
+		public void ThrowExpressionConversion()
+		{
+			// C# standard 10.2.17: throw expressions convert to any type
+			Assert.That(conversions.ImplicitConversion(new ThrowResolveResult(), compilation.FindType(KnownTypeCode.String)), Is.EqualTo(C.ThrowExpressionConversion));
+			Assert.That(conversions.ImplicitConversion(new ThrowResolveResult(), compilation.FindType(KnownTypeCode.Int32)), Is.EqualTo(C.ThrowExpressionConversion));
+		}
+
+		[Test]
+		public void StandardImplicitConversions()
+		{
+			// C# standard 10.4.2: standard implicit conversions exclude user-defined conversions
+			Assert.That(conversions.StandardImplicitConversion(compilation.FindType(typeof(int)), compilation.FindType(typeof(long))), Is.EqualTo(C.ImplicitNumericConversion));
+			Assert.That(conversions.StandardImplicitConversion(compilation.FindType(typeof(string)), compilation.FindType(typeof(object))), Is.EqualTo(C.ImplicitReferenceConversion));
+			Assert.That(conversions.StandardImplicitConversion(compilation.FindType(typeof(DateTime)), compilation.FindType(typeof(DateTimeOffset))), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void MethodGroupConversion_GenericMethodTypeInference()
+		{
+			// C# standard 10.8: delegate parameter types are used to infer the type
+			// arguments of a generic method group
+			// delegate int D(string s, int i);
+			// D d = F;  with  static T F<T>(string s, T t)  -- T=int is inferred
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.GenericMethods), "F",
+				typeof(MethodGroupConversionTestCases.DStrIntRetInt));
+			Assert.That(c.IsValid);
+			Assert.That(c.Method.TypeArguments.Single().IsKnownType(KnownTypeCode.Int32));
+		}
+
+		[Test]
+		public void MethodGroupConversion_GenericMethodExplicitTypeArguments()
+		{
+			// C# standard 10.8:
+			// delegate int E();
+			// E e = G<int>;  with  static T G<T>()
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.GenericMethods), "G",
+				typeof(MethodGroupConversionTestCases.DRetInt),
+				typeArguments: new[] { compilation.FindType(KnownTypeCode.Int32) });
+			Assert.That(c.IsValid);
+			Assert.That(c.Method.TypeArguments.Single().IsKnownType(KnownTypeCode.Int32));
+		}
+
+		[Test]
+		public void MethodGroupConversion_CannotInferFromReturnType()
+		{
+			// C# standard 10.8: the return type of the delegate is not used for inference
+			// E e = G;  with  static T G<T>()
+			var c = MethodGroupConversion(typeof(MethodGroupConversionTestCases.GenericMethods), "G",
+				typeof(MethodGroupConversionTestCases.DRetInt));
+			Assert.That(!c.IsValid);
+		}
+
+		[Test]
+		public void AnonymousFunctionConversions()
+		{
+			// C# standard 10.7.1: compatibility of an anonymous function with a delegate type.
+			// TestLambda stands in for a lambda whose body is an expression of the given type;
+			// the signature checks under test here are performed by CSharpConversions itself.
+			IType intType = compilation.FindType(KnownTypeCode.Int32);
+			var intParam = new IParameter[] { new DefaultParameter(intType, "x") };
+
+			// (int x) => intExpr  is compatible with Func<int, int> and Func<int, double>
+			Assert.That(conversions.ImplicitConversion(new TestLambda(intType, intParam), compilation.FindType(typeof(Func<int, int>))).IsValid);
+			Assert.That(conversions.ImplicitConversion(new TestLambda(intType, intParam), compilation.FindType(typeof(Func<int, double>))).IsValid);
+			// parameter count mismatch
+			Assert.That(conversions.ImplicitConversion(new TestLambda(intType, intParam), compilation.FindType(typeof(Func<int>))), Is.EqualTo(C.None));
+			// an explicitly typed parameter must have the delegate's parameter type
+			Assert.That(conversions.ImplicitConversion(new TestLambda(intType, intParam), compilation.FindType(typeof(Func<double, int>))), Is.EqualTo(C.None));
+			// an implicitly typed parameter list is incompatible with ref/out parameters
+			Assert.That(conversions.ImplicitConversion(
+				new TestLambda(intType, new IParameter[] { new DefaultParameter(SpecialType.UnknownType, "x") }, isImplicitlyTyped: true),
+				compilation.FindType(typeof(MethodGroupConversionTestCases.DRefObj))), Is.EqualTo(C.None));
+			// an anonymous method without a signature accepts any parameter list without out parameters
+			Assert.That(conversions.ImplicitConversion(
+				new TestLambda(intType, hasParameterList: false, isAnonymousMethod: true),
+				compilation.FindType(typeof(Func<int, int>))).IsValid);
+		}
+
+		[Test]
+		public void LambdaToExpressionTreeConversion()
+		{
+			// C# standard 10.7.1: a lambda expression compatible with D is compatible with
+			// Expression<D>; anonymous methods are not.
+			IType intType = compilation.FindType(KnownTypeCode.Int32);
+			var intParam = new IParameter[] { new DefaultParameter(intType, "x") };
+			Assert.That(conversions.ImplicitConversion(new TestLambda(intType, intParam),
+				compilation.FindType(typeof(System.Linq.Expressions.Expression<Func<int, int>>))).IsValid);
+			Assert.That(conversions.ImplicitConversion(
+				new TestLambda(intType, hasParameterList: false, isAnonymousMethod: true),
+				compilation.FindType(typeof(System.Linq.Expressions.Expression<Func<int, int>>))), Is.EqualTo(C.None));
+		}
+
+		/// <summary>
+		/// Stands in for a lambda or anonymous method whose body is an expression of a fixed type.
+		/// </summary>
+		sealed class TestLambda : LambdaResolveResult
+		{
+			readonly IType bodyReturnType;
+			readonly IParameter[] parameters;
+
+			public TestLambda(IType bodyReturnType, IParameter[] parameters = null,
+				bool hasParameterList = true, bool isAnonymousMethod = false, bool isImplicitlyTyped = false)
+			{
+				this.bodyReturnType = bodyReturnType;
+				this.parameters = parameters ?? new IParameter[0];
+				this.HasParameterList = hasParameterList;
+				this.IsAnonymousMethod = isAnonymousMethod;
+				this.IsImplicitlyTyped = isImplicitlyTyped;
+			}
+
+			public override bool HasParameterList { get; }
+			public override bool IsAnonymousMethod { get; }
+			public override bool IsImplicitlyTyped { get; }
+			public override bool IsAsync => false;
+			public override IReadOnlyList<IParameter> Parameters => parameters;
+			public override IType ReturnType => bodyReturnType;
+			public override ResolveResult Body => null;
+
+			public override IType GetInferredReturnType(IType[] parameterTypes)
+			{
+				return bodyReturnType;
+			}
+
+			public override Conversion IsValid(IType[] parameterTypes, IType returnType, CSharpConversions conversions)
+			{
+				return conversions.ImplicitConversion(bodyReturnType, returnType);
+			}
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
@@ -1592,6 +1592,18 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 				Is.EqualTo(C.None));
 		}
 
+		[Test, Ignore("Known bug: CSharpConversions does not support nullable conversions derived from tuple conversions, but csc accepts them")]
+		public void LiftedTupleConversions()
+		{
+			// csc accepts the nullable conversions derived from tuple conversions:
+			//   (int, string) t = (1, "one");
+			//   (long, object)? a = t;
+			//   (int, string)? tn = t;
+			//   (long, object)? b = tn;
+			Assert.That(ImplicitConversion(typeof((int, string)), typeof((long, object)?)).IsValid, "(int, string) -> (long, object)?");
+			Assert.That(ImplicitConversion(typeof((int, string)?), typeof((long, object)?)).IsValid, "(int, string)? -> (long, object)?");
+		}
+
 		[Test]
 		public void UserDefinedImplicitConversion_OperatorDeclaredInBaseClassOfSource()
 		{

--- a/ICSharpCode.Decompiler.Tests/Semantics/ExplicitConversionTest.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ExplicitConversionTest.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 using ICSharpCode.Decompiler.CSharp.Resolver;
@@ -697,6 +698,50 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(c.ConversionAfterUserDefinedOperator.IsValid);
 			Assert.That(c.ConversionAfterUserDefinedOperator.IsExplicit);
 			Assert.That(c.ConversionAfterUserDefinedOperator.IsNumericConversion);
+		}
+
+		[Test]
+		public void EnumerationConversionsWithFloatingPointTypes()
+		{
+			// C# standard 10.3.3: explicit enumeration conversions include float and double
+			var explicitEnumerationConversion = C.EnumerationConversion(false, false);
+			Assert.That(ExplicitConversion(typeof(float), typeof(StringComparison)), Is.EqualTo(explicitEnumerationConversion));
+			Assert.That(ExplicitConversion(typeof(double), typeof(StringComparison)), Is.EqualTo(explicitEnumerationConversion));
+			Assert.That(ExplicitConversion(typeof(StringComparison), typeof(float)), Is.EqualTo(explicitEnumerationConversion));
+			Assert.That(ExplicitConversion(typeof(StringComparison), typeof(double)), Is.EqualTo(explicitEnumerationConversion));
+		}
+
+		[Test]
+		public void ExplicitTupleConversions()
+		{
+			// C# standard 10.3.6: explicit tuple conversion with explicit element conversions
+			Assert.That(ExplicitConversion(typeof((long, object)), typeof((int, string))),
+				Is.EqualTo(C.TupleConversion(ImmutableArray.Create(C.ExplicitNumericConversion, C.ExplicitReferenceConversion))));
+			// arity mismatch
+			Assert.That(ExplicitConversion(typeof((long, object)), typeof(ValueTuple<int>)), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void UnboxingConversionViaVariance()
+		{
+			// C# standard 10.3.7: unboxing from an interface that is variance-convertible
+			// to/from an interface implemented by the value type
+			Assert.That(ExplicitConversion(typeof(IEnumerable<string>), typeof(StructImplementingIEnumerableOfString)), Is.EqualTo(C.UnboxingConversion));
+			Assert.That(ExplicitConversion(typeof(IEnumerable<object>), typeof(StructImplementingIEnumerableOfString)), Is.EqualTo(C.UnboxingConversion));
+			Assert.That(ExplicitConversion(typeof(IEnumerable<int>), typeof(StructImplementingIEnumerableOfString)), Is.EqualTo(C.None));
+		}
+
+		[Test]
+		public void ExplicitTypeParameterConversionFromEffectiveBaseClass()
+		{
+			// C# standard 10.3.8: for T known to be a reference type, explicit reference
+			// conversions exist from the effective base class (and its base classes) to T,
+			// and from T to interfaces it does not implement
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T",
+				constraints: new[] { compilation.FindType(typeof(StringComparer)) });
+			Assert.That(conversions.ExplicitConversion(compilation.FindType(typeof(StringComparer)), t), Is.EqualTo(C.ExplicitReferenceConversion));
+			Assert.That(conversions.ExplicitConversion(compilation.FindType(KnownTypeCode.Object), t), Is.EqualTo(C.ExplicitReferenceConversion));
+			Assert.That(conversions.ExplicitConversion(t, compilation.FindType(typeof(IConvertible))), Is.EqualTo(C.ExplicitReferenceConversion));
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/Semantics/ExplicitConversionTest.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ExplicitConversionTest.cs
@@ -731,6 +731,29 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(ExplicitConversion(typeof(IEnumerable<int>), typeof(StructImplementingIEnumerableOfString)), Is.EqualTo(C.None));
 		}
 
+		[Test, Ignore("Known bug: CSharpConversions does not support nullable conversions derived from tuple conversions, but csc accepts them")]
+		public void ExplicitLiftedTupleConversions()
+		{
+			// csc accepts the explicit nullable conversions derived from tuple conversions:
+			//   (int, string)? tn = ...;
+			//   (long, object) c = ((long, object))tn;
+			//   (int, string)? d = ((int, string)?)lo;  with lo of type (long, object)?
+			Assert.That(ExplicitConversion(typeof((int, string)?), typeof((long, object))).IsValid, "(int, string)? -> (long, object)");
+			Assert.That(ExplicitConversion(typeof((long, object)?), typeof((int, string)?)).IsValid, "(long, object)? -> (int, string)?");
+		}
+
+		[Test, Ignore("Known bug: CSharpConversions rejects explicit user-defined conversions to a nullable target when the operator result needs an explicit numeric conversion, but csc accepts them")]
+		public void UserDefinedExplicitConversion_ExplicitNumericConversionToNullableTarget()
+		{
+			// csc accepts:
+			//   int? d = (int?)new ImplicitToLong();       -- UD op to long, then explicit long -> int?
+			//   int? e = (int?)new ExplicitToLongOrUInt(); -- UD ops to long/uint, then explicit -> int?
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ImplicitToLong), typeof(int?));
+			Assert.That(c.IsValid, "(int?)ImplicitToLong");
+			var c2 = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToLongOrUInt), typeof(int?));
+			Assert.That(c2.IsValid, "(int?)ExplicitToLongOrUInt");
+		}
+
 		[Test]
 		public void ExplicitTypeParameterConversionFromEffectiveBaseClass()
 		{

--- a/ICSharpCode.Decompiler.Tests/Semantics/ExplicitConversionTest.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ExplicitConversionTest.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using ICSharpCode.Decompiler.CSharp.Resolver;
 using ICSharpCode.Decompiler.Semantics;
@@ -286,656 +287,416 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(ExplicitConversion(typeof(Enum), typeof(int?)), Is.EqualTo(C.None));
 		}
 
-		/* TODO: we should probably revive these tests somehow
-		Conversion ResolveCast(string program)
+		/// <summary>
+		/// Converts a constant expression (e.g. an integer literal) to the target type.
+		/// </summary>
+		Conversion ExplicitConstantConversion(object value, Type to)
 		{
-			return Resolve<ConversionResolveResult>(program).Conversion;
+			IType fromType = compilation.FindType(value.GetType());
+			IType to2 = compilation.FindType(to).AcceptVisitor(new ConversionTest.ReplaceSpecialTypesVisitor());
+			return conversions.ExplicitConversion(new ConstantResolveResult(fromType, value), to2);
 		}
 
 		[Test]
 		public void ObjectToTypeParameter()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T>(object o) {
-		T t = $(T)o$;
-	}
-}";
-			Assert.AreEqual(C.UnboxingConversion, ResolveCast(program));
+			// void M<T>(object o) { T t = (T)o; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			Assert.That(conversions.ExplicitConversion(compilation.FindType(KnownTypeCode.Object), t), Is.EqualTo(C.UnboxingConversion));
 		}
 
 		[Test]
 		public void UnrelatedClassToTypeParameter()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T>(string o) {
-		T t = $(T)o$;
-	}
-}";
-			Assert.AreEqual(C.None, ResolveCast(program));
+			// void M<T>(string o) { T t = (T)o; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			Assert.That(conversions.ExplicitConversion(compilation.FindType(KnownTypeCode.String), t), Is.EqualTo(C.None));
 		}
 
 		[Test]
 		public void IntefaceToTypeParameter()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T>(IDisposable o) {
-		T t = $(T)o$;
-	}
-}";
-			Assert.AreEqual(C.UnboxingConversion, ResolveCast(program));
+			// void M<T>(IDisposable o) { T t = (T)o; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			Assert.That(conversions.ExplicitConversion(compilation.FindType(typeof(IDisposable)), t), Is.EqualTo(C.UnboxingConversion));
 		}
 
 		[Test]
 		public void TypeParameterToInterface()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T>(T t) {
-		IDisposable d = $(IDisposable)t$;
-	}
-}";
-			Assert.AreEqual(C.BoxingConversion, ResolveCast(program));
+			// void M<T>(T t) { IDisposable d = (IDisposable)t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			Assert.That(conversions.ExplicitConversion(t, compilation.FindType(typeof(IDisposable))), Is.EqualTo(C.BoxingConversion));
 		}
 
 		[Test]
 		public void ValueTypeToTypeParameter()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T>(ValueType o) where T : struct {
-		T t = $(T)o$;
-	}
-}";
-			Assert.AreEqual(C.UnboxingConversion, ResolveCast(program));
+			// void M<T>(ValueType o) where T : struct { T t = (T)o; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasValueTypeConstraint: true);
+			Assert.That(conversions.ExplicitConversion(compilation.FindType(typeof(ValueType)), t), Is.EqualTo(C.UnboxingConversion));
 		}
 
 		[Test]
 		public void InvalidTypeParameterConversion()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) {
-		U u = $(U)t$;
-	}
-}";
-			Assert.AreEqual(C.None, ResolveCast(program));
+			// void M<T, U>(T t) { U u = (U)t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			Assert.That(conversions.ExplicitConversion(t, u), Is.EqualTo(C.None));
 		}
 
 		[Test]
 		public void TypeParameterConversion1()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where T : U {
-		U u = $(U)t$;
-	}
-}";
-			Assert.AreEqual(C.BoxingConversion, ResolveCast(program));
+			// void M<T, U>(T t) where T : U { U u = (U)t; }
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", constraints: new[] { u });
+			Assert.That(conversions.ExplicitConversion(t, u), Is.EqualTo(C.BoxingConversion));
 		}
 
 		[Test]
 		public void TypeParameterConversion1Array()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where T : U {
-		U[] u = $(U[])t$;
-	}
-}";
-			Assert.AreEqual(C.None, ResolveCast(program));
+			// void M<T, U>(T[] t) where T : U { U[] u = (U[])t; }
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U");
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", constraints: new[] { u });
+			Assert.That(conversions.ExplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.None));
 		}
 
 		[Test]
 		public void TypeParameterConversion2()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where U : T {
-		U u = $(U)t$;
-	}
-}";
-			Assert.AreEqual(C.UnboxingConversion, ResolveCast(program));
+			// void M<T, U>(T t) where U : T { U u = (U)t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", constraints: new[] { t });
+			Assert.That(conversions.ExplicitConversion(t, u), Is.EqualTo(C.UnboxingConversion));
 		}
 
 		[Test]
 		public void TypeParameterConversion2Array()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where U : T {
-		U[] u = $(U[])t$;
-	}
-}";
-			Assert.AreEqual(C.None, ResolveCast(program));
+			// void M<T, U>(T[] t) where U : T { U[] u = (U[])t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", constraints: new[] { t });
+			Assert.That(conversions.ExplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.None));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterConversionWithClassConstraint()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where T : class where U : class, T {
-		U u = $(U)t$;
-	}
-}";
-			Assert.AreEqual(C.ExplicitReferenceConversion, ResolveCast(program));
+			// void M<T, U>(T t) where T : class where U : class, T { U u = (U)t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasReferenceTypeConstraint: true);
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", hasReferenceTypeConstraint: true, constraints: new[] { t });
+			Assert.That(conversions.ExplicitConversion(t, u), Is.EqualTo(C.ExplicitReferenceConversion));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterArrayConversionWithClassConstraint()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where T : class where U : class, T {
-		U[] u = $(U[])t$;
-	}
-}";
-			Assert.AreEqual(C.ExplicitReferenceConversion, ResolveCast(program));
+			// void M<T, U>(T[] t) where T : class where U : class, T { U[] u = (U[])t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T", hasReferenceTypeConstraint: true);
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", hasReferenceTypeConstraint: true, constraints: new[] { t });
+			Assert.That(conversions.ExplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.ExplicitReferenceConversion));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterConversionWithClassConstraintOnlyOnT()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T t) where U : class, T {
-		U u = $(U)t$;
-	}
-}";
-			Assert.AreEqual(C.ExplicitReferenceConversion, ResolveCast(program));
+			// void M<T, U>(T t) where U : class, T { U u = (U)t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", hasReferenceTypeConstraint: true, constraints: new[] { t });
+			Assert.That(conversions.ExplicitConversion(t, u), Is.EqualTo(C.ExplicitReferenceConversion));
 		}
 
 		[Test]
 		public void ImplicitTypeParameterArrayConversionWithClassConstraintOnlyOnT()
 		{
-			string program = @"using System;
-class Test {
-	public void M<T, U>(T[] t) where U : class, T {
-		U[] u = $(U[])t$;
-	}
-}";
-			Assert.AreEqual(C.ExplicitReferenceConversion, ResolveCast(program));
+			// void M<T, U>(T[] t) where U : class, T { U[] u = (U[])t; }
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			ITypeParameter u = new DefaultTypeParameter(compilation, SymbolKind.Method, 1, "U", hasReferenceTypeConstraint: true, constraints: new[] { t });
+			Assert.That(conversions.ExplicitConversion(new ArrayType(compilation, t), new ArrayType(compilation, u)), Is.EqualTo(C.ExplicitReferenceConversion));
 		}
 
 		[Test]
 		public void SimpleUserDefinedConversion()
 		{
-			var rr = Resolve<ConversionResolveResult>(@"
-class C1 {}
-class C2 {
-	public static explicit operator C1(C2 c2) {
-		return null;
-	}
-}
-class C {
-	public void M() {
-		var c2 = new C2();
-		C1 c1 = $(C1)c2$;
-	}
-}");
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("op_Explicit", rr.Conversion.Method.Name);
+			// C1 c1 = (C1)c2;  with  explicit operator C1(C2 c2)
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.SimpleSource),
+				typeof(UserDefinedExplicitConversionTestCases.SimpleTarget));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Name, Is.EqualTo("op_Explicit"));
 		}
 
 		[Test]
 		public void ExplicitReferenceConversionFollowedByUserDefinedConversion()
 		{
-			var rr = Resolve<ConversionResolveResult>(@"
-		class B {}
-		class S : B {}
-		class T {
-			public static explicit operator T(S s) { return null; }
-		}
-		class Test {
-			void Run(B b) {
-				T t = $(T)b$;
-			}
-		}");
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("B", rr.Input.Type.Name);
+			// class S : B, explicit operator T(S s);
+			// T t = (T)b;  with b of type B needs the explicit reference conversion B -> S first
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.BaseClass),
+				typeof(UserDefinedExplicitConversionTestCases.TFromDerived));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
 		}
 
 		[Test]
 		public void ImplicitUserDefinedConversionFollowedByExplicitNumericConversion()
 		{
-			var rr = Resolve<ConversionResolveResult>(@"
-		struct T {
-			public static implicit operator float(T t) { return 0; }
-		}
-		class Test {
-			void Run(T t) {
-				int x = $(int)t$;
-			}
-		}");
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
+			// struct T { implicit operator float(T t) }
+			// int x = (int)t;
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.TImplicitToFloat), typeof(int));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
 			// even though the user-defined conversion is implicit, the combined conversion is explicit
-			Assert.That(rr.Conversion.IsExplicit);
+			Assert.That(c.IsExplicit);
 		}
 
 		[Test]
 		public void BothDirectConversionAndBaseClassConversionAvailable()
 		{
-			var rr = Resolve<ConversionResolveResult>(@"
-		class B {}
-		class S : B {}
-		class T {
-			public static explicit operator T(S s) { return null; }
-			public static explicit operator T(B b) { return null; }
-		}
-		class Test {
-			void Run(B b) {
-				T t = $(T)b$;
-			}
-		}");
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("b", rr.Conversion.Method.Parameters.Single().Name);
+			// class S : B, T with explicit operators from S ("s") and from B ("b");
+			// T t = (T)b;  picks the operator from B
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.BaseClass),
+				typeof(UserDefinedExplicitConversionTestCases.TFromDerivedOrBase));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters.Single().Name, Is.EqualTo("b"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_PicksExactSourceTypeIfPossible()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator Convertible(int i) {return new Convertible(); }
-	public static explicit operator Convertible(short s) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		var a = $(Convertible)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("i", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators from int ("i") and short ("s");
+			// (Convertible)33
+			var c = ExplicitConstantConversion(33, typeof(UserDefinedExplicitConversionTestCases.ExplicitFromIntOrShort));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_PicksMostEncompassedSourceTypeIfPossible()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator Convertible(long l) {return new Convertible(); }
-	public static explicit operator Convertible(uint ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		var a = $(Convertible)(ushort)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("ui", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators from long ("l") and uint ("ui");
+			// (Convertible)(ushort)33
+			var c = ExplicitConstantConversion((ushort)33, typeof(UserDefinedExplicitConversionTestCases.ExplicitFromLongOrUInt));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_PicksMostEncompassingSourceType()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator Convertible(int i) {return new Convertible(); }
-	public static explicit operator Convertible(ushort us) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		var a = $(Convertible)(long)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("i", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators from int ("i") and ushort ("us");
+			// (Convertible)(long)33
+			var c = ExplicitConstantConversion((long)33, typeof(UserDefinedExplicitConversionTestCases.ExplicitFromIntOrUShort));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_NoMostEncompassingSourceTypeIsInvalid()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator Convertible(uint i) {return new Convertible(); }
-	public static explicit operator Convertible(short us) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		var a = $(Convertible)(long)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(!rr.Conversion.IsValid);
+			// explicit operators from uint and short; neither source type encompasses the
+			// other, so the conversion from long is ambiguous.
+			var c = ExplicitConstantConversion((long)33, typeof(UserDefinedExplicitConversionTestCases.ExplicitFromUIntOrShort));
+			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_PicksExactTargetTypeIfPossible()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator int(Convertible i) {return 0; }
-	public static explicit operator short(Convertible s) {return 0; }
-}
-class Test {
-	public void M() {
-		var a = $(int)new Convertible()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("i", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators to int ("i") and short ("s");
+			// (int)new Convertible()
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToIntOrShort), typeof(int));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_PicksMostEncompassingTargetTypeIfPossible()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator int(Convertible i) {return 0; }
-	public static explicit operator ushort(Convertible us) {return 0; }
-}
-class Test {
-	public void M() {
-		var a = $(ulong)new Convertible()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("us", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators to int ("i") and ushort ("us");
+			// (ulong)new Convertible()
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToIntOrUShort), typeof(ulong));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("us"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_PicksMostEncompassedTargetType()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator long(Convertible l) { return 0; }
-	public static explicit operator uint(Convertible ui) { return 0; }
-}
-class Test {
-	public void M() {
-		var a = $(ushort)new Convertible()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("ui", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators to long ("l") and uint ("ui");
+			// (ushort)new Convertible()
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToLongOrUInt), typeof(ushort));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_NoMostEncompassedTargetTypeIsInvalid()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator ulong(Convertible l) { return 0; }
-	public static explicit operator int(Convertible ui) { return 0; }
-}
-class Test {
-	public void M() {
-		var a = $(ushort)new Convertible()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(!rr.Conversion.IsValid);
+			// explicit operators to ulong and int; neither target type encompasses the
+			// other, so the conversion to ushort is ambiguous.
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToULongOrInt), typeof(ushort));
+			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_AmbiguousIsInvalid()
 		{
-			string program = @"using System;
-class Convertible1 {
-	public static explicit operator Convertible2(Convertible1 c) {return 0; }
-}
-class Convertible2 {
-	public static explicit operator Convertible2(Convertible1 c) {return 0; }
-}
-class Test {
-	public void M() {
-		var a = $(Convertible2)new Convertible1()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(!rr.Conversion.IsValid);
+			// Both ExplicitAmbiguousA and ExplicitAmbiguousB declare
+			// explicit operator ExplicitAmbiguousB(ExplicitAmbiguousA).
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitAmbiguousA),
+				typeof(UserDefinedExplicitConversionTestCases.ExplicitAmbiguousB));
+			Assert.That(!c.IsValid);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_Lifted()
 		{
-			string program = @"using System;
-struct Convertible {
-	public static explicit operator Convertible(int i) {return new Convertible(); }
-}
-class Test {
-	public void M(int? i) {
-		 a = $(Convertible?)i$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.That(rr.Conversion.IsLifted);
+			// struct Convertible { explicit operator Convertible(int i) }
+			// (Convertible?)i  with i of type int?
+			var c = ExplicitConversion(typeof(int?), typeof(UserDefinedExplicitConversionTestCases.ExplicitFromInt?));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.IsLifted);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversionFollowedByImplicitNullableConversion()
 		{
-			string program = @"using System;
-struct Convertible {
-	public static explicit operator Convertible(int i) {return new Convertible(); }
-}
-class Test {
-	public void M(int i) {
-		 a = $(Convertible?)i$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.That(!rr.Conversion.IsLifted);
+			// struct Convertible { explicit operator Convertible(int i) }
+			// (Convertible?)i  with i of type int
+			var c = ExplicitConversion(typeof(int), typeof(UserDefinedExplicitConversionTestCases.ExplicitFromInt?));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(!c.IsLifted);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_ExplicitNullable_ThenUserDefined()
 		{
-			string program = @"using System;
-struct Convertible {
-	public static explicit operator Convertible(int i) {return new Convertible(); }
-	public static explicit operator Convertible?(int? ni) {return new Convertible(); }
-}
-class Test {
-	public void M(int? i) {
-		 a = $(Convertible)i$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.That(!rr.Conversion.IsLifted);
-			Assert.AreEqual("i", rr.Conversion.Method.Parameters[0].Name);
+			// struct Convertible with explicit operators from int ("i") and from int? ("ni");
+			// (Convertible)i  with i of type int? unwraps the nullable and uses the int operator
+			var c = ExplicitConversion(typeof(int?), typeof(UserDefinedExplicitConversionTestCases.ExplicitNullableConvertible));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(!c.IsLifted);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("i"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_DefinedNullableTakesPrecedenceOverLifted()
 		{
-			string program = @"using System;
-struct Convertible {
-	public static explicit operator Convertible(int i) {return new Convertible(); }
-	public static explicit operator Convertible?(int? ni) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		 a = $(Convertible?)(int?)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.That(!rr.Conversion.IsLifted);
-			Assert.AreEqual("ni", rr.Conversion.Method.Parameters[0].Name);
+			// struct Convertible with explicit operators from int ("i") and from int? ("ni");
+			// (Convertible?)(int?)33  -- the user-defined nullable operator wins over the
+			// lifted form of the int operator.
+			var c = ExplicitConversion(typeof(int?), typeof(UserDefinedExplicitConversionTestCases.ExplicitNullableConvertible?));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(!c.IsLifted);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ni"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_UIntConstant()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator Convertible(long l) {return new Convertible(); }
-	public static explicit operator Convertible(uint ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		var a = $(Convertible)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("ui", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators from long ("l") and uint ("ui");
+			// (Convertible)33  -- the constant 33 converts to uint, which is more specific
+			var c = ExplicitConstantConversion(33, typeof(UserDefinedExplicitConversionTestCases.ExplicitFromLongOrUInt));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_NullableUIntConstant()
 		{
-			string program = @"using System;
-class Convertible {
-	public static explicit operator Convertible(long? l) {return new Convertible(); }
-	public static explicit operator Convertible(uint? ui) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		Convertible a = $(Convertible)33$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("ui", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators from long? ("l") and uint? ("ui");
+			// (Convertible)33
+			var c = ExplicitConstantConversion(33, typeof(UserDefinedExplicitConversionTestCases.ExplicitFromNullableLongOrNullableUInt));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ui"));
 		}
 
 		[Test]
 		public void UseDefinedExplicitConversion_Lifted()
 		{
-			string program = @"
-struct Convertible {
-	public static explicit operator Convertible(int i) { return new Convertible(); }
-}
-class Test {
-	public void M(int? i) {
-		a = $(Convertible?)i$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.That(rr.Conversion.IsLifted);
-			Assert.That(rr.Input is LocalResolveResult);
+			// Same conversion as UserDefinedExplicitConversion_Lifted, but through the
+			// ResolveResult-based entry point (the original test cast a local variable).
+			var c = conversions.ExplicitConversion(
+				new ResolveResult(compilation.FindType(typeof(int?))),
+				compilation.FindType(typeof(UserDefinedExplicitConversionTestCases.ExplicitFromInt?)));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.IsLifted);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_Short_Or_NullableByte_Target()
 		{
-			string program = @"using System;
-class Test {
-	public static explicit operator short(Test s) { return 0; }
-	public static explicit operator byte?(Test b) { return 0; }
-}
-class Program {
-	public static void Main(string[] args)
-	{
-		int? x = $(int?)new Test()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("System.Int16", rr.Conversion.Method.ReturnType.FullName);
+			// explicit operators to short ("s") and byte? ("b");
+			// (int?)new Test()
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToShortOrNullableByte), typeof(int?));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.ReturnType.FullName, Is.EqualTo("System.Int16"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_Byte_Or_NullableShort_Target()
 		{
-			string program = @"using System;
-class Test {
-	public static explicit operator byte(Test b) { return 0; }
-	public static explicit operator short?(Test s) { return 0; }
-}
-class Program {
-	public static void Main(string[] args)
-	{
-		int? x = $(int?)new Test()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("s", rr.Conversion.Method.Parameters[0].Name);
+			// explicit operators to byte ("b") and short? ("s");
+			// (int?)new Test()
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitToByteOrNullableShort), typeof(int?));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("s"));
 		}
 
 		[Test]
 		public void ExplicitConversionOperatorsCanOverrideApplicableImplicitOnes()
 		{
-			string program = @"
-struct Convertible {
-	public static explicit operator int(Convertible ci) {return 0; }
-	public static implicit operator short(Convertible cs) {return 0; }
-}
-class Test {
-	static void Main() {
-		int i = $(int)new Convertible()$; // csc uses the explicit conversion operator
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.IsUserDefined);
-			Assert.AreEqual("ci", rr.Conversion.Method.Parameters[0].Name);
+			// struct Convertible { explicit operator int(Convertible ci); implicit operator short(Convertible cs); }
+			// int i = (int)new Convertible();  -- csc uses the explicit conversion operator
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ExplicitIntImplicitShort), typeof(int));
+			Assert.That(c.IsValid);
+			Assert.That(c.IsUserDefined);
+			Assert.That(c.Method.Parameters[0].Name, Is.EqualTo("ci"));
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_ConversionBeforeUserDefinedOperatorIsCorrect()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator Convertible(int l) {return new Convertible(); }
-}
-class Test {
-	public void M() {
-		long i = 33;
-		Convertible a = $(Convertible)i$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.ConversionBeforeUserDefinedOperator.IsValid);
-			Assert.That(rr.Conversion.ConversionBeforeUserDefinedOperator.IsExplicit);
-			Assert.That(rr.Conversion.ConversionBeforeUserDefinedOperator.IsNumericConversion);
-			Assert.That(rr.Conversion.ConversionAfterUserDefinedOperator.IsIdentityConversion);
+			// implicit operator Convertible(int l); casting a long goes long -> int -> Convertible,
+			// with an explicit numeric conversion before the operator.
+			var c = ExplicitConversion(typeof(long), typeof(UserDefinedExplicitConversionTestCases.ImplicitFromInt));
+			Assert.That(c.IsValid);
+			Assert.That(c.ConversionBeforeUserDefinedOperator.IsValid);
+			Assert.That(c.ConversionBeforeUserDefinedOperator.IsExplicit);
+			Assert.That(c.ConversionBeforeUserDefinedOperator.IsNumericConversion);
+			Assert.That(c.ConversionAfterUserDefinedOperator.IsIdentityConversion);
 		}
 
 		[Test]
 		public void UserDefinedExplicitConversion_ConversionAfterUserDefinedOperatorIsCorrect()
 		{
-			string program = @"using System;
-class Convertible {
-	public static implicit operator long(Convertible i) {return 0; }
-}
-class Test {
-	public void M() {
-		int a = $(int)new Convertible()$;
-	}
-}";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.Conversion.IsValid);
-			Assert.That(rr.Conversion.ConversionBeforeUserDefinedOperator.IsIdentityConversion);
-			Assert.That(rr.Conversion.ConversionAfterUserDefinedOperator.IsValid);
-			Assert.That(rr.Conversion.ConversionAfterUserDefinedOperator.IsExplicit);
-			Assert.That(rr.Conversion.ConversionAfterUserDefinedOperator.IsNumericConversion);
-		}*/
+			// implicit operator long(Convertible i); casting to int goes Convertible -> long -> int,
+			// with an explicit numeric conversion after the operator.
+			var c = ExplicitConversion(typeof(UserDefinedExplicitConversionTestCases.ImplicitToLong), typeof(int));
+			Assert.That(c.IsValid);
+			Assert.That(c.ConversionBeforeUserDefinedOperator.IsIdentityConversion);
+			Assert.That(c.ConversionAfterUserDefinedOperator.IsValid);
+			Assert.That(c.ConversionAfterUserDefinedOperator.IsExplicit);
+			Assert.That(c.ConversionAfterUserDefinedOperator.IsNumericConversion);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
+++ b/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
@@ -966,6 +966,252 @@ namespace ICSharpCode.Decompiler.Tests.TypeSystem
 	}
 
 	/// <summary>
+	/// Fixtures for the ExplicitConversionsTest.UserDefined* tests: types with user-defined
+	/// (mostly explicit) conversion operators. Operator parameter names are significant,
+	/// several tests assert which operator was chosen by its parameter name.
+	/// </summary>
+	public static class UserDefinedExplicitConversionTestCases
+	{
+		public class SimpleTarget { }
+
+		public class SimpleSource
+		{
+			public static explicit operator SimpleTarget(SimpleSource c2)
+			{
+				return null;
+			}
+		}
+
+		public class BaseClass { }
+
+		public class DerivedClass : BaseClass { }
+
+		public class TFromDerived
+		{
+			public static explicit operator TFromDerived(DerivedClass s)
+			{
+				return null;
+			}
+		}
+
+		public struct TImplicitToFloat
+		{
+			public static implicit operator float(TImplicitToFloat t)
+			{
+				return 0;
+			}
+		}
+
+		public class TFromDerivedOrBase
+		{
+			public static explicit operator TFromDerivedOrBase(DerivedClass s)
+			{
+				return null;
+			}
+			public static explicit operator TFromDerivedOrBase(BaseClass b)
+			{
+				return null;
+			}
+		}
+
+		public class ExplicitFromIntOrShort
+		{
+			public static explicit operator ExplicitFromIntOrShort(int i)
+			{
+				return new ExplicitFromIntOrShort();
+			}
+			public static explicit operator ExplicitFromIntOrShort(short s)
+			{
+				return new ExplicitFromIntOrShort();
+			}
+		}
+
+		public class ExplicitFromLongOrUInt
+		{
+			public static explicit operator ExplicitFromLongOrUInt(long l)
+			{
+				return new ExplicitFromLongOrUInt();
+			}
+			public static explicit operator ExplicitFromLongOrUInt(uint ui)
+			{
+				return new ExplicitFromLongOrUInt();
+			}
+		}
+
+		public class ExplicitFromIntOrUShort
+		{
+			public static explicit operator ExplicitFromIntOrUShort(int i)
+			{
+				return new ExplicitFromIntOrUShort();
+			}
+			public static explicit operator ExplicitFromIntOrUShort(ushort us)
+			{
+				return new ExplicitFromIntOrUShort();
+			}
+		}
+
+		public class ExplicitFromUIntOrShort
+		{
+			public static explicit operator ExplicitFromUIntOrShort(uint i)
+			{
+				return new ExplicitFromUIntOrShort();
+			}
+			public static explicit operator ExplicitFromUIntOrShort(short us)
+			{
+				return new ExplicitFromUIntOrShort();
+			}
+		}
+
+		public class ExplicitToIntOrShort
+		{
+			public static explicit operator int(ExplicitToIntOrShort i)
+			{
+				return 0;
+			}
+			public static explicit operator short(ExplicitToIntOrShort s)
+			{
+				return 0;
+			}
+		}
+
+		public class ExplicitToIntOrUShort
+		{
+			public static explicit operator int(ExplicitToIntOrUShort i)
+			{
+				return 0;
+			}
+			public static explicit operator ushort(ExplicitToIntOrUShort us)
+			{
+				return 0;
+			}
+		}
+
+		public class ExplicitToLongOrUInt
+		{
+			public static explicit operator long(ExplicitToLongOrUInt l)
+			{
+				return 0;
+			}
+			public static explicit operator uint(ExplicitToLongOrUInt ui)
+			{
+				return 0;
+			}
+		}
+
+		public class ExplicitToULongOrInt
+		{
+			public static explicit operator ulong(ExplicitToULongOrInt l)
+			{
+				return 0;
+			}
+			public static explicit operator int(ExplicitToULongOrInt ui)
+			{
+				return 0;
+			}
+		}
+
+		public class ExplicitAmbiguousA
+		{
+			public static explicit operator ExplicitAmbiguousB(ExplicitAmbiguousA c)
+			{
+				return null;
+			}
+		}
+
+		public class ExplicitAmbiguousB
+		{
+			public static explicit operator ExplicitAmbiguousB(ExplicitAmbiguousA c)
+			{
+				return null;
+			}
+		}
+
+		public struct ExplicitFromInt
+		{
+			public static explicit operator ExplicitFromInt(int i)
+			{
+				return default(ExplicitFromInt);
+			}
+		}
+
+		public struct ExplicitNullableConvertible
+		{
+			public static explicit operator ExplicitNullableConvertible(int i)
+			{
+				return default(ExplicitNullableConvertible);
+			}
+			public static explicit operator ExplicitNullableConvertible?(int? ni)
+			{
+				return default(ExplicitNullableConvertible);
+			}
+		}
+
+		public class ExplicitFromNullableLongOrNullableUInt
+		{
+			public static explicit operator ExplicitFromNullableLongOrNullableUInt(long? l)
+			{
+				return new ExplicitFromNullableLongOrNullableUInt();
+			}
+			public static explicit operator ExplicitFromNullableLongOrNullableUInt(uint? ui)
+			{
+				return new ExplicitFromNullableLongOrNullableUInt();
+			}
+		}
+
+		public class ExplicitToShortOrNullableByte
+		{
+			public static explicit operator short(ExplicitToShortOrNullableByte s)
+			{
+				return 0;
+			}
+			public static explicit operator byte?(ExplicitToShortOrNullableByte b)
+			{
+				return 0;
+			}
+		}
+
+		public class ExplicitToByteOrNullableShort
+		{
+			public static explicit operator byte(ExplicitToByteOrNullableShort b)
+			{
+				return 0;
+			}
+			public static explicit operator short?(ExplicitToByteOrNullableShort s)
+			{
+				return 0;
+			}
+		}
+
+		public struct ExplicitIntImplicitShort
+		{
+			public static explicit operator int(ExplicitIntImplicitShort ci)
+			{
+				return 0;
+			}
+			public static implicit operator short(ExplicitIntImplicitShort cs)
+			{
+				return 0;
+			}
+		}
+
+		public class ImplicitFromInt
+		{
+			public static implicit operator ImplicitFromInt(int l)
+			{
+				return new ImplicitFromInt();
+			}
+		}
+
+		public class ImplicitToLong
+		{
+			public static implicit operator long(ImplicitToLong i)
+			{
+				return 0;
+			}
+		}
+	}
+
+	/// <summary>
 	/// Fixture for ConversionTest.ExpansiveInheritance: a contravariant interface whose
 	/// implementing interface expands the type argument recursively.
 	/// </summary>

--- a/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
+++ b/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -671,6 +672,23 @@ namespace ICSharpCode.Decompiler.Tests.TypeSystem
 
 		public delegate void DStrInt(string s, int a);
 
+		public delegate int DStrIntRetInt(string s, int i);
+
+		public delegate int DRetInt();
+
+		public class GenericMethods
+		{
+			public static T F<T>(string s, T t)
+			{
+				return t;
+			}
+
+			public static T G<T>()
+			{
+				return default(T);
+			}
+		}
+
 		public class ObjParamInstance
 		{
 			public void F(object o) { }
@@ -962,6 +980,35 @@ namespace ICSharpCode.Decompiler.Tests.TypeSystem
 			{
 				return null;
 			}
+		}
+
+		public class OperatorInBaseClass
+		{
+			public static implicit operator string(OperatorInBaseClass a)
+			{
+				return null;
+			}
+		}
+
+		public class DerivedFromOperatorInBaseClass : OperatorInBaseClass
+		{
+		}
+	}
+
+	/// <summary>
+	/// Fixture for boxing/unboxing conversions that involve variance on an implemented
+	/// interface (C# standard 10.2.9 and 10.3.7).
+	/// </summary>
+	public struct StructImplementingIEnumerableOfString : IEnumerable<string>
+	{
+		public IEnumerator<string> GetEnumerator()
+		{
+			return null;
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return null;
 		}
 	}
 

--- a/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
+++ b/ICSharpCode.Decompiler.Tests/TypeSystem/TypeSystemTestCase.cs
@@ -571,6 +571,410 @@ namespace ICSharpCode.Decompiler.Tests.TypeSystem
 		public void Dispose() { }
 	}
 
+	/// <summary>
+	/// Fixtures for ConversionTest.MethodGroupConversion_* tests: delegate types and
+	/// per-test method sets, resolved through hand-built MethodGroupResolveResults.
+	/// </summary>
+	public static class MethodGroupConversionTestCases
+	{
+		public delegate void DVoid();
+
+		public class VoidStatic
+		{
+			public static void M() { }
+		}
+
+		public class VoidInstance
+		{
+			public void M() { }
+		}
+
+		public delegate object DObjInt(int argument);
+
+		public class ReturnObjectFromInt
+		{
+			public static object M(int argument)
+			{
+				return null;
+			}
+		}
+
+		public class ReturnIntFromInt
+		{
+			public static int M(int argument)
+			{
+				return 0;
+			}
+		}
+
+		public class ReturnStringFromInt
+		{
+			public static string M(int argument)
+			{
+				return null;
+			}
+		}
+
+		public delegate void DRefObj(ref object o);
+
+		public delegate void DObj(object o);
+
+		public delegate void DStr(string a);
+
+		public class RefObjParam
+		{
+			public static void M(ref object o) { }
+		}
+
+		public class RefDynamicParam
+		{
+			public static void M(ref dynamic o) { }
+		}
+
+		public class OutObjParam
+		{
+			public static void M(out object o)
+			{
+				o = null;
+			}
+		}
+
+		public class ObjParam
+		{
+			public static void M(object o) { }
+		}
+
+		public class DynamicParam
+		{
+			public static void M(dynamic o) { }
+		}
+
+		public class OverloadObjectOrOptionalString
+		{
+			public static void M(object x) { }
+			public static void M(string x = null) { }
+		}
+
+		public class OverloadObjectOrStringPlusOptional
+		{
+			public static void M(object x) { }
+			public static void M(string x, string y = null) { }
+		}
+
+		public class OverloadObjectOrParamsString
+		{
+			public static void M(object x) { }
+			public static void M(params string[] x) { }
+		}
+
+		public delegate void DInt(int a);
+
+		public delegate void DStrInt(string s, int a);
+
+		public class ObjParamInstance
+		{
+			public void F(object o) { }
+		}
+
+		public class ObjListParamInstance
+		{
+			public void F(List<object> l) { }
+		}
+
+		public class ObjReturnInstance
+		{
+			public object F()
+			{
+				return null;
+			}
+		}
+
+		public class DynamicParamInstance
+		{
+			public void F(dynamic o) { }
+		}
+
+		public class DynamicListParamInstance
+		{
+			public void F(List<dynamic> l) { }
+		}
+
+		public class DynamicReturnInstance
+		{
+			public dynamic F()
+			{
+				return null;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Extension method fixture for the ConversionTest.MethodGroupConversion_ExtensionMethod*
+	/// tests (extension methods require a top-level static class).
+	/// </summary>
+	public static class MethodGroupConversionExt
+	{
+		public static void M(this string s, int x) { }
+	}
+
+	/// <summary>
+	/// Fixtures for the ConversionTest.UserDefined* tests: types with user-defined implicit
+	/// conversion operators. Operator parameter names are significant, several tests assert
+	/// which operator was chosen by its parameter name.
+	/// </summary>
+	public static class UserDefinedConversionTestCases
+	{
+		public struct TFromUInt
+		{
+			public static implicit operator TFromUInt(uint a)
+			{
+				return default(TFromUInt);
+			}
+		}
+
+		public struct TFromString
+		{
+			public static implicit operator TFromString(string a)
+			{
+				return default(TFromString);
+			}
+		}
+
+		public struct SToNullableShort
+		{
+			public static implicit operator short?(SToNullableShort s)
+			{
+				return 0;
+			}
+		}
+
+		public class ConvertibleFromIntOrShort
+		{
+			public static implicit operator ConvertibleFromIntOrShort(int i)
+			{
+				return new ConvertibleFromIntOrShort();
+			}
+			public static implicit operator ConvertibleFromIntOrShort(short s)
+			{
+				return new ConvertibleFromIntOrShort();
+			}
+		}
+
+		public class ConvertibleFromLongOrUInt
+		{
+			public static implicit operator ConvertibleFromLongOrUInt(long l)
+			{
+				return new ConvertibleFromLongOrUInt();
+			}
+			public static implicit operator ConvertibleFromLongOrUInt(uint ui)
+			{
+				return new ConvertibleFromLongOrUInt();
+			}
+		}
+
+		public class ConvertibleFromULongOrInt
+		{
+			public static implicit operator ConvertibleFromULongOrInt(ulong l)
+			{
+				return new ConvertibleFromULongOrInt();
+			}
+			public static implicit operator ConvertibleFromULongOrInt(int ui)
+			{
+				return new ConvertibleFromULongOrInt();
+			}
+		}
+
+		public class ConvertibleToIntOrShort
+		{
+			public static implicit operator int(ConvertibleToIntOrShort i)
+			{
+				return 0;
+			}
+			public static implicit operator short(ConvertibleToIntOrShort s)
+			{
+				return 0;
+			}
+		}
+
+		public class ConvertibleToIntOrUShort
+		{
+			public static implicit operator int(ConvertibleToIntOrUShort i)
+			{
+				return 0;
+			}
+			public static implicit operator ushort(ConvertibleToIntOrUShort us)
+			{
+				return 0;
+			}
+		}
+
+		public class ConvertibleToUIntOrShort
+		{
+			public static implicit operator uint(ConvertibleToUIntOrShort i)
+			{
+				return 0;
+			}
+			public static implicit operator short(ConvertibleToUIntOrShort us)
+			{
+				return 0;
+			}
+		}
+
+		public class AmbiguousA
+		{
+			public static implicit operator AmbiguousB(AmbiguousA c)
+			{
+				return null;
+			}
+		}
+
+		public class AmbiguousB
+		{
+			public static implicit operator AmbiguousB(AmbiguousA c)
+			{
+				return null;
+			}
+		}
+
+		public struct NullableConvertible
+		{
+			public static implicit operator NullableConvertible(int i)
+			{
+				return default(NullableConvertible);
+			}
+			public static implicit operator NullableConvertible?(int? ni)
+			{
+				return default(NullableConvertible);
+			}
+		}
+
+		public class ConvertibleFromNullableLongOrNullableUInt
+		{
+			public static implicit operator ConvertibleFromNullableLongOrNullableUInt(long? l)
+			{
+				return new ConvertibleFromNullableLongOrNullableUInt();
+			}
+			public static implicit operator ConvertibleFromNullableLongOrNullableUInt(uint? ui)
+			{
+				return new ConvertibleFromNullableLongOrNullableUInt();
+			}
+		}
+
+		public class ToNullableIntOrShort
+		{
+			public static implicit operator int?(ToNullableIntOrShort i)
+			{
+				return 0;
+			}
+			public static implicit operator short(ToNullableIntOrShort s)
+			{
+				return 0;
+			}
+		}
+
+		public class ToShortOrNullableByte
+		{
+			public static implicit operator short(ToShortOrNullableByte s)
+			{
+				return 0;
+			}
+			public static implicit operator byte?(ToShortOrNullableByte b)
+			{
+				return 0;
+			}
+		}
+
+		public class ToByteOrNullableShort
+		{
+			public static implicit operator byte(ToByteOrNullableShort b)
+			{
+				return 0;
+			}
+			public static implicit operator short?(ToByteOrNullableShort s)
+			{
+				return 0;
+			}
+		}
+
+		public class FromIntOrNullableLong
+		{
+			public static implicit operator FromIntOrNullableLong(int i)
+			{
+				return new FromIntOrNullableLong();
+			}
+			public static implicit operator FromIntOrNullableLong(long? l)
+			{
+				return new FromIntOrNullableLong();
+			}
+		}
+
+		public class FromNullableIntOrLong
+		{
+			public static implicit operator FromNullableIntOrLong(int? i)
+			{
+				return new FromNullableIntOrLong();
+			}
+			public static implicit operator FromNullableIntOrLong(long l)
+			{
+				return new FromNullableIntOrLong();
+			}
+		}
+
+		public class FromNullableIntOrNullableLong
+		{
+			public static implicit operator FromNullableIntOrNullableLong(int? i)
+			{
+				return new FromNullableIntOrNullableLong();
+			}
+			public static implicit operator FromNullableIntOrNullableLong(long? l)
+			{
+				return new FromNullableIntOrNullableLong();
+			}
+		}
+
+		public class ConvertibleFromLong
+		{
+			public static implicit operator ConvertibleFromLong(long l)
+			{
+				return new ConvertibleFromLong();
+			}
+		}
+
+		public class ConvertibleToInt
+		{
+			public static implicit operator int(ConvertibleToInt i)
+			{
+				return 0;
+			}
+		}
+
+		public class ConvertibleToString
+		{
+			public static implicit operator string(ConvertibleToString a)
+			{
+				return null;
+			}
+		}
+
+		public class JsNumber
+		{
+			public static implicit operator JsNumber(int d)
+			{
+				return null;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Fixture for ConversionTest.ExpansiveInheritance: a contravariant interface whose
+	/// implementing interface expands the type argument recursively.
+	/// </summary>
+	public static class ExpansiveInheritanceTestCases
+	{
+		public interface A<in U> { }
+		public interface B<X> : A<A<B<X>>> { }
+	}
+
 	public class ClassWithAttributeOnTypeParameter<[Double(2)] T> { }
 
 	[Guid("790C6E0B-9194-4cc9-9426-A48A63185696"), InterfaceType(ComInterfaceType.InterfaceIsDual)]


### PR DESCRIPTION
Revives the NRefactory-era conversion tests that were commented out in `ConversionTests.cs` and `ExplicitConversionTest.cs` ("TODO: we should probably revive these tests somehow") and extends the suites so that every rule of the [conversions chapter of the draft-v8 C# standard](https://github.com/dotnet/csharpstandard/blob/draft-v8/standard/conversions.md) has a test case.

- All commented-out tests now run without a resolver or AST: method groups via directly constructed `MethodGroupResolveResult`s over fixture types compiled into the test assembly (extension methods injected through the internal `extensionMethods` field), type-parameter conversions via `DefaultTypeParameter` with cross-referencing constraints, user-defined operators as metadata-backed fixture types, and constant expressions via `ConstantResolveResult`.
- Deviations from the NRefactory originals are documented inline. Notably, `MethodGroupConversion_RefArgumentObjectVsDynamic` now expects a valid conversion: object/dynamic mismatch in a `ref` position is an identity conversion and current csc accepts the assignment.
- New tests fill every remaining chapter-10 gap: exhaustive implicit/explicit numeric matrices, the full boxing/unboxing rule set including variance, tuple literals and nullable-annotation/ValueTuple identity, interpolated-string and throw-expression conversions, generic method groups (type inference, explicit type arguments, no inference from the return type), and the anonymous-function compatibility checks `CSharpConversions` performs itself.
- Two rules are implementation gaps and carry `[Ignore]`d placeholder tests: default literal conversions (10.2.16, an explicit TODO in `CSharpConversions`) and switch expression conversions (10.2.18, no ResolveResult representation).
- Differentially fuzzing the classification matrix against csc surfaced two real `CSharpConversions` bugs, captured as `[Ignore]`d known-bug tests: nullable conversions derived from tuple conversions are missing entirely, and explicit user-defined conversions to a nullable target are rejected when the operator result additionally needs an explicit numeric conversion.

This pull request was authored by an AI agent (Claude Code) operated by @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)