### PR TITLE
Fix #2032: avoid propagating mutated SROA fields

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.Expected.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 {
@@ -166,13 +167,22 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			Console.WriteLine("{0} {1}", field1, field2);
 		}
 
-//		public void Test9()
-//		{
-//			Program thisField = this;
-//			int field1 = 1;
-//			string field2 = "Hello World!";
-//			thisField = new Program();
-//			Console.WriteLine("{0} {1}", this, thisField);
-//		}
+		public void Test9()
+		{
+			Program thisField = this;
+			int field1 = 1;
+			string field2 = "Hello World!";
+			thisField = new Program();
+			Console.WriteLine("{0} {1}", this, thisField);
+		}
+
+		public void Test10()
+		{
+			Program thisField = this;
+			int field1 = 1;
+			string field2 = "Hello World!";
+			Interlocked.Exchange(ref thisField, new Program());
+			Console.WriteLine("{0} {1}", this, thisField);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.Expected.cs
@@ -191,5 +191,31 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			string field2 = "Hello World!";
 			Console.WriteLine("{0} {1} {2}", this, field1, field2);
 		}
+
+		public void Test12(Program other)
+		{
+			int field1 = 1;
+			string field2 = "Hello World!";
+			other = new Program();
+			Console.WriteLine("{0} {1}", this, other);
+		}
+
+		public void Test13(Program other)
+		{
+			DisplayClass displayClass = new DisplayClass {
+				thisField = other,
+				field1 = 1,
+				field2 = "Hello World!"
+			};
+			Invoke(delegate {
+				displayClass.thisField = new Program();
+			});
+			Console.WriteLine("{0} {1}", this, displayClass.thisField);
+		}
+
+		private static void Invoke(Action action)
+		{
+			action();
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.Expected.cs
@@ -184,5 +184,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			Interlocked.Exchange(ref thisField, new Program());
 			Console.WriteLine("{0} {1}", this, thisField);
 		}
+
+		public void Test11()
+		{
+			int field1 = 1;
+			string field2 = "Hello World!";
+			Console.WriteLine("{0} {1} {2}", this, field1, field2);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 {
@@ -180,15 +181,26 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			Console.WriteLine("{0} {1}", displayClass.field1, displayClass.field2);
 		}
 
-		//		public void Test9()
-		//		{
-		//			DisplayClass displayClass = new DisplayClass {
-		//				thisField = this,
-		//				field1 = 1,
-		//				field2 = "Hello World!"
-		//			};
-		//			displayClass.thisField = new Program();
-		//			Console.WriteLine("{0} {1}", this, displayClass.thisField);
-		//		}
+		public void Test9()
+		{
+			DisplayClass displayClass = new DisplayClass {
+				thisField = this,
+				field1 = 1,
+				field2 = "Hello World!"
+			};
+			displayClass.thisField = new Program();
+			Console.WriteLine("{0} {1}", this, displayClass.thisField);
+		}
+
+		public void Test10()
+		{
+			DisplayClass displayClass = new DisplayClass {
+				thisField = this,
+				field1 = 1,
+				field2 = "Hello World!"
+			};
+			Interlocked.Exchange(ref displayClass.thisField, new Program());
+			Console.WriteLine("{0} {1}", this, displayClass.thisField);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.cs
@@ -212,5 +212,38 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			};
 			Console.WriteLine("{0} {1} {2}", displayClass.thisField, displayClass.field1, displayClass.field2);
 		}
+
+		// The one case where mutation and propagation still coexist: the field is initialized
+		// from a parameter that is loaded exactly once, so the store can be redirected to it.
+		public void Test12(Program other)
+		{
+			DisplayClass displayClass = new DisplayClass {
+				thisField = other,
+				field1 = 1,
+				field2 = "Hello World!"
+			};
+			displayClass.thisField = new Program();
+			Console.WriteLine("{0} {1}", this, displayClass.thisField);
+		}
+
+		// The same mutation from inside a lambda: capturing the display class keeps it
+		// materialized, so propagation never arises here.
+		public void Test13(Program other)
+		{
+			DisplayClass displayClass = new DisplayClass {
+				thisField = other,
+				field1 = 1,
+				field2 = "Hello World!"
+			};
+			Invoke(delegate {
+				displayClass.thisField = new Program();
+			});
+			Console.WriteLine("{0} {1}", this, displayClass.thisField);
+		}
+
+		private static void Invoke(Action action)
+		{
+			action();
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/AggressiveScalarReplacementOfAggregates.cs
@@ -202,5 +202,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			Interlocked.Exchange(ref displayClass.thisField, new Program());
 			Console.WriteLine("{0} {1}", this, displayClass.thisField);
 		}
+
+		public void Test11()
+		{
+			DisplayClass displayClass = new DisplayClass {
+				thisField = this,
+				field1 = 1,
+				field2 = "Hello World!"
+			};
+			Console.WriteLine("{0} {1} {2}", displayClass.thisField, displayClass.field1, displayClass.field2);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformDisplayClassUsage.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformDisplayClassUsage.cs
@@ -820,12 +820,23 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					{
 						context.Step($"Remove initializer of {inst.Variable.Name}", inst);
 						ILInstruction firstInlinedStore = null;
+						// Stores are appended after the initializer, in source order; a store that
+						// is dropped must not leave a gap, so the position is tracked separately
+						// from the loop index.
+						int insertionIndex = inst.ChildIndex;
 						for (int i = 1; i < initBlock.Instructions.Count; i++)
 						{
 							var stobj = (StObj)initBlock.Instructions[i];
 							var variable = displayClass.VariablesToDeclare[(IField)((LdFlda)stobj.Target).Field.MemberDefinition];
+							// A propagated field is replaced by the variable it was initialized from,
+							// so keeping its initializer would assign that variable to itself - and
+							// where the variable is 'this', the result is not even valid C#. Stores
+							// outside an object-initializer block are dropped in VisitStObj under the
+							// same condition.
+							if (variable.CanPropagate && variable.Initializers.Contains(stobj))
+								continue;
 							var inlinedStore = new StLoc(variable.GetOrDeclare(), stobj.Value).WithILRange(stobj);
-							parentBlock.Instructions.Insert(inst.ChildIndex + i, inlinedStore);
+							parentBlock.Instructions.Insert(++insertionIndex, inlinedStore);
 							firstInlinedStore ??= inlinedStore;
 						}
 						context.EndStep(firstInlinedStore);

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformDisplayClassUsage.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformDisplayClassUsage.cs
@@ -227,6 +227,19 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						{
 							variable = AddVariable(container, null, field);
 						}
+						if (variable.CanPropagate && !IsReadOnlyOrInitializerUse(ldflda, variable))
+						{
+							// The field is mutated after initialization (stored again, or its address
+							// escapes). Propagation is only sound if the store can be redirected to
+							// the propagated variable: possible for parameters (their remaining uses
+							// are restricted in ResolveVariableToPropagate), but not for 'this' and
+							// not for a variable that is itself a scalar-replaced display class.
+							var propagatedVariable = variable.GetOrDeclare();
+							if (propagatedVariable.IsThis() || displayClasses.ContainsKey(propagatedVariable))
+							{
+								variable.Propagate(null);
+							}
+						}
 						container.VariablesToDeclare[keyField] = variable;
 						return true;
 					case StObj stobj when stobj.MatchStObj(out var target, out ILInstruction value, out _) && value == use:
@@ -242,6 +255,23 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					default:
 						return false;
 				}
+			}
+		}
+
+		/// <summary>
+		/// True when the given field access is a plain read or one of the recorded
+		/// initializer stores; false for any other store or for an escaping address.
+		/// </summary>
+		static bool IsReadOnlyOrInitializerUse(LdFlda ldflda, VariableToDeclare variable)
+		{
+			switch (ldflda.Parent)
+			{
+				case LdObj:
+					return true;
+				case StObj store when store.Target == ldflda:
+					return variable.Initializers.Contains(store);
+				default:
+					return false;
 			}
 		}
 

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformDisplayClassUsage.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformDisplayClassUsage.cs
@@ -227,7 +227,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						{
 							variable = AddVariable(container, null, field);
 						}
-						if (variable.CanPropagate && !IsReadOnlyOrInitializerUse(ldflda, variable))
+						if (variable.CanPropagate && !IsPlainReadOrInitializerStore(ldflda, variable))
 						{
 							// The field is mutated after initialization (stored again, or its address
 							// escapes). Propagation is only sound if the store can be redirected to
@@ -262,7 +262,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		/// True when the given field access is a plain read or one of the recorded
 		/// initializer stores; false for any other store or for an escaping address.
 		/// </summary>
-		static bool IsReadOnlyOrInitializerUse(LdFlda ldflda, VariableToDeclare variable)
+		static bool IsPlainReadOrInitializerStore(LdFlda ldflda, VariableToDeclare variable)
 		{
 			switch (ldflda.Parent)
 			{


### PR DESCRIPTION
## Summary
- Keep aggressive SROA from propagating a display-class field to its source variable when the field is assigned again after initialization.
- Re-enable the existing AggressiveScalarReplacementOfAggregates Test9 regression case.

Fixes #2032

## Testing
- OPENSSL_ENABLE_SHA1_SIGNATURES=1 dotnet test --project ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj --filter 'FullyQualifiedName~UglyTestRunner.AggressiveScalarReplacementOfAggregates' --report-trx