### PR TITLE
Represent VB.NET parameterized properties as accessor methods in C# output

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -148,6 +148,7 @@
     <None Include="TestCases\VBPretty\Issue1906.vb" />
     <None Include="TestCases\VBPretty\Issue2192.vb" />
     <None Include="TestCases\VBPretty\Select.vb" />
+    <None Include="TestCases\VBPretty\ParameterizedProperties.vb" />
     <None Include="TestCases\ILPretty\Unsafe.il" />
     <None Include="TestCases\ILPretty\Issue1389.il" />
     <None Include="TestCases\ILPretty\SequenceOfNestedIfs.il" />

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -158,6 +158,7 @@
     <None Include="TestCases\Disassembler\Pretty\SecurityDeclarations.il" />
     <None Include="TestCases\ILPretty\Issue1038.il" />
     <None Include="TestCases\ILPretty\Issue1145.il" />
+    <None Include="TestCases\ILPretty\NoAccessorProperties.il" />
     <None Include="TestCases\ILPretty\Issue1047.il" />
     <None Include="TestCases\ILPretty\Issue959.il" />
   </ItemGroup>
@@ -202,6 +203,8 @@
     <None Include="TestCases\ILPretty\FSharpUsing_Release.cs" />
     <Compile Remove="TestCases\ILPretty\GuessAccessors.cs" />
     <None Include="TestCases\ILPretty\GuessAccessors.cs" />
+    <Compile Remove="TestCases\ILPretty\NoAccessorProperties.cs" />
+    <None Include="TestCases\ILPretty\NoAccessorProperties.cs" />
     <Compile Remove="TestCases\ILPretty\Issue1145.cs" />
     <None Include="TestCases\ILPretty\Issue1145.cs" />
     <Compile Remove="TestCases\ILPretty\Issue1325.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -160,6 +160,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task NoAccessorProperties()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task Issue1145()
 		{
 			await Run();

--- a/ICSharpCode.Decompiler.Tests/Output/CSharpAmbienceTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Output/CSharpAmbienceTests.cs
@@ -374,6 +374,25 @@ namespace ICSharpCode.Decompiler.Tests.Output
 			ambience.ConversionFlags = ConversionFlags.All & ~(ConversionFlags.ShowBody | ConversionFlags.PlaceReturnTypeAfterParameterList);
 			Assert.That(ambience.ConvertSymbol(indexer), Is.EqualTo("public dynamic dynamic.this[int]"));
 		}
+
+		[Test]
+		public void ParameterizedProperty()
+		{
+			// A named property with parameters (VB.NET parameterized property); C# has no
+			// syntax for it, but signature surfaces show the parameter list in parentheses.
+			var property = new FakeProperty(compilation) {
+				Name = "Data",
+				ReturnType = compilation.FindType(KnownTypeCode.Int32),
+				DeclaringType = SpecialType.Dynamic,
+				Parameters = new IParameter[] { new DefaultParameter(compilation.FindType(KnownTypeCode.Int32), "index") },
+			};
+
+			ambience.ConversionFlags = ILSpyMainTreeViewMemberFlags;
+			Assert.That(ambience.ConvertSymbol(property), Is.EqualTo("Data(int) : int"));
+
+			ambience.ConversionFlags = ConversionFlags.All & ~(ConversionFlags.ShowBody | ConversionFlags.PlaceReturnTypeAfterParameterList);
+			Assert.That(ambience.ConvertSymbol(property), Is.EqualTo("public int dynamic.Data(int index)"));
+		}
 		#endregion
 
 		#region Test types

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue1325.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue1325.cs
@@ -35,13 +35,15 @@ namespace Issue1325
 
 	internal class Test
 	{
-		public string Parameterized {
-			get {
-				throw new NotImplementedException();
-			}
-			set {
-				throw new NotImplementedException();
-			}
+		// C# has no syntax for parameterized property 'Parameterized'.
+		public string get_Parameterized(int i)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void set_Parameterized(int i, string value)
+		{
+			throw new NotImplementedException();
 		}
 		public string Unparameterized { get; set; }
 	}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/NoAccessorProperties.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/NoAccessorProperties.cs
@@ -1,0 +1,9 @@
+public class BrokenProperties
+{
+	private int _field;
+
+	public int Touch(int i)
+	{
+		return _field + i;
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/NoAccessorProperties.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/NoAccessorProperties.il
@@ -1,0 +1,33 @@
+// Property rows without any MethodSemantics accessors (corrupt or hand-written
+// metadata). The type system skips such properties, whether parameterized or not;
+// decompilation must not crash on them.
+.class public auto ansi beforefieldinit BrokenProperties extends [mscorlib]System.Object
+{
+	.field private int32 _field
+
+	.property instance int32 Parameterized(int32)
+	{
+	} // end of property BrokenProperties::Parameterized
+
+	.property instance int32 Plain()
+	{
+	} // end of property BrokenProperties::Plain
+
+	.method public hidebysig instance int32 Touch (int32 i) cil managed
+	{
+		.maxstack 8
+		ldarg.0
+		ldfld int32 BrokenProperties::_field
+		ldarg.1
+		add
+		ret
+	} // end of method BrokenProperties::Touch
+
+	.method public hidebysig specialname rtspecialname instance void .ctor () cil managed
+	{
+		.maxstack 8
+		ldarg.0
+		call instance void [mscorlib]System.Object::.ctor()
+		ret
+	} // end of method BrokenProperties::.ctor
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.cs
@@ -3,8 +3,7 @@ using System;
 
 public interface IParameterized
 {
-	// C# has no syntax for parameterized properties; the accessors of
-	// property 'IndexedValue' are emitted as ordinary methods.
+	// C# has no syntax for parameterized property 'IndexedValue'.
 	int get_IndexedValue(int index);
 	void set_IndexedValue(int index, int Value);
 }
@@ -13,8 +12,7 @@ public class ParameterizedProperties : IParameterized
 {
 	private int _field;
 
-	// C# has no syntax for parameterized properties; the accessors of
-	// property 'SharedProp' are emitted as ordinary methods.
+	// C# has no syntax for parameterized property 'SharedProp'.
 	public static int get_SharedProp(int index)
 	{
 		return index;
@@ -24,8 +22,7 @@ public class ParameterizedProperties : IParameterized
 	{
 	}
 
-	// C# has no syntax for parameterized properties; the accessors of
-	// property 'IndexedValue' are emitted as ordinary methods.
+	// C# has no syntax for parameterized property 'IndexedValue'.
 	public int get_IndexedValue(int index)
 	{
 		return _field;
@@ -36,16 +33,14 @@ public class ParameterizedProperties : IParameterized
 		_field = value;
 	}
 
-	// C# has no syntax for parameterized properties; the accessors of
-	// property 'ReadOnlyProp' are emitted as ordinary methods.
+	// C# has no syntax for parameterized property 'ReadOnlyProp'.
 	public int get_ReadOnlyProp(int index)
 	{
 		return index;
 	}
 
-	// C# has no syntax for parameterized properties; the accessors of
-	// property 'Attributed' are emitted as ordinary methods. The property's
-	// attributes are kept below under the inert 'property:' target (CS0657).
+	// C# has no syntax for parameterized property 'Attributed'.
+	// Its 'property:' attributes below are ignored by the compiler (CS0657).
 	[property: Obsolete("read-write parameterized property")]
 	public int get_Attributed(int index)
 	{

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.cs
@@ -1,0 +1,68 @@
+#pragma warning disable 657
+using System;
+
+public interface IParameterized
+{
+	// C# has no syntax for parameterized properties; the accessors of
+	// property 'IndexedValue' are emitted as ordinary methods.
+	int get_IndexedValue(int index);
+	void set_IndexedValue(int index, int Value);
+}
+
+public class ParameterizedProperties : IParameterized
+{
+	private int _field;
+
+	// C# has no syntax for parameterized properties; the accessors of
+	// property 'SharedProp' are emitted as ordinary methods.
+	public static int get_SharedProp(int index)
+	{
+		return index;
+	}
+
+	public static void set_SharedProp(int index, int value)
+	{
+	}
+
+	// C# has no syntax for parameterized properties; the accessors of
+	// property 'IndexedValue' are emitted as ordinary methods.
+	public int get_IndexedValue(int index)
+	{
+		return _field;
+	}
+
+	public void set_IndexedValue(int index, int value)
+	{
+		_field = value;
+	}
+
+	// C# has no syntax for parameterized properties; the accessors of
+	// property 'ReadOnlyProp' are emitted as ordinary methods.
+	public int get_ReadOnlyProp(int index)
+	{
+		return index;
+	}
+
+	// C# has no syntax for parameterized properties; the accessors of
+	// property 'Attributed' are emitted as ordinary methods. The property's
+	// attributes are kept below under the inert 'property:' target (CS0657).
+	[property: Obsolete("read-write parameterized property")]
+	public int get_Attributed(int index)
+	{
+		return index;
+	}
+
+	public void set_Attributed(int index, int value)
+	{
+	}
+
+	public void Use()
+	{
+		ParameterizedProperties.set_SharedProp(1, 2);
+		_field = ParameterizedProperties.get_SharedProp(3);
+		this.set_IndexedValue(4, 5);
+		_field = this.get_IndexedValue(6);
+		((IParameterized)this).set_IndexedValue(7, 8);
+		_field = ((IParameterized)this).get_IndexedValue(9);
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.cs
@@ -8,6 +8,32 @@ public interface IParameterized
 	void set_IndexedValue(int index, int Value);
 }
 
+public class ParameterizedBase
+{
+	// C# has no syntax for parameterized property 'Virt'.
+	public virtual int get_Virt(int index)
+	{
+		return index;
+	}
+
+	public virtual void set_Virt(int index, int value)
+	{
+	}
+}
+
+public class ParameterizedDerived : ParameterizedBase
+{
+	// C# has no syntax for parameterized property 'Virt'.
+	public override int get_Virt(int index)
+	{
+		return checked(index + 1);
+	}
+
+	public override void set_Virt(int index, int value)
+	{
+	}
+}
+
 public class ParameterizedProperties : IParameterized
 {
 	private int _field;
@@ -28,15 +54,33 @@ public class ParameterizedProperties : IParameterized
 		return _field;
 	}
 
+	int IParameterized.get_IndexedValue(int index)
+	{
+		//ILSpy generated this explicit interface implementation from .override directive in get_IndexedValue
+		return this.get_IndexedValue(index);
+	}
+
 	public void set_IndexedValue(int index, int value)
 	{
 		_field = value;
+	}
+
+	void IParameterized.set_IndexedValue(int index, int value)
+	{
+		//ILSpy generated this explicit interface implementation from .override directive in set_IndexedValue
+		this.set_IndexedValue(index, value);
 	}
 
 	// C# has no syntax for parameterized property 'ReadOnlyProp'.
 	public int get_ReadOnlyProp(int index)
 	{
 		return index;
+	}
+
+	// C# has no syntax for parameterized property 'SetOnly'.
+	public void set_SetOnly(int index, int value)
+	{
+		_field = checked(index + value);
 	}
 
 	// C# has no syntax for parameterized property 'Attributed'.
@@ -51,6 +95,18 @@ public class ParameterizedProperties : IParameterized
 	{
 	}
 
+	// C# has no syntax for parameterized property 'Overloaded'.
+	public int get_Overloaded(int a)
+	{
+		return a;
+	}
+
+	// C# has no syntax for parameterized property 'Overloaded'.
+	public int get_Overloaded(int a, int b)
+	{
+		return checked(a + b);
+	}
+
 	public void Use()
 	{
 		ParameterizedProperties.set_SharedProp(1, 2);
@@ -59,5 +115,33 @@ public class ParameterizedProperties : IParameterized
 		_field = this.get_IndexedValue(6);
 		((IParameterized)this).set_IndexedValue(7, 8);
 		_field = ((IParameterized)this).get_IndexedValue(9);
+	}
+}
+
+public class RenamedImplementation : IParameterized
+{
+	private int _value;
+
+	// C# has no syntax for parameterized property 'Renamed'.
+	public int get_Renamed(int index)
+	{
+		return _value;
+	}
+
+	int IParameterized.get_IndexedValue(int index)
+	{
+		//ILSpy generated this explicit interface implementation from .override directive in get_Renamed
+		return this.get_Renamed(index);
+	}
+
+	public void set_Renamed(int index, int value)
+	{
+		_value = value;
+	}
+
+	void IParameterized.set_IndexedValue(int index, int value)
+	{
+		//ILSpy generated this explicit interface implementation from .override directive in set_Renamed
+		this.set_Renamed(index, value);
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.vb
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.vb
@@ -32,6 +32,12 @@ Public Class ParameterizedProperties
 		End Get
 	End Property
 
+	Public WriteOnly Property SetOnly(index As Integer) As Integer
+		Set(value As Integer)
+			_field = index + value
+		End Set
+	End Property
+
 	<Obsolete("read-write parameterized property")>
 	Public Property Attributed(index As Integer) As Integer
 		Get
@@ -39,6 +45,18 @@ Public Class ParameterizedProperties
 		End Get
 		Set(value As Integer)
 		End Set
+	End Property
+
+	Public ReadOnly Property Overloaded(a As Integer) As Integer
+		Get
+			Return a
+		End Get
+	End Property
+
+	Public ReadOnly Property Overloaded(a As Integer, b As Integer) As Integer
+		Get
+			Return a + b
+		End Get
 	End Property
 
 	Public Sub Use()
@@ -50,4 +68,41 @@ Public Class ParameterizedProperties
 		p.IndexedValue(7) = 8
 		_field = p.IndexedValue(9)
 	End Sub
+End Class
+
+Public Class ParameterizedBase
+	Public Overridable Property Virt(index As Integer) As Integer
+		Get
+			Return index
+		End Get
+		Set(value As Integer)
+		End Set
+	End Property
+End Class
+
+Public Class ParameterizedDerived
+	Inherits ParameterizedBase
+
+	Public Overrides Property Virt(index As Integer) As Integer
+		Get
+			Return index + 1
+		End Get
+		Set(value As Integer)
+		End Set
+	End Property
+End Class
+
+Public Class RenamedImplementation
+	Implements IParameterized
+
+	Private _value As Integer
+
+	Public Property Renamed(index As Integer) As Integer Implements IParameterized.IndexedValue
+		Get
+			Return _value
+		End Get
+		Set(value As Integer)
+			_value = value
+		End Set
+	End Property
 End Class

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.vb
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/ParameterizedProperties.vb
@@ -1,0 +1,53 @@
+Imports System
+
+Public Interface IParameterized
+	Property IndexedValue(index As Integer) As Integer
+End Interface
+
+Public Class ParameterizedProperties
+	Implements IParameterized
+
+	Private _field As Integer
+
+	Public Shared Property SharedProp(index As Integer) As Integer
+		Get
+			Return index
+		End Get
+		Set(value As Integer)
+		End Set
+	End Property
+
+	Public Property IndexedValue(index As Integer) As Integer Implements IParameterized.IndexedValue
+		Get
+			Return _field
+		End Get
+		Set(value As Integer)
+			_field = value
+		End Set
+	End Property
+
+	Public ReadOnly Property ReadOnlyProp(index As Integer) As Integer
+		Get
+			Return index
+		End Get
+	End Property
+
+	<Obsolete("read-write parameterized property")>
+	Public Property Attributed(index As Integer) As Integer
+		Get
+			Return index
+		End Get
+		Set(value As Integer)
+		End Set
+	End Property
+
+	Public Sub Use()
+		SharedProp(1) = 2
+		_field = SharedProp(3)
+		IndexedValue(4) = 5
+		_field = IndexedValue(6)
+		Dim p As IParameterized = Me
+		p.IndexedValue(7) = 8
+		_field = p.IndexedValue(9)
+	End Sub
+End Class

--- a/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
@@ -114,6 +114,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task ParameterizedProperties([ValueSource(nameof(defaultOptions))] CompilerOptions options)
+		{
+			await Run(options: options | CompilerOptions.Library);
+		}
+
+		[Test]
 		public async Task Select([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
 			await Run(options: options | CompilerOptions.Library);

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -2510,6 +2510,7 @@ namespace ICSharpCode.Decompiler.CSharp
 					}
 				}
 				result.Add(accessorDecl);
+				result.AddRange(AddInterfaceImplHelpers(accessorDecl, accessor, typeSystemAstBuilder));
 			}
 			return result;
 		}

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1338,7 +1338,14 @@ namespace ICSharpCode.Decompiler.CSharp
 					case HandleKind.PropertyDefinition:
 						IProperty property = module.GetDefinition((PropertyDefinitionHandle)entity);
 						parentExtensionInfo = property.ResolveExtensionInfo();
-						syntaxTree.Members.Add(DoDecompile(property, decompileRun, new SimpleTypeResolveContext(property), parentExtensionInfo));
+						if (property.IsParameterizedProperty())
+						{
+							syntaxTree.Members.AddRange(DecompileParameterizedProperty(property, decompileRun, new SimpleTypeResolveContext(property), parentExtensionInfo));
+						}
+						else
+						{
+							syntaxTree.Members.Add(DoDecompile(property, decompileRun, new SimpleTypeResolveContext(property), parentExtensionInfo));
+						}
 						if (first)
 						{
 							parentTypeDef = property.DeclaringTypeDefinition;
@@ -1869,6 +1876,15 @@ namespace ICSharpCode.Decompiler.CSharp
 						{
 							return;
 						}
+						if (property.IsParameterizedProperty())
+						{
+							foreach (var accessorDecl in DecompileParameterizedProperty(property, decompileRun, decompilationContext, null))
+							{
+								entityMap.Add(property, accessorDecl);
+								EnqueueReferencedMembers(accessorDecl);
+							}
+							return;
+						}
 						entityDecl = DoDecompile(property, decompileRun, decompilationContext.WithCurrentMember(property), null);
 						entityMap.Add(property, entityDecl);
 						break;
@@ -1897,19 +1913,24 @@ namespace ICSharpCode.Decompiler.CSharp
 						throw new ArgumentOutOfRangeException("Unexpected member type");
 				}
 
-				foreach (var node in entityDecl.Descendants)
+				EnqueueReferencedMembers(entityDecl);
+
+				void EnqueueReferencedMembers(EntityDeclaration decl)
 				{
-					var rr = node.GetResolveResult();
-					if (rr is MemberResolveResult mrr
-						&& mrr.Member.DeclaringTypeDefinition == typeDef
-						&& !(mrr.Member is IMethod { IsLocalFunction: true }))
+					foreach (var node in decl.Descendants)
 					{
-						workList.Enqueue(mrr.Member);
-					}
-					else if (rr is TypeResolveResult trr
-						&& trr.Type.GetDefinition()?.DeclaringTypeDefinition == typeDef)
-					{
-						workList.Enqueue(trr.Type.GetDefinition()!);
+						var rr = node.GetResolveResult();
+						if (rr is MemberResolveResult mrr
+							&& mrr.Member.DeclaringTypeDefinition == typeDef
+							&& !(mrr.Member is IMethod { IsLocalFunction: true }))
+						{
+							workList.Enqueue(mrr.Member);
+						}
+						else if (rr is TypeResolveResult trr
+							&& trr.Type.GetDefinition()?.DeclaringTypeDefinition == typeDef)
+						{
+							workList.Enqueue(trr.Type.GetDefinition()!);
+						}
 					}
 				}
 			}
@@ -2047,7 +2068,10 @@ namespace ICSharpCode.Decompiler.CSharp
 				{
 					methodDecl.Modifiers |= Modifiers.Extern;
 				}
-				if (method.SymbolKind == SymbolKind.Method && !method.IsExplicitInterfaceImplementation
+				// Accessors qualify only when they are emitted as ordinary methods (parameterized
+				// properties); an Accessor node cannot carry the 'new' modifier.
+				if ((method.SymbolKind == SymbolKind.Method || (method.SymbolKind == SymbolKind.Accessor && methodDecl is MethodDeclaration))
+					&& !method.IsExplicitInterfaceImplementation
 					&& methodDefinition.HasFlag(System.Reflection.MethodAttributes.Virtual) == methodDefinition.HasFlag(System.Reflection.MethodAttributes.NewSlot))
 				{
 					SetNewModifier(methodDecl);
@@ -2454,6 +2478,40 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 			}
 			return false;
+		}
+
+		/// <summary>
+		/// Decompiles a parameterized property (a named property with parameters, e.g. from
+		/// VB.NET) into declarations of its accessor methods, because C# has no syntax for
+		/// such properties. The property-level attributes are placed on the first accessor
+		/// under the 'property:' attribute target, which is not valid for methods and is
+		/// therefore ignored by the C# compiler (CS0657): recompilation neither loses the
+		/// attributes from the source nor misapplies them to the accessor method.
+		/// </summary>
+		List<EntityDeclaration> DecompileParameterizedProperty(IProperty property, DecompileRun decompileRun, ITypeResolveContext decompilationContext, ExtensionInfo? extensionInfo)
+		{
+			var result = new List<EntityDeclaration>(2);
+			var typeSystemAstBuilder = CreateAstBuilder(decompileRun.Settings);
+			foreach (var accessor in new[] { property.Getter, property.Setter })
+			{
+				if (accessor == null)
+					continue;
+				var accessorDecl = DoDecompile(accessor, decompileRun, decompilationContext.WithCurrentMember(accessor), extensionInfo);
+				if (result.Count == 0)
+				{
+					accessorDecl.AddLeadingTrivia(new Comment($" C# has no syntax for parameterized property '{property.Name}'."));
+					var attributes = property.GetAttributes().Select(typeSystemAstBuilder.ConvertAttribute).ToList();
+					if (attributes.Count > 0)
+					{
+						var attrSection = new AttributeSection { AttributeTarget = "property" };
+						attrSection.Attributes.AddRange(attributes);
+						accessorDecl.Attributes.InsertAfter(null, attrSection);
+						accessorDecl.AddLeadingTrivia(new Comment(" Its 'property:' attributes below are ignored by the compiler (CS0657)."));
+					}
+				}
+				result.Add(accessorDecl);
+			}
+			return result;
 		}
 
 		EntityDeclaration DoDecompile(IProperty property, DecompileRun decompileRun, ITypeResolveContext decompilationContext, ExtensionInfo? extensionInfo)

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpAmbience.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpAmbience.cs
@@ -148,6 +148,12 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 					var subst = new TypeParameterSubstitution(extensionGroup.TypeParameters, null);
 					parameters = extensionGroup.Marker.Specialize(subst).Parameters.Select(p => astBuilder.ConvertParameter(p));
 				}
+				else if (symbol is IProperty { SymbolKind: SymbolKind.Property } parameterizedProperty)
+				{
+					// C# property syntax has no parameter list, so the converted node carries
+					// none; parameterized properties take theirs from the symbol.
+					parameters = parameterizedProperty.Parameters.Select(p => astBuilder.ConvertParameter(p));
+				}
 				else
 				{
 					parameters = node.GetChildren(Slots.Parameter);
@@ -256,6 +262,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				case SymbolKind.Operator:
 				case SymbolKind.Constructor:
 				case SymbolKind.Destructor:
+				case SymbolKind.Property when ((IProperty)e).Parameters.Count > 0:
 					return (ConversionFlags & ConversionFlags.ShowParameterList) != 0;
 				default:
 					return false;

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1871,6 +1871,12 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 					return ConvertDestructor((IMethod)entity);
 				case SymbolKind.Accessor:
 					IMethod accessor = (IMethod)entity;
+					if (accessor.AccessorOwner is IProperty owner && owner.IsParameterizedProperty())
+					{
+						// C# cannot represent the parameterized property itself; its accessors
+						// are declared as ordinary methods.
+						return ConvertMethod(accessor);
+					}
 					Accessibility ownerAccessibility = accessor.AccessorOwner?.Accessibility ?? Accessibility.None;
 					return ConvertAccessor(accessor, accessor.AccessorKind, ownerAccessibility, false)!;
 				default:

--- a/ICSharpCode.Decompiler/CSharp/Transforms/AddXmlDocumentationTransform.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/AddXmlDocumentationTransform.cs
@@ -47,6 +47,13 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					if (!(entityDecl.GetSymbol() is IEntity entity))
 						continue;
 					string doc = provider.GetDocumentation(entity);
+					if (doc == null && entity is IMethod { AccessorOwner: IProperty owner } accessor
+						&& owner.IsParameterizedProperty() && accessor.Equals(owner.Getter ?? owner.Setter))
+					{
+						// A parameterized property is decompiled to its accessor methods; show the
+						// property's documentation on the first accessor.
+						doc = provider.GetDocumentation(owner);
+					}
 					if (doc != null)
 					{
 						context.Step("Add XML documentation", entityDecl);

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -172,6 +172,17 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		/// <summary>
+		/// Gets whether the property is a parameterized property that is not an indexer,
+		/// i.e. a named property with parameters (a VB.NET parameterized property or a
+		/// C++/CLI indexed property). C# has no syntax for declaring or using such a
+		/// property; only its accessor methods can be represented.
+		/// </summary>
+		public static bool IsParameterizedProperty(this IProperty property)
+		{
+			return property.SymbolKind == SymbolKind.Property && property.Parameters.Count > 0;
+		}
+
+		/// <summary>
 		/// Gets whether the type is an open type (contains type parameters).
 		/// </summary>
 		/// <example>

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -1551,7 +1551,15 @@ namespace ICSharpCode.ILSpy.TextView
 				// XmlDocLoader handles every layout the decompiler library knows about: .xml
 				// beside the .dll, .NET Framework reference-assemblies paths, and (recently)
 				// the modern .NET ref pack at dotnet/packs/Microsoft.NETCore.App.Ref/...
-				var documentation = XmlDocLoader.LoadDocumentation(metadata)?.GetDocumentation(entity.GetIdString());
+				var provider = XmlDocLoader.LoadDocumentation(metadata);
+				var documentation = provider?.GetDocumentation(entity.GetIdString());
+				if (documentation == null && entity is IMethod { AccessorOwner: IProperty owner })
+				{
+					// Accessors of parameterized properties appear as ordinary methods in the
+					// C# output; show the owning property's documentation for them.
+					documentation = provider?.GetDocumentation(owner.GetIdString());
+					entity = owner;
+				}
 				if (documentation == null)
 					return;
 				renderer.AddXmlDocumentation(documentation, entity, resolver: ResolveDocReference);


### PR DESCRIPTION
Addresses #1089 (and its sub-issues #1644, #2003; also the declaration half of the old #339/#1560 reports).

CLI metadata allows named properties with arbitrary parameter lists (VB.NET parameterized properties, C++/CLI indexed properties, COM PIAs); C# has syntax only for the default member. ILSpy previously emitted a parameterless property whose accessor bodies referenced the vanished parameters -- uncompilable output (see the `Issue1325` fixture diff in this PR for a before/after).

**Example** -- given this VB.NET input:

```vb
<Obsolete("read-write parameterized property")>
Public Property Attributed(index As Integer) As Integer
    Get
        Return index
    End Get
    Set(value As Integer)
    End Set
End Property
```

ILSpy previously produced (uncompilable -- `index` is not declared anywhere):

```csharp
[Obsolete("read-write parameterized property")]
public int Attributed {
    get {
        return index;
    }
    set {
    }
}
```

and now produces:

```csharp
// C# has no syntax for parameterized property 'Attributed'.
// Its 'property:' attributes below are ignored by the compiler (CS0657).
[property: Obsolete("read-write parameterized property")]
public int get_Attributed(int index)
{
    return index;
}

public void set_Attributed(int index, int value)
{
}
```

with call sites reading `x.set_Attributed(1, 42);` / `int v = x.get_Attributed(1);`, and XML documentation (a `P:` entry) shown on the first accessor and in tooltips.

**Declarations** (this PR): a parameterized non-indexer property now decompiles to its accessors as ordinary methods, with

- a comment documenting the deliberate deviation,
- the property-level attributes preserved on the first accessor under the `property:` attribute target. That target is not valid on method declarations, so the compiler ignores the attribute block with warning CS0657: the attributes stay visible and greppable in source, and recompilation neither drops them silently nor misapplies them to the accessor method. (For comparison, Visual Studio's metadata-as-source view renders such properties as bare accessor signatures and drops the property attributes entirely.)

**Call sites** already lower to direct accessor calls (`t.set_Named(1, 2, value)`) on master; the new fixture pins that behavior. This is the sanctioned C# consumption pattern: Roslyn exposes the accessors of properties whose shape C# cannot bind as regular callable methods (no CS0571), the same speakable-accessor pattern C# 14 made user-facing for extension-member disambiguation. Verified by compiling C# against a VB assembly using `get_`/`set_` calls, including implicit and explicit interface implementations of the accessors.

**Why not indexer syntax + `[IndexerName]`**: all indexers of a type must share one name, so it fails for types with several differently-named indexed properties (the common COM-PIA shape), static parameterized properties, and explicit interface implementations -- and it would create a default member the original type does not have, while making direct accessor calls in sibling decompiled files illegal (CS0571). Not general enough to be worth the per-form call-site coupling.

**Documentation**: the compiler-generated XML documentation file has a `P:` entry for the property, which no emitted member id matches anymore; the decompiled output places the property's documentation on the first accessor, and the text-view tooltip shows it for either accessor.

**Signature surfaces**: the tree/tooltip/search rendering of parameterized properties had lost its parameter list at some point long before the Avalonia rewrite (the ambience read parameters from the converted AST node, which C# property syntax cannot carry); this PR restores it, rendering `Data(int) : int` with parentheses to match VB.NET usage syntax and distinguish these from indexers.

**Known limitation** (inherent to any C# projection): recompiling the output produces plain methods without property metadata, so VB.NET consumers of a *recompiled* assembly lose property-access syntax. Whole-project output currently surfaces CS0657 warnings; the generated projects define no `NoWarn` mechanism today, so this PR does not introduce one.

Tests: new `VBPretty/ParameterizedProperties` fixture (interface + implicit/explicit implementation, static, read-only, attributed, virtual/override, overloaded, and renamed-`Implements` properties -- the last generating the same explicit-interface-implementation forwarder stubs as the ordinary method path -- plus consuming code), green across all 12 VB compiler configurations on Linux; `ILPretty/Issue1325` expectation updated from the old uncompilable output; full decompiler suite green (2517 passed / 0 failed / 38 skipped).

This PR was prepared by an AI agent (Claude) on behalf of @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
