### PR TITLE
Load ILSpy.sln via a relative path in the DotRush settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,7 @@
         "ILSpy-tests/**": true
     },
     "dotnet.defaultSolution": "ILSpy.sln",
+    "dotrush.roslyn.projectOrSolutionFiles": [
+        "ILSpy.sln"
+    ],
 }


### PR DESCRIPTION
With no configured solution, DotRush only auto-loads a workspace when the folder contains exactly one solution file. This repo has several (`ILSpy.sln`, `ILSpy.Installer.sln`, `ILSpy.VSExtensions.slnx`, two `.slnf` filters), so the extension shows a picker and then writes the chosen **absolute** path back into `.vscode/settings.json` — dirtying every fresh clone and worktree.

DotRush's language server is launched with the workspace folder as its working directory and resolves `dotrush.roslyn.projectOrSolutionFiles` entries via `Path.GetFullPath`, so a committed relative `ILSpy.sln` works in any checkout location and suppresses both the picker and the write-back. Inert for anyone not using DotRush, and mirrors the existing `dotnet.defaultSolution` entry.

*This PR was authored by an AI agent (Claude Code) operated by @siegfriedpammer.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)