### PR TITLE
Do not pass /shared to compilers that cannot reach a compiler server

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.VB.cs
@@ -135,9 +135,8 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 					}
 				}
 
-				// note: the /shared switch is undocumented. It allows us to use the VBCSCompiler.exe compiler
-				// server to speed up testing
-				if (roslynVersion != "legacy")
+				// See UseCompilerServer for why /shared is not passed to every compiler.
+				if (roslynVersion != "legacy" && UseCompilerServer(roslynVersion))
 				{
 					otherOptions += "/shared ";
 				}

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -232,6 +232,23 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 		}
 
 		/// <summary>
+		/// Whether to pass the undocumented /shared switch, which makes the compiler use the
+		/// VBCSCompiler compiler server and so avoids paying compiler startup per invocation.
+		/// The dotnet-hosted Roslyn 2.x build cannot start its compiler server under a current
+		/// 'dotnet' host (the roll-forward in WrapCompiler applies to csc/vbc itself, not to
+		/// the server process the client tries to spawn), so with /shared every invocation
+		/// first waits out the client's full 20-second new-server connection timeout before
+		/// falling back to a sub-second in-process compile. Only the dotnet-hosted Roslyn 3.0+
+		/// builds get the switch on non-Windows platforms; the Mono-hosted 1.x compilers skip
+		/// it too rather than rely on the server protocol working under Mono.
+		/// </summary>
+		static bool UseCompilerServer(string roslynVersion)
+		{
+			return OperatingSystem.IsWindows()
+				|| Version.Parse(RoslynToolset.SanitizeVersion(roslynVersion)).Major > 2;
+		}
+
+		/// <summary>
 		/// Wraps an external compiler invocation. The .NET Framework builds of the Roslyn
 		/// compilers (csc.exe/vbc.exe) are directly executable on Windows and are hosted by
 		/// Mono elsewhere; the .NET builds ship as a .dll that must be launched through the
@@ -717,11 +734,12 @@ namespace System.Runtime.CompilerServices
 
 				HashSet<string> noWarn = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-				// note: the /shared switch is undocumented. It allows us to use the VBCSCompiler.exe compiler
-				// server to speed up testing
 				if (roslynVersion != "legacy")
 				{
-					otherOptions += "/shared ";
+					if (UseCompilerServer(roslynVersion))
+					{
+						otherOptions += "/shared ";
+					}
 					var version = Version.Parse(RoslynToolset.SanitizeVersion(roslynVersion));
 					if (!targetNet40 && version.Major > 2)
 					{


### PR DESCRIPTION
Since #3914 enabled the Roslyn 1.x/2.x configurations on non-Windows, the Linux decompiler-tests CI step went from ~2 to ~31 minutes (and the macOS job from ~10 to ~53 minutes total).

The TRX artifacts show where the time goes: the ~340 `UseRoslyn2_10_0` test cases average **20.7 s each**, while every other toolset averages 0.2 s. The compile itself is not slow -- invoking the same 2.10 `csc.dll` by hand takes 0.7 s. The cost is the `/shared` switch the test harness passes to every Roslyn invocation: the dotnet-hosted Roslyn 2.x client cannot start its VBCSCompiler server under a current `dotnet` host (the `--roll-forward` only applies to csc/vbc itself, not to the server process the client spawns), so each invocation waits out the client's full 20-second new-server connection timeout and then falls back to a sub-second in-process compile. Measured with the same trivial compile: 0.7 s without `/shared`, 20.8 s with it (of which only ~1 s is CPU time).

This gates `/shared` on Windows-or-Roslyn-3.0+, keeping the compiler server where it works and dropping it for the dotnet-hosted 2.x and Mono-hosted 1.x builds. Locally the `InlineAssignmentTest` matrix drops from 25 s to 6 s, with the 2.10 cases going from 21.5 s to 2.5 s; the full VBPretty suite passes.

This should also make it feasible to re-enable the decompiler tests on macOS (skipped in #3941's follow-up commit for being the slowest job) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)