### PR TITLE
Emit C# 7.1 default literals

### DIFF
--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -489,6 +489,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task OverloadResolution([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task PatternMatching([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -495,6 +495,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task TargetTypedDefault([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task PatternMatching([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -483,6 +483,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task DefaultLiteral([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task PatternMatching([ValueSource(nameof(roslyn2OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ConversionTests.cs
@@ -1615,14 +1615,20 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			Assert.That(c.Method.DeclaringType.Name, Is.EqualTo("OperatorInBaseClass"));
 		}
 
-		[Test, Ignore("C# standard 10.2.16 is not implemented: CSharpConversions.ImplicitConversion has a TODO for default literal conversions, and no ResolveResult represents a typeless default literal")]
+		[Test]
 		public void DefaultLiteralConversions()
 		{
-			// C# standard 10.2.16: an implicit conversion exists from a default_literal to
-			// any type, producing the default value of the inferred type. Once the semantic
-			// model gains a typeless default-literal ResolveResult, this test should assert
-			// that it converts to int, string, int? and type parameters.
-			Assert.Fail("Default literal conversions are not implemented.");
+			// C# standard 10.2.16: an implicit conversion exists from a default_literal to any type
+			var defaultLiteral = new DefaultLiteralResolveResult();
+			// a default_value_expression is a constant expression (C# standard 12.8.21)
+			Assert.That(defaultLiteral.IsCompileTimeConstant);
+			Assert.That(conversions.ImplicitConversion(defaultLiteral, compilation.FindType(KnownTypeCode.Int32)), Is.EqualTo(C.DefaultLiteralConversion));
+			Assert.That(conversions.ImplicitConversion(defaultLiteral, compilation.FindType(KnownTypeCode.String)), Is.EqualTo(C.DefaultLiteralConversion));
+			Assert.That(conversions.ImplicitConversion(defaultLiteral, compilation.FindType(typeof(int?))), Is.EqualTo(C.DefaultLiteralConversion));
+			ITypeParameter t = new DefaultTypeParameter(compilation, SymbolKind.Method, 0, "T");
+			Assert.That(conversions.ImplicitConversion(defaultLiteral, t), Is.EqualTo(C.DefaultLiteralConversion));
+			// explicit conversions include all implicit conversions, so (T)default is also valid
+			Assert.That(conversions.ExplicitConversion(defaultLiteral, compilation.FindType(KnownTypeCode.Int32)), Is.EqualTo(C.DefaultLiteralConversion));
 		}
 
 		[Test, Ignore("C# standard 10.2.18 is not implemented: no ResolveResult represents a switch expression; the decompiler converts each arm separately in ILAst")]

--- a/ICSharpCode.Decompiler.Tests/Semantics/OverloadResolutionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/OverloadResolutionTests.cs
@@ -22,6 +22,7 @@ using System.Linq;
 using System.Linq.Expressions;
 
 using ICSharpCode.Decompiler.CSharp.Resolver;
+using ICSharpCode.Decompiler.CSharp.Syntax;
 using ICSharpCode.Decompiler.Semantics;
 using ICSharpCode.Decompiler.Tests.TypeSystem;
 using ICSharpCode.Decompiler.TypeSystem;
@@ -346,6 +347,110 @@ namespace ICSharpCode.Decompiler.Tests.Semantics
 			{
 				Method(a => a.ToString());
 			}
+		}
+
+		OverloadResolution ResolveWithDefaultLiteralArgument(params IMethod[] candidates)
+		{
+			var or = new OverloadResolution(compilation, new ResolveResult[] { new DefaultLiteralResolveResult() });
+			foreach (var candidate in candidates)
+			{
+				Assert.That(or.AddCandidate(candidate), Is.EqualTo(OverloadResolutionErrors.None));
+			}
+			return or;
+		}
+
+		[Test]
+		public void DefaultLiteralArgumentPrefersBetterConversionTarget()
+		{
+			// csc resolves M(default) by the better conversion target:
+			// M(int)/M(long) -> int; M(object)/M(string) -> string; M(int)/M(int?) -> int
+			var mInt = MakeMethod(typeof(int));
+			var or = ResolveWithDefaultLiteralArgument(mInt, MakeMethod(typeof(long)));
+			Assert.That(!or.IsAmbiguous);
+			Assert.That(or.BestCandidate, Is.SameAs(mInt));
+
+			var mString = MakeMethod(typeof(string));
+			or = ResolveWithDefaultLiteralArgument(MakeMethod(typeof(object)), mString);
+			Assert.That(!or.IsAmbiguous);
+			Assert.That(or.BestCandidate, Is.SameAs(mString));
+
+			mInt = MakeMethod(typeof(int));
+			or = ResolveWithDefaultLiteralArgument(mInt, MakeMethod(typeof(int?)));
+			Assert.That(!or.IsAmbiguous);
+			Assert.That(or.BestCandidate, Is.SameAs(mInt));
+		}
+
+		[Test]
+		public void DefaultLiteralArgumentWithoutBetterConversionTargetIsAmbiguous()
+		{
+			// csc: M(default) with M(int)/M(string) is CS0121
+			var or = ResolveWithDefaultLiteralArgument(MakeMethod(typeof(int)), MakeMethod(typeof(string)));
+			Assert.That(or.IsAmbiguous);
+		}
+
+		[Test]
+		public void DefaultLiteralArgumentDoesNotParticipateInTypeInference()
+		{
+			// csc: G(default) with G<T>(T) is CS0411 (cannot infer the type argument)
+			var m = compilation.FindType(typeof(DefaultLiteralGenericTestCase)).GetMethods(m2 => m2.Name == "G").Single();
+			var or = new OverloadResolution(compilation, new ResolveResult[] { new DefaultLiteralResolveResult() });
+			Assert.That(or.AddCandidate(m), Is.EqualTo(OverloadResolutionErrors.TypeInferenceFailed));
+			Assert.That(!or.FoundApplicableCandidate);
+		}
+
+		class DefaultLiteralGenericTestCase
+		{
+			public static T G<T>(T x)
+			{
+				return x;
+			}
+
+			public static T H<T>(T a, T b)
+			{
+				return a;
+			}
+		}
+
+		[Test]
+		public void DefaultLiteralArgumentRidesAlongInTypeInference()
+		{
+			// csc: F("x", default) with F<T>(T, T) infers T=string;
+			// F(default, default) is CS0411.
+			var m = compilation.FindType(typeof(DefaultLiteralGenericTestCase)).GetMethods(m2 => m2.Name == "H").Single();
+			var or = new OverloadResolution(compilation, new ResolveResult[] {
+				new ResolveResult(compilation.FindType(KnownTypeCode.String)),
+				new DefaultLiteralResolveResult()
+			});
+			Assert.That(or.AddCandidate(m), Is.EqualTo(OverloadResolutionErrors.None));
+			Assert.That(or.FoundApplicableCandidate);
+			Assert.That(((IMethod)or.GetBestCandidateWithSubstitutedTypeArguments()).TypeArguments.Single().IsKnownType(KnownTypeCode.String));
+
+			or = new OverloadResolution(compilation, new ResolveResult[] {
+				new DefaultLiteralResolveResult(),
+				new DefaultLiteralResolveResult()
+			});
+			Assert.That(or.AddCandidate(m), Is.EqualTo(OverloadResolutionErrors.TypeInferenceFailed));
+		}
+
+		[Test]
+		public void BinaryOperatorWithDefaultLiteralOperand()
+		{
+			// csc: "i == default" uses the int equality operator, "s == default" the string one;
+			// "default == default" is an error (CS8315).
+			var resolver = new CSharpResolver(compilation);
+			var i = new ResolveResult(compilation.FindType(KnownTypeCode.Int32));
+			var s = new ResolveResult(compilation.FindType(KnownTypeCode.String));
+
+			var rr = resolver.ResolveBinaryOperator(BinaryOperatorType.Equality, i, new DefaultLiteralResolveResult());
+			Assert.That(!rr.IsError);
+			Assert.That(rr.Type.IsKnownType(KnownTypeCode.Boolean));
+
+			rr = resolver.ResolveBinaryOperator(BinaryOperatorType.Equality, s, new DefaultLiteralResolveResult());
+			Assert.That(!rr.IsError);
+			Assert.That(rr.Type.IsKnownType(KnownTypeCode.Boolean));
+
+			rr = resolver.ResolveBinaryOperator(BinaryOperatorType.Equality, new DefaultLiteralResolveResult(), new DefaultLiteralResolveResult());
+			Assert.That(rr.IsError);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/OverloadResolution.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/OverloadResolution.cs
@@ -43,7 +43,81 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			Issue2444.M2();
 			Issue2741.B.Test(new Issue2741.C());
 			ExtensionMethodDemo.Issue2165.Test();
+#if CS71
+			DefaultLiteralTests();
+#endif
 		}
+
+#if CS71
+		static void DefaultLiteralTests()
+		{
+			// The decompiled output may shorten default(T) to a default literal;
+			// re-compilation must still pick the same overloads and operators.
+			DefaultOverload(default(DataStruct));
+			DefaultOverload(default(OtherStruct));
+			DefaultNullableOverload(default(DataStruct));
+			Console.WriteLine(default(DataStruct) == new DataStruct());
+			Console.WriteLine(GenericDefault("x", default));
+			Console.WriteLine(GenericDefault(42, default));
+		}
+
+		struct DataStruct
+		{
+			public int Field;
+
+			public static bool operator ==(DataStruct a, DataStruct b)
+			{
+				Console.WriteLine("DataStruct operator ==");
+				return a.Field == b.Field;
+			}
+
+			public static bool operator !=(DataStruct a, DataStruct b)
+			{
+				return a.Field != b.Field;
+			}
+
+			public override bool Equals(object obj)
+			{
+				return obj is DataStruct other && Field == other.Field;
+			}
+
+			public override int GetHashCode()
+			{
+				return Field;
+			}
+		}
+
+		struct OtherStruct
+		{
+			public int Field;
+		}
+
+		static void DefaultOverload(DataStruct data)
+		{
+			Console.WriteLine("DefaultOverload(DataStruct)");
+		}
+
+		static void DefaultOverload(OtherStruct data)
+		{
+			Console.WriteLine("DefaultOverload(OtherStruct)");
+		}
+
+		static void DefaultNullableOverload(DataStruct data)
+		{
+			Console.WriteLine("DefaultNullableOverload(DataStruct)");
+		}
+
+		static void DefaultNullableOverload(DataStruct? data)
+		{
+			Console.WriteLine("DefaultNullableOverload(DataStruct?)");
+		}
+
+		static T GenericDefault<T>(T a, T b)
+		{
+			Console.WriteLine("GenericDefault: " + typeof(T).Name);
+			return b;
+		}
+#endif
 
 		#region ConstructorTest
 		static void ConstructorTest()

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue2260SwitchString.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue2260SwitchString.cs
@@ -5,8 +5,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 	{
 		private void dgvItemList_CellValueChanged(object sender, DataGridViewCellEventArgs e)
 		{
-			string text = default(string);
-			string s = default(string);
+			string text = default;
+			string s = default;
 			switch (text)
 			{
 				case "rowno":
@@ -16,7 +16,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 					break;
 				case "stock_qty":
 					{
-						decimal result2 = default(decimal);
+						decimal result2 = default;
 						if (!decimal.TryParse(s, out result2))
 						{
 							new object();
@@ -29,12 +29,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 					}
 				case "new_price":
 					{
-						decimal num = default(decimal);
+						decimal num = default;
 						break;
 					}
 				case "new_price4":
 					{
-						decimal result4 = default(decimal);
+						decimal result4 = default;
 						if (decimal.TryParse(s, out result4) && !(result4 < 0m))
 						{
 						}
@@ -42,7 +42,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 					}
 				case "new_price1":
 					{
-						decimal result3 = default(decimal);
+						decimal result3 = default;
 						if (!decimal.TryParse(s, out result3))
 						{
 							new object();
@@ -57,7 +57,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 					}
 				case "new_price2":
 					{
-						decimal result = default(decimal);
+						decimal result = default;
 						if (!decimal.TryParse(s, out result))
 						{
 							new object();

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncUsing.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncUsing.cs
@@ -49,7 +49,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static async void TestAsyncUsingNullableStruct()
 		{
-			await using (AsyncDisposableStruct? asyncDisposableStruct = new AsyncDisposableStruct?(default(AsyncDisposableStruct)))
+			await using (AsyncDisposableStruct? asyncDisposableStruct = new AsyncDisposableStruct?(default))
 			{
 				Use(asyncDisposableStruct);
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncUsing.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/AsyncUsing.cs
@@ -41,7 +41,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static async void TestAsyncUsingStruct()
 		{
-			await using (AsyncDisposableStruct asyncDisposableStruct = default(AsyncDisposableStruct))
+			await using (AsyncDisposableStruct asyncDisposableStruct = default)
 			{
 				Use(asyncDisposableStruct);
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
@@ -4257,7 +4257,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 		public static void CustomStructAddTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p += default(CustomStruct);
 			num += default(CustomStruct);
 			Use(ref num);
@@ -4284,7 +4284,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructSubtractTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p -= default(CustomStruct);
 			num -= default(CustomStruct);
 			Use(ref num);
@@ -4311,7 +4311,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructMultiplyTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p *= default(CustomStruct);
 			num *= default(CustomStruct);
 			Use(ref num);
@@ -4338,7 +4338,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructDivideTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p /= default(CustomStruct);
 			num /= default(CustomStruct);
 			Use(ref num);
@@ -4365,7 +4365,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructModulusTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p %= default(CustomStruct);
 			num %= default(CustomStruct);
 			Use(ref num);
@@ -4392,7 +4392,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructLeftShiftTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p <<= 5;
 			num <<= 5;
 			Use(ref num);
@@ -4419,7 +4419,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructRightShiftTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p >>= 5;
 			num >>= 5;
 			Use(ref num);
@@ -4472,7 +4472,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructBitAndTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p &= default(CustomStruct);
 			num &= default(CustomStruct);
 			Use(ref num);
@@ -4499,7 +4499,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructBitOrTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p |= default(CustomStruct);
 			num |= default(CustomStruct);
 			Use(ref num);
@@ -4526,7 +4526,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructBitXorTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			p ^= default(CustomStruct);
 			num ^= default(CustomStruct);
 			Use(ref num);
@@ -4553,7 +4553,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructPostIncTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			X(p++);
 			X(num++);
 			Use(ref num);
@@ -4580,7 +4580,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructPreIncTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			X(++p);
 			X(++num);
 			Use(ref num);
@@ -4606,7 +4606,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 		public static void CustomStructPostDecTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			X(p--);
 			X(num--);
 			Use(ref num);
@@ -4633,7 +4633,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructPreDecTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
-			CustomStruct num = default(CustomStruct);
+			CustomStruct num = default;
 			X(--p);
 			X(--num);
 			Use(ref num);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/CompoundAssignmentTest.cs
@@ -4257,7 +4257,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 		public static void CustomStructAddTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p += default(CustomStruct);
 			num += default(CustomStruct);
 			Use(ref num);
@@ -4284,7 +4288,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructSubtractTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p -= default(CustomStruct);
 			num -= default(CustomStruct);
 			Use(ref num);
@@ -4311,7 +4319,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructMultiplyTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p *= default(CustomStruct);
 			num *= default(CustomStruct);
 			Use(ref num);
@@ -4338,7 +4350,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructDivideTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p /= default(CustomStruct);
 			num /= default(CustomStruct);
 			Use(ref num);
@@ -4365,7 +4381,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructModulusTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p %= default(CustomStruct);
 			num %= default(CustomStruct);
 			Use(ref num);
@@ -4392,7 +4412,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructLeftShiftTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p <<= 5;
 			num <<= 5;
 			Use(ref num);
@@ -4419,7 +4443,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructRightShiftTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p >>= 5;
 			num >>= 5;
 			Use(ref num);
@@ -4472,7 +4500,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructBitAndTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p &= default(CustomStruct);
 			num &= default(CustomStruct);
 			Use(ref num);
@@ -4499,7 +4531,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructBitOrTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p |= default(CustomStruct);
 			num |= default(CustomStruct);
 			Use(ref num);
@@ -4526,7 +4562,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructBitXorTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			p ^= default(CustomStruct);
 			num ^= default(CustomStruct);
 			Use(ref num);
@@ -4553,7 +4593,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructPostIncTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			X(p++);
 			X(num++);
 			Use(ref num);
@@ -4580,7 +4624,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructPreIncTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			X(++p);
 			X(++num);
 			Use(ref num);
@@ -4606,7 +4654,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		}
 		public static void CustomStructPostDecTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			X(p--);
 			X(num--);
 			Use(ref num);
@@ -4633,7 +4685,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static void CustomStructPreDecTest(CustomStruct p, CustomClass c, CustomStruct2 s)
 		{
+#if CS71
 			CustomStruct num = default;
+#else
+			CustomStruct num = default(CustomStruct);
+#endif
 			X(--p);
 			X(--num);
 			Use(ref num);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -43,7 +43,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator MyInt(int x)
 			{
-				return default(MyInt);
+				return default;
 			}
 		}
 
@@ -53,8 +53,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public void Deconstruct(out T a, out T2 b)
 			{
-				a = default(T);
-				b = default(T2);
+				a = default;
+				b = default;
 			}
 		}
 
@@ -64,9 +64,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public void Deconstruct(out T a, out T2 b, out T3 c)
 			{
-				a = default(T);
-				b = default(T2);
-				c = default(T3);
+				a = default;
+				b = default;
+				c = default;
 			}
 		}
 
@@ -135,12 +135,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private (T, T2) GetTuple<T, T2>()
 		{
-			return default((T, T2));
+			return default;
 		}
 
 		private (T, T2, T3) GetTuple<T, T2, T3>()
 		{
-			return default((T, T2, T3));
+			return default;
 		}
 
 		private AssignmentTargets Get(int i)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DefaultLiteral.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DefaultLiteral.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Threading.Tasks;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class DefaultLiteral
+	{
+		public struct Data
+		{
+			public int Field;
+
+			public static Data operator +(Data a, Data b)
+			{
+				return new Data {
+					Field = a.Field + b.Field
+				};
+			}
+		}
+
+		public int this[Data d] => d.Field;
+
+		public int DeclarationWithInitializer()
+		{
+			Data data = default;
+			return data.Field + data.Field;
+		}
+
+		public int Assignment(Data data)
+		{
+			int field = data.Field;
+			data = default;
+			return field + data.Field;
+		}
+
+		public Data Return()
+		{
+			return default;
+		}
+
+		public T ReturnGeneric<T>()
+		{
+			return default;
+		}
+
+		public async Task<Data> ReturnAsync()
+		{
+			await Task.Yield();
+			return default;
+		}
+
+		public string ArgumentsStayTyped()
+		{
+			return Overloaded(default(Data));
+		}
+
+		public int UnambiguousArgumentStaysTyped()
+		{
+			return Single(default(Data));
+		}
+
+		public int IndexerArgumentStaysTyped()
+		{
+			return this[default(Data)];
+		}
+
+		public Data OperatorOperandStaysTyped(Data data)
+		{
+			return data + default(Data);
+		}
+
+		public string NonIdentityConversionsStayTyped()
+		{
+			object obj = default(Data);
+			return obj.ToString() + obj.ToString();
+		}
+
+		private int Single(Data data)
+		{
+			return data.Field;
+		}
+
+		private string Overloaded(Data x)
+		{
+			return "Data";
+		}
+
+		private string Overloaded(Data? x)
+		{
+			return "Data?";
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DefaultLiteral.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DefaultLiteral.cs
@@ -34,6 +34,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
+		public struct OtherData
+		{
+			public int Field;
+		}
+
 		public int this[Data d] => d.Field;
 
 		public int DeclarationWithInitializer()
@@ -65,14 +70,24 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return default;
 		}
 
-		public string ArgumentsStayTyped()
+		public string AmbiguousArgumentStaysTyped()
 		{
 			return Overloaded(default(Data));
 		}
 
-		public int UnambiguousArgumentStaysTyped()
+		public string BetterConversionTargetArgument()
 		{
-			return Single(default(Data));
+			return OverloadedNullable(default);
+		}
+
+		public int UnambiguousArgument()
+		{
+			return Single(default);
+		}
+
+		public string BoxedArgumentStaysTyped()
+		{
+			return Boxed(default(Data));
 		}
 
 		public int IndexerArgumentStaysTyped()
@@ -96,12 +111,27 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return data.Field;
 		}
 
+		private string Boxed(object o)
+		{
+			return o.ToString();
+		}
+
 		private string Overloaded(Data x)
 		{
 			return "Data";
 		}
 
-		private string Overloaded(Data? x)
+		private string Overloaded(OtherData x)
+		{
+			return "OtherData";
+		}
+
+		private string OverloadedNullable(Data x)
+		{
+			return "Data";
+		}
+
+		private string OverloadedNullable(Data? x)
 		{
 			return "Data?";
 		}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -255,7 +255,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 		{
 			public Func<TCaptured> GetFunc(Func<TNonCaptured, TCaptured> f)
 			{
-				TCaptured captured = f(default(TNonCaptured));
+				TCaptured captured = f(default);
 				return delegate {
 					Console.WriteLine(captured.GetType().FullName);
 					return captured;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -255,7 +255,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 		{
 			public Func<TCaptured> GetFunc(Func<TNonCaptured, TCaptured> f)
 			{
+#if CS71
 				TCaptured captured = f(default);
+#else
+				TCaptured captured = f(default(TNonCaptured));
+#endif
 				return delegate {
 					Console.WriteLine(captured.GetType().FullName);
 					return captured;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
@@ -966,7 +966,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static DateTime ParseDateTime(this object str)
 		{
-			return default(DateTime);
+			return default;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
@@ -966,7 +966,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static DateTime ParseDateTime(this object str)
 		{
+#if CS71
 			return default;
+#else
+			return default(DateTime);
+#endif
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -73,7 +73,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 
 			public S this[int index] {
 				get {
+#if CS71
 					return default;
+#else
+					return default(S);
+#endif
 				}
 				set {
 				}
@@ -81,7 +85,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 
 			public S this[object key] {
 				get {
+#if CS71
 					return default;
+#else
+					return default(S);
+#endif
 				}
 				set {
 				}
@@ -158,7 +166,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 
 			public StructData(int initialValue)
 			{
+#if CS71
 				this = default;
+#else
+				this = default(StructData);
+#endif
 				Field = initialValue;
 				Property = initialValue;
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -73,7 +73,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 
 			public S this[int index] {
 				get {
-					return default(S);
+					return default;
 				}
 				set {
 				}
@@ -81,7 +81,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 
 			public S this[object key] {
 				get {
-					return default(S);
+					return default;
 				}
 				set {
 				}
@@ -158,7 +158,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 
 			public StructData(int initialValue)
 			{
-				this = default(StructData);
+				this = default;
 				Field = initialValue;
 				Property = initialValue;
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InlineArrayTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InlineArrayTests.cs
@@ -125,12 +125,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public Byte16 GetByte16()
 		{
-			return default(Byte16);
+			return default;
 		}
 
 		public Generic16<T> GetGeneric<T>()
 		{
-			return default(Generic16<T>);
+			return default;
 		}
 
 		public int GetIndex()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3571_A.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3571_A.cs
@@ -8,13 +8,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		[StructLayout(LayoutKind.Sequential, Size = 1)]
 		public readonly struct fsResult
 		{
-			public static fsResult Success => default(fsResult);
-			public static fsResult Failure => default(fsResult);
+			public static fsResult Success => default;
+			public static fsResult Failure => default;
 			public bool Succeeded => true;
 			public bool Failed => false;
 			public static fsResult operator +(fsResult a, fsResult b)
 			{
-				return default(fsResult);
+				return default;
 			}
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3571_B.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3571_B.cs
@@ -6,13 +6,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.Issue3571_B
 	[StructLayout(LayoutKind.Sequential, Size = 1)]
 	public readonly struct fsResult
 	{
-		public static fsResult Success => default(fsResult);
-		public static fsResult Failure => default(fsResult);
+		public static fsResult Success => default;
+		public static fsResult Failure => default;
 		public bool Succeeded => true;
 		public bool Failed => false;
 		public static fsResult operator +(fsResult a, fsResult b)
 		{
-			return default(fsResult);
+			return default;
 		}
 	}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3571_C.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3571_C.cs
@@ -25,13 +25,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.Issue3571_Helper
 	[StructLayout(LayoutKind.Sequential, Size = 1)]
 	public readonly struct fsResult
 	{
-		public static fsResult Success => default(fsResult);
-		public static fsResult Failure => default(fsResult);
+		public static fsResult Success => default;
+		public static fsResult Failure => default;
 		public bool Succeeded => true;
 		public bool Failed => false;
 		public static fsResult operator +(fsResult a, fsResult b)
 		{
-			return default(fsResult);
+			return default;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3584.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3584.cs
@@ -14,7 +14,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			get {
 				if (i >= Length || i < 0)
 				{
+#if CS71
 					return default;
+#else
+					return default(T);
+#endif
 				}
 				if (results[i] != null && results[i].Equals(default(T)))
 				{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3584.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3584.cs
@@ -14,7 +14,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			get {
 				if (i >= Length || i < 0)
 				{
-					return default(T);
+					return default;
 				}
 				if (results[i] != null && results[i].Equals(default(T)))
 				{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3909.cs
@@ -35,7 +35,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public virtual U? ReturnOnly<U>()
 			{
-				return default(U);
+				return default;
 			}
 
 			public virtual T?[] Nested<T>(T?[] values)
@@ -78,7 +78,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public override U? ReturnOnly<U>() where U : default
 			{
-				return default(U);
+				return default;
 			}
 
 			public override T?[] Nested<T>(T?[] values) where T : default

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -155,7 +155,7 @@ namespace LocalFunctions
 				int StaticInvokeAsFunc2<T>(Func<T, int> func)
 #endif
 				{
-					return func(default(T));
+					return func(default);
 				}
 #if CS80
 				static int StaticMethod<T3>() where T3 : struct

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -38,7 +38,7 @@ namespace LocalFunctions
 			public int MixedLocalFunction<T2>() where T2 : ICloneable, IConvertible
 			{
 #pragma warning disable CS0219
-				T2 t2 = default(T2);
+				T2 t2 = default;
 				object z = this;
 				for (int i = 0; i < 10; i++)
 				{
@@ -52,7 +52,7 @@ namespace LocalFunctions
 					int NonStaticMethod<T3>(int unused)
 #endif
 					{
-						t2 = default(T2);
+						t2 = default;
 						int l = 0;
 						return NonStaticMethod3<T1>() + NonStaticMethod3<T2>() + z.GetHashCode();
 						int NonStaticMethod3<T4>()
@@ -118,7 +118,7 @@ namespace LocalFunctions
 
 			public int MixedLocalFunction2Delegate<T2>() where T2 : ICloneable, IConvertible
 			{
-				T2 t2 = default(T2);
+				T2 t2 = default;
 				object z = this;
 				for (int i = 0; i < 10; i++)
 				{
@@ -126,7 +126,7 @@ namespace LocalFunctions
 					i2 += StaticInvokeAsFunc(NonStaticMethod<object>);
 					int NonStaticMethod<T3>()
 					{
-						t2 = default(T2);
+						t2 = default;
 						int l = 0;
 						return StaticInvokeAsFunc(NonStaticMethod3<T1>) + StaticInvokeAsFunc(NonStaticMethod3<T2>) + z.GetHashCode();
 						int NonStaticMethod3<T4>()
@@ -209,19 +209,19 @@ namespace LocalFunctions
 			public static void Test_CaptureT<T2>()
 			{
 #pragma warning disable CS0219
-				T2 t2 = default(T2);
+				T2 t2 = default;
 				Method<int>();
 				void Method<T3>()
 				{
-					t2 = default(T2);
+					t2 = default;
 					T2 t2x = t2;
-					T3 t3 = default(T3);
+					T3 t3 = default;
 					Method2();
 					void Method2()
 					{
-						t2 = default(T2);
+						t2 = default;
 						t2x = t2;
-						t3 = default(T3);
+						t3 = default;
 					}
 				}
 #pragma warning restore CS0219

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Loops.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Loops.cs
@@ -515,7 +515,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static T LastOrDefault<T>(IEnumerable<T> items)
 		{
+#if CS71
 			T result = default;
+#else
+			T result = default(T);
+#endif
 			foreach (T item in items)
 			{
 				result = item;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Loops.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Loops.cs
@@ -515,7 +515,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static T LastOrDefault<T>(IEnumerable<T> items)
 		{
-			T result = default(T);
+			T result = default;
 			foreach (T item in items)
 			{
 				result = item;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MultidimensionalArray.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MultidimensionalArray.cs
@@ -37,7 +37,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public void TestB(S x, ref S y)
 			{
 				b[5, 3] = new S[10];
-				b[5, 3][0] = default(S);
+				b[5, 3][0] = default;
 				b[5, 3][1] = x;
 				b[5, 3][2] = y;
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MultidimensionalArray.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MultidimensionalArray.cs
@@ -37,7 +37,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public void TestB(S x, ref S y)
 			{
 				b[5, 3] = new S[10];
+#if CS71
 				b[5, 3][0] = default;
+#else
+				b[5, 3][0] = default(S);
+#endif
 				b[5, 3][1] = x;
 				b[5, 3][2] = y;
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullPropagation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullPropagation.cs
@@ -50,7 +50,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public readonly int ReadonlyIntVal;
 			public MyClass Field;
 			public MyStruct? Property1 => null;
-			public MyStruct Property2 => default(MyStruct);
+			public MyStruct Property2 => default;
 			public MyStruct? this[int index] => null;
 			public MyStruct? Method1(int arg)
 			{
@@ -58,7 +58,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 			public MyStruct Method2(int arg)
 			{
-				return default(MyStruct);
+				return default;
 			}
 
 			public void Done()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullPropagation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullPropagation.cs
@@ -50,7 +50,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public readonly int ReadonlyIntVal;
 			public MyClass Field;
 			public MyStruct? Property1 => null;
+#if CS71
 			public MyStruct Property2 => default;
+#else
+			public MyStruct Property2 => default(MyStruct);
+#endif
 			public MyStruct? this[int index] => null;
 			public MyStruct? Method1(int arg)
 			{
@@ -58,7 +62,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 			public MyStruct Method2(int arg)
 			{
+#if CS71
 				return default;
+#else
+				return default(MyStruct);
+#endif
 			}
 
 			public void Done()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullableRefTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullableRefTypes.cs
@@ -118,7 +118,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 	{
 		public static TValue? Default<TValue>()
 		{
-			return default(TValue);
+			return default;
 		}
 
 		public static void CallDefault()
@@ -205,7 +205,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		[return: MaybeNull]
 		public T FirstOrDefault<T>(IEnumerable<T> source)
 		{
-			return default(T);
+			return default;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
@@ -46,7 +46,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private bool TryGet<T>(out T result)
 		{
-			result = default(T);
+			result = default;
 			return true;
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OverloadResolution.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OverloadResolution.cs
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#pragma warning disable 660, 661
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class OverloadResolution
+	{
+		public struct Data
+		{
+			public int Field;
+
+			public static bool operator ==(Data a, Data b)
+			{
+				return a.Field == b.Field;
+			}
+
+			public static bool operator !=(Data a, Data b)
+			{
+				return a.Field != b.Field;
+			}
+		}
+
+		public struct OtherData
+		{
+			public int Field;
+		}
+
+		public void IntegerOverloads()
+		{
+			Integer(1);
+			Integer((short)1);
+			Integer(1L);
+		}
+
+		public void ReferenceTypeOverloads()
+		{
+			RefType("string");
+			RefType((object)"string");
+			RefType(null);
+			RefType((object)null);
+		}
+
+		public void NullableOverloads()
+		{
+			NullableInt(1);
+			NullableInt((int?)1);
+			NullableInt(null);
+		}
+
+		public void ParamsOverloads(int n)
+		{
+			Params(1);
+			Params(1, 2);
+			Params(default, default, default);
+			Params(new int[n]);
+		}
+
+		public void GenericOverloads()
+		{
+			Generic(1);
+			Generic<int>(1);
+		}
+
+		public string AmbiguousDefaultArgumentStaysTyped()
+		{
+			return Ambiguous(default(Data));
+		}
+
+		public string DefaultArgumentWithBetterConversionTarget()
+		{
+			return WithNullable(default);
+		}
+
+		public bool EqualityWithDefaultStaysTyped(Data data)
+		{
+			return data == default(Data);
+		}
+
+		private static void Integer(short s)
+		{
+		}
+
+		private static void Integer(int i)
+		{
+		}
+
+		private static void Integer(long l)
+		{
+		}
+
+		private static void RefType(object o)
+		{
+		}
+
+		private static void RefType(string s)
+		{
+		}
+
+		private static void NullableInt(int i)
+		{
+		}
+
+		private static void NullableInt(int? i)
+		{
+		}
+
+		private static void Params(int i)
+		{
+		}
+
+		private static void Params(params int[] xs)
+		{
+		}
+
+		private static void Generic(int i)
+		{
+		}
+
+		private static void Generic<T>(T a)
+		{
+		}
+
+		private static string Ambiguous(Data x)
+		{
+			return "Data";
+		}
+
+		private static string Ambiguous(OtherData x)
+		{
+			return "OtherData";
+		}
+
+		private static string WithNullable(Data x)
+		{
+			return "Data";
+		}
+
+		private static string WithNullable(Data? x)
+		{
+			return "Data?";
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PointerArithmetic.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PointerArithmetic.cs
@@ -56,7 +56,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public unsafe static void AssignmentGuidPointerToDateTimePointerDefault(Guid* ptr)
 		{
+#if CS71
 			((DateTime*)ptr)[2] = default;
+#else
+			((DateTime*)ptr)[2] = default(DateTime);
+#endif
 		}
 
 		public unsafe static void AssignmentGuidPointerToDateTimePointer_2(Guid* ptr)
@@ -66,7 +70,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public unsafe static void AssignmentGuidPointerToDateTimePointerDefault_2(Guid* ptr)
 		{
+#if CS71
 			*(DateTime*)(ptr + 2) = default;
+#else
+			*(DateTime*)(ptr + 2) = default(DateTime);
+#endif
 		}
 
 		public unsafe static DateTime AccessGuidPointerToDateTimePointer(Guid* ptr)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PointerArithmetic.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/PointerArithmetic.cs
@@ -56,7 +56,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public unsafe static void AssignmentGuidPointerToDateTimePointerDefault(Guid* ptr)
 		{
-			((DateTime*)ptr)[2] = default(DateTime);
+			((DateTime*)ptr)[2] = default;
 		}
 
 		public unsafe static void AssignmentGuidPointerToDateTimePointer_2(Guid* ptr)
@@ -66,7 +66,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public unsafe static void AssignmentGuidPointerToDateTimePointerDefault_2(Guid* ptr)
 		{
-			*(DateTime*)(ptr + 2) = default(DateTime);
+			*(DateTime*)(ptr + 2) = default;
 		}
 
 		public unsafe static DateTime AccessGuidPointerToDateTimePointer(Guid* ptr)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -33,12 +33,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 	{
 		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult> fn)
 		{
-			return default(Maybe<TResult>);
+			return default;
 		}
 
 		public static Maybe<T> Where<T>(this Maybe<T> a, Func<T, bool> predicate)
 		{
-			return default(Maybe<T>);
+			return default;
 		}
 	}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -33,12 +33,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 	{
 		public static Maybe<TResult> Select<T, TResult>(this Maybe<T> a, Func<T, TResult> fn)
 		{
+#if CS71
 			return default;
+#else
+			return default(Maybe<TResult>);
+#endif
 		}
 
 		public static Maybe<T> Where<T>(this Maybe<T> a, Func<T, bool> predicate)
 		{
+#if CS71
 			return default;
+#else
+			return default(Maybe<T>);
+#endif
 		}
 	}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefFields.cs
@@ -27,12 +27,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public Span<int> ScopedSpan(scoped Span<int> span)
 		{
-			return default(Span<int>);
+			return default;
 		}
 
 		public void OutSpan(out Span<int> span)
 		{
-			span = default(Span<int>);
+			span = default;
 		}
 
 		public void Calls()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StaticAbstractInterfaceMembers.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StaticAbstractInterfaceMembers.cs
@@ -98,7 +98,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.StaticAbstractInterfaceM
 		}
 		static virtual implicit operator T(string s)
 		{
-			return default(T);
+			return default;
 		}
 		static virtual explicit operator string(T t)
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StringInterpolation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StringInterpolation.cs
@@ -150,7 +150,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static TReturn Get<TReturn>()
 		{
-			return default(TReturn);
+			return default;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StringInterpolation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/StringInterpolation.cs
@@ -150,7 +150,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static TReturn Get<TReturn>()
 		{
+#if CS71
 			return default;
+#else
+			return default(TReturn);
+#endif
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Structs.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Structs.cs
@@ -30,7 +30,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if CS100
 		public StructWithDefaultCtor M()
 		{
+#if CS71
 			return default;
+#else
+			return default(StructWithDefaultCtor);
+#endif
 		}
 
 		public StructWithDefaultCtor M2()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Structs.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Structs.cs
@@ -30,7 +30,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if CS100
 		public StructWithDefaultCtor M()
 		{
-			return default(StructWithDefaultCtor);
+			return default;
 		}
 
 		public StructWithDefaultCtor M2()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TargetTypedDefault.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TargetTypedDefault.cs
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq.Expressions;
+using System.Threading;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public class TargetTypedDefault
+	{
+		public struct ValueHolder
+		{
+			public int Value;
+		}
+
+		public enum Flavor
+		{
+			None,
+			Sweet
+		}
+
+#if !OPT
+		public Guid guidField = default;
+#else
+		public Guid guidField;
+#endif
+
+		public void OptGuid(Guid guid = default(Guid))
+		{
+		}
+
+		public void OptCancellationToken(CancellationToken cancellationToken = default(CancellationToken))
+		{
+		}
+
+		public void OptTimeSpan(TimeSpan timeSpan = default(TimeSpan))
+		{
+		}
+
+		public void OptDateTime(DateTime dateTime = default(DateTime))
+		{
+		}
+
+		public void OptCustomStruct(ValueHolder holder = default(ValueHolder))
+		{
+		}
+
+		public void OptDecimal(decimal d = 0m)
+		{
+		}
+
+		public void OptNullable(int? x = null)
+		{
+		}
+
+		public void OptEnum(Flavor flavor = Flavor.None)
+		{
+		}
+
+		public void OptString(string s = null)
+		{
+		}
+
+		public void OptInt(int i = 0)
+		{
+		}
+
+		public void OptGeneric<T>(T value = default(T))
+		{
+		}
+
+		public void OptGenericStruct<T>(T value = default(T)) where T : struct
+		{
+		}
+
+		public void OptTuple((int, string) pair = default((int, string)))
+		{
+		}
+
+		public void CallsWithExplicitDefaults()
+		{
+			OptGuid();
+			OptCancellationToken();
+			OptTimeSpan();
+			OptCustomStruct();
+			OptNullable();
+			OptString();
+			OptGeneric<Guid>();
+			OptTuple();
+		}
+
+		public void TakeGuid(Guid guid)
+		{
+		}
+
+		public void TakeInGuid(in Guid guid)
+		{
+		}
+
+		public void Over(int x)
+		{
+		}
+
+		public void Over(string s)
+		{
+		}
+
+		public void OverStruct(Guid guid)
+		{
+		}
+
+		public void OverStruct(TimeSpan timeSpan)
+		{
+		}
+
+		public void CallOverloads()
+		{
+			Over(0);
+			Over(null);
+			OverStruct(default(Guid));
+			OverStruct(default(TimeSpan));
+		}
+
+		public void ArgumentPositions(bool b, Guid guid)
+		{
+			TakeGuid(default);
+			TakeInGuid(default(Guid));
+			TakeGuid(b ? guid : default(Guid));
+		}
+
+		public T GenericReturn<T>()
+		{
+			return default;
+		}
+
+		public T GenericClassReturn<T>() where T : class
+		{
+			return null;
+		}
+
+		public T GenericNewReturn<T>() where T : new()
+		{
+			return default;
+		}
+
+		public ValueHolder StructReturn()
+		{
+			return default;
+		}
+
+		public (int, string) TupleReturn()
+		{
+			return default;
+		}
+
+		public int? NullableReturn()
+		{
+			return null;
+		}
+
+		public void OutDefault(out Guid guid)
+		{
+			guid = default;
+		}
+
+		public bool GuidIsDefault(Guid guid)
+		{
+			return guid == default(Guid);
+		}
+
+		public bool TimeSpanIsDefault(TimeSpan timeSpan)
+		{
+			return timeSpan == default(TimeSpan);
+		}
+
+		public bool IntIsDefault(int i)
+		{
+			return i == 0;
+		}
+
+		public bool NullableIsDefault(int? x)
+		{
+			return !x.HasValue;
+		}
+
+		public string CoalesceDefault(string s)
+		{
+			return s ?? null;
+		}
+
+		public T[] DefaultInitializedArray<T>()
+		{
+			return new T[3];
+		}
+
+		public unsafe int* PointerDefault()
+		{
+			return null;
+		}
+
+		public Expression<Func<Guid>> GuidExpressionTree()
+		{
+			return () => default(Guid);
+		}
+
+		public Expression<Func<int>> ZeroExpressionTree()
+		{
+			return () => 0;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
@@ -547,7 +547,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private unsafe void Issue990()
 		{
+#if CS71
 			Data data = default;
+#else
+			Data data = default(Data);
+#endif
 			Data* ptr = &data;
 			ConvertIntToFloat(ptr->Position.GetHashCode());
 		}
@@ -562,7 +566,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private static T Get<T>()
 		{
+#if CS71
 			return default;
+#else
+			return default(T);
+#endif
 		}
 
 		private unsafe static ResultStruct NestedFixedBlocks(byte[] array)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UnsafeCode.cs
@@ -547,7 +547,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private unsafe void Issue990()
 		{
-			Data data = default(Data);
+			Data data = default;
 			Data* ptr = &data;
 			ConvertIntToFloat(ptr->Position.GetHashCode());
 		}
@@ -562,7 +562,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private static T Get<T>()
 		{
-			return default(T);
+			return default;
 		}
 
 		private unsafe static ResultStruct NestedFixedBlocks(byte[] array)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UserDefinedConversions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UserDefinedConversions.cs
@@ -36,7 +36,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator C(bool b)
 			{
-				return default(C);
+				return default;
 			}
 		}
 
@@ -77,12 +77,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator C(bool b)
 			{
-				return default(C);
+				return default;
 			}
 
 			public static implicit operator C(A a)
 			{
-				return default(C);
+				return default;
 			}
 
 			public static bool operator ==(C a, C b)
@@ -141,12 +141,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator T(in int val)
 			{
-				return default(T);
+				return default;
 			}
 
 			public static explicit operator T(in long val)
 			{
-				return default(T);
+				return default;
 			}
 		}
 
@@ -156,7 +156,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator T(in U u)
 			{
-				return default(T);
+				return default;
 			}
 
 			public static explicit operator int(in U u)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UserDefinedConversions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UserDefinedConversions.cs
@@ -36,7 +36,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator C(bool b)
 			{
+#if CS71
 				return default;
+#else
+				return default(C);
+#endif
 			}
 		}
 
@@ -77,12 +81,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator C(bool b)
 			{
+#if CS71
 				return default;
+#else
+				return default(C);
+#endif
 			}
 
 			public static implicit operator C(A a)
 			{
+#if CS71
 				return default;
+#else
+				return default(C);
+#endif
 			}
 
 			public static bool operator ==(C a, C b)
@@ -141,12 +153,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator T(in int val)
 			{
+#if CS71
 				return default;
+#else
+				return default(T);
+#endif
 			}
 
 			public static explicit operator T(in long val)
 			{
+#if CS71
 				return default;
+#else
+				return default(T);
+#endif
 			}
 		}
 
@@ -156,7 +176,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 			public static implicit operator T(in U u)
 			{
+#if CS71
 				return default;
+#else
+				return default(T);
+#endif
 			}
 
 			public static explicit operator int(in U u)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Using.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Using.cs
@@ -50,12 +50,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if !ROSLYN3
 			public static implicit operator TypeB_Issue3385(TypeA_Issue3385 a)
 			{
-				return default(TypeB_Issue3385);
+				return default;
 			}
 #else
 			public static implicit operator TypeB_Issue3385(in TypeA_Issue3385 a)
 			{
-				return default(TypeB_Issue3385);
+				return default;
 			}
 #endif
 		}
@@ -191,7 +191,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public static void Issue3385()
 		{
 #if ROSLYN3
-			using (TypeA_Issue3385 a = default(TypeA_Issue3385))
+			using (TypeA_Issue3385 a = default)
 #else
 			using (TypeA_Issue3385 typeA_Issue = default(TypeA_Issue3385))
 #endif

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Using.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Using.cs
@@ -50,12 +50,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if !ROSLYN3
 			public static implicit operator TypeB_Issue3385(TypeA_Issue3385 a)
 			{
+#if CS71
 				return default;
+#else
+				return default(TypeB_Issue3385);
+#endif
 			}
 #else
 			public static implicit operator TypeB_Issue3385(in TypeA_Issue3385 a)
 			{
+#if CS71
 				return default;
+#else
+				return default(TypeB_Issue3385);
+#endif
 			}
 #endif
 		}
@@ -191,9 +199,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public static void Issue3385()
 		{
 #if ROSLYN3
+#if CS71
 			using (TypeA_Issue3385 a = default)
 #else
+			using (TypeA_Issue3385 a = default(TypeA_Issue3385))
+#endif
+#else
+#if CS71
+			using (TypeA_Issue3385 typeA_Issue = default)
+#else
 			using (TypeA_Issue3385 typeA_Issue = default(TypeA_Issue3385))
+#endif
 #endif
 			{
 #if ROSLYN3

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UsingVariables.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/UsingVariables.cs
@@ -113,7 +113,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public void UsingVarPatternBasedDispose()
 		{
 			Console.WriteLine("before using");
-			using RefStructWithDispose refStructWithDispose = default(RefStructWithDispose);
+			using RefStructWithDispose refStructWithDispose = default;
 			Console.WriteLine("inside using");
 			refStructWithDispose.Use();
 		}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ValueTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ValueTypes.cs
@@ -134,7 +134,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if !(ROSLYN && OPT) || COPY_PROPAGATION_FIXED
 		public static S InitObj1()
 		{
-			S result = default(S);
+			S result = default;
 			MakeArray();
 			return result;
 		}
@@ -142,12 +142,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static S InitObj2()
 		{
-			return default(S);
+			return default;
 		}
 
 		public static void InitObj3(out S p)
 		{
-			p = default(S);
+			p = default;
 		}
 
 		public static S CallValueTypeCtor()
@@ -252,7 +252,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static T Get<T>()
 		{
-			return default(T);
+			return default;
 		}
 
 		public static void CallOnTemporary()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ValueTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ValueTypes.cs
@@ -134,7 +134,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #if !(ROSLYN && OPT) || COPY_PROPAGATION_FIXED
 		public static S InitObj1()
 		{
+#if CS71
 			S result = default;
+#else
+			S result = default(S);
+#endif
 			MakeArray();
 			return result;
 		}
@@ -142,12 +146,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static S InitObj2()
 		{
+#if CS71
 			return default;
+#else
+			return default(S);
+#endif
 		}
 
 		public static void InitObj3(out S p)
 		{
+#if CS71
 			p = default;
+#else
+			p = default(S);
+#endif
 		}
 
 		public static S CallValueTypeCtor()
@@ -252,7 +264,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public static T Get<T>()
 		{
+#if CS71
 			return default;
+#else
+			return default(T);
+#endif
 		}
 
 		public static void CallOnTemporary()

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/Async.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/Async.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.VBPretty
 		public async void AwaitDefaultYieldAwaitable()
 		{
 #if LEGACY_VBC || (OPTIMIZE && !ROSLYN4)
-			YieldAwaitable yieldAwaitable2 = default(YieldAwaitable);
+			YieldAwaitable yieldAwaitable2 = default;
 			YieldAwaitable yieldAwaitable = yieldAwaitable2;
 			await yieldAwaitable;
 #else
@@ -51,7 +51,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.VBPretty
 		public async void AwaitDefaultHopToThreadPool()
 		{
 #if LEGACY_VBC || (OPTIMIZE && !ROSLYN4)
-			HopToThreadPoolAwaitable hopToThreadPoolAwaitable2 = default(HopToThreadPoolAwaitable);
+			HopToThreadPoolAwaitable hopToThreadPoolAwaitable2 = default;
 			HopToThreadPoolAwaitable hopToThreadPoolAwaitable = hopToThreadPoolAwaitable2;
 			await hopToThreadPoolAwaitable;
 #else

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/Issue1906.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/Issue1906.cs
@@ -4,6 +4,6 @@ public class Issue1906
 {
 	public void M()
 	{
-		Console.WriteLine(Math.Min(Math.Max(long.MinValue, default(long)), long.MaxValue));
+		Console.WriteLine(Math.Min(Math.Max(long.MinValue, default), long.MaxValue));
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Annotations.cs
+++ b/ICSharpCode.Decompiler/CSharp/Annotations.cs
@@ -363,4 +363,13 @@ namespace ICSharpCode.Decompiler.CSharp
 	{
 		public static readonly UseImplicitlyTypedOutAnnotation Instance = new UseImplicitlyTypedOutAnnotation();
 	}
+
+	/// <summary>
+	/// Annotates a DefaultValueExpression in an argument position if overload resolution
+	/// determined that the untyped default literal would select the same member.
+	/// </summary>
+	public class UseImplicitlyTypedDefaultAnnotation
+	{
+		public static readonly UseImplicitlyTypedDefaultAnnotation Instance = new UseImplicitlyTypedDefaultAnnotation();
+	}
 }

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -244,6 +244,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				new DeclareVariables(), // should run after most transforms that modify statements
 				new TransformFieldAndConstructorInitializers(), // must run after DeclareVariables
 				new PrettifyAssignments(), // must run after DeclareVariables
+				new IntroduceDefaultLiterals(), // must run after DeclareVariables and TransformFieldAndConstructorInitializers
 				new IntroduceUsingDeclarations(),
 				new IntroduceExtensionMethods(), // must run after IntroduceUsingDeclarations
 				new IntroduceQueryExpressions(), // must run after IntroduceExtensionMethods

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -57,6 +57,7 @@ namespace ICSharpCode.Decompiler.CSharp
 
 			public bool AddNamesToPrimitiveValues;
 			public bool UseImplicitlyTypedOut;
+			public bool UseImplicitlyTypedDefault;
 			public bool IsExpandedForm;
 			public int Length => Arguments.Length;
 
@@ -91,10 +92,14 @@ namespace ICSharpCode.Decompiler.CSharp
 				return argumentNames;
 			}
 
-			public IList<ResolveResult> GetArgumentResolveResults(int skipCount = 0)
+			public IList<ResolveResult> GetArgumentResolveResults(int skipCount = 0, bool substituteDefaultLiterals = false)
 			{
 				var expectedParameters = ExpectedParameters;
 				var useImplicitlyTypedOut = UseImplicitlyTypedOut;
+				// Untyped default literals are only substituted for overload resolution rechecks;
+				// the final resolve results keep the typed constants, which transforms such as
+				// ReplaceMethodCallsWithOperators pattern-match on.
+				var useImplicitlyTypedDefault = substituteDefaultLiterals && UseImplicitlyTypedDefault;
 
 				return Arguments
 					.SelectWithIndex(GetResolveResult)
@@ -107,8 +112,23 @@ namespace ICSharpCode.Decompiler.CSharp
 					var param = expectedParameters[index];
 					if (useImplicitlyTypedOut && param.ReferenceKind == ReferenceKind.Out && expression.Type is ByReferenceType brt)
 						return new OutVarResolveResult(brt.ElementType);
+					if (useImplicitlyTypedDefault && IsImplicitlyTypedDefaultCandidate(param, expression))
+						return new DefaultLiteralResolveResult();
 					return expression.ResolveResult;
 				}
+			}
+
+			/// <summary>
+			/// Gets whether the argument is a default value expression that can be passed to
+			/// overload resolution as an untyped default literal. Requires an identity
+			/// conversion to the parameter type: with any weaker conversion the literal would
+			/// change the value (e.g. a boxing target turns a boxed struct into null).
+			/// </summary>
+			static bool IsImplicitlyTypedDefaultCandidate(IParameter param, TranslatedExpression expression)
+			{
+				return param.ReferenceKind == ReferenceKind.None
+					&& expression.Expression is DefaultValueExpression
+					&& expression.Type.Equals(param.Type);
 			}
 
 			public IList<ResolveResult> GetArgumentResolveResultsDirect(int skipCount = 0)
@@ -124,25 +144,42 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				var argumentNames = GetArgumentNames(skipCount);
 				int argumentCount = GetActualArgumentCount();
+				var arguments = Arguments;
+				var expectedParameters = ExpectedParameters;
 				var useImplicitlyTypedOut = UseImplicitlyTypedOut;
+				var useImplicitlyTypedDefault = UseImplicitlyTypedDefault;
 				if (argumentNames == null)
 				{
-					return Arguments.Skip(skipCount).Take(argumentCount).Select(arg => AddAnnotations(arg.Expression));
+					return arguments.SelectWithIndex((index, arg) => (index, arg)).Skip(skipCount).Take(argumentCount)
+						.Select(p => AddAnnotations(p.index, p.arg));
 				}
 				else
 				{
 					Debug.Assert(skipCount == 0);
-					return Arguments.Take(argumentCount).Zip(argumentNames.Take(argumentCount),
-						(arg, name) => {
+					return arguments.SelectWithIndex((index, arg) => (index, arg)).Take(argumentCount)
+						.Zip(argumentNames.Take(argumentCount),
+						(p, name) => {
 							if (name == null)
-								return AddAnnotations(arg.Expression);
+								return AddAnnotations(p.index, p.arg);
 							else
-								return new NamedArgumentExpression(name, AddAnnotations(arg.Expression));
+								return new NamedArgumentExpression(name, AddAnnotations(p.index, p.arg));
 						});
 				}
 
-				Expression AddAnnotations(Expression expression)
+				Expression AddAnnotations(int index, TranslatedExpression argument)
 				{
+					var expression = argument.Expression;
+					if (useImplicitlyTypedDefault
+						&& expression is DefaultValueExpression { Type: not null }
+						&& IsImplicitlyTypedDefaultCandidate(expectedParameters[index], argument))
+					{
+						// The type is not removed here: later transforms may move the
+						// expression out of the argument position (e.g. into an operator
+						// operand, where the untyped literal would be invalid).
+						// IntroduceDefaultLiterals only acts on the annotation if the
+						// expression is still an argument.
+						expression.AddAnnotation(UseImplicitlyTypedDefaultAnnotation.Instance);
+					}
 					if (!useImplicitlyTypedOut)
 						return expression;
 					if (expression.GetResolveResult() is ByReferenceResolveResult { ReferenceKind: ReferenceKind.Out } brrr)
@@ -419,6 +456,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				argumentList.FirstOptionalArgumentIndex = -1;
 				argumentList.AddNamesToPrimitiveValues = false;
 				argumentList.UseImplicitlyTypedOut = false;
+				argumentList.UseImplicitlyTypedDefault = false;
 				int regularParameterCount = ((VarArgInstanceMethod)method).RegularParameterCount;
 				var argListArg = new UndocumentedExpression();
 				argListArg.UndocumentedExpressionType = UndocumentedExpressionType.ArgList;
@@ -696,6 +734,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			argumentList.ArgumentNames = null;
 			argumentList.AddNamesToPrimitiveValues = false;
 			argumentList.UseImplicitlyTypedOut = false;
+			argumentList.UseImplicitlyTypedDefault = false;
 			var transform = GetRequiredTransformationsForCall(expectedTargetDetails, method, ref unused,
 				ref argumentList, CallTransformation.None, out _);
 			Debug.Assert((transform & ~(CallTransformation.NoOptionalArgumentAllowed | CallTransformation.NoNamedArgsForPrettiness)) == 0);
@@ -1039,6 +1078,9 @@ namespace ICSharpCode.Decompiler.CSharp
 			list.IsPrimitiveValue = isPrimitiveValue;
 			list.FirstOptionalArgumentIndex = firstOptionalArgumentIndex;
 			list.UseImplicitlyTypedOut = true;
+			// Operator method calls may later be rewritten to operator syntax by
+			// ReplaceMethodCallsWithOperators, where a default literal operand would be invalid.
+			list.UseImplicitlyTypedDefault = expressionBuilder.settings.DefaultLiterals && !method.IsOperator;
 			list.AddNamesToPrimitiveValues = expressionBuilder.settings.NamedArguments && expressionBuilder.settings.NonTrailingNamedArguments;
 			return list;
 		}
@@ -1236,7 +1278,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			bool skipTargetCast = method.Accessibility <= Accessibility.Protected && expressionBuilder.IsBaseTypeOfCurrentType(method.DeclaringTypeDefinition);
 			OverloadResolutionErrors errors;
 			while ((errors = IsUnambiguousCall(expectedTargetDetails, method, targetResolveResult, typeArguments,
-				argumentList.GetArgumentResolveResults().ToArray(), argumentList.GetArgumentNames(), argumentList.FirstOptionalArgumentIndex, out foundMethod,
+				argumentList.GetArgumentResolveResults(substituteDefaultLiterals: true).ToArray(), argumentList.GetArgumentNames(), argumentList.FirstOptionalArgumentIndex, out foundMethod,
 				out var bestCandidateIsExpandedForm)) != OverloadResolutionErrors.None || bestCandidateIsExpandedForm != argumentList.IsExpandedForm)
 			{
 				switch (errors)
@@ -1273,6 +1315,12 @@ namespace ICSharpCode.Decompiler.CSharp
 						else if (argumentList.FirstOptionalArgumentIndex >= 0)
 						{
 							argumentList.FirstOptionalArgumentIndex = -1;
+						}
+						else if (argumentList.UseImplicitlyTypedDefault)
+						{
+							// Prefer restoring explicitly typed default expressions over
+							// more invasive fixes like casting all arguments.
+							argumentList.UseImplicitlyTypedDefault = false;
 						}
 						else if (!argumentsCasted)
 						{
@@ -1854,6 +1902,7 @@ namespace ICSharpCode.Decompiler.CSharp
 							});
 					}
 				}
+				argumentList.UseImplicitlyTypedDefault = false;
 				return atce.WithRR(new CSharpInvocationResolveResult(
 					target, method, argumentList.GetArgumentResolveResults(),
 					isExpandedForm: argumentList.IsExpandedForm, argumentToParameterMap: argumentList.ArgumentToParameterMap
@@ -1862,7 +1911,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			else
 			{
 				while (IsUnambiguousCall(expectedTargetDetails, method, null, Empty<IType>.Array,
-					argumentList.GetArgumentResolveResults().ToArray(),
+					argumentList.GetArgumentResolveResults(substituteDefaultLiterals: true).ToArray(),
 					argumentList.GetArgumentNames(), argumentList.FirstOptionalArgumentIndex, out _,
 					out var bestCandidateIsExpandedForm) != OverloadResolutionErrors.None || bestCandidateIsExpandedForm != argumentList.IsExpandedForm)
 				{
@@ -1874,6 +1923,11 @@ namespace ICSharpCode.Decompiler.CSharp
 					if (argumentList.FirstOptionalArgumentIndex >= 0)
 					{
 						argumentList.FirstOptionalArgumentIndex = -1;
+						continue;
+					}
+					if (argumentList.UseImplicitlyTypedDefault)
+					{
+						argumentList.UseImplicitlyTypedDefault = false;
 						continue;
 					}
 					CastArguments(argumentList.Arguments, argumentList.ExpectedParameters);

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -870,11 +870,14 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			StartNode(defaultValueExpression);
 
 			WriteKeyword(DefaultValueExpression.DefaultKeyword);
-			LPar();
-			Space(policy.SpacesWithinTypeOfParentheses);
-			defaultValueExpression.Type.AcceptVisitor(this);
-			Space(policy.SpacesWithinTypeOfParentheses);
-			RPar();
+			if (defaultValueExpression.Type is not null)
+			{
+				LPar();
+				Space(policy.SpacesWithinTypeOfParentheses);
+				defaultValueExpression.Type.AcceptVisitor(this);
+				Space(policy.SpacesWithinTypeOfParentheses);
+				RPar();
+			}
 
 			EndNode(defaultValueExpression);
 		}

--- a/ICSharpCode.Decompiler/CSharp/Resolver/CSharpConversions.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/CSharpConversions.cs
@@ -124,7 +124,8 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 			if (c != Conversion.None)
 				return c;
 			// C# 9.0 spec: §10.2.16 default literal conversions
-			// TODO
+			if (resolveResult is DefaultLiteralResolveResult)
+				return Conversion.DefaultLiteralConversion;
 			if (resolveResult.IsCompileTimeConstant)
 			{
 				c = StandardImplicitConversion(resolveResult.Type, toType, allowTuple);

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/DefaultValueExpression.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/DefaultValueExpression.cs
@@ -37,6 +37,6 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		public const string DefaultKeyword = "default";
 
 		[Slot("Type")]
-		public partial AstType Type { get; set; }
+		public partial AstType? Type { get; set; }
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceDefaultLiterals.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceDefaultLiterals.cs
@@ -62,6 +62,17 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			IType type = defaultValueExpression.Type.GetResolveResult().Type;
 			if (type.Kind is TypeKind.Unknown or TypeKind.None)
 				return;
+			if (defaultValueExpression.Annotation<UseImplicitlyTypedDefaultAnnotation>() != null
+				&& IsInArgumentPosition(defaultValueExpression))
+			{
+				// CallBuilder verified via overload resolution that the untyped literal
+				// selects the same member; the annotation only counts if the expression
+				// is still in an argument position (transforms may have moved it, e.g.
+				// into an operator operand, where the untyped literal would be invalid).
+				context.Step("Replace argument default(" + type.Name + ") with default literal", defaultValueExpression);
+				defaultValueExpression.Type = null;
+				return;
+			}
 			IType? targetType = GetTargetType(defaultValueExpression);
 			if (targetType == null)
 				return;
@@ -72,6 +83,15 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				return;
 			context.Step("Replace default(" + type.Name + ") with default literal", defaultValueExpression);
 			defaultValueExpression.Type = null;
+		}
+
+		static bool IsInArgumentPosition(Expression expression)
+		{
+			AstNode node = expression;
+			if (node.Parent is NamedArgumentExpression)
+				node = node.Parent;
+			return node.Slot?.Kind == Slots.Argument
+				&& node.Parent is (InvocationExpression or ObjectCreateExpression);
 		}
 
 		IType? GetTargetType(DefaultValueExpression defaultValueExpression)

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceDefaultLiterals.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceDefaultLiterals.cs
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+
+using ICSharpCode.Decompiler.CSharp.Resolver;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ICSharpCode.Decompiler.CSharp.Transforms
+{
+	/// <summary>
+	/// Replaces "default(T)" with the default literal "default" (C# 7.1) where the target type
+	/// of the expression is explicit in the surrounding syntax and identical to T, so the
+	/// shorter form cannot change semantics: initializers of variable and field declarations
+	/// with an explicit type, right-hand sides of simple assignments, and return statements.
+	/// Arguments and operands are left alone, because there the default literal participates
+	/// in overload resolution, operator resolution and type inference.
+	/// </summary>
+	/// <remarks>
+	/// Must run after DeclareVariables and TransformFieldAndConstructorInitializers, which
+	/// produce the declaration initializers this transform inspects.
+	/// </remarks>
+	class IntroduceDefaultLiterals : DepthFirstAstVisitor, IAstTransform
+	{
+		[AllowNull]
+		TransformContext context;
+		[AllowNull]
+		CSharpConversions conversions;
+
+		public void Run(AstNode rootNode, TransformContext context)
+		{
+			if (!context.Settings.DefaultLiterals)
+				return;
+			this.context = context;
+			this.conversions = CSharpConversions.Get(context.TypeSystem);
+			rootNode.AcceptVisitor(this);
+		}
+
+		public override void VisitDefaultValueExpression(DefaultValueExpression defaultValueExpression)
+		{
+			base.VisitDefaultValueExpression(defaultValueExpression);
+			if (defaultValueExpression.Type is null)
+				return;
+			IType type = defaultValueExpression.Type.GetResolveResult().Type;
+			if (type.Kind is TypeKind.Unknown or TypeKind.None)
+				return;
+			IType? targetType = GetTargetType(defaultValueExpression);
+			if (targetType == null)
+				return;
+			// Only an identity conversion guarantees that the value is unchanged:
+			// e.g. in "object o = default(SomeStruct);" the struct is boxed (non-null),
+			// while "object o = default;" would be null.
+			if (!conversions.IdentityConversion(type, targetType))
+				return;
+			context.Step("Replace default(" + type.Name + ") with default literal", defaultValueExpression);
+			defaultValueExpression.Type = null;
+		}
+
+		IType? GetTargetType(DefaultValueExpression defaultValueExpression)
+		{
+			switch (defaultValueExpression.Parent)
+			{
+				case VariableInitializer { Parent: VariableDeclarationStatement declaration }:
+					if (declaration.Type is SimpleType { Identifier: "var" })
+						return null;
+					return declaration.Type.GetResolveResult().Type;
+				case VariableInitializer { Parent: FieldDeclaration field }:
+					return field.ReturnType.GetResolveResult().Type;
+				case AssignmentExpression { Operator: AssignmentOperatorType.Assign } assignment when assignment.Right == defaultValueExpression:
+					return assignment.Left.GetResolveResult().Type;
+				case ReturnStatement returnStatement:
+					return GetEnclosingReturnType(returnStatement);
+				default:
+					return null;
+			}
+		}
+
+		static IType? GetEnclosingReturnType(ReturnStatement returnStatement)
+		{
+			for (AstNode? node = returnStatement.Parent; node != null; node = node.Parent)
+			{
+				switch (node)
+				{
+					case LambdaExpression:
+					case AnonymousMethodExpression:
+						// The return type of an anonymous function is inferred from its body,
+						// so replacing default(T) could change the function's type.
+						return null;
+					case EntityDeclaration entity:
+						if (entity.GetSymbol() is not IMethod method)
+							return null;
+						IType returnType = method.ReturnType;
+						if ((entity.Modifiers & Modifiers.Async) != 0)
+						{
+							if (returnType.TypeParameterCount == 1
+								&& (TaskType.IsTask(returnType) || TaskType.IsCustomTask(returnType, out _)))
+							{
+								returnType = returnType.TypeArguments[0];
+							}
+							else
+							{
+								return null;
+							}
+						}
+						return returnType;
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -107,6 +107,10 @@ namespace ICSharpCode.Decompiler
 				patternMatching = false;
 				useRefLocalsForAccurateOrderOfEvaluation = false;
 			}
+			if (languageVersion < CSharp.LanguageVersion.CSharp7_1)
+			{
+				defaultLiterals = false;
+			}
 			if (languageVersion < CSharp.LanguageVersion.CSharp7_2)
 			{
 				introduceReadonlyAndInModifiers = false;
@@ -204,7 +208,8 @@ namespace ICSharpCode.Decompiler
 			if (introduceRefModifiersOnStructs || introduceReadonlyAndInModifiers
 				|| nonTrailingNamedArguments || refExtensionMethods || introducePrivateProtectedAccessibilty)
 				return CSharp.LanguageVersion.CSharp7_2;
-			// C# 7.1 missing
+			if (defaultLiterals)
+				return CSharp.LanguageVersion.CSharp7_1;
 			if (outVariables || throwExpressions || tupleTypes || tupleConversions
 				|| discards || localFunctions || deconstruction || patternMatching || useRefLocalsForAccurateOrderOfEvaluation)
 				return CSharp.LanguageVersion.CSharp7;
@@ -1641,6 +1646,25 @@ namespace ICSharpCode.Decompiler
 				if (throwExpressions != value)
 				{
 					throwExpressions = value;
+					OnPropertyChanged();
+				}
+			}
+		}
+
+		bool defaultLiterals = true;
+
+		/// <summary>
+		/// Gets/Sets whether "default" literals without an explicit type should be used
+		/// where the target type of the expression is explicit in the surrounding syntax.
+		/// </summary>
+		[Category("C# 7.1 / VS 2017.3")]
+		[Description("DecompilerSettings.UseDefaultLiterals")]
+		public bool DefaultLiterals {
+			get { return defaultLiterals; }
+			set {
+				if (defaultLiterals != value)
+				{
+					defaultLiterals = value;
 					OnPropertyChanged();
 				}
 			}

--- a/ICSharpCode.Decompiler/Semantics/Conversion.cs
+++ b/ICSharpCode.Decompiler/Semantics/Conversion.cs
@@ -97,6 +97,11 @@ namespace ICSharpCode.Decompiler.Semantics
 		/// </summary>
 		public static readonly Conversion ImplicitSpanConversion = new BuiltinConversion(true, 13);
 
+		/// <summary>
+		/// C# 7.1 default literal being converted to an arbitrary type.
+		/// </summary>
+		public static readonly Conversion DefaultLiteralConversion = new BuiltinConversion(true, 14);
+
 		public static Conversion UserDefinedConversion(IMethod operatorMethod, bool isImplicit, Conversion conversionBeforeUserDefinedOperator, Conversion conversionAfterUserDefinedOperator, bool isLifted = false, bool isAmbiguous = false)
 		{
 			if (operatorMethod == null)
@@ -257,6 +262,7 @@ namespace ICSharpCode.Decompiler.Semantics
 
 			public override bool IsInlineArrayConversion => type == 12;
 			public override bool IsImplicitSpanConversion => type == 13;
+			public override bool IsDefaultLiteralConversion => type == 14;
 
 			public override string ToString()
 			{
@@ -296,6 +302,8 @@ namespace ICSharpCode.Decompiler.Semantics
 						return "inline array conversion";
 					case 13:
 						return "implicit span conversion";
+					case 14:
+						return "default-literal conversion";
 				}
 				return (isImplicit ? "implicit " : "explicit ") + name + " conversion";
 			}
@@ -486,6 +494,10 @@ namespace ICSharpCode.Decompiler.Semantics
 		}
 
 		public virtual bool IsThrowExpressionConversion {
+			get { return false; }
+		}
+
+		public virtual bool IsDefaultLiteralConversion {
 			get { return false; }
 		}
 

--- a/ICSharpCode.Decompiler/Semantics/DefaultLiteralResolveResult.cs
+++ b/ICSharpCode.Decompiler/Semantics/DefaultLiteralResolveResult.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ICSharpCode.Decompiler.Semantics
+{
+	/// <summary>
+	/// Represents a typeless default literal `default`, which is implicitly convertible
+	/// to any type (C# standard 10.2.16 default literal conversions).
+	/// </summary>
+	class DefaultLiteralResolveResult : ResolveResult
+	{
+		public DefaultLiteralResolveResult() : base(SpecialType.NoType)
+		{
+		}
+
+		// A default_value_expression is a constant expression (C# standard 12.8.21);
+		// like the null literal, the typeless default literal is modeled as a constant
+		// with value null (the target-typed value is only known after conversion).
+		public override bool IsCompileTimeConstant {
+			get { return true; }
+		}
+
+		public override object ConstantValue {
+			get { return null; }
+		}
+	}
+}

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1641,6 +1641,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use &quot;default&quot; literals without an explicit type.
+        /// </summary>
+        public static string DecompilerSettings_UseDefaultLiterals {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.UseDefaultLiterals", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use discards.
         /// </summary>
         public static string DecompilerSettings_UseDiscards {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -576,6 +576,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.UnsignedRightShift" xml:space="preserve">
     <value>Unsigned right shift (&gt;&gt;&gt;)</value>
   </data>
+  <data name="DecompilerSettings.UseDefaultLiterals" xml:space="preserve">
+    <value>Use "default" literals without an explicit type</value>
+  </data>
   <data name="DecompilerSettings.UseDiscards" xml:space="preserve">
     <value>Use discards</value>
   </data>


### PR DESCRIPTION
Implements target-typed `default` output (C# 7.1), building on the conversion-test groundwork from #3912.

**Semantics layer**
- `Conversion.DefaultLiteralConversion` and `DefaultLiteralResolveResult` implement the standard's default literal conversions (10.2.16), resolving the long-standing TODO in `CSharpConversions.ImplicitConversion`. The resolve result is a compile-time constant, like the null literal.
- Unit tests pin overload resolution, operator resolution and type inference behavior for default-literal arguments against compiled csc probes: better-conversion-target tie-breaks, CS0121-style ambiguity, no participation in type inference (CS0411) but riding along when another argument fixes the type parameter, and binary operators with one default operand. No production changes were needed there — the existing resolution stack already matches csc.

**Syntax + emission**
- `DefaultValueExpression.Type` is now optional; without a type the output visitor prints the bare `default` literal.
- New `DecompilerSettings.DefaultLiterals` (C# 7.1, on by default) and `IntroduceDefaultLiterals` transform: `default(T)` becomes `default` in contexts where the target type is explicit in the surrounding syntax and identical to T — declaration/field initializers, simple assignment right-hand sides, and return statements (including async `Task<T>`). An identity conversion is required, because e.g. `object o = default(SomeStruct);` boxes a non-null struct while the bare literal would be null.
- Call arguments follow the implicitly-typed-out-variable pattern: the overload resolution recheck receives untyped `DefaultLiteralResolveResult`s and falls back to the typed form if the expected member is no longer the unique winner. Validated arguments are annotated rather than rewritten, because later transforms can move an argument into an operator operand where the untyped literal would be invalid; `IntroduceDefaultLiterals` honors the annotation only if the expression is still in an argument position. Operator method calls never participate.

**Tests**
- New `DefaultLiteral` pretty fixture covering the positive contexts and the must-stay-typed ones (ambiguous overloads, boxing targets, indexer arguments, user-defined operator operands, `== default` comparisons).
- New `OverloadResolution` pretty fixture pinning the disambiguation syntax CallBuilder emits (numeric/object casts, `(int?)`, params expanded vs. array form, explicit type arguments, typed vs. bare default), plus a CS71 section in the Correctness fixture executing the same shapes so the recompiled output must pick the same overloads at run time.
- Fixture updates across the suite are gated with `#if CS71` so pre-7.1 compiler configurations (legacy csc, mcs, Roslyn 1.3.2 — filtered out on non-Windows platforms) keep compiling the typed form.

This pull request was authored by an AI agent (Claude Code) operated by @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)