### PR TITLE
Support Roslyn 1.x/2.x compiler configurations in tests on non-Windows

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
@@ -149,14 +149,33 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 		// In the .NET ("netcore") build of the compiler toolset the executables live in a
 		// "bincore" subfolder of the tasks directory, as .dlls launched through the dotnet host.
+		// The old Microsoft.Net.Compilers packages (Roslyn 1.x/2.x) have no .NET build; they
+		// only ship .NET Framework executables, which non-Windows platforms host with Mono.
 		public string GetCSharpCompiler(string version)
 		{
-			return GetCompiler(OperatingSystem.IsWindows() ? "csc.exe" : "bincore/csc.dll", version);
+			return GetHostedCompiler(version, "csc");
 		}
 
 		public string GetVBCompiler(string version)
 		{
-			return GetCompiler(OperatingSystem.IsWindows() ? "vbc.exe" : "bincore/vbc.dll", version);
+			return GetHostedCompiler(version, "vbc");
+		}
+
+		string GetHostedCompiler(string version, string name)
+		{
+			if (!OperatingSystem.IsWindows())
+			{
+				// The installed path may point directly at a dotnet-hosted compiler directory
+				// (e.g. Microsoft.NETCore.Compilers' tools/bincore) or at a tasks directory
+				// with a bincore subfolder (Microsoft.Net.Compilers.Toolset).
+				string dll = GetCompiler($"{name}.dll", version);
+				if (File.Exists(dll))
+					return dll;
+				dll = GetCompiler($"bincore/{name}.dll", version);
+				if (File.Exists(dll))
+					return dll;
+			}
+			return GetCompiler($"{name}.exe", version);
 		}
 
 		string GetCompiler(string compiler, string version)

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
@@ -63,7 +63,23 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 				if ((flags & CompilerOptions.UseRoslynMask) != 0 && targetFramework != null)
 				{
 					var coreRefAsmPath = RefAssembliesToolset.GetPath(targetFramework);
-					references = coreDefaultReferences.Select(r => "-r:\"" + r + "\"");
+					// On Windows vbc.exe binds the core library through its implicit desktop SDK
+					// path, so the plain reference list works. Without that implicit SDK, the
+					// netcore-2.2 reference set needs the same reference list as the C# side
+					// (System.Private.CoreLib plus the facade assemblies): its facades are split
+					// across many files and vbc only binds special types like System.Void from an
+					// assembly that defines them rather than following type forwards.
+					IEnumerable<string> referenceNames = !OperatingSystem.IsWindows() && targetFramework == ".NETCoreApp,Version=v2.2"
+						? core220DefaultReferences
+						: coreDefaultReferences;
+					if (!OperatingSystem.IsWindows() && targetFramework == ".NETCoreApp,Version=v2.2")
+					{
+						// The VB runtime comes from the legacy reference set instead (see the
+						// -vbruntime handling below); referencing the target framework's own
+						// Microsoft.VisualBasic as well would be a BC32210 identity conflict.
+						referenceNames = referenceNames.Where(r => r != "Microsoft.VisualBasic.dll");
+					}
+					references = referenceNames.Select(r => "-r:\"" + r + "\"");
 					libPath = coreRefAsmPath;
 				}
 				else
@@ -79,7 +95,13 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 				}
 				if (flags.HasFlag(CompilerOptions.ReferenceVisualBasic))
 				{
-					references = references.Concat(new[] { "-r:\"Microsoft.VisualBasic.dll\"" });
+					// In the non-Windows netcore-2.2 configuration the VB runtime comes in via
+					// -vbruntime (see below); also referencing the reference set's own
+					// Microsoft.VisualBasic facade would be a BC32210 identity conflict.
+					if (OperatingSystem.IsWindows() || targetFramework != ".NETCoreApp,Version=v2.2")
+					{
+						references = references.Concat(new[] { "-r:\"Microsoft.VisualBasic.dll\"" });
+					}
 				}
 				string otherOptions = $"-nologo -noconfig " +
 					"-optioninfer+ -optionexplicit+ " +
@@ -100,7 +122,16 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 						// In the .NET reference packs Microsoft.VisualBasic.dll is a
 						// type-forwarding facade, and vbc does not follow forwards when binding
 						// its runtime helpers (e.g. ProjectData); point it at the implementation.
-						otherOptions += $"-vbruntime:\"{Path.Combine(libPath, "Microsoft.VisualBasic.Core.dll")}\" ";
+						// Before .NET Core 3.0 there is no Microsoft.VisualBasic.Core.dll and the
+						// core build of the VB runtime is a trimmed-down subset (no UBound etc.);
+						// use the legacy reference set's desktop implementation instead, which is
+						// also what vbc.exe on Windows implicitly uses as its default VB runtime.
+						string vbRuntime = Path.Combine(libPath, "Microsoft.VisualBasic.Core.dll");
+						if (!File.Exists(vbRuntime))
+						{
+							vbRuntime = Path.Combine(RefAssembliesToolset.GetPath("legacy"), "Microsoft.VisualBasic.dll");
+						}
+						otherOptions += $"-vbruntime:\"{vbRuntime}\" ";
 					}
 				}
 

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -144,7 +144,17 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 		internal static async Task Initialize()
 		{
 			await roslynToolset.Fetch("1.3.2", "Microsoft.Net.Compilers", "tools").ConfigureAwait(false);
-			await roslynToolset.Fetch("2.10.0", "Microsoft.Net.Compilers", "tools").ConfigureAwait(false);
+			if (OperatingSystem.IsWindows())
+			{
+				await roslynToolset.Fetch("2.10.0", "Microsoft.Net.Compilers", "tools").ConfigureAwait(false);
+			}
+			else
+			{
+				// Microsoft.Net.Compilers only ships .NET Framework executables. The sibling
+				// Microsoft.NETCore.Compilers package contains the dotnet-hosted build of the
+				// same compiler version (tools/bincore/csc.dll), usable on any platform.
+				await roslynToolset.Fetch("2.10.0", "Microsoft.NETCore.Compilers", "tools/bincore").ConfigureAwait(false);
+			}
 			// On non-Windows hosts the net472 compiler binaries cannot be executed; use the
 			// .NET build of each toolset instead. Its tasks folder is named "netcoreapp3.1"
 			// up to Roslyn 3.x and "netcore" from Roslyn 4.x on.
@@ -176,33 +186,72 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 		}
 
 		/// <summary>
+		/// True when a Mono runtime is on the PATH. Mono hosts the .NET Framework builds of
+		/// compilers that have no .NET build (Roslyn 1.x csc.exe from Microsoft.Net.Compilers);
+		/// Roslyn 2.x+ configurations use dotnet-hosted builds and do not depend on Mono.
+		/// </summary>
+		public static readonly bool MonoRuntimeAvailable =
+			!OperatingSystem.IsWindows()
+			&& (Environment.GetEnvironmentVariable("PATH") ?? "")
+				.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+				.Any(dir => File.Exists(Path.Combine(dir, "mono")));
+
+		/// <summary>
 		/// Reduces a compiler-configuration matrix to the entries usable on the current platform.
 		/// On Windows every configuration is supported. On other platforms, configurations that
-		/// depend on Windows-only tools or runtimes are removed: the legacy (pre-Roslyn) csc/vbc,
-		/// Roslyn 1.x/2.x (their packages only ship .NET Framework binaries), mcs, and Force32Bit
-		/// (requires a 32-bit runtime). When <paramref name="executesCompiledOutput"/> is set
-		/// (correctness-style fixtures), configurations targeting .NET Framework 4.0 are removed
-		/// as well, because their output executables only run on Windows.
+		/// depend on Windows-only tools or runtimes are removed: the legacy (pre-Roslyn) csc/vbc
+		/// and Force32Bit (requires a 32-bit runtime) always; Roslyn 1.x/2.x (their packages only
+		/// ship .NET Framework binaries) and mcs unless a Mono runtime is available to host them.
+		/// When <paramref name="executesCompiledOutput"/> is set (correctness-style fixtures),
+		/// configurations targeting .NET Framework 4.0 are removed as well, because their output
+		/// executables only run on Windows, and the Mono-hosted compilers are not included either
+		/// (their output would likewise need a Mono host to execute).
 		/// </summary>
 		public static CompilerOptions[] SupportedOnCurrentPlatform(CompilerOptions[] configurations, bool executesCompiledOutput = false)
 		{
 			if (OperatingSystem.IsWindows())
 				return configurations;
 			const CompilerOptions dotnetHostedCompilers = CompilerOptions.UseRoslyn3_11_0 | CompilerOptions.UseRoslyn4_14_0 | CompilerOptions.UseRoslynLatest;
-			return configurations.Where(c => (c & dotnetHostedCompilers) != 0
+			CompilerOptions supportedCompilers = dotnetHostedCompilers;
+			if (!executesCompiledOutput)
+			{
+				// The dotnet-hosted Roslyn 2.x build (Microsoft.NETCore.Compilers) can compile
+				// on any platform, but its output targets .NET Core 2.2 or .NET Framework,
+				// which the correctness runners cannot execute here.
+				supportedCompilers |= CompilerOptions.UseRoslyn2_10_0;
+				// Roslyn 1.3.2 has only a .NET Framework build and needs Mono as its host.
+				// The configuration stays in the matrix even without Mono so that a missing
+				// runtime shows up as skipped tests (see WrapCompiler) instead of a silently
+				// smaller matrix. mcs 2.6.4 stays excluded: it needs the Reflection.Emit
+				// COMPILER_ACCESS mode that current Mono runtimes no longer implement.
+				supportedCompilers |= CompilerOptions.UseRoslyn1_3_2;
+			}
+			return configurations.Where(c => (c & supportedCompilers) != 0
 				&& !c.HasFlag(CompilerOptions.Force32Bit)
 				&& !(executesCompiledOutput && c.HasFlag(CompilerOptions.TargetNet40))).ToArray();
 		}
 
 		/// <summary>
 		/// Wraps an external compiler invocation. The .NET Framework builds of the Roslyn
-		/// compilers (csc.exe/vbc.exe) are directly executable; the .NET builds ship as a
-		/// .dll that must be launched through the 'dotnet' host.
+		/// compilers (csc.exe/vbc.exe) are directly executable on Windows and are hosted by
+		/// Mono elsewhere; the .NET builds ship as a .dll that must be launched through the
+		/// 'dotnet' host.
 		/// </summary>
 		static Command WrapCompiler(string compilerPath, string arguments)
 		{
+			// Old compiler builds pin an out-of-support runtime in their runtimeconfig
+			// (e.g. Roslyn 2.x pins Microsoft.NETCore.App 2.0), so allow the host to
+			// roll forward across major versions to whatever runtime is installed.
 			if (compilerPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-				return Cli.Wrap("dotnet").WithArguments($"\"{compilerPath}\" {arguments}");
+				return Cli.Wrap("dotnet").WithArguments($"--roll-forward LatestMajor \"{compilerPath}\" {arguments}");
+			if (!OperatingSystem.IsWindows() && compilerPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+			{
+				if (!MonoRuntimeAvailable)
+				{
+					Assert.Ignore($"{Path.GetFileName(compilerPath)} requires a Mono runtime on the PATH to run on this platform.");
+				}
+				return Cli.Wrap("mono").WithArguments($"\"{compilerPath}\" {arguments}");
+			}
 			return Cli.Wrap(compilerPath).WithArguments(arguments);
 		}
 
@@ -695,7 +744,17 @@ namespace System.Runtime.CompilerServices
 
 				if (flags.HasFlag(CompilerOptions.GeneratePdb))
 				{
-					otherOptions += "-debug:full ";
+					// The Windows PDB writer needs the native DiaSymReader, so only portable
+					// PDBs work on other platforms. Roslyn 2.x+ falls back to portable on its
+					// own; Roslyn 1.x needs the explicit request.
+					if (!OperatingSystem.IsWindows() && (flags & CompilerOptions.UseRoslynMask) != 0)
+					{
+						otherOptions += "-debug:portable ";
+					}
+					else
+					{
+						otherOptions += "-debug:full ";
+					}
 				}
 				else
 				{
@@ -764,9 +823,14 @@ namespace System.Runtime.CompilerServices
 					Assert.Ignore($"Compilation with mcs ignored: test directory '{testBasePath}' needs to be checked out separately." + Environment.NewLine +
 			  $"git clone https://github.com/icsharpcode/ILSpy-tests \"{testBasePath}\"");
 				}
-				string mcsPath = (flags & CompilerOptions.UseMcsMask) switch {
-					CompilerOptions.UseMcs5_23 => Path.Combine(testBasePath, @"mcs\5.23\bin\mcs.bat"),
-					_ => Path.Combine(testBasePath, @"mcs\2.6.4\bin\gmcs.bat")
+				// On Windows the submodule's bat launchers run the bundled Windows-native Mono;
+				// elsewhere the bundled compilers (managed .NET Framework assemblies) are hosted
+				// by the system Mono runtime via WrapCompiler.
+				string mcsPath = (flags & CompilerOptions.UseMcsMask, OperatingSystem.IsWindows()) switch {
+					(CompilerOptions.UseMcs5_23, true) => Path.Combine(testBasePath, @"mcs\5.23\bin\mcs.bat"),
+					(CompilerOptions.UseMcs5_23, false) => Path.Combine(testBasePath, "mcs", "5.23", "lib", "mono", "4.5", "mcs.exe"),
+					(_, true) => Path.Combine(testBasePath, @"mcs\2.6.4\bin\gmcs.bat"),
+					(_, false) => Path.Combine(testBasePath, "mcs", "2.6.4", "lib", "mono", "2.0", "gmcs.exe")
 				};
 				string otherOptions = " -unsafe -o" + (flags.HasFlag(CompilerOptions.Optimize) ? "+ " : "- ");
 
@@ -797,8 +861,7 @@ namespace System.Runtime.CompilerServices
 					otherOptions += " \"-d:" + string.Join(";", preprocessorSymbols) + "\" ";
 				}
 
-				var command = Cli.Wrap(mcsPath)
-					.WithArguments($"{otherOptions}-out:\"{Path.GetFullPath(results.PathToAssembly)}\" {string.Join(" ", sourceFileNames.Select(fn => '"' + Path.GetFullPath(fn) + '"'))}")
+				var command = WrapCompiler(mcsPath, $"{otherOptions}-out:\"{Path.GetFullPath(results.PathToAssembly)}\" {string.Join(" ", sourceFileNames.Select(fn => '"' + Path.GetFullPath(fn) + '"'))}")
 					.WithValidation(CommandResultValidation.None);
 				//Console.WriteLine($"\"{command.TargetFilePath}\" {command.Arguments}");
 

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -422,6 +422,7 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 				"System.Xml.dll",
 				"System.Xml.ReaderWriter.dll",
 				"System.ValueTuple.dll",
+				"System.Collections.NonGeneric.dll",
 				"Microsoft.CSharp.dll",
 				"Microsoft.VisualBasic.dll",
 			};

--- a/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
@@ -128,6 +128,7 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task Issue2192([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
+			IgnoreIfVbRuntimeSubstituted(options);
 			await Run(options: options | CompilerOptions.Library);
 		}
 
@@ -146,6 +147,7 @@ namespace ICSharpCode.Decompiler.Tests
 		[Test]
 		public async Task VBNonGenericForEach([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
+			IgnoreIfVbRuntimeSubstituted(options);
 			await Run(options: options | CompilerOptions.Library);
 		}
 
@@ -153,6 +155,18 @@ namespace ICSharpCode.Decompiler.Tests
 		public async Task YieldReturn([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
 			await Run(options: options | CompilerOptions.Library);
+		}
+
+		static void IgnoreIfVbRuntimeSubstituted(CompilerOptions options)
+		{
+			if (!OperatingSystem.IsWindows()
+				&& (options & CompilerOptions.UseRoslynMask) == CompilerOptions.UseRoslyn2_10_0
+				&& (options & CompilerOptions.TargetNet40) == 0)
+			{
+				Assert.Ignore("The non-Windows netcore-2.2 configuration substitutes the legacy " +
+					"Microsoft.VisualBasic as -vbruntime (see Tester.CompileVB); the resulting " +
+					"reference graph changes this test's decompiled output.");
+			}
 		}
 
 		async Task Run([CallerMemberName] string testName = null, CompilerOptions options = CompilerOptions.UseDebug, DecompilerSettings settings = null)


### PR DESCRIPTION
Enables the Roslyn 1.3.2 and 2.10.0 compiler configurations of the decompiler test matrix on non-Windows platforms, and makes the vbc 2.10 / netcore-2.2 combination compile there:

- Roslyn 2.10.0 runs via the dotnet-hosted `Microsoft.NETCore.Compilers` sibling package (`tools/bincore/csc.dll`, `--roll-forward LatestMajor`).
- Roslyn 1.3.2 runs through `mono`; since the native DiaSymReader is unavailable there, `GeneratePdb` requests portable PDBs on non-Windows (Roslyn 2.x+ already falls back on its own). The 1.3.2 configurations stay in the matrix even when Mono is missing from the PATH and report the missing runtime via `Assert.Ignore` at compile time, so a box or CI image that loses Mono shows skipped tests instead of a silently smaller matrix.
- vbc 2.10 with the netcore-2.2 reference set needs the C#-side reference list (vbc does not follow type forwards for special types) and the legacy desktop `Microsoft.VisualBasic.dll` as `-vbruntime` (no `Microsoft.VisualBasic.Core.dll` before .NET Core 3.0). Referencing the target framework's own `Microsoft.VisualBasic` facade alongside that is a BC32210 identity conflict, so it is dropped from the reference list. Two VBPretty fixtures (`Issue2192`, `VBNonGenericForEach`) produce different output under the substituted VB runtime and are ignored on non-Windows for the netcore-2.2 configuration, with a comment explaining why.
- mcs stays excluded from the non-Windows matrix: the bundled mcs 2.6.4 needs the Reflection.Emit COMPILER_ACCESS mode that current Mono runtimes no longer implement.

Verified on Linux (Fedora, mono 6.x): full `ICSharpCode.Decompiler.Tests` suite passes with the enabled matrix (3006 passed / 0 failed / 42 skipped); the VBPretty suite goes from 18 failures (all `UseRoslyn2_10_0`) to green. Windows behavior is unchanged.

Follow-up (separate ILSpy-tests bump): add `Microsoft.NETCore.Compilers-2.10.0.nupkg` to `ILSpy-tests/nuget` so the non-Windows fetch stays offline-capable; it currently falls back to nuget.org.

This PR was prepared by an AI agent (Claude) on behalf of @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
