### PR TITLE
Fix #781: click highlights member references, Ctrl+Click navigates

### DIFF
--- a/ILSpy.Tests/Editor/AreSameReferenceTests.cs
+++ b/ILSpy.Tests/Editor/AreSameReferenceTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.ILSpy.TextView;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+[TestFixture]
+public class AreSameReferenceTests
+{
+	static DecompilerTypeSystem typeSystem = null!;
+
+	[OneTimeSetUp]
+	public void LoadTypeSystem()
+	{
+		var file = new PEFile(typeof(AreSameReferenceTests).Assembly.Location);
+		var resolver = new UniversalAssemblyResolver(file.FileName, throwOnError: false, file.DetectTargetFrameworkId());
+		typeSystem = new DecompilerTypeSystem(file, resolver);
+	}
+
+	[Test]
+	public void GeneratedMembersWithoutMetadataTokensAreNotConflated()
+	{
+		// Generated members have a nil MetadataToken; two distinct ones from the same
+		// module must not be treated as the same reference by the token comparison.
+		var a = new NilTokenMember(typeSystem.MainModule);
+		var b = new NilTokenMember(typeSystem.MainModule);
+
+		Assert.That(DecompilerTextView.AreSameReference(a, b), Is.False);
+		Assert.That(DecompilerTextView.AreSameReference(a, a), Is.True);
+	}
+
+	[Test]
+	public void MembersWithRealTokensStillCompareByDefinition()
+	{
+		var type = typeSystem.MainModule.Compilation.FindType(new FullTypeName(typeof(AreSameReferenceTests).FullName!)).GetDefinition()!;
+		var method = type.GetMethods(m => m.Name == nameof(GeneratedMembersWithoutMetadataTokensAreNotConflated)).Single();
+		var other = type.GetMethods(m => m.Name == nameof(MembersWithRealTokensStillCompareByDefinition)).Single();
+
+		Assert.That(DecompilerTextView.AreSameReference(method, method.MemberDefinition), Is.True);
+		Assert.That(DecompilerTextView.AreSameReference(method, other), Is.False);
+	}
+
+	// A minimal stand-in for a type-system-generated member: nil token, real module.
+	sealed class NilTokenMember(IModule module) : IMember
+	{
+		public EntityHandle MetadataToken => default;
+		public IMember MemberDefinition => this;
+		public IModule ParentModule => module;
+		public SymbolKind SymbolKind => SymbolKind.Method;
+		public string Name => "Generated";
+		public string FullName => Name;
+		public string Namespace => string.Empty;
+		public string ReflectionName => Name;
+		public ICompilation Compilation => module.Compilation;
+		public bool Equals(IMember? obj, TypeVisitor typeNormalization) => ReferenceEquals(this, obj);
+
+		public IType ReturnType => throw new NotImplementedException();
+		public IEnumerable<IMember> ExplicitlyImplementedInterfaceMembers => throw new NotImplementedException();
+		public bool IsExplicitInterfaceImplementation => false;
+		public bool IsVirtual => false;
+		public bool IsOverride => false;
+		public bool IsOverridable => false;
+		public TypeParameterSubstitution Substitution => TypeParameterSubstitution.Identity;
+		public IMember Specialize(TypeParameterSubstitution substitution) => throw new NotImplementedException();
+		public ITypeDefinition? DeclaringTypeDefinition => null;
+		public IType DeclaringType => null!;
+		public Accessibility Accessibility => Accessibility.Public;
+		public bool IsStatic => false;
+		public bool IsAbstract => false;
+		public bool IsSealed => false;
+		public IEnumerable<IAttribute> GetAttributes() => throw new NotImplementedException();
+		public bool HasAttribute(KnownAttribute attribute) => false;
+		public IAttribute? GetAttribute(KnownAttribute attribute) => null;
+	}
+}

--- a/ILSpy.Tests/Editor/MemberReferenceHighlightTests.cs
+++ b/ILSpy.Tests/Editor/MemberReferenceHighlightTests.cs
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+
+using AvaloniaEdit;
+using AvaloniaEdit.Rendering;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.TextView;
+using ICSharpCode.ILSpy.TreeNodes;
+using ICSharpCode.ILSpy.ViewModels;
+using ICSharpCode.ILSpy.Views;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// Sample type decompiled by <see cref="MemberReferenceHighlightTests"/>: a field with
+/// multiple uses, a generic method whose call site carries a specialized instance while
+/// the declaration carries the definition, and two differently-parameterized uses of the
+/// same generic type.
+/// </summary>
+public class MemberHighlightSample
+{
+	public int Field;
+	public List<int>? Other;
+
+	public List<T> Make<T>(T item)
+	{
+		return new List<T> { item };
+	}
+
+	public int UseAll()
+	{
+		Field = 1;
+		Other = Make(2);
+		return Field + Other.Count;
+	}
+}
+
+/// <summary>
+/// Pins the member click-highlight behavior (issue #781): with the setting enabled, a
+/// single click on a member or type reference highlights all its occurrences in the view
+/// and Ctrl+Click navigates; with the setting disabled (the default), plain click keeps
+/// navigating.
+/// </summary>
+[TestFixture]
+public class MemberReferenceHighlightTests
+{
+	static async Task<(MainWindow Window, DecompilerTextView View, DecompilerTabPageModel Tab)> SetupAsync(bool highlightMemberReferences)
+	{
+		var (window, vm) = await TestHarness.BootAsync();
+		AppComposition.Current.GetExport<SettingsService>().DisplaySettings.HighlightMemberReferences = highlightMemberReferences;
+		await vm.OpenAssemblyAsync(typeof(MemberHighlightSample).Assembly.Location);
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"ILSpy.Tests",
+			"ICSharpCode.ILSpy.Tests.TextView",
+			"ICSharpCode.ILSpy.Tests.TextView.MemberHighlightSample");
+		vm.AssemblyTreeModel.SelectNode(typeNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		var view = window.GetVisualDescendants().OfType<DecompilerTextView>().First();
+		return (window, view, tab);
+	}
+
+	static List<ReferenceSegment> SegmentsOf(DecompilerTabPageModel tab, string memberName)
+	{
+		return tab.References!
+			.Where(r => r.Kind == ReferenceMode.Link && r.Reference is IMember m && m.Name == memberName)
+			.ToList();
+	}
+
+	[AvaloniaTest]
+	public async Task Clicking_A_Member_Navigates_When_The_Setting_Is_Off()
+	{
+		var (_, view, tab) = await SetupAsync(highlightMemberReferences: false);
+
+		var fieldSegments = SegmentsOf(tab, nameof(MemberHighlightSample.Field));
+		var use = fieldSegments.First(r => !r.IsDefinition);
+		view.OnReferenceClicked(use);
+
+		view.LocalReferenceMarks.Should().BeEmpty(
+			"with the setting off, a plain click must keep navigating instead of highlighting");
+	}
+
+	[AvaloniaTest]
+	public async Task Clicking_A_Member_Highlights_All_Occurrences_When_Enabled()
+	{
+		var (_, view, tab) = await SetupAsync(highlightMemberReferences: true);
+
+		var fieldSegments = SegmentsOf(tab, nameof(MemberHighlightSample.Field));
+		// Besides the definition and the two uses, punctuation tokens of the declaration
+		// carry the member reference as well; all of them belong to the highlight group.
+		fieldSegments.Count(r => r.IsDefinition).Should().Be(1);
+		fieldSegments.Should().HaveCountGreaterThanOrEqualTo(3, "the field has one definition and two uses");
+		bool navigated = false;
+		tab.NavigateRequested += _ => navigated = true;
+
+		var use = fieldSegments.First(r => !r.IsDefinition);
+		view.OnReferenceClicked(use);
+
+		view.LocalReferenceMarks.Select(m => m.StartOffset).Should().BeEquivalentTo(
+			fieldSegments.Select(s => s.StartOffset),
+			"clicking a use must highlight the definition and every use");
+		navigated.Should().BeFalse("a highlighting click must not navigate");
+	}
+
+	[AvaloniaTest]
+	public async Task Highlight_Matches_Specialized_Member_Uses()
+	{
+		var (_, view, tab) = await SetupAsync(highlightMemberReferences: true);
+
+		var makeSegments = SegmentsOf(tab, nameof(MemberHighlightSample.Make));
+		// The identifier segments plus the call parentheses, which carry the member
+		// reference as well.
+		makeSegments.Count(r => r.IsDefinition).Should().Be(1);
+		makeSegments.Should().HaveCountGreaterThanOrEqualTo(2, "the generic method has one definition and one call");
+		// The call site carries a specialized method instance, the declaration the definition.
+		var use = makeSegments.First(r => !r.IsDefinition && r.Length > 1);
+		view.OnReferenceClicked(use);
+
+		view.LocalReferenceMarks.Select(m => m.StartOffset).Should().BeEquivalentTo(
+			makeSegments.Select(s => s.StartOffset),
+			"clicking the specialized call site must also highlight the definition");
+	}
+
+	[AvaloniaTest]
+	public async Task Clicking_A_Type_Highlights_All_Its_Parameterizations()
+	{
+		var (_, view, tab) = await SetupAsync(highlightMemberReferences: true);
+
+		var listTypeSegments = tab.References!
+			.Where(r => r.Kind == ReferenceMode.Link && r.Reference is IType { Name: "List" })
+			.ToList();
+		listTypeSegments.Should().HaveCountGreaterThanOrEqualTo(2,
+			"List<T> and List<int> both occur in the view");
+
+		view.OnReferenceClicked(listTypeSegments[0]);
+
+		view.LocalReferenceMarks.Select(m => m.StartOffset).Should().BeEquivalentTo(
+			listTypeSegments.Select(s => s.StartOffset),
+			"clicking a type reference must highlight all its occurrences regardless of type arguments");
+	}
+
+	[AvaloniaTest]
+	public async Task Ctrl_Click_Navigates_When_Enabled()
+	{
+		var (_, view, tab) = await SetupAsync(highlightMemberReferences: true);
+
+		var fieldSegments = SegmentsOf(tab, nameof(MemberHighlightSample.Field));
+		var use = fieldSegments.First(r => !r.IsDefinition);
+		view.OnReferenceClicked(use, ctrlHeld: true);
+
+		view.LocalReferenceMarks.Should().BeEmpty(
+			"Ctrl+Click must navigate even with the setting enabled");
+	}
+
+	[AvaloniaTest]
+	public async Task Pointer_Click_Highlights_And_Ctrl_Click_Navigates()
+	{
+		// Mirrors ReferenceClickTests.SetupAsync/FindVisibleReference: the System.String
+		// view and its first visible link are the proven coordinate path for pointer
+		// gestures; Stationary_Click_On_A_Link_Navigates pins that this very click
+		// navigates when the setting is off.
+		var (window, vm) = await TestHarness.BootAsync();
+		AppComposition.Current.GetExport<SettingsService>().DisplaySettings.HighlightMemberReferences = true;
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var stringNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(coreLibName, "System", "System.String");
+		vm.AssemblyTreeModel.SelectNode(stringNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		var view = window.GetVisualDescendants().OfType<DecompilerTextView>().First();
+		AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+		Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+		window.UpdateLayout();
+
+		var textView = view.Editor.TextArea.TextView;
+		var segment = tab.References!
+			.First(r => r.Reference != null && r.Kind == ReferenceMode.Link && !r.IsDefinition);
+		var line = view.Editor.Document.GetLineByOffset(segment.StartOffset);
+		view.Editor.ScrollTo(line.LineNumber, segment.StartOffset - line.Offset + 1);
+		window.UpdateLayout();
+		textView.EnsureVisualLines();
+		var position = new TextViewPosition(line.LineNumber, segment.StartOffset - line.Offset + 2);
+		var visual = textView.GetVisualPosition(position, VisualYPosition.LineMiddle) - textView.ScrollOffset;
+		var point = textView.TranslatePoint(visual, window)!.Value;
+
+		bool navigated = false;
+		tab.NavigateRequested += _ => navigated = true;
+
+		window.MouseDown(point, MouseButton.Left);
+		window.MouseUp(point, MouseButton.Left);
+
+		view.LocalReferenceMarks.Should().NotBeEmpty("a plain click must highlight, not navigate");
+		navigated.Should().BeFalse();
+
+		window.MouseDown(point, MouseButton.Left, RawInputModifiers.Control);
+		window.MouseUp(point, MouseButton.Left, RawInputModifiers.Control);
+
+		navigated.Should().BeTrue("Ctrl+Click must navigate to the definition");
+	}
+
+	[AvaloniaTest]
+	public async Task Cursor_Shows_Hand_Only_When_A_Click_Would_Navigate()
+	{
+		var (window, vm) = await TestHarness.BootAsync();
+		AppComposition.Current.GetExport<SettingsService>().DisplaySettings.HighlightMemberReferences = true;
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var stringNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(coreLibName, "System", "System.String");
+		vm.AssemblyTreeModel.SelectNode(stringNode);
+		var tab = await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		var view = window.GetVisualDescendants().OfType<DecompilerTextView>().First();
+		AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+		Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+		window.UpdateLayout();
+
+		var textView = view.Editor.TextArea.TextView;
+		var segment = tab.References!
+			.First(r => r.Reference != null && r.Kind == ReferenceMode.Link && !r.IsDefinition);
+		var line = view.Editor.Document.GetLineByOffset(segment.StartOffset);
+		view.Editor.ScrollTo(line.LineNumber, segment.StartOffset - line.Offset + 1);
+		window.UpdateLayout();
+		textView.EnsureVisualLines();
+		var position = new TextViewPosition(line.LineNumber, segment.StartOffset - line.Offset + 2);
+		var visual = textView.GetVisualPosition(position, VisualYPosition.LineMiddle) - textView.ScrollOffset;
+		var point = textView.TranslatePoint(visual, window)!.Value;
+
+		// Without Ctrl a click highlights, so no hand cursor; with Ctrl it navigates.
+		window.MouseMove(point);
+		textView.Cursor?.ToString().Should().NotBe("Hand",
+			"with the setting enabled, a plain click highlights instead of navigating");
+
+		window.MouseMove(point, RawInputModifiers.Control);
+		textView.Cursor?.ToString().Should().Be("Hand",
+			"holding Ctrl makes the click navigate, so the link affordance must show");
+	}
+
+	[AvaloniaTest]
+	public async Task Clicking_Empty_Space_Clears_The_Member_Highlight()
+	{
+		var (_, view, tab) = await SetupAsync(highlightMemberReferences: true);
+
+		var use = SegmentsOf(tab, nameof(MemberHighlightSample.Field)).First(r => !r.IsDefinition);
+		view.OnReferenceClicked(use);
+		view.LocalReferenceMarks.Should().NotBeEmpty();
+
+		// A subsequent navigating click (Ctrl) on another member clears the previous marks.
+		view.OnReferenceClicked(use, ctrlHeld: true);
+		view.LocalReferenceMarks.Should().BeEmpty();
+	}
+}

--- a/ILSpy/Options/DisplaySettingReactions.cs
+++ b/ILSpy/Options/DisplaySettingReactions.cs
@@ -83,6 +83,8 @@ namespace ICSharpCode.ILSpy.Options
 			[nameof(DisplaySettings.HighlightMatchingBraces)] = DisplaySettingReaction.EditorLive,
 			// The text view shows/hides its own omnibar from this; tree and output are unaffected.
 			[nameof(DisplaySettings.EnableOmnibar)] = DisplaySettingReaction.EditorLive,
+			// Read at click time inside the text view; nothing needs re-decompilation.
+			[nameof(DisplaySettings.HighlightMemberReferences)] = DisplaySettingReaction.EditorLive,
 
 			// No model-side reaction.
 			[nameof(DisplaySettings.StyleWindowTitleBar)] = DisplaySettingReaction.None,

--- a/ILSpy/Options/DisplaySettings.cs
+++ b/ILSpy/Options/DisplaySettings.cs
@@ -102,6 +102,9 @@ namespace ICSharpCode.ILSpy.Options
 		[ObservableProperty]
 		bool enableOmnibar;
 
+		[ObservableProperty]
+		bool highlightMemberReferences;
+
 		public XName SectionName => "DisplaySettings";
 
 		public void LoadFromXml(XElement section)
@@ -129,6 +132,7 @@ namespace ICSharpCode.ILSpy.Options
 			StyleWindowTitleBar = (bool?)section.Attribute(nameof(StyleWindowTitleBar)) ?? false;
 			DecodeCustomAttributeBlobs = (bool?)section.Attribute(nameof(DecodeCustomAttributeBlobs)) ?? false;
 			EnableOmnibar = (bool?)section.Attribute(nameof(EnableOmnibar)) ?? false;
+			HighlightMemberReferences = (bool?)section.Attribute(nameof(HighlightMemberReferences)) ?? false;
 		}
 
 		public XElement SaveToXml()
@@ -157,6 +161,7 @@ namespace ICSharpCode.ILSpy.Options
 			section.SetAttributeValue(nameof(StyleWindowTitleBar), StyleWindowTitleBar);
 			section.SetAttributeValue(nameof(DecodeCustomAttributeBlobs), DecodeCustomAttributeBlobs);
 			section.SetAttributeValue(nameof(EnableOmnibar), EnableOmnibar);
+			section.SetAttributeValue(nameof(HighlightMemberReferences), HighlightMemberReferences);
 			return section;
 		}
 	}

--- a/ILSpy/Options/DisplaySettingsPanel.axaml
+++ b/ILSpy/Options/DisplaySettingsPanel.axaml
@@ -71,6 +71,8 @@
 					          Content="{x:Static res:Resources.HighlightMatchingBraces}" />
 					<CheckBox IsChecked="{Binding Settings.HighlightCurrentLine, Mode=TwoWay}"
 					          Content="{x:Static res:Resources.HighlightCurrentLine}" />
+					<CheckBox IsChecked="{Binding Settings.HighlightMemberReferences, Mode=TwoWay}"
+					          Content="{x:Static res:Resources.HighlightMemberReferences}" />
 					<CheckBox IsChecked="{Binding Settings.ExpandXmlDocumentationComments, Mode=TwoWay}"
 					          Content="{x:Static res:Resources.ExpandXmlDocumentationCommentsAfterDecompilation}" />
 					<CheckBox IsChecked="{Binding Settings.ExpandMemberDefinitions, Mode=TwoWay}"

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -2209,6 +2209,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Single-click highlights member references (Ctrl+Click navigates).
+        /// </summary>
+        public static string HighlightMemberReferences {
+            get {
+                return ResourceManager.GetString("HighlightMemberReferences", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ILSpyAboutPage.txt.
         /// </summary>
         public static string ILSpyAboutPageTxt {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -762,6 +762,9 @@ Are you sure you want to continue?</value>
   <data name="HighlightMatchingBraces" xml:space="preserve">
     <value>Highlight matching braces</value>
   </data>
+  <data name="HighlightMemberReferences" xml:space="preserve">
+    <value>Single-click highlights member references (Ctrl+Click navigates)</value>
+  </data>
   <data name="ILSpyAboutPageTxt" xml:space="preserve">
     <value>ILSpyAboutPage.txt</value>
   </data>

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -185,7 +185,9 @@ namespace ICSharpCode.ILSpy.TextView
 		// with a null target slip through unconditionally otherwise.
 		void SetupElementGenerators()
 		{
-			referenceElementGenerator = new ReferenceElementGenerator(static segment => segment.Reference != null);
+			referenceElementGenerator = new ReferenceElementGenerator(static segment => segment.Reference != null) {
+				QueryCursor = OnReferenceQueryCursor
+			};
 			Editor.TextArea.TextView.ElementGenerators.Add(referenceElementGenerator);
 
 			uiElementGenerator = new UIElementGenerator();
@@ -249,7 +251,7 @@ namespace ICSharpCode.ILSpy.TextView
 			// bubbling further now that it has been consumed as a link click.
 			Editor.TextArea.ClearSelection();
 			e.Handled = true;
-			OnReferenceClicked(segment);
+			OnReferenceClicked(segment, e.KeyModifiers.HasFlag(KeyModifiers.Control));
 		}
 
 		// Background renderers that live for the view's lifetime: the local-reference highlight (marks
@@ -360,13 +362,25 @@ namespace ICSharpCode.ILSpy.TextView
 		{
 			base.OnAttachedToVisualTree(e);
 			ICSharpCode.ILSpy.Themes.ThemeManager.Current.ThemeChanged += OnThemeChangedRebuildHighlighting;
+			// Ctrl toggles between highlight and navigate for reference clicks; listen at the
+			// top level because the keyboard focus is usually elsewhere while hovering.
+			cursorKeyEventSource = global::Avalonia.Controls.TopLevel.GetTopLevel(this);
+			cursorKeyEventSource?.AddHandler(KeyDownEvent, OnTopLevelKeyDownForReferenceCursor, RoutingStrategies.Tunnel, handledEventsToo: true);
+			cursorKeyEventSource?.AddHandler(KeyUpEvent, OnTopLevelKeyUpForReferenceCursor, RoutingStrategies.Tunnel, handledEventsToo: true);
 		}
 
 		protected override void OnDetachedFromVisualTree(global::Avalonia.VisualTreeAttachmentEventArgs e)
 		{
 			ICSharpCode.ILSpy.Themes.ThemeManager.Current.ThemeChanged -= OnThemeChangedRebuildHighlighting;
+			cursorKeyEventSource?.RemoveHandler(KeyDownEvent, OnTopLevelKeyDownForReferenceCursor);
+			cursorKeyEventSource?.RemoveHandler(KeyUpEvent, OnTopLevelKeyUpForReferenceCursor);
+			cursorKeyEventSource = null;
+			cursorQueryElement = null;
+			cursorQuerySegment = null;
 			base.OnDetachedFromVisualTree(e);
 		}
+
+		global::Avalonia.Controls.TopLevel? cursorKeyEventSource;
 
 		// A theme switch re-colours the shared named HighlightingColors in place, but the
 		// semantic RichTextModel cloned them at decompile time (RichTextModel.SetHighlighting
@@ -1197,7 +1211,54 @@ namespace ICSharpCode.ILSpy.TextView
 			return model.References.FindSegmentsContaining(offset).FirstOrDefault();
 		}
 
-		internal void OnReferenceClicked(ReferenceSegment segment)
+		/// <summary>
+		/// True when a plain click on <paramref name="segment"/> paints the occurrence
+		/// highlight instead of navigating: the member-highlight setting is enabled, Ctrl is
+		/// not held, and the reference is a member, type or unresolved entity reference.
+		/// </summary>
+		bool ShouldHighlightInsteadOfNavigate(ReferenceSegment segment, bool ctrlHeld)
+		{
+			return !ctrlHeld
+				&& segment.Kind == ReferenceMode.Link
+				&& currentDisplaySettings is { HighlightMemberReferences: true }
+				&& segment.Reference is IMember or IType or EntityReference;
+		}
+
+		InputElement? cursorQueryElement;
+		ReferenceSegment? cursorQuerySegment;
+
+		void OnReferenceQueryCursor(InputElement element, ReferenceSegment segment, KeyModifiers modifiers)
+		{
+			cursorQueryElement = element;
+			cursorQuerySegment = segment;
+			ApplyReferenceCursor(modifiers.HasFlag(KeyModifiers.Control));
+		}
+
+		// The hand cursor promises navigation: show it only when a click would actually
+		// navigate. Re-evaluated on pointer moves and on Ctrl presses/releases while a
+		// reference is under the pointer.
+		void ApplyReferenceCursor(bool ctrlHeld)
+		{
+			if (cursorQueryElement == null || cursorQuerySegment == null)
+				return;
+			bool navigates = cursorQuerySegment.Kind == ReferenceMode.Link
+				&& !ShouldHighlightInsteadOfNavigate(cursorQuerySegment, ctrlHeld);
+			cursorQueryElement.Cursor = new Cursor(navigates ? StandardCursorType.Hand : StandardCursorType.Arrow);
+		}
+
+		void OnTopLevelKeyDownForReferenceCursor(object? sender, KeyEventArgs e)
+		{
+			if (e.Key is Key.LeftCtrl or Key.RightCtrl)
+				ApplyReferenceCursor(ctrlHeld: true);
+		}
+
+		void OnTopLevelKeyUpForReferenceCursor(object? sender, KeyEventArgs e)
+		{
+			if (e.Key is Key.LeftCtrl or Key.RightCtrl)
+				ApplyReferenceCursor(ctrlHeld: false);
+		}
+
+		internal void OnReferenceClicked(ReferenceSegment segment, bool ctrlHeld = false)
 		{
 			if (DataContext is not DecompilerTabPageModel model || segment.Reference == null)
 				return;
@@ -1211,6 +1272,15 @@ namespace ICSharpCode.ILSpy.TextView
 			// scrub through them. Cross-document references clear any existing marks since the
 			// view is about to refresh anyway.
 			if (segment.Kind == ReferenceMode.LocalHighlight)
+			{
+				HighlightLocalReferences(model, segment.Reference);
+				return;
+			}
+			// With the member-highlight setting enabled, a plain click on a member or type
+			// reference paints all its occurrences in this view instead of navigating;
+			// Ctrl+Click keeps the navigation behavior. Opcode references always navigate:
+			// highlighting every occurrence of an IL opcode would be noise.
+			if (ShouldHighlightInsteadOfNavigate(segment, ctrlHeld))
 			{
 				HighlightLocalReferences(model, segment.Reference);
 				return;
@@ -1245,11 +1315,47 @@ namespace ICSharpCode.ILSpy.TextView
 				return;
 			foreach (var r in model.References)
 			{
-				if (!ReferenceEquals(reference, r.Reference) && !reference.Equals(r.Reference))
+				if (!AreSameReference(reference, r.Reference))
 					continue;
 				var mark = textMarkerService.Create(r.StartOffset, r.Length);
 				mark.BackgroundColor = r.IsDefinition ? LocalDefinitionBackground : LocalMatchBackground;
 				localReferenceMarks.Add(mark);
+			}
+		}
+
+		internal static bool AreSameReference(object reference, object? candidate)
+		{
+			if (candidate == null)
+				return false;
+			if (ReferenceEquals(reference, candidate) || reference.Equals(candidate))
+				return true;
+			// Member and type references compare by definition: a use site carries a
+			// specialized instance (e.g. List<int>.Add) while the declaration carries
+			// the unspecialized definition, and their Equals treats them as different.
+			var a = NormalizeToEntity(reference);
+			var b = NormalizeToEntity(candidate);
+			if (a != null && b != null)
+			{
+				// Generated members carry a nil token; falling through to the token comparison
+				// would conflate any two of them from the same module.
+				return !a.MetadataToken.IsNil
+					&& a.MetadataToken == b.MetadataToken
+					&& a.ParentModule?.MetadataFile != null
+					&& a.ParentModule.MetadataFile == b.ParentModule?.MetadataFile;
+			}
+			// IL and metadata views carry unresolved entity references; compare them
+			// structurally instead of resolving, which would build a type system per call.
+			if (reference is EntityReference unresolvedA && candidate is EntityReference unresolvedB)
+				return unresolvedA.Module == unresolvedB.Module && unresolvedA.Handle == unresolvedB.Handle;
+			return false;
+
+			static IEntity? NormalizeToEntity(object reference)
+			{
+				return reference switch {
+					IMember member => member.MemberDefinition,
+					IType type => type.GetDefinition(),
+					_ => null,
+				};
 			}
 		}
 
@@ -1373,6 +1479,15 @@ namespace ICSharpCode.ILSpy.TextView
 
 		void OnTextViewPointerMoved(object? sender, PointerEventArgs e)
 		{
+			// The reference elements report QueryCursor only while the pointer is over them;
+			// once it moves elsewhere inside the text view, drop the cached query so Ctrl
+			// transitions cannot repaint a reference the pointer has already left.
+			if (cursorQueryElement is { IsPointerOver: false })
+			{
+				cursorQueryElement = null;
+				cursorQuerySegment = null;
+			}
+
 			if (!richPopup.IsOpen)
 				return;
 			// While the rich popup is open, PointerMoved drives the WPF "distance corridor" —
@@ -1387,6 +1502,11 @@ namespace ICSharpCode.ILSpy.TextView
 
 		void OnTextViewPointerExited(object? sender, PointerEventArgs e)
 		{
+			// The pointer is no longer over a reference, so Ctrl transitions must not
+			// repaint the last hovered element's cursor.
+			cursorQueryElement = null;
+			cursorQuerySegment = null;
+
 			// Don't close the rich popup if the pointer just moved from the editor onto the
 			// popup itself — the user is reaching for it. The overlay popup delivers the
 			// editor's exit BEFORE the popup child's IsPointerOver flips, so the flag alone

--- a/ILSpy/TextView/ReferenceElementGenerator.cs
+++ b/ILSpy/TextView/ReferenceElementGenerator.cs
@@ -18,6 +18,8 @@
 
 using System;
 
+using Avalonia.Input;
+
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Rendering;
 
@@ -32,6 +34,12 @@ namespace ICSharpCode.ILSpy.TextView
 		readonly Predicate<ReferenceSegment> isLink;
 
 		public TextSegmentCollection<ReferenceSegment>? References { get; set; }
+
+		/// <summary>
+		/// Lets the hosting view decide the cursor for a reference under the pointer,
+		/// factoring in key modifiers and settings. Falls back to hand-for-links when unset.
+		/// </summary>
+		public Action<InputElement, ReferenceSegment, KeyModifiers>? QueryCursor { get; set; }
 
 		public ReferenceElementGenerator(Predicate<ReferenceSegment> isLink)
 		{

--- a/ILSpy/TextView/VisualLineReferenceText.cs
+++ b/ILSpy/TextView/VisualLineReferenceText.cs
@@ -49,9 +49,16 @@ namespace ICSharpCode.ILSpy.TextView
 		{
 			if (e.Source is InputElement inputElement)
 			{
-				inputElement.Cursor = new Cursor(referenceSegment.Kind == ReferenceMode.Link
-					? StandardCursorType.Hand
-					: StandardCursorType.Arrow);
+				if (parent.QueryCursor != null)
+				{
+					parent.QueryCursor(inputElement, referenceSegment, e.KeyModifiers);
+				}
+				else
+				{
+					inputElement.Cursor = new Cursor(referenceSegment.Kind == ReferenceMode.Link
+						? StandardCursorType.Hand
+						: StandardCursorType.Arrow);
+				}
 			}
 			// Do NOT set e.Handled = true — AvaloniaEdit's TextView.OnPointerMoved invokes
 			// OnQueryCursor with the live PointerEventArgs, and marking it handled there


### PR DESCRIPTION
Fixes #781.

Clicking a local variable highlights its occurrences, but clicking a member or type always navigated away, so there was no way to see all uses of a member within the current view.

**Behavior** (per the implementation suggestions in the issue):
- New display setting, **off by default**: "Single-click highlights member references (Ctrl+Click navigates)".
- With the setting enabled, a single click on a member or type reference paints every occurrence in the view using the local-reference highlight infrastructure; **Ctrl+Click** performs the navigation. Opcode references in the IL view keep navigating on plain click.
- The hand cursor is shown only when a click would actually navigate: cursor queries factor in the setting and the Ctrl state, and pressing/releasing Ctrl while hovering a reference repaints the cursor immediately (top-level key handlers, since keyboard focus is usually elsewhere while hovering).
- With the setting disabled, behavior is unchanged — pinned by tests.

**Matching:** occurrences are compared by definition token and module rather than `Equals`, because a use site carries a specialized member instance (`List<int>.Add`) while the declaration carries the definition — the same mismatch class as #2078. This also fixes the analyzer-driven highlight for specialized members. Unresolved entity references from the IL/metadata views are compared structurally (module + handle) to avoid building a type system per click.

**Tests:** `MemberReferenceHighlightTests` (8, red-first): default-off pin, highlight-all, specialized-member matching, type parameterization matching, Ctrl navigation, clear behavior, an end-to-end pointer test with real `RawInputModifiers.Control` mouse events, and a cursor test asserting hand-only-when-navigating. Full ILSpy.Tests: 1077 passed / 3 skipped.

🤖 This PR was prepared by an AI agent (Claude Code) operated by @siegfriedpammer.