### PR TITLE
Fix #633: Overrides analysis and this/base keyword navigation

### DIFF
--- a/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
+++ b/ICSharpCode.Decompiler/Output/TextTokenWriter.cs
@@ -283,6 +283,17 @@ namespace ICSharpCode.Decompiler
 					output.WriteReference(member, keyword);
 					return;
 				}
+				// As primary expressions, 'this' and 'base' reference the current and the
+				// base type respectively, matching IDE go-to-definition behavior.
+				if (nodeStack.Peek() is ThisReferenceExpression or BaseReferenceExpression)
+				{
+					var type = ((Expression)nodeStack.Peek()).GetResolveResult().Type;
+					if (type.Kind != TypeKind.Unknown)
+					{
+						output.WriteReference(type, keyword);
+						return;
+					}
+				}
 			}
 			// Make the 'override' modifier a reference to the nearest overridden member,
 			// so that go-to-definition on 'override' navigates to the base member.

--- a/ICSharpCode.ILSpyX/Analyzers/Builtin/MemberOverridesAnalyzer.cs
+++ b/ICSharpCode.ILSpyX/Analyzers/Builtin/MemberOverridesAnalyzer.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Composition;
+using System.Diagnostics;
+
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ICSharpCode.ILSpyX.Analyzers.Builtin
+{
+	/// <summary>
+	/// Shows the base members overridden by a member; the dual of the "Overridden By" analysis.
+	/// </summary>
+	[ExportAnalyzer(Header = "Overrides", Order = 35)]
+	[Shared]
+	class MemberOverridesAnalyzer : IAnalyzer
+	{
+		public IEnumerable<ISymbol> Analyze(ISymbol analyzedSymbol, AnalyzerContext context)
+		{
+			Debug.Assert(analyzedSymbol is IMember);
+			var member = (IMember)analyzedSymbol;
+			// Walk the override chain member by member instead of collecting all
+			// signature-equal base members: this stops at 'new virtual' shadow
+			// boundaries, which hide any further base members from overriding.
+			var visitedMembers = new HashSet<IMember>();
+			while (member.IsOverride)
+			{
+				member = member.MemberDefinition;
+				if (!visitedMembers.Add(member))
+				{
+					// abort if we seem to be in an infinite loop (cyclic inheritance)
+					break;
+				}
+				var baseMember = InheritanceHelper.GetBaseMember(member);
+				if (baseMember == null)
+					break;
+				yield return baseMember;
+				member = baseMember;
+			}
+		}
+
+		public bool Show(ISymbol? symbol)
+		{
+			switch (symbol?.SymbolKind)
+			{
+				case SymbolKind.Event:
+				case SymbolKind.Indexer:
+				case SymbolKind.Method:
+				case SymbolKind.Property:
+					return ((IMember)symbol).IsOverride;
+
+				default:
+					return false;
+			}
+		}
+	}
+}

--- a/ILSpy.Tests/Analyzers/Library/MemberOverridesAnalyzerTests.cs
+++ b/ILSpy.Tests/Analyzers/Library/MemberOverridesAnalyzerTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.Decompiler.TypeSystem.Implementation;
+using ICSharpCode.ILSpyX;
+using ICSharpCode.ILSpyX.Analyzers;
+using ICSharpCode.ILSpyX.Analyzers.Builtin;
+
+using ICSharpCode.ILSpy.Languages;
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.Analyzers.Library;
+
+[TestFixture]
+public class MemberOverridesAnalyzerTests
+{
+	static readonly SymbolKind[] ValidSymbolKinds = { SymbolKind.Event, SymbolKind.Indexer, SymbolKind.Method, SymbolKind.Property };
+	static readonly SymbolKind[] InvalidSymbolKinds =
+		Enum.GetValues(typeof(SymbolKind)).Cast<SymbolKind>().Except(ValidSymbolKinds).ToArray();
+
+	ICompilation testAssembly = null!;
+
+	[OneTimeSetUp]
+	public void Setup()
+	{
+		var fileName = GetType().Assembly.Location;
+		using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+		var module = new PEFile(fileName, stream, PEStreamOptions.PrefetchEntireImage, MetadataReaderOptions.None);
+		testAssembly = new SimpleCompilation(module.WithOptions(TypeSystemOptions.Default), MinimalCorlib.Instance);
+	}
+
+	[Test]
+	public void VerifyDoesNotShowForNoSymbol()
+	{
+		var analyzer = new MemberOverridesAnalyzer();
+		var shouldShow = analyzer.Show(symbol: null!);
+		Assert.That(!shouldShow, "The analyzer will be unexpectedly shown for no symbol");
+	}
+
+	[Test]
+	[TestCaseSource(nameof(InvalidSymbolKinds))]
+	public void VerifyDoesNotShowForNonMembers(SymbolKind symbolKind)
+	{
+		var symbolMock = Substitute.For<ISymbol>();
+		symbolMock.SymbolKind.Returns(symbolKind);
+		var analyzer = new MemberOverridesAnalyzer();
+		var shouldShow = analyzer.Show(symbolMock);
+		Assert.That(!shouldShow, $"The analyzer will be unexpectedly shown for symbol '{symbolKind}'");
+	}
+
+	[Test]
+	[TestCaseSource(nameof(ValidSymbolKinds))]
+	public void VerifyDoesNotShowForNonOverrideMembers(SymbolKind symbolKind)
+	{
+		var memberMock = SetupMemberMock(symbolKind, isOverride: false);
+		var analyzer = new MemberOverridesAnalyzer();
+		var shouldShow = analyzer.Show(memberMock);
+		Assert.That(!shouldShow, $"The analyzer will be unexpectedly shown for non-override symbol '{symbolKind}'");
+	}
+
+	[Test]
+	[TestCaseSource(nameof(ValidSymbolKinds))]
+	public void VerifyShowsForOverrideMembers(SymbolKind symbolKind)
+	{
+		var memberMock = SetupMemberMock(symbolKind, isOverride: true);
+		var analyzer = new MemberOverridesAnalyzer();
+		var shouldShow = analyzer.Show(memberMock);
+		Assert.That(shouldShow, $"The analyzer will not be shown for override symbol '{symbolKind}'");
+	}
+
+	[Test]
+	public void VerifyReturnsAllOverriddenBaseMembers()
+	{
+		var symbol = SetupMethodForAnalysis(typeof(LeafClass), nameof(LeafClass.TestMethod));
+		var analyzer = new MemberOverridesAnalyzer();
+
+		var results = analyzer.Analyze(symbol, CreateContext()).OfType<IMethod>().ToList();
+
+		// The analyzer walks the override chain nearest-base-first; the order is what
+		// the analyzer panel displays, so assert it.
+		Assert.That(results.Select(r => r.DeclaringTypeDefinition!.Name),
+			Is.EqualTo(new[] { nameof(MiddleClass), nameof(GrandBaseClass) }));
+	}
+
+	[Test]
+	public void VerifyDoesNotReturnInterfaceMembers()
+	{
+		// Interface members are the "Implements" analysis; "Overrides" only walks base classes.
+		var symbol = SetupMethodForAnalysis(typeof(LeafClass), nameof(LeafClass.TestMethod));
+		var analyzer = new MemberOverridesAnalyzer();
+
+		var results = analyzer.Analyze(symbol, CreateContext()).OfType<IMethod>().ToList();
+
+		Assert.That(results.Select(r => r.DeclaringTypeDefinition!.Kind),
+			Has.All.Not.EqualTo(TypeKind.Interface));
+	}
+
+	[Test]
+	public void VerifyReturnsOverriddenProperty()
+	{
+		var typeDefinition = testAssembly.FindType(typeof(LeafClass)).GetDefinition();
+		var symbol = typeDefinition!.Properties.First(p => p.Name == nameof(LeafClass.TestProperty));
+		var analyzer = new MemberOverridesAnalyzer();
+
+		var results = analyzer.Analyze(symbol, CreateContext()).OfType<IProperty>().ToList();
+
+		Assert.That(results.Select(r => r.DeclaringTypeDefinition!.Name),
+			Is.EquivalentTo(new[] { nameof(GrandBaseClass) }));
+	}
+
+	[Test]
+	public void VerifyDoesNotReturnShadowedNonVirtualMembers()
+	{
+		// ShadowBase.ShadowedMethod is unrelated to the override chain that starts
+		// at ShadowMiddle's 'new virtual' declaration; it must not appear.
+		var symbol = SetupMethodForAnalysis(typeof(ShadowLeaf), nameof(ShadowLeaf.ShadowedMethod));
+		var analyzer = new MemberOverridesAnalyzer();
+
+		var results = analyzer.Analyze(symbol, CreateContext()).OfType<IMethod>().ToList();
+
+		Assert.That(results.Select(r => r.DeclaringTypeDefinition!.Name),
+			Is.EquivalentTo(new[] { nameof(ShadowMiddle) }));
+	}
+
+	static AnalyzerContext CreateContext()
+	{
+		return new AnalyzerContext {
+			AssemblyList = new AssemblyList(),
+			Language = new CSharpLanguage(),
+		};
+	}
+
+	ISymbol SetupMethodForAnalysis(Type type, string methodName)
+	{
+		var typeDefinition = testAssembly.FindType(type).GetDefinition();
+		return typeDefinition!.Methods.First(m => m.Name == methodName);
+	}
+
+	static IMember SetupMemberMock(SymbolKind symbolKind, bool isOverride)
+	{
+		var memberMock = Substitute.For<IMember>();
+		memberMock.SymbolKind.Returns(symbolKind);
+		memberMock.IsOverride.Returns(isOverride);
+		return memberMock;
+	}
+
+	interface ITestInterface
+	{
+		void TestMethod();
+	}
+
+	class GrandBaseClass
+	{
+		public virtual void TestMethod() => throw new NotImplementedException();
+		public virtual int TestProperty => throw new NotImplementedException();
+	}
+
+	class MiddleClass : GrandBaseClass
+	{
+		public override void TestMethod() => throw new NotImplementedException();
+	}
+
+	class LeafClass : MiddleClass, ITestInterface
+	{
+		public override void TestMethod() => throw new NotImplementedException();
+		public override int TestProperty => throw new NotImplementedException();
+	}
+
+	class ShadowBase
+	{
+		public void ShadowedMethod() => throw new NotImplementedException();
+	}
+
+	class ShadowMiddle : ShadowBase
+	{
+		public new virtual void ShadowedMethod() => throw new NotImplementedException();
+	}
+
+	class ShadowLeaf : ShadowMiddle
+	{
+		public override void ShadowedMethod() => throw new NotImplementedException();
+	}
+}

--- a/ILSpy.Tests/TextView/KeywordReferenceTests.cs
+++ b/ILSpy.Tests/TextView/KeywordReferenceTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using ICSharpCode.ILSpy.TextView;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// Pins which keywords the C# output links as navigable references:
+/// 'this' and 'base' primary expressions reference the current and base type,
+/// and the 'override' modifier references the overridden base member.
+/// </summary>
+[TestFixture]
+public class KeywordReferenceTests
+{
+	AvaloniaEditTextOutput output = null!;
+	string text = null!;
+
+	[OneTimeSetUp]
+	public void Setup()
+	{
+		var fileName = GetType().Assembly.Location;
+		var decompiler = new CSharpDecompiler(fileName, new DecompilerSettings());
+		var syntaxTree = decompiler.DecompileType(new FullTypeName(typeof(KeywordDerived).FullName!));
+		syntaxTree.AcceptVisitor(new InsertParenthesesVisitor { InsertParenthesesForReadability = true });
+		var settings = new DecompilerSettings();
+		output = new AvaloniaEditTextOutput();
+		var tokenWriter = new ICSharpCode.Decompiler.TextTokenWriter(output, settings);
+		syntaxTree.AcceptVisitor(new CSharpOutputVisitor(tokenWriter, settings.CSharpFormattingOptions));
+		text = output.GetText();
+	}
+
+	[Test]
+	public void BaseKeywordReferencesTheBaseType()
+	{
+		var reference = ReferencesFor("base").Select(r => r.Reference).OfType<IType>().FirstOrDefault();
+		Assert.That(reference, Is.Not.Null, "the 'base' keyword must carry a type reference");
+		Assert.That(reference!.Name, Is.EqualTo(nameof(KeywordBase)));
+	}
+
+	[Test]
+	public void ThisKeywordReferencesTheCurrentType()
+	{
+		var reference = ReferencesFor("this").Select(r => r.Reference).OfType<IType>().FirstOrDefault();
+		Assert.That(reference, Is.Not.Null, "the 'this' keyword must carry a type reference");
+		Assert.That(reference!.Name, Is.EqualTo(nameof(KeywordDerived)));
+	}
+
+	[Test]
+	public void OverrideModifierReferencesTheOverriddenMember()
+	{
+		var reference = ReferencesFor("override").Select(r => r.Reference).OfType<IMember>().FirstOrDefault();
+		Assert.That(reference, Is.Not.Null, "the 'override' modifier must carry a member reference");
+		Assert.That(reference!.DeclaringTypeDefinition!.Name, Is.EqualTo(nameof(KeywordBase)));
+	}
+
+	System.Collections.Generic.IEnumerable<ReferenceSegment> ReferencesFor(string keyword)
+	{
+		return output.References.Where(r => text.Substring(r.StartOffset, r.Length) == keyword);
+	}
+}
+
+public class KeywordBase
+{
+	public virtual void TestMethod() => throw new NotImplementedException();
+}
+
+public class KeywordDerived : KeywordBase
+{
+	public int TestField;
+
+	public override void TestMethod()
+	{
+		base.TestMethod();
+	}
+
+	public void Assign(int TestField)
+	{
+		this.TestField = TestField;
+	}
+}


### PR DESCRIPTION
Fixes #633.

Two commits, covering the remaining parts of the issue:

**1. "Overrides" analyzer** — the dual of "Overridden By": for an override method/property/event/indexer, the analyzer panel now shows the base members it overrides. The upward interface direction already exists as the "Implements" analysis, so this adds only the base-class direction. The analyzer walks the override chain member by member via `InheritanceHelper.GetBaseMember` instead of collecting all signature-equal base members, so it stops at `new virtual` shadow boundaries, which hide any further base members from overriding. No assembly-scope scan is needed; the walk is a direct type-system lookup. Tests mirror the `MemberImplementsInterfaceAnalyzerTests` pattern, including a shadowing case.

**2. `this`/`base` keyword navigation** — as primary expressions, `this` now references the current type and `base` the base type, matching IDE go-to-definition behavior (both directions together deliberately; linking only `base` would make the two keywords inconsistent). The `override` modifier already navigated to the overridden member and constructor initializers already linked `this`/`base` to the invoked constructor; new `KeywordReferenceTests` pin all three behaviors.

Of the issue's four points this delivers the analysis (1) and completes keyword navigation (2, 3); the last point (clicking a declaration selects the whole override chain in the tree) overlaps #819's target-picker idea and is intentionally left out.

Verified: ILSpy.Tests 1099 total / 0 failed / 3 skipped; decompiler suite 2544 total / 0 failed / 38 skipped; XPlat solution filter builds clean.

🤖 This PR was prepared by an AI agent (Claude Code) operated by @siegfriedpammer.