### PR TITLE
Fix #3652: Apostrophe in identifiers must not start a char literal

### DIFF
--- a/ILSpy/TextView/CSharp-Mode.xshd
+++ b/ILSpy/TextView/CSharp-Mode.xshd
@@ -117,7 +117,10 @@
 		</Span>
 		
 		<Span color="Char">
-			<Begin>'</Begin>
+			<!-- Not preceded by an identifier character: names compiled from F# and
+			     obfuscated assemblies may contain apostrophes (e.g. x'), which must not
+			     start a char literal (issue #3652). -->
+			<Begin>(?&lt;![\w'])'</Begin>
 			<End>'</End>
 			<RuleSet>
 				<!-- span for escape sequences -->


### PR DESCRIPTION
Fixes #3652.

The interactive view intentionally shows verbatim metadata names (`EscapeInvalidIdentifiers` only runs for save/export paths), so names compiled from F# or obfuscated assemblies can contain apostrophes (e.g. `x'`). The `Char` span in `CSharp-Mode.xshd` opened at *any* `'`, so such a name started a char-literal span that colored everything up to the next apostrophe.

The fix adds a negative lookbehind `(?<![\w'])` to the span's `Begin` regex: an apostrophe glued to the end of an identifier character can never start a real C# char literal. Ordinary char literals (including `'\n'` and a literal following an apostrophe-name on the same line) still highlight correctly; both cases are covered by new tests, which were red before the grammar change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)