### PR TITLE
Annotate ICSharpCode.Decompiler for AOT compatibility

### DIFF
--- a/ICSharpCode.BamlDecompiler/ICSharpCode.BamlDecompiler.csproj
+++ b/ICSharpCode.BamlDecompiler/ICSharpCode.BamlDecompiler.csproj
@@ -73,7 +73,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
   
   <Target Name="ILSpyUpdateAssemblyInfo" AfterTargets="ResolveProjectReferences">

--- a/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj
+++ b/ICSharpCode.Decompiler.PowerShell/ICSharpCode.Decompiler.PowerShell.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -89,7 +89,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.ILSpyX\ICSharpCode.ILSpyX.csproj" />
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ICSharpCode.Decompiler/DecompilerException.cs
+++ b/ICSharpCode.Decompiler/DecompilerException.cs
@@ -111,7 +111,7 @@ namespace ICSharpCode.Decompiler
 
 #if NET5_0_OR_GREATER
 		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "All uses of the MethodInfo returned from frame.GetMethod() are null-checked.")]
-#endif	
+#endif
 		static string GetStackTrace(Exception exception)
 		{
 			// Output stacktrace in custom format (very similar to Exception.StackTrace

--- a/ICSharpCode.Decompiler/DecompilerException.cs
+++ b/ICSharpCode.Decompiler/DecompilerException.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Metadata.Ecma335;
@@ -67,6 +68,9 @@ namespace ICSharpCode.Decompiler
 		}
 
 		// This constructor is needed for serialization.
+#if NET5_0_OR_GREATER
+		[Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
 		protected DecompilerException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 		}
@@ -105,6 +109,9 @@ namespace ICSharpCode.Decompiler
 				return type;
 		}
 
+#if NET5_0_OR_GREATER
+		[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "All uses of the MethodInfo returned from frame.GetMethod() are null-checked.")]
+#endif	
 		static string GetStackTrace(Exception exception)
 		{
 			// Output stacktrace in custom format (very similar to Exception.StackTrace

--- a/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
+++ b/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs
@@ -1276,6 +1276,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			{ FieldAttributes.Public, "public" },
 		};
 
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
 		internal static readonly EnumNameCollection<FieldAttributes> fieldAttributes = new EnumNameCollection<FieldAttributes>() {
 			{ FieldAttributes.Static, "static" },
 			{ FieldAttributes.Literal, "literal" },
@@ -1284,6 +1285,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			{ FieldAttributes.RTSpecialName, "rtspecialname" },
 			{ FieldAttributes.NotSerialized, "notserialized" },
 		};
+#pragma warning restore SYSLIB0050 // Type or member is obsolete
 
 		public void DisassembleField(MetadataFile module, FieldDefinitionHandle handle)
 		{
@@ -1584,6 +1586,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			{ TypeAttributes.UnicodeClass, "unicode" },
 		};
 
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
 		internal static readonly EnumNameCollection<TypeAttributes> typeAttributes = new EnumNameCollection<TypeAttributes>() {
 			{ TypeAttributes.Abstract, "abstract" },
 			{ TypeAttributes.Sealed, "sealed" },
@@ -1594,6 +1597,7 @@ namespace ICSharpCode.Decompiler.Disassembler
 			{ TypeAttributes.BeforeFieldInit, "beforefieldinit" },
 			{ TypeAttributes.HasSecurity, null },
 		};
+#pragma warning restore SYSLIB0050 // Type or member is obsolete
 
 		public void DisassembleType(MetadataFile module, TypeDefinitionHandle type)
 		{

--- a/ICSharpCode.Decompiler/Documentation/XmlDocLoader.cs
+++ b/ICSharpCode.Decompiler/Documentation/XmlDocLoader.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -36,6 +37,9 @@ namespace ICSharpCode.Decompiler.Documentation
 		static readonly Lazy<XmlDocumentationProvider> mscorlibDocumentation = new Lazy<XmlDocumentationProvider>(LoadMscorlibDocumentation);
 		static readonly ConditionalWeakTable<MetadataFile, XmlDocumentationProvider> cache = new();
 
+#if NET5_0_OR_GREATER
+		[UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = $"'System.Reflection.Assembly.Location.get' always returns an empty string for assemblies embedded in a single-file app. This is a valid input for {nameof(TryLoadModernRefPackDocumentation)}.")]
+#endif
 		static XmlDocumentationProvider LoadMscorlibDocumentation()
 		{
 			string xmlDocFile = FindXmlDocumentation("mscorlib.dll", TargetRuntime.Net_4_0)

--- a/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
+++ b/ICSharpCode.Decompiler/ICSharpCode.Decompiler.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
     <!-- Carry every distribution RID in the lock file so a RID-specific `dotnet publish -r <rid>` of a
          consuming app (ILSpy) restores in locked mode (RestoreLockedMode below) on any host OS, with no
          per-publish restore escape hatch. Must match ILSpy.csproj's RuntimeIdentifiers. -->
@@ -80,6 +80,10 @@
     </GetPackageVersionDependsOn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
@@ -101,7 +105,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
 
     <!-- Specifies the version of Microsoft.NETCore.App.Ref to obtain nullability information from. -->

--- a/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/ControlFlow/AsyncAwaitDecompiler.cs
@@ -767,7 +767,7 @@ namespace ICSharpCode.Decompiler.IL.ControlFlow
 			var metadata = context.PEFile.Metadata;
 			var moveNextMethod = metadata.GetTypeDefinition((TypeDefinitionHandle)stateMachineType.MetadataToken)
 				.GetMethods().FirstOrDefault(f => metadata.GetString(metadata.GetMethodDefinition(f).Name) == "MoveNext");
-			if (moveNextMethod == null)
+			if (moveNextMethod.IsNil)
 				throw new SymbolicAnalysisFailedException();
 			moveNextFunction = YieldReturnDecompiler.CreateILAst(moveNextMethod, context);
 			if (!(moveNextFunction.Body is BlockContainer blockContainer))

--- a/ICSharpCode.Decompiler/Metadata/EnumUnderlyingTypeResolveException.cs
+++ b/ICSharpCode.Decompiler/Metadata/EnumUnderlyingTypeResolveException.cs
@@ -29,6 +29,9 @@ namespace ICSharpCode.Decompiler.Metadata
 		public EnumUnderlyingTypeResolveException() { }
 		public EnumUnderlyingTypeResolveException(string message) : base(message) { }
 		public EnumUnderlyingTypeResolveException(string message, Exception inner) : base(message, inner) { }
+#if NET5_0_OR_GREATER
+		[Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
 		protected EnumUnderlyingTypeResolveException(
 		  SerializationInfo info,
 		  StreamingContext context) : base(info, context) { }
@@ -40,6 +43,9 @@ namespace ICSharpCode.Decompiler.Metadata
 		public MetadataFileNotSupportedException() { }
 		public MetadataFileNotSupportedException(string message) : base(message) { }
 		public MetadataFileNotSupportedException(string message, Exception inner) : base(message, inner) { }
+#if NET5_0_OR_GREATER
+		[Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
 		protected MetadataFileNotSupportedException(
 		  SerializationInfo info,
 		  StreamingContext context) : base(info, context) { }

--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -418,6 +418,16 @@ namespace ICSharpCode.Decompiler.Metadata
 			return path ?? version?.ToString() ?? ".";
 		}
 
+#if NET5_0_OR_GREATER
+		[UnconditionalSuppressMessage("SingleFile", "IL3002:Avoid calling members marked with 'RequiresAssemblyFilesAttribute' when publishing as a single-file", Justification = "This method returns null when the module has no file path.")]
+#endif
+		static string? GetSystemObjectModuleFullyQualifiedName()
+		{
+			// FullyQualifiedName returns "<Unknown>" for modules with no file path.
+			string? path = typeof(object).Module.FullyQualifiedName;
+			return path is "<Unknown>" ? null : path;
+		}
+
 		string? ResolveInternal(IAssemblyReference name)
 		{
 			if (name == null)
@@ -428,12 +438,14 @@ namespace ICSharpCode.Decompiler.Metadata
 				return assembly;
 
 			string[] framework_dirs;
-			string framework_dir;
+			string? framework_dir;
 
 			switch (decompilerRuntime)
 			{
 				case DecompilerRuntime.Mono:
-					framework_dir = Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName)!;
+					framework_dir = Path.GetDirectoryName(GetSystemObjectModuleFullyQualifiedName());
+					if (string.IsNullOrEmpty(framework_dir))
+						goto NotFound;
 					framework_dirs = new[] { framework_dir, Path.Combine(framework_dir, "Facades") };
 					break;
 				case DecompilerRuntime.NETCoreApp:
@@ -454,7 +466,9 @@ namespace ICSharpCode.Decompiler.Metadata
 					framework_dirs = new[] { framework_dir };
 					break;
 				default:
-					framework_dir = Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName)!;
+					framework_dir = Path.GetDirectoryName(GetSystemObjectModuleFullyQualifiedName());
+					if (string.IsNullOrEmpty(framework_dir))
+						goto NotFound;
 					framework_dirs = new[] { framework_dir };
 					break;
 			}
@@ -494,12 +508,15 @@ namespace ICSharpCode.Decompiler.Metadata
 				// regardless of the requested version (the runtime itself rolls forward in the
 				// same way). Without this, e.g. the type-forwards of a netstandard facade
 				// (pointing to a versioned System.Runtime) are unresolvable on such hosts.
-				string runtimeDir = Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName)!;
+				string? runtimeDir = Path.GetDirectoryName(GetSystemObjectModuleFullyQualifiedName());
+				if (string.IsNullOrEmpty(runtimeDir))
+					goto NotFound;
 				assembly = SearchDirectory(name, runtimeDir);
 				if (assembly != null)
 					return assembly;
 			}
 
+			NotFound:
 			if (throwOnError)
 				throw new ResolutionException(name, null, null);
 			return null;
@@ -562,7 +579,7 @@ namespace ICSharpCode.Decompiler.Metadata
 			if (decompilerRuntime != DecompilerRuntime.NETCoreApp)
 			{
 				if (corlib.Version == version || IsSpecialVersionOrRetargetable(reference))
-					return typeof(object).Module.FullyQualifiedName;
+					return GetSystemObjectModuleFullyQualifiedName();
 			}
 
 			if (reference.PublicKeyToken == null)
@@ -649,7 +666,10 @@ namespace ICSharpCode.Decompiler.Metadata
 
 		string? GetMonoMscorlibBasePath(Version version)
 		{
-			var path = Directory.GetParent(typeof(object).Module.FullyQualifiedName)!.Parent!.FullName;
+			string? corLibModulePath = GetSystemObjectModuleFullyQualifiedName();
+			if (corLibModulePath == null)
+				return null;
+			var path = Directory.GetParent(corLibModulePath)!.Parent!.FullName;
 			if (version.Major == 1)
 				path = Path.Combine(path, "1.0");
 			else if (version.Major == 2)
@@ -710,11 +730,14 @@ namespace ICSharpCode.Decompiler.Metadata
 			return paths;
 		}
 
-		static string GetCurrentMonoGac()
+		static string? GetCurrentMonoGac()
 		{
+			string? corlibModulePath = GetSystemObjectModuleFullyQualifiedName();
+			if (string.IsNullOrEmpty(corlibModulePath))
+				return null;
 			return Path.Combine(
 				Directory.GetParent(
-					Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName)!)!.FullName,
+					Path.GetDirectoryName(corlibModulePath)!)!.FullName,
 				"gac");
 		}
 

--- a/ICSharpCode.Decompiler/NRTAttributes.cs
+++ b/ICSharpCode.Decompiler/NRTAttributes.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if !NET5_0_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis
 {
 	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
@@ -23,3 +24,4 @@ namespace System.Diagnostics.CodeAnalysis
 		}
 	}
 }
+#endif

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataField.cs
@@ -147,11 +147,13 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				b.Add(KnownAttribute.FieldOffset, KnownTypeCode.Int32, offset);
 			}
 
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
 			// NonSerializedAttribute
 			if ((fieldDef.Attributes & FieldAttributes.NotSerialized) != 0)
 			{
 				b.Add(KnownAttribute.NonSerialized);
 			}
+#pragma warning restore SYSLIB0050 // Type or member is obsolete
 
 			// SpecialName
 			if ((fieldDef.Attributes & (FieldAttributes.SpecialName | FieldAttributes.RTSpecialName)) == FieldAttributes.SpecialName)

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/MetadataTypeDefinition.cs
@@ -393,9 +393,11 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 			var metadata = module.metadata;
 			var typeDefinition = metadata.GetTypeDefinition(handle);
 
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
 			// SerializableAttribute
 			if ((typeDefinition.Attributes & TypeAttributes.Serializable) != 0)
 				b.Add(KnownAttribute.Serializable);
+#pragma warning restore SYSLIB0050 // Type or member is obsolete
 
 			// ComImportAttribute
 			if ((typeDefinition.Attributes & TypeAttributes.Import) != 0)

--- a/ICSharpCode.Decompiler/TypeSystem/ReferenceResolvingException.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ReferenceResolvingException.cs
@@ -57,6 +57,9 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		/// </summary>
 		/// <param name="info">The object that holds the serialized object data.</param>
 		/// <param name="context">The contextual information about the source or destination.</param>
+#if NET5_0_OR_GREATER
+		[Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
 		protected ReferenceResolvingException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
 			: base(info, context)
 		{

--- a/ICSharpCode.Decompiler/TypeSystem/ReflectionNameParseException.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/ReflectionNameParseException.cs
@@ -49,11 +49,17 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		// This constructor is needed for serialization.
+#if NET5_0_OR_GREATER
+		[Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
 		protected ReflectionNameParseException(SerializationInfo info, StreamingContext context) : base(info, context)
 		{
 			position = info.GetInt32("position");
 		}
 
+#if NET5_0_OR_GREATER
+		[Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
 		public override void GetObjectData(SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData(info, context);

--- a/ICSharpCode.Decompiler/Util/Index.cs
+++ b/ICSharpCode.Decompiler/Util/Index.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable enable
+#if NETSTANDARD2_0
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -164,3 +165,4 @@ namespace System
 		}
 	}
 }
+#endif

--- a/ICSharpCode.Decompiler/packages.lock.json
+++ b/ICSharpCode.Decompiler/packages.lock.json
@@ -116,6 +116,71 @@
     ".NETStandard,Version=v2.0/linux-x64": {},
     ".NETStandard,Version=v2.0/osx-arm64": {},
     ".NETStandard,Version=v2.0/win-arm64": {},
-    ".NETStandard,Version=v2.0/win-x64": {}
+    ".NETStandard,Version=v2.0/win-x64": {},
+    "net10.0": {
+      "Microsoft.CodeAnalysis.NetAnalyzers": {
+        "type": "Direct",
+        "requested": "[10.0.302, )",
+        "resolved": "10.0.302",
+        "contentHash": "mbJSf5EOYkgnPQ0jO0qo4AByQYDGbBZDs0+23xdkK2ckuvYJGlPT1nPR0WCSnzwXdiVypOTZ4ArcT4H/X/f1mQ=="
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "4Iw41e2h7I4t70SJcX2GCmbyKJIlA273Cfm9RJMM050/3VBejGAG1KcthP5Z2L6SQcbfbf6BhNWO26+ZG+GzMg=="
+      },
+      "Microsoft.Sbom.Targets": {
+        "type": "Direct",
+        "requested": "[4.1.5, )",
+        "resolved": "4.1.5",
+        "contentHash": "i5z+cNu/cOcdO0AgFB8aXk8w6In2H+haaDfSgd9ImvQIK+rSHavHZIogVoAZLL8jLwYx4bAcs5b7EyuMMG4mQQ=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[10.0.301, )",
+        "resolved": "10.0.301",
+        "contentHash": "S9U9Ye2bylMeDkzdNh+TsbRUNr6rkBORrnXDk45maPIxVvTmHV1SN2/qtZ/6yO7cdWmQv1LHv77yIeG6Q3nvMQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "10.0.301",
+          "Microsoft.SourceLink.Common": "10.0.301",
+          "System.IO.Hashing": "10.0.10"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "QhkXUl2gNrQtvPmtBTQHb0YsUrDiDQ2QS09YbtTTiSjGcf7NBqtYbrG/BE06zcBPCKEwQGzIv13IVdXNOSub2w=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Direct",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "ANiqLu3DxW9kol/hMmTWbt3414t9ftdIuiIU7j80okq2YzAueo120M442xk1kDJWtmZTqWQn7wHDvMRipVOEOQ=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "10.0.301",
+        "contentHash": "9Tah8f2BYuXlff9nIsJAeQJcqnijJTXNraIcTOF2f/f9kLmg0HNWPlMemnD6FBLd/UQcE0s9Vze2zCkA6nrZAA==",
+        "dependencies": {
+          "System.IO.Hashing": "10.0.10"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "10.0.301",
+        "contentHash": "oz44EclJdAYVZcRb9dSbWd+6RaE+8a4j5zdE+O7yw5qPRZZhu3pcpDZ/Moy6pLeIXZqBP1FMd8CSE0sgJAGV0g=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "eE839zyWZD/UBZYzP2lu9fhHX6RWe63/jz3Jxf+JumzO/db+Vc2s7CMiDwxk9ti2NTUft2tdRx31Rw2OjKbecA=="
+      }
+    },
+    "net10.0/linux-x64": {},
+    "net10.0/osx-arm64": {},
+    "net10.0/win-arm64": {},
+    "net10.0/win-x64": {}
   }
 }

--- a/ICSharpCode.ILSpyCmd.Tests/ICSharpCode.ILSpyCmd.Tests.csproj
+++ b/ICSharpCode.ILSpyCmd.Tests/ICSharpCode.ILSpyCmd.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ICSharpCode.ILSpyCmd\ICSharpCode.ILSpyCmd.csproj" />
   </ItemGroup>
 

--- a/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
+++ b/ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj
@@ -54,7 +54,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.ILSpyX\ICSharpCode.ILSpyX.csproj" />
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ICSharpCode.BamlDecompiler\ICSharpCode.BamlDecompiler.csproj" />
   </ItemGroup>
 

--- a/ICSharpCode.ILSpyX/ICSharpCode.ILSpyX.csproj
+++ b/ICSharpCode.ILSpyX/ICSharpCode.ILSpyX.csproj
@@ -106,7 +106,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <Target Name="ILSpyUpdateAssemblyInfo" AfterTargets="ResolveProjectReferences">

--- a/ILSpy.BamlDecompiler.Tests.Windows/ILSpy.BamlDecompiler.Tests.Windows.csproj
+++ b/ILSpy.BamlDecompiler.Tests.Windows/ILSpy.BamlDecompiler.Tests.Windows.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.Decompiler.Tests\ICSharpCode.Decompiler.Tests.csproj" />
     <ProjectReference Include="..\ICSharpCode.BamlDecompiler\ICSharpCode.BamlDecompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.BamlDecompiler\ICSharpCode.BamlDecompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
+++ b/ILSpy.ReadyToRun/ILSpy.ReadyToRun.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ICSharpCode.ILSpyX\ICSharpCode.ILSpyX.csproj" />
   </ItemGroup>
 

--- a/ILSpy.Tests.Windows/ILSpy.Tests.Windows.csproj
+++ b/ILSpy.Tests.Windows/ILSpy.Tests.Windows.csproj
@@ -59,6 +59,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ILSpy.Tests\ILSpy.Tests.csproj" />
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
   </ItemGroup>

--- a/ILSpy.Tests/ILSpy.Tests.csproj
+++ b/ILSpy.Tests/ILSpy.Tests.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
     <!-- Build the sample plugin so the composition test has something to load, but DON'T copy
          Test.Plugin.dll into the test output: AppComposition scans *.Plugin.dll next to the test

--- a/ILSpy/ILSpy.csproj
+++ b/ILSpy/ILSpy.csproj
@@ -127,7 +127,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.ILSpyX\ICSharpCode.ILSpyX.csproj" />
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ICSharpCode.BamlDecompiler\ICSharpCode.BamlDecompiler.csproj" />
   </ItemGroup>
 

--- a/TestPlugin/TestPlugin.csproj
+++ b/TestPlugin/TestPlugin.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILSpy\ILSpy.csproj" />
-    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" />
+    <ProjectReference Include="..\ICSharpCode.Decompiler\ICSharpCode.Decompiler.csproj" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Problem

Currently, the `ICSharpCode.Decompiler` package is not annotated for AOT compatibility, so downstream consumers get build warnings when trying to compile with NativeAOT.

### Solution

* I added a .NET 10 target.
* I added `UnconditionalSuppressMessage` attributes to suppress build warnings where necessary. Of course, all suppressions are annotated with justifications for why they're actually safe.
  * Unfortunately, `UnconditionalSuppressMessage` is only available on .NET 5 and later.
* I added obsolete attributes to several serialization-related methods to align with .NET 10 (and fix the compile errors it was giving me).
* I fixed some code that was not compatible with AOT to make it compatible.

