### PR TITLE
Pin format.ps1 to Git Bash on Windows

### DIFF
--- a/BuildTools/format.ps1
+++ b/BuildTools/format.ps1
@@ -5,7 +5,17 @@ $ErrorActionPreference = 'Stop'
 $env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
 Push-Location (Join-Path $PSScriptRoot '..')
 try {
-    bash BuildTools/pre-commit --format
+    # On Windows, a bare `bash` can resolve to the WSL launcher (System32\bash.exe),
+    # which runs the hook inside a Linux distro where the CRLF-checked-out script
+    # cannot even be parsed. Pin to Git Bash, the same CRLF-tolerant shell git
+    # itself uses to run the pre-commit hook.
+    $bash = if ($IsWindows) {
+        Join-Path (Split-Path (Split-Path (Get-Command git).Source)) 'bin\bash.exe'
+    }
+    else {
+        'bash'
+    }
+    & $bash BuildTools/pre-commit --format
 }
 finally {
     Pop-Location


### PR DESCRIPTION
## Why `format.ps1` failed

`format.ps1` invoked the hook with a bare `bash`. On Windows, PATH can resolve that to `C:\WINDOWS\system32\bash.exe` -- the **WSL launcher** -- not Git Bash. The hook script then executes inside the WSL distro and dies immediately with:

```
BuildTools/pre-commit: line 6: $'\r': command not found
...syntax error near unexpected token `$'in\r''
```

That's the classic CRLF failure: the repo is `* text=auto`, so on Windows `BuildTools/pre-commit` is checked out with CRLF line endings, and Linux bash treats each `\r` as part of the command. Switching the WSL distribution doesn't help -- any Linux distro's bash chokes the same way, and even with clean line endings the WSL path would need a Linux `dotnet` and would install a Linux `dotnet-format` rather than the Windows one.

Git Bash tolerates CRLF scripts and is what git itself uses when it runs the real pre-commit hook -- which is why committing worked while `format.ps1` didn't.

## The fix

On Windows, resolve Git Bash from `git.exe`'s install location (`<git-root>\bin\bash.exe`) instead of taking whatever `bash` is first on PATH; non-Windows platforms keep using plain `bash`.

Verified: `.\BuildTools\format.ps1` now runs dotnet-format over `ILSpy.sln` and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
