### PR TITLE
Fix #1142: recover enum members for out-of-range constant operands

### DIFF
--- a/ICSharpCode.Decompiler.Tests/DisassemblerPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/DisassemblerPrettyTestRunner.cs
@@ -53,6 +53,17 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task NegativeConstants()
+		{
+			await Run();
+			// CodeAssert ignores comments, so pin the hexadecimal rendering explicitly.
+			string result = File.ReadAllText(Path.Combine(TestCasePath, nameof(NegativeConstants) + ".result.il"));
+			Assert.That(result, Does.Contain("ldc.i4 -501 // 0xfffffe0b"));
+			Assert.That(result, Does.Contain("ldc.i8 -2 // 0xfffffffffffffffe"));
+			Assert.That(result, Does.Contain("ldc.i4 300\r\n").Or.Contain("ldc.i4 300\n"));
+		}
+
+		[Test]
 		public async Task GenericConstraints()
 		{
 			await Run();

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -98,6 +98,7 @@
     <None Include="TestCases\Correctness\StackTypes.il" />
     <None Include="TestCases\Correctness\Uninit.vb" />
     <None Include="TestCases\Disassembler\Pretty\GenericConstraints.il" />
+    <None Include="TestCases\Disassembler\Pretty\NegativeConstants.il" />
     <None Include="TestCases\Disassembler\Pretty\InterfaceImplAttributes.il" />
     <None Include="TestCases\Disassembler\Pretty\SortMembers.expected.il" />
     <None Include="TestCases\Disassembler\Pretty\SortMembers.il" />

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -126,6 +126,7 @@
     <None Include="TestCases\ILPretty\Issue2104.il" />
     <None Include="TestCases\ILPretty\Issue3421.il" />
     <None Include="TestCases\ILPretty\WeirdEnums.il" />
+    <None Include="TestCases\ILPretty\EnumArithmeticOutOfRange.il" />
     <None Include="TestCases\ILPretty\ConstantBlobs.il" />
     <None Include="TestCases\ILPretty\CS1xSwitch_Debug.il" />
     <None Include="TestCases\ILPretty\CS1xSwitch_Release.il" />
@@ -199,6 +200,8 @@
     <Compile Remove="TestCases\ILPretty\InstanceOperatorCall.cs" />
     <None Include="TestCases\ILPretty\InstanceOperatorCall.cs" />
     <None Include="TestCases\ILPretty\InstanceOperatorCall.il" />
+    <Compile Remove="TestCases\ILPretty\EnumArithmeticOutOfRange.cs" />
+    <None Include="TestCases\ILPretty\EnumArithmeticOutOfRange.cs" />
     <Compile Remove="TestCases\ILPretty\EmptyBodies.cs" />
     <None Include="TestCases\ILPretty\EmptyBodies.cs" />
     <Compile Remove="TestCases\ILPretty\TruncatedAccessorBody.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -360,6 +360,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task EnumArithmeticOutOfRange()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task GuessAccessors()
 		{
 			await Run();

--- a/ICSharpCode.Decompiler.Tests/TestCases/Disassembler/Pretty/NegativeConstants.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Disassembler/Pretty/NegativeConstants.il
@@ -1,0 +1,45 @@
+.assembly extern mscorlib
+{
+	.publickeytoken = (
+		b7 7a 5c 56 19 34 e0 89
+	)
+	.ver 4:0:0:0
+}
+.assembly NegativeConstants
+{
+	.ver 1:0:0:0
+}
+
+.module NegativeConstants.dll
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003 // WindowsCui
+.corflags 0x00000001 // ILOnly
+
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class public auto ansi abstract sealed beforefieldinit NegativeConstants
+	extends [mscorlib]System.Object
+{
+	// Methods
+	.method public hidebysig static 
+		int32 Constants () cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 1
+		// Code size: 22 (0x16)
+		.maxstack 8
+
+		IL_0000: ldc.i4 -501 // 0xfffffe0b
+		IL_0005: ldc.i4 300
+		IL_000a: add
+		IL_000b: conv.i8
+		IL_000c: ldc.i8 -2 // 0xfffffffffffffffe
+		IL_0015: ret
+	} // end of method NegativeConstants::Constants
+
+} // end of class NegativeConstants
+

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EnumArithmeticOutOfRange.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EnumArithmeticOutOfRange.cs
@@ -1,0 +1,22 @@
+// The constants are out of range for the enums' underlying types, so they must not be
+// recovered as the members whose bit patterns they happen to truncate to (Val1 in both
+// cases): the enum arithmetic would compute a different result than the IL does.
+public enum ByteEnum : byte
+{
+	Val1 = 112
+}
+public static class EnumArithmeticOutOfRange
+{
+	public static int SubtractFromUShortEnum(UShortEnum value)
+	{
+		return (int)value - -501;
+	}
+	public static int SubtractFromByteEnum(ByteEnum value)
+	{
+		return (int)value - 70000;
+	}
+}
+public enum UShortEnum : ushort
+{
+	Val1 = 65035
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EnumArithmeticOutOfRange.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/EnumArithmeticOutOfRange.il
@@ -1,0 +1,50 @@
+#define CORE_ASSEMBLY "System.Runtime"
+
+.assembly extern CORE_ASSEMBLY
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 4:0:0:0
+}
+
+// The constant operands below are out of range for the enums' underlying types, but their
+// low bits do match a member: -501 truncates to UShortEnum.Val1 (0xfe0b) and 70000 to
+// ByteEnum.Val1 (0x70). Reinterpreting them as those members would change the result of the
+// subtraction, so the decompiler has to keep the integer arithmetic.
+
+.class public auto ansi sealed UShortEnum
+    extends [CORE_ASSEMBLY]System.Enum
+{
+    .field public specialname rtspecialname uint16 value__
+    .field public static literal valuetype UShortEnum Val1 = uint16(0xfe0b)
+}
+
+.class public auto ansi sealed ByteEnum
+    extends [CORE_ASSEMBLY]System.Enum
+{
+    .field public specialname rtspecialname uint8 value__
+    .field public static literal valuetype ByteEnum Val1 = uint8(0x70)
+}
+
+.class public auto ansi abstract sealed beforefieldinit EnumArithmeticOutOfRange
+    extends [CORE_ASSEMBLY]System.Object
+{
+    .method public hidebysig static int32 SubtractFromUShortEnum (valuetype UShortEnum 'value') cil managed
+    {
+        .maxstack 8
+
+        ldarg.0
+        ldc.i4 -501
+        sub
+        ret
+    }
+
+    .method public hidebysig static int32 SubtractFromByteEnum (valuetype ByteEnum 'value') cil managed
+    {
+        .maxstack 8
+
+        ldarg.0
+        ldc.i4 70000
+        sub
+        ret
+    }
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TypeAnalysisTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TypeAnalysisTests.cs
@@ -245,6 +245,39 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return byteArray[(ushort)i];
 		}
 
+		public void EnumSubtractionWithHighBitValues(UIntEnum value)
+		{
+			if (value - UIntEnum.Val1 <= 4)
+			{
+				Console.WriteLine(value - UIntEnum.Val1);
+			}
+		}
+
+		public void EnumSubtractionWithHighBitValues16(UShortEnum value)
+		{
+			// A 16-bit enum member always fits its underlying type as a positive constant,
+			// so the compiler emits it as such and enum-minus-underlying resolves right away.
+			if ((int)(value - 65035) <= 4)
+			{
+				Console.WriteLine((int)(value - 65035));
+			}
+		}
+
+		public void EnumSubtractionWithHighBitValues64(ULongEnum value)
+		{
+			if (value - ULongEnum.Val1 <= 4)
+			{
+				Console.WriteLine(value - ULongEnum.Val1);
+			}
+		}
+
+		public void EnumSubtractionWithZeroExtendedValue(ULongEnum value)
+		{
+			// Val3 is emitted as a zero-extended uint constant (ldc.i4.m1 + conv.u8), so it
+			// must not be reinterpreted as the sign-extended long -1.
+			Console.WriteLine((ulong)(value - uint.MaxValue));
+		}
+
 		public StringComparison EnumDiffNumber(StringComparison data)
 		{
 			return data - 1;
@@ -344,5 +377,24 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return (int)a == 0;
 		}
+	}
+
+	public enum UIntEnum : uint
+	{
+		Val1 = 4294966795u,
+		Val2 = 4294966799u
+	}
+
+	public enum ULongEnum : ulong
+	{
+		Val1 = 18446744073709551115uL,
+		Val2 = 18446744073709551119uL,
+		Val3 = 4294967295uL
+	}
+
+	public enum UShortEnum : ushort
+	{
+		Val1 = 65035,
+		Val2 = 65039
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -1709,6 +1709,26 @@ namespace ICSharpCode.Decompiler.CSharp
 			}
 
 			var rr = resolverWithOverflowCheck.ResolveBinaryOperator(op, left.ResolveResult, right.ResolveResult);
+			if ((rr.IsError || NullableType.GetUnderlyingType(rr.Type).GetStackType() != inst.UnderlyingResultType
+				|| !IsCompatibleWithSign(rr.Type, inst.Sign))
+				&& op is BinaryOperatorType.Add or BinaryOperatorType.Subtract
+				&& (left.Type.Kind == TypeKind.Enum || right.Type.Kind == TypeKind.Enum))
+			{
+				// enum +/- constant did not resolve (e.g. an int constant whose numeric value
+				// does not fit the unsigned underlying type, issue #1142); the IL constant is
+				// the enum's bit pattern, so retry with it reinterpreted in the enum type
+				// before falling back to integer arithmetic with casts.
+				var adjustedLeft = AdjustConstantExpressionToType(left, right.Type);
+				var adjustedRight = AdjustConstantExpressionToType(right, left.Type);
+				var adjustedRR = resolverWithOverflowCheck.ResolveBinaryOperator(op, adjustedLeft.ResolveResult, adjustedRight.ResolveResult);
+				if (!(adjustedRR.IsError || NullableType.GetUnderlyingType(adjustedRR.Type).GetStackType() != inst.UnderlyingResultType
+					|| !IsCompatibleWithSign(adjustedRR.Type, inst.Sign)))
+				{
+					left = adjustedLeft;
+					right = adjustedRight;
+					rr = adjustedRR;
+				}
+			}
 			if (rr.IsError || NullableType.GetUnderlyingType(rr.Type).GetStackType() != inst.UnderlyingResultType
 				|| !IsCompatibleWithSign(rr.Type, inst.Sign))
 			{
@@ -4003,7 +4023,13 @@ namespace ICSharpCode.Decompiler.CSharp
 			}
 			else if (typeHint.Kind == TypeKind.Enum || typeHint.IsKnownType(KnownTypeCode.Char) || typeHint.IsCSharpSmallIntegerType())
 			{
-				var castRR = resolver.WithCheckForOverflow(true).ResolveCast(typeHint, rr);
+				// An IL constant is a bit pattern: converting it to an integer type at least as
+				// wide only reinterprets it, which is lossless even where the numeric value
+				// changes sign (e.g. int -501 for a uint-based enum member 0xfffffe0b, or for a
+				// ulong-based one where the IL sign-extends it with conv.i8). Only narrowing can
+				// lose information, so limit the overflow check to that case.
+				bool mayBeLossy = !rr.Type.GetStackType().IsIntegerType() || rr.Type.GetSize() > typeHint.GetSize();
+				var castRR = resolver.WithCheckForOverflow(mayBeLossy).ResolveCast(typeHint, rr);
 				if (castRR.IsCompileTimeConstant && !castRR.IsError)
 				{
 					rr = castRR;

--- a/ICSharpCode.Decompiler/Disassembler/MethodBodyDisassembler.cs
+++ b/ICSharpCode.Decompiler/Disassembler/MethodBodyDisassembler.cs
@@ -422,11 +422,23 @@ namespace ICSharpCode.Decompiler.Disassembler
 						break;
 					case OperandType.I:
 						output.Write(' ');
-						DisassemblerHelpers.WriteOperand(output, blob.ReadInt32());
+						int operand32 = blob.ReadInt32();
+						DisassemblerHelpers.WriteOperand(output, operand32);
+						if (operand32 < 0)
+						{
+							// A negative operand is usually the two's-complement rendering of a bit
+							// mask or high unsigned constant; show the hexadecimal form alongside.
+							output.Write($" // 0x{unchecked((uint)operand32):x8}");
+						}
 						break;
 					case OperandType.I8:
 						output.Write(' ');
-						DisassemblerHelpers.WriteOperand(output, blob.ReadInt64());
+						long operand64 = blob.ReadInt64();
+						DisassemblerHelpers.WriteOperand(output, operand64);
+						if (operand64 < 0)
+						{
+							output.Write($" // 0x{unchecked((ulong)operand64):x16}");
+						}
 						break;
 					case OperandType.ShortR:
 						output.Write(' ');


### PR DESCRIPTION
Fixes #1142.

**Commit 1 -- the decompiler fix.** Addition/subtraction on an enum whose constant operand's numeric value does not fit the underlying type (an `int` constant standing for a high `uint` member: `ldc.i4 -501` for `0xfffffe0b`) failed to resolve as enum arithmetic and fell back to integer arithmetic with casts. The same source expression could even render two different ways in one method, depending on context:

```csharp
// before
if ((uint)((int)myEnum - -501) <= 4u)
{
    Console.WriteLine((uint)myEnum - 4294966795u);
}

// after
if (myEnum - MyEnum.Val1 <= 4)
{
    Console.WriteLine(myEnum - MyEnum.Val1);
}
```

Mechanics: when the plain binary-operator resolution fails its validity check, `HandleBinaryNumeric` retries once with constant operands reinterpreted in the enum type, keeping the adjusted form only if it passes the same check; `AdjustConstantToType` gains an unchecked-cast fallback for enum targets, valid because the reinterpretation is lossless whenever the constant's stack type matches the enum's underlying stack type (the IL constant *is* the member's bit pattern). Deliberately a fallback stage and not a pre-adjustment: an eager variant rewrote valid `data - 1` (enum minus underlying, yielding the enum -- see `EnumDiffNumber` in `TypeAnalysisTests`) into nonsense like `data - StringComparison.CurrentCultureIgnoreCase`. The new fixture methods were verified red before the fix (producing exactly the broken output above).

**Commit 2 -- the IL-view nicety from the issue discussion.** Negative `ldc.i4`/`ldc.i8` operands now carry their hexadecimal form as a comment, `ldc.i4 -501 // 0xfffffe0b` (dotPeek parity). Short forms (`ldc.i4.s`) stay bare -- their range is readable. Because the disassembler round-trip comparer strips comments, the new `Disassembler/Pretty/NegativeConstants` test pins the rendering with explicit content asserts.

Not addressed (separable style question): printing large unsigned constants as hex outside bitwise contexts (`return 4294966795u;` vs `0xFFFFFE0B`) -- the existing `ShouldDisplayAsHex` heuristic is bitwise-only and widening it is a taste decision.

Full decompiler suite green on Linux (2507 passed / 0 failed / 38 skipped).

This PR was prepared by an AI agent (Claude) on behalf of @siegfriedpammer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)