### PR TITLE
Reconstruct nested deconstruction designations

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
@@ -182,6 +182,51 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			NestedDeconstruction_ForEachDictionary_Conversions(new Dictionary<string, NestedInner> {
 				{ "k1", new NestedInner { Value = 19 } }
 			});
+			NestedTupleDeconstruction_Values((20, (21, 22)));
+			NestedTupleDeconstruction_Depth3((23, (24, (25, 26))));
+			NestedTupleDeconstruction_Conversions((27, (28, 29)));
+			NestedTupleDeconstruction_ElementUsedOutside((30, (31, 32)));
+			NestedTupleDeconstruction_ForEach(new List<(int, (int, int))> {
+				(33, (34, 35)),
+				(36, (37, 38))
+			});
+		}
+
+		public void NestedTupleDeconstruction_Values((int, (int, int)) t)
+		{
+			Console.WriteLine("NestedTupleDeconstruction_Values:");
+			var (x, (a, b)) = t;
+			Console.WriteLine(x + " " + a + " " + b);
+		}
+
+		public void NestedTupleDeconstruction_Depth3((int, (int, (int, int))) t)
+		{
+			Console.WriteLine("NestedTupleDeconstruction_Depth3:");
+			var (x, (a, (b, c))) = t;
+			Console.WriteLine(x + " " + a + " " + b + " " + c);
+		}
+
+		public void NestedTupleDeconstruction_Conversions((int, (int, int)) t)
+		{
+			Console.WriteLine("NestedTupleDeconstruction_Conversions:");
+			(long x, (long a, long b)) = t;
+			Console.WriteLine(x + " " + a + " " + b);
+		}
+
+		public void NestedTupleDeconstruction_ElementUsedOutside((int, (int, int)) t)
+		{
+			Console.WriteLine("NestedTupleDeconstruction_ElementUsedOutside:");
+			var (x, inner) = t;
+			Console.WriteLine(x + " " + inner.Item1 + " " + inner.Item2);
+		}
+
+		public void NestedTupleDeconstruction_ForEach(List<(int, (int, int))> list)
+		{
+			Console.WriteLine("NestedTupleDeconstruction_ForEach:");
+			foreach (var (x, (a, b)) in list)
+			{
+				Console.WriteLine(x + " " + a + " " + b);
+			}
 		}
 
 		public class ConstrainedSource

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
@@ -15,6 +15,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		}
 	}
 
+	static class TupleClassExtensions
+	{
+		public static void Deconstruct<T1, T2>(this Tuple<T1, T2> tuple, out T1 item1, out T2 item2)
+		{
+			item1 = tuple.Item1;
+			item2 = tuple.Item2;
+		}
+	}
+
 	class DeconstructionTests
 	{
 		public static void Main()
@@ -153,6 +162,206 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 				new NestedOuter { Value = 2 }
 			});
 			NestedDeconstruction_DiscardedElement(new KeyValuePair<object, DiscardData>("key", default(DiscardData)));
+			NestedDeconstruction_ClassInner(new ClassInnerOuter { Value = 7 });
+			NestedDeconstruction_Depth3(new DeepOuter { Value = 3 });
+			NestedDeconstruction_LhsSideEffects_DeconstructionOrder_Assignments();
+			NestedDeconstruction_Conversions_AfterAllDeconstructCalls();
+			NestedDeconstruction_TypedDeclaration_Conversions(new NestedOuter { Value = 5 });
+			NestedDeconstruction_DiscardWithSideEffectTargets();
+			NestedDeconstruction_SystemTupleSource(Tuple.Create(8, new NestedInner { Value = 4 }));
+			NestedDeconstruction_CheckedConversions(new NestedOuter { Value = 9 });
+			NestedDeconstruction_GenericConstraintSource(new ConstrainedSource { Value = 11 });
+			NestedDeconstruction_InParameterSource(new NestedOuter { Value = 12 });
+			NestedDeconstruction_ConditionalSource(c: true, new NestedOuter { Value = 13 }, new NestedOuter { Value = 14 });
+			NestedDeconstruction_TupleOuterConversions((15, new NestedInner { Value = 6 }));
+			NestedDeconstruction_TypedConversions_UnrelatedCallAfter(new NestedOuter { Value = 16 });
+			NestedDeconstruction_NullableConversions(new NestedOuter { Value = 17 });
+			NestedDeconstruction_MyIntConversionOnNestedLeaves(new NestedOuter { Value = 18 });
+			NestedDeconstruction_ForEachDictionary_Conversions(new Dictionary<string, NestedInner> {
+				{ "k1", new NestedInner { Value = 19 } }
+			});
+		}
+
+		public class ConstrainedSource
+		{
+			public int Value;
+
+			public void Deconstruct(out int a, out NestedInner inner)
+			{
+				Console.WriteLine("ConstrainedSource.Deconstruct");
+				a = Value;
+				inner = new NestedInner { Value = Value * 10 };
+			}
+		}
+
+		public void NestedDeconstruction_SystemTupleSource(Tuple<int, NestedInner> tup)
+		{
+			Console.WriteLine("NestedDeconstruction_SystemTupleSource:");
+			(long x, (long a, long b)) = tup;
+			int z = Side();
+			Console.WriteLine(x + " " + a + " " + b + " " + z);
+		}
+
+		public void NestedDeconstruction_CheckedConversions(NestedOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_CheckedConversions:");
+			checked
+			{
+				(long x, (long a, long b)) = o;
+				Console.WriteLine(x + " " + a + " " + b);
+			}
+		}
+
+		public void NestedDeconstruction_GenericConstraintSource<T>(T o) where T : ConstrainedSource
+		{
+			Console.WriteLine("NestedDeconstruction_GenericConstraintSource:");
+			var (a, (c, d)) = o;
+			Console.WriteLine(a + " " + c + " " + d);
+		}
+
+		public void NestedDeconstruction_InParameterSource(in NestedOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_InParameterSource:");
+			(long x, (long a, long b)) = o;
+			Console.WriteLine(x + " " + a + " " + b);
+		}
+
+		public void NestedDeconstruction_ConditionalSource(bool c, NestedOuter o1, NestedOuter o2)
+		{
+			Console.WriteLine("NestedDeconstruction_ConditionalSource:");
+			(long x, (int a, int b)) = c ? o1 : o2;
+			int z = Side();
+			Console.WriteLine(x + " " + a + " " + b + " " + z);
+		}
+
+		public void NestedDeconstruction_TupleOuterConversions((int, NestedInner) tup)
+		{
+			Console.WriteLine("NestedDeconstruction_TupleOuterConversions:");
+			(long x, (long a, long b)) = tup;
+			Console.WriteLine(x + " " + a + " " + b);
+		}
+
+		public void NestedDeconstruction_TypedConversions_UnrelatedCallAfter(NestedOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_TypedConversions_UnrelatedCallAfter:");
+			(long x, (long a, long b)) = o;
+			int z = Side();
+			Console.WriteLine(x + " " + a + " " + b + " " + z);
+		}
+
+		public void NestedDeconstruction_NullableConversions(NestedOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_NullableConversions:");
+			(long? x, (long? a, int? b)) = o;
+			Console.WriteLine(x + " " + a + " " + b);
+		}
+
+		public void NestedDeconstruction_MyIntConversionOnNestedLeaves(NestedOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_MyIntConversionOnNestedLeaves:");
+			(MyInt x, (MyInt a, long b)) = o;
+			Console.WriteLine(x + " " + a + " " + b);
+		}
+
+		public void NestedDeconstruction_ForEachDictionary_Conversions(Dictionary<string, NestedInner> d)
+		{
+			Console.WriteLine("NestedDeconstruction_ForEachDictionary_Conversions:");
+			foreach ((string k, (long a, long b)) in d)
+			{
+				Console.WriteLine(k + " " + a + " " + b);
+			}
+		}
+
+		// The evaluation order of a deconstruction-assignment is: (1) all side-effects of
+		// the left-hand-side targets, (2) all Deconstruct invocations, (3) conversions,
+		// (4) assignments. Get(i), the Deconstruct methods, MyInt's implicit conversions,
+		// and the property setters all print, so any phase reordering breaks the output diff.
+		public void NestedDeconstruction_LhsSideEffects_DeconstructionOrder_Assignments()
+		{
+			Console.WriteLine("NestedDeconstruction_LhsSideEffects_DeconstructionOrder_Assignments:");
+			(Get(0).IntProperty, (Get(1).IntProperty, Get(2).IntProperty)) = new NestedOuter { Value = 11 };
+		}
+
+		public void NestedDeconstruction_Conversions_AfterAllDeconstructCalls()
+		{
+			Console.WriteLine("NestedDeconstruction_Conversions_AfterAllDeconstructCalls:");
+			(Get(0).My, (Get(1).IntProperty, Get(2).My)) = new NestedOuter { Value = 21 };
+		}
+
+		public void NestedDeconstruction_TypedDeclaration_Conversions(NestedOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_TypedDeclaration_Conversions:");
+			(MyInt x, (long a, MyInt b)) = o;
+			Console.WriteLine(x);
+			Console.WriteLine(a);
+			Console.WriteLine(b);
+		}
+
+		public void NestedDeconstruction_DiscardWithSideEffectTargets()
+		{
+			Console.WriteLine("NestedDeconstruction_DiscardWithSideEffectTargets:");
+			(Get(0).IntProperty, (_, Get(1).My)) = new NestedOuter { Value = 31 };
+		}
+
+		public int Side()
+		{
+			Console.WriteLine("Side()");
+			return 5;
+		}
+
+		public class NestedClassInner
+		{
+			public int Value;
+
+			public void Deconstruct(out int a, out int b)
+			{
+				Console.WriteLine("NestedClassInner.Deconstruct");
+				a = Value + 1;
+				b = Value + 2;
+			}
+		}
+
+		public struct ClassInnerOuter
+		{
+			public int Value;
+
+			public void Deconstruct(out int x, out NestedClassInner inner)
+			{
+				Console.WriteLine("ClassInnerOuter.Deconstruct");
+				x = Value;
+				inner = new NestedClassInner { Value = Value * 10 };
+			}
+		}
+
+		public void NestedDeconstruction_ClassInner(ClassInnerOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_ClassInner:");
+			var (x, (a, b)) = o;
+			Console.WriteLine(x);
+			Console.WriteLine(a);
+			Console.WriteLine(b);
+		}
+
+		public struct DeepOuter
+		{
+			public int Value;
+
+			public void Deconstruct(out int x, out ClassInnerOuter mid)
+			{
+				Console.WriteLine("DeepOuter.Deconstruct");
+				x = Value;
+				mid = new ClassInnerOuter { Value = Value * 100 };
+			}
+		}
+
+		public void NestedDeconstruction_Depth3(DeepOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_Depth3:");
+			var (x, (y, (a, b))) = o;
+			Console.WriteLine(x);
+			Console.WriteLine(y);
+			Console.WriteLine(a);
+			Console.WriteLine(b);
 		}
 
 		public struct DiscardData

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
@@ -169,6 +169,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			NestedDeconstruction_TypedDeclaration_Conversions(new NestedOuter { Value = 5 });
 			NestedDeconstruction_DiscardWithSideEffectTargets();
 			NestedDeconstruction_HiddenDeconstructMethod(default(HidingOuter));
+			NestedDeconstruction_TupleWithCustomElement((7, new NestedInner { Value = 3 }));
 			NestedDeconstruction_SystemTupleSource(Tuple.Create(8, new NestedInner { Value = 4 }));
 			NestedDeconstruction_CheckedConversions(new NestedOuter { Value = 9 });
 			NestedDeconstruction_GenericConstraintSource(new ConstrainedSource { Value = 11 });
@@ -353,6 +354,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		{
 			Console.WriteLine("Side()");
 			return 5;
+		}
+
+		// A tuple deconstruction whose element is custom-deconstructed, followed by an
+		// unrelated assignment: the tuple part must not be consumed into a pattern rooted
+		// in the element's Deconstruct call.
+		public void NestedDeconstruction_TupleWithCustomElement((int, NestedInner) tup)
+		{
+			Console.WriteLine("NestedDeconstruction_TupleWithCustomElement:");
+			var (x, (_, _)) = tup;
+			int z = Side();
+			Console.WriteLine(x * x + z);
 		}
 
 		public class NestedClassInner

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/DeconstructionTests.cs
@@ -168,6 +168,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			NestedDeconstruction_Conversions_AfterAllDeconstructCalls();
 			NestedDeconstruction_TypedDeclaration_Conversions(new NestedOuter { Value = 5 });
 			NestedDeconstruction_DiscardWithSideEffectTargets();
+			NestedDeconstruction_HiddenDeconstructMethod(default(HidingOuter));
 			NestedDeconstruction_SystemTupleSource(Tuple.Create(8, new NestedInner { Value = 4 }));
 			NestedDeconstruction_CheckedConversions(new NestedOuter { Value = 9 });
 			NestedDeconstruction_GenericConstraintSource(new ConstrainedSource { Value = 11 });
@@ -301,6 +302,51 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 		{
 			Console.WriteLine("NestedDeconstruction_DiscardWithSideEffectTargets:");
 			(Get(0).IntProperty, (_, Get(1).My)) = new NestedOuter { Value = 31 };
+		}
+
+		public class HidingBase
+		{
+			public int Value;
+
+			public void Deconstruct(out string a, out double b)
+			{
+				Console.WriteLine("HidingBase.Deconstruct");
+				a = "base" + Value;
+				b = 0.5;
+			}
+		}
+
+		public class HidingDerived : HidingBase
+		{
+			public new void Deconstruct(out string a, out double b)
+			{
+				Console.WriteLine("HidingDerived.Deconstruct");
+				a = "derived";
+				b = 99.5;
+			}
+		}
+
+		public struct HidingOuter
+		{
+			public void Deconstruct(out int x, out HidingDerived d)
+			{
+				Console.WriteLine("HidingOuter.Deconstruct");
+				x = 1;
+				d = new HidingDerived { Value = 5 };
+			}
+		}
+
+		// The base-typed view forces the call to bind to HidingBase.Deconstruct; a nested
+		// designation cannot express that, because it rebinds on the element's static type,
+		// where the hiding method wins.
+		public void NestedDeconstruction_HiddenDeconstructMethod(HidingOuter o)
+		{
+			Console.WriteLine("NestedDeconstruction_HiddenDeconstructMethod:");
+			var (_, d) = o;
+			HidingBase b = d;
+			var (a, c) = b;
+			Console.WriteLine(a);
+			Console.WriteLine(c);
 		}
 
 		public int Side()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -22,6 +22,14 @@ using System.Runtime.InteropServices;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
+	public class DeconstructionBase
+	{
+	}
+
+	public class DeconstructionDerived : DeconstructionBase
+	{
+	}
+
 	public static class DeconstructionExt
 	{
 		public static void Deconstruct<K, V>(this KeyValuePair<K, V> pair, out K key, out V value)
@@ -34,6 +42,27 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			item1 = tuple.Item1;
 			item2 = tuple.Item2;
+		}
+
+		public static void Deconstruct(this DeconstructionBase b, out int a, out int c)
+		{
+			a = 1;
+			c = 2;
+		}
+
+		public static void Deconstruct(this DeconstructionDerived d, out int a, out int c)
+		{
+			a = 3;
+			c = 4;
+		}
+	}
+
+	public class DeconstructionOuter
+	{
+		public void Deconstruct(out int x, out DeconstructionDerived d)
+		{
+			x = 1;
+			d = new DeconstructionDerived();
 		}
 	}
 
@@ -529,6 +558,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		// The store opcode is sign-agnostic - stind.i4 reports int for a uint target and
 		// stind.i1 reports sbyte for a byte one - so the element type of the target cannot
 		// be taken from it: doing so refuses every one of these deconstructions.
+		// The IL calls the extension declared on the base type, forced by the cast. Folding
+		// this into a nested designation would rebind Deconstruct on the element's static
+		// type, where the extension declared on the derived type wins and returns different
+		// values, so the call has to stay explicit.
+		public void Nested_CompetingExtensionDeconstruct(DeconstructionOuter o)
+		{
+			o.Deconstruct(out var x, out var d);
+			((DeconstructionBase)d).Deconstruct(out int a, out int c);
+			Console.WriteLine(x);
+			Console.WriteLine(a);
+			Console.WriteLine(c);
+		}
+
 		public unsafe void Pointer_NoConversion_Tuple_UInt(uint* p)
 		{
 			int value;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -322,6 +322,33 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value2);
 		}
 
+		public unsafe void Pointer_NoConversion_Tuple(int* p)
+		{
+			int value;
+			(*p, value) = GetTuple<int, int>();
+			Console.WriteLine(value);
+			Console.WriteLine(value);
+		}
+
+		// The store opcode is sign-agnostic - stind.i4 reports int for a uint target and
+		// stind.i1 reports sbyte for a byte one - so the element type of the target cannot
+		// be taken from it: doing so refuses every one of these deconstructions.
+		public unsafe void Pointer_NoConversion_Tuple_UInt(uint* p)
+		{
+			int value;
+			(*p, value) = GetTuple<uint, int>();
+			Console.WriteLine(value);
+			Console.WriteLine(value);
+		}
+
+		public unsafe void Pointer_NoConversion_Tuple_Byte(byte* p)
+		{
+			int value;
+			(*p, value) = GetTuple<byte, int>();
+			Console.WriteLine(value);
+			Console.WriteLine(value);
+		}
+
 		public void Property_NoConversion_Custom()
 		{
 			(Get(0).NMy, Get(1).My) = GetSource<MyInt?, MyInt>();

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -551,6 +551,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 #endif
 		}
 
+		// Same, but the escaping element is in the first position. Every leaf of the
+		// wrongly nested node precedes the assigned ones there, so the retry that demotes
+		// it has to be reached before the pattern is judged to start mid-way.
+		public void LocalVariable_TupleInner_FirstElementUsedOutside()
+		{
+			var (tuple2, value) = GetTuple<(int, int), int>();
+			Console.WriteLine(tuple2.Item1);
+			Console.WriteLine(value);
+		}
+
 		public void ForEach_Nested_TupleInner()
 		{
 			foreach (var (value, (value2, value3)) in GetList<(int, (int, int))>())

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -443,26 +443,64 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value);
 		}
 
-		// Nested deconstruction of a tuple element (ldfld chains, no Deconstruct call)
-		// is not re-sugared: var (value, (value2, value3)) = GetTuple<int, (int, int)>();
 		public void LocalVariable_Nested_TupleInner()
 		{
-			(int, (int, int)) tuple = GetTuple<int, (int, int)>();
-			(int, int) item = tuple.Item2;
-			var (value, _) = tuple;
-			var (value2, value3) = item;
+			var (value, (value2, value3)) = GetTuple<int, (int, int)>();
 			Console.WriteLine(value);
 			Console.WriteLine(value2);
 			Console.WriteLine(value3);
 		}
 
+		public void LocalVariable_Nested_TupleInner_Depth3()
+		{
+			var (value, (value2, (value3, value4))) = GetTuple<int, (int, (int, int))>();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+			Console.WriteLine(value4);
+		}
+
+		public void LocalVariable_Nested_TupleInner_BothElements()
+		{
+			var ((value, value2), (value3, value4)) = GetTuple<(int, int), (int, int)>();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+			Console.WriteLine(value4);
+		}
+
+		public void LocalVariable_Nested_TupleInner_Conversions()
+		{
+			int value;
+			long value2;
+			long value3;
+			(value, (value2, value3)) = GetTuple<int, (int, int)>();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+		}
+
+		// The element variable escapes the deconstruction, so it must stay a designator
+		// leaf instead of becoming a nested designation.
+		public void LocalVariable_TupleInner_ElementUsedOutside()
+		{
+#if OPT
+			(int, (int, int)) tuple = GetTuple<int, (int, int)>();
+			int item = tuple.Item1;
+			(int, int) item2 = tuple.Item2;
+			Console.WriteLine(item);
+			Console.WriteLine(item2.Item1);
+#else
+			var (value, tuple2) = GetTuple<int, (int, int)>();
+			Console.WriteLine(value);
+			Console.WriteLine(tuple2.Item1);
+#endif
+		}
+
 		public void ForEach_Nested_TupleInner()
 		{
-			foreach (var item2 in GetList<(int, (int, int))>())
+			foreach (var (value, (value2, value3)) in GetList<(int, (int, int))>())
 			{
-				(int, int) item = item2.Item2;
-				var (value, _) = item2;
-				var (value2, value3) = item;
 				Console.WriteLine(value);
 				Console.WriteLine(value2);
 				Console.WriteLine(value3);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -469,6 +469,60 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value4);
 		}
 
+		// Both sources are already materialized, so the element stores of the two
+		// deconstructions are adjacent with nothing in between. Locating the enclosing
+		// designation of the second one must not walk into the first one's stores.
+		public void LocalVariable_Nested_TupleInner_AfterAdjacentDeconstruction((int, (int, int)) source, (int, (int, int)) source2)
+		{
+			var (value, (value2, value3)) = source;
+			var (value4, (value5, value6)) = source2;
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+			Console.WriteLine(value4);
+			Console.WriteLine(value5);
+			Console.WriteLine(value6);
+		}
+
+		// A statement that is not part of the designation sits between the temporary and
+		// the reads of it, so the enclosing pattern cannot reach them; they have to be
+		// reconstructed on their own rather than deferred to a match that never happens.
+		public void LocalVariable_Nested_TupleInner_BarrierBeforeInnerReads((int, (int, int)) source)
+		{
+			(int, int) item = source.Item2;
+			Console.WriteLine(source.Item1);
+			var (value, value2) = item;
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+		}
+
+		// Same, but the barrier sits between the temporary and the outer element read.
+		public void LocalVariable_Nested_TupleInner_BarrierAfterTemporary((int, (int, int)) source)
+		{
+			(int, int) item = source.Item2;
+			Console.WriteLine(GetInt());
+			var (value, _) = source;
+			var (value2, value3) = item;
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+		}
+
+		// Same, but the preceding statements are plain element reads that keep the inner
+		// tuple whole, so they are element stores without being a deconstruction. Locating
+		// the enclosing designation walks back over them; the run they belong to is itself
+		// a deconstruction, so both are reconstructed.
+		public void LocalVariable_Nested_TupleInner_AfterAdjacentElementReads((int, (int, int)) source, (int, (int, int)) source2)
+		{
+			var (value, tuple2) = source;
+			var (value2, (value3, value4)) = source2;
+			Console.WriteLine(value);
+			Console.WriteLine(tuple2);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+			Console.WriteLine(value4);
+		}
+
 		public void LocalVariable_Nested_TupleInner_Conversions()
 		{
 			int value;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -159,6 +159,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return default((T, T2, T3));
 		}
 
+		private int GetInt()
+		{
+			return 0;
+		}
+
 		private AssignmentTargets Get(int i)
 		{
 			return null;
@@ -169,6 +174,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			var (myInt3, myInt4) = GetSource<MyInt?, MyInt>();
 			Console.WriteLine(myInt3);
 			Console.WriteLine(myInt4);
+		}
+
+		public void LocalVariable_NoConversion_Custom_UnrelatedAssignmentAfter()
+		{
+			var (myInt3, myInt4) = GetSource<MyInt?, MyInt>();
+			int value = GetInt();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value);
 		}
 
 		public void LocalVariable_NoConversion_Tuple()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -29,6 +29,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			key = pair.Key;
 			value = pair.Value;
 		}
+
+		public static void Deconstruct<T1, T2>(this Tuple<T1, T2> tuple, out T1 item1, out T2 item2)
+		{
+			item1 = tuple.Item1;
+			item2 = tuple.Item2;
+		}
 	}
 
 	internal class DeconstructionTests
@@ -159,9 +165,24 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return default((T, T2, T3));
 		}
 
+		private List<T> GetList<T>()
+		{
+			return null;
+		}
+
 		private int GetInt()
 		{
 			return 0;
+		}
+
+		private Tuple<T, T2> GetTupleClass<T, T2>()
+		{
+			return null;
+		}
+
+		private Dictionary<string, T> GetStringDictionary<T>()
+		{
+			return null;
 		}
 
 		private AssignmentTargets Get(int i)
@@ -336,6 +357,167 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value2);
 		}
 
+		public void LocalVariable_Nested_ClassInner()
+		{
+			var (myInt3, (myInt4, value)) = GetSource<MyInt?, DeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value);
+		}
+
+		public void LocalVariable_Nested_StructInner()
+		{
+			var (myInt3, (myInt4, value)) = GetSource<MyInt?, StructDeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value);
+		}
+
+		public void LocalVariable_Nested_StructOuterAndInner()
+		{
+			var (myInt3, (myInt4, value)) = GetStructSource<MyInt?, StructDeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value);
+		}
+
+		public void LocalVariable_Nested_BothElementsNested()
+		{
+			var ((myInt3, value), (myInt4, value2)) = GetSource<DeconstructionSource<MyInt?, int>, StructDeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(value);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value2);
+		}
+
+		public void LocalVariable_Nested_Depth3()
+		{
+			var (myInt3, (myInt4, (value, value2))) = GetSource<MyInt?, DeconstructionSource<MyInt, StructDeconstructionSource<int, int>>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+		}
+
+		public void LocalVariable_Nested_DiscardInnerElement()
+		{
+			var (myInt3, (myInt4, _)) = GetSource<MyInt?, StructDeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+		}
+
+		public void LocalVariable_Nested_SystemTupleSource()
+		{
+			var (myInt3, (myInt4, value)) = GetTupleClass<MyInt?, DeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt3);
+			Console.WriteLine(myInt4);
+			Console.WriteLine(value);
+		}
+
+		// Nested deconstruction of a tuple element (ldfld chains, no Deconstruct call)
+		// is not re-sugared: var (value, (value2, value3)) = GetTuple<int, (int, int)>();
+		public void LocalVariable_Nested_TupleInner()
+		{
+			(int, (int, int)) tuple = GetTuple<int, (int, int)>();
+			(int, int) item = tuple.Item2;
+			var (value, _) = tuple;
+			var (value2, value3) = item;
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+		}
+
+		public void ForEach_Nested_TupleInner()
+		{
+			foreach (var item2 in GetList<(int, (int, int))>())
+			{
+				(int, int) item = item2.Item2;
+				var (value, _) = item2;
+				var (value2, value3) = item;
+				Console.WriteLine(value);
+				Console.WriteLine(value2);
+				Console.WriteLine(value3);
+			}
+		}
+
+		public void LocalVariable_Nested_TypedConversions_UnrelatedCallAfter()
+		{
+			long value;
+			MyInt myInt2;
+			long value2;
+			(value, (myInt2, value2)) = GetSource<int, DeconstructionSource<MyInt, int>>();
+			int value3 = GetInt();
+			Console.WriteLine(value);
+			Console.WriteLine(myInt2);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+		}
+
+		public void LocalVariable_Nested_IntToLongConversion()
+		{
+			int value;
+			MyInt myInt2;
+			long value2;
+			(value, (myInt2, value2)) = GetSource<int, DeconstructionSource<MyInt, int>>();
+			Console.WriteLine(value);
+			Console.WriteLine(myInt2);
+			Console.WriteLine(value2);
+		}
+
+		public void LocalVariable_Nested_ElementDeconstructedAfterBarrier()
+		{
+			GetSource<MyInt?, DeconstructionSource<MyInt, int>>().Deconstruct(out var a, out var b);
+			Console.WriteLine(a);
+			var (myInt2, value) = b;
+			Console.WriteLine(myInt2);
+			Console.WriteLine(value);
+		}
+
+		public void LocalVariable_Nested_OuterElementUsedTwice()
+		{
+			GetSource<MyInt?, DeconstructionSource<MyInt, int>>().Deconstruct(out var a, out var b);
+			var (myInt2, value) = b;
+			Console.WriteLine(a);
+			Console.WriteLine(a);
+			Console.WriteLine(myInt2);
+			Console.WriteLine(value);
+		}
+
+		public void ForEach_Nested()
+		{
+			foreach (var (myInt3, (myInt4, value)) in GetList<StructDeconstructionSource<MyInt?, DeconstructionSource<MyInt, int>>>())
+			{
+				Console.WriteLine(myInt3);
+				Console.WriteLine(myInt4);
+				Console.WriteLine(value);
+			}
+		}
+
+		public void ForEach_Nested_KeyValuePair()
+		{
+			foreach (var (value, (myInt2, value2)) in GetStringDictionary<StructDeconstructionSource<MyInt, int>>())
+			{
+				Console.WriteLine(value);
+				Console.WriteLine(myInt2);
+				Console.WriteLine(value2);
+			}
+		}
+
+		public void Property_Nested_NoConversion()
+		{
+			(Get(0).Int, (Get(1).My, Get(2).String)) = GetSource<int, DeconstructionSource<MyInt, string>>();
+		}
+
+		public void Property_Nested_IntToLongConversion()
+		{
+			(Get(0).Int, (Get(1).My, Get(2).Long)) = GetSource<int, DeconstructionSource<MyInt, int>>();
+		}
+
+		public void Property_Nested_DiscardInnerElement()
+		{
+			(Get(0).NMy, (_, Get(1).My)) = GetSource<MyInt?, DeconstructionSource<int, MyInt>>();
+		}
+
 		public unsafe void Pointer_NoConversion_Tuple(int* p)
 		{
 			int value;
@@ -360,6 +542,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			int value;
 			(*p, value) = GetTuple<byte, int>();
 			Console.WriteLine(value);
+			Console.WriteLine(value);
+		}
+
+		public unsafe void Pointer_Nested_Custom(int* p)
+		{
+			MyInt myInt2;
+			int value;
+			(*p, (myInt2, value)) = GetSource<int, DeconstructionSource<MyInt, int>>();
+			Console.WriteLine(myInt2);
 			Console.WriteLine(value);
 		}
 

--- a/ICSharpCode.Decompiler/IL/Instructions/DeconstructInstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/DeconstructInstruction.cs
@@ -259,12 +259,41 @@ namespace ICSharpCode.Decompiler.IL
 					if (stobj.Target.InferType(typeSystem) is ByReferenceType brt)
 						expectedType = brt.ElementType;
 					else
-						expectedType = SpecialType.UnknownType;
+					{
+						// Pointer targets do not infer a ByReferenceType. stobj.Type cannot stand
+						// in for the element type: it comes from the store opcode, which is
+						// sign-agnostic, so a uint* and an int* both report int32 and a byte*
+						// reports sbyte. Recover the declared type instead, and only fall back to
+						// the store where the target is not a pointer at all.
+						expectedType = GetPointerElementType(stobj.Target, typeSystem) ?? stobj.Type;
+					}
 					value = stobj.Value;
 					return true;
 				default:
 					return false;
 			}
+		}
+
+		/// <summary>
+		/// The element type of a pointer-typed target. A pointer passing through a stack slot
+		/// is typed IntPtr there, so the declared type has to be taken from the definition the
+		/// slot was filled from. Returns null if the target is not a pointer.
+		/// </summary>
+		static IType GetPointerElementType(ILInstruction target, ICompilation typeSystem)
+		{
+			// Bounded because a definition chain could be cyclic in invalid IL.
+			for (int step = 0; step < 4; step++)
+			{
+				if (target.InferType(typeSystem) is PointerType pointerType)
+					return pointerType.ElementType;
+				if (!target.MatchLdLoc(out var v) || !v.IsSingleDefinition
+					|| v.StoreInstructions.Count != 1 || !(v.StoreInstructions[0] is StLoc store))
+				{
+					return null;
+				}
+				target = store.Value;
+			}
+			return null;
 		}
 
 		internal override void CheckInvariant(ILPhase phase)

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -20,11 +20,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Resources;
 
 using ICSharpCode.Decompiler.CSharp.Resolver;
 using ICSharpCode.Decompiler.TypeSystem;
@@ -33,8 +31,47 @@ using ICSharpCode.Decompiler.Util;
 namespace ICSharpCode.Decompiler.IL.Transforms
 {
 	/// <summary>
-	/// 
+	/// Detects that a run of statements is a lowered deconstruction assignment - rooted in a
+	/// Deconstruct call or in tuple element reads, including nested designations - and folds
+	/// it into a single DeconstructInstruction.
 	/// </summary>
+	/*
+		stloc tuple(call MakeIntIntTuple(ldloc this))
+	----
+		stloc myInt(call op_Implicit(ldfld Item2(ldloca tuple)))
+		stloc a(ldfld Item1(ldloca tuple))
+		stloc b(ldloc myInt)
+	==>
+		deconstruct {
+			init:
+				<empty>
+			deconstruct:
+				match.deconstruct(temp = ldloca tuple) {
+					match(result0 = deconstruct.result 0(temp)),
+					match(result1 = deconstruct.result 1(temp))
+				}
+			conversions: {
+				stloc conv2(call op_Implicit(ldloc result1))
+			}
+			assignments: {
+				stloc a(ldloc result0)
+				stloc b(ldloc conv2)
+			}
+		}
+
+		A nested designation over Deconstruct calls (var (x, (a, b)) = o;) chains the calls,
+		with a defensive copy for struct elements:
+			call Deconstruct(ldloc o, ldloca x', ldloca inner)
+			call Deconstruct(ldloca inner, ldloca a', ldloca b')
+			...conversions/assignments over the leaves x', a', b'...
+
+		A nested designation over tuples (var (x, (a, b)) = t;) is lowered to one temporary
+		per nested designation, followed by element reads in depth-first leaf order:
+			stloc inner(ldobj(ldflda Item2(ldloca t)))
+			stloc x(ldobj(ldflda Item1(ldloca t)))
+			stloc a(ldobj(ldflda Item1(ldloca inner)))
+			stloc b(ldobj(ldflda Item2(ldloca inner)))
+	 * */
 	class DeconstructionTransform : IStatementTransform
 	{
 		StatementTransformContext context = null!;
@@ -43,30 +80,6 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		ILVariable? tupleVariable;
 		TupleType? tupleType;
 
-		/*
-			stloc tuple(call MakeIntIntTuple(ldloc this))
-		----
-			stloc myInt(call op_Implicit(ldfld Item2(ldloca tuple)))
-			stloc a(ldfld Item1(ldloca tuple))
-			stloc b(ldloc myInt)
-		==>
-			deconstruct {
-				init:
-					<empty>
-				deconstruct:
-					match.deconstruct(temp = ldloca tuple) {
-						match(result0 = deconstruct.result 0(temp)),
-						match(result1 = deconstruct.result 1(temp))
-					}
-				conversions: {
-					stloc conv2(call op_Implicit(ldloc result1))
-				}
-				assignments: {
-					stloc a(ldloc result0)
-					stloc b(ldloc conv2)
-				}
-			}
-		 * */
 		void IStatementTransform.Run(Block block, int pos, StatementTransformContext context)
 		{
 			if (!context.Settings.Deconstruction)
@@ -97,120 +110,31 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			this.deconstructionResults = null!;
 		}
 
-		struct ConversionInfo
-		{
-			public IType? inputType;
-			public Conv? conv;
-		}
-
 		/// <summary>
-		/// Get index of deconstruction result or tuple element
-		/// Returns -1 on failure.
-		/// </summary>
-		int FindIndex(ILInstruction inst, out Action<DeconstructInstruction>? delayedActions)
-		{
-			delayedActions = null;
-			if (inst.MatchLdLoc(out var v))
-			{
-				if (!deconstructionResultsLookup.TryGetValue(v, out int index))
-					return -1;
-				return index;
-			}
-			if (inst.MatchLdFld(out _, out _))
-			{
-				if (!TupleTransform.MatchTupleFieldAccess((LdFlda)((LdObj)inst).Target, out var tupleType, out var target, out int index))
-					return -1;
-				// Item fields are one-based, we use zero-based indexing.
-				index--;
-				// normalize tuple type
-				tupleType = TupleType.FromUnderlyingType(context.TypeSystem, tupleType);
-				if (!target.MatchLdLoca(out v))
-					return -1;
-				if (this.tupleVariable == null)
-				{
-					this.tupleVariable = v;
-					this.tupleType = (TupleType)tupleType;
-					this.deconstructionResults = new ILVariable[this.tupleType.Cardinality];
-				}
-				if (this.tupleType!.Cardinality < 2)
-					return -1;
-				if (v != tupleVariable || !this.tupleType.Equals(tupleType))
-					return -1;
-				if (this.deconstructionResults[index] == null)
-				{
-					var freshVar = new ILVariable(VariableKind.StackSlot, this.tupleType.ElementTypes[index]) { Name = "E_" + index };
-					delayedActions += _ => context.Function.Variables.Add(freshVar);
-					this.deconstructionResults[index] = freshVar;
-				}
-				delayedActions += _ => {
-					inst.ReplaceWith(new LdLoc(this.deconstructionResults[index]!));
-				};
-				return index;
-			}
-			return -1;
-		}
-
-		/// <summary>
-		/// stloc v(value)
-		/// expr(..., deconstruct { ... }, ...)
+		/// call Deconstruct(target, ldloca out0, ...) [+ nested Deconstruct calls]
+		///   | stloc temp(ldobj(ldflda ItemN(ldloca tuple))) ... [nested tuple designations]
+		/// stloc conv0(conv(...)) ...
+		/// assignments ...
 		/// =>
-		/// expr(..., deconstruct { init: stloc v(value) ... }, ...)
+		/// deconstruct { init: pattern: conversions: assignments: }   (see class comment)
 		/// </summary>
-		bool InlineDeconstructionInitializer(Block block, int pos)
-		{
-			if (!block.Instructions[pos].MatchStLoc(out var v, out var value))
-				return false;
-			if (!(v.IsSingleDefinition && v.LoadCount == 1))
-				return false;
-			if (pos + 1 >= block.Instructions.Count)
-				return false;
-			var result = ILInlining.FindLoadInNext(block.Instructions[pos + 1], v, value, InliningOptions.FindDeconstruction);
-			if (result.Type != ILInlining.FindResultType.Deconstruction)
-				return false;
-			var deconstruction = (DeconstructInstruction)result.LoadInst;
-			LdLoc loadInst = v.LoadInstructions[0];
-			if (!loadInst.IsDescendantOf(deconstruction.Assignments))
-				return false;
-			if (loadInst.SlotInfo == StObj.TargetSlot)
-			{
-				if (value.OpCode == OpCode.LdFlda || value.OpCode == OpCode.LdElema)
-					return false;
-			}
-			if (deconstruction.Init.Count > 0)
-			{
-				var a = deconstruction.Init[0].Variable.LoadInstructions.Single();
-				var b = v.LoadInstructions.Single();
-				if (!b.IsBefore(a))
-					return false;
-			}
-			context.Step("InlineDeconstructionInitializer", block.Instructions[pos]);
-			deconstruction.Init.Insert(0, (StLoc)block.Instructions[pos]);
-			block.Instructions.RemoveAt(pos);
-			v.Kind = VariableKind.DeconstructionInitTemporary;
-			return true;
-		}
-
 		bool TransformDeconstruction(Block block, int pos)
 		{
 			int startPos = pos;
-			Action<DeconstructInstruction>? delayedActions = null;
-			if (MatchDeconstruction(block.Instructions[pos], out IMethod? deconstructMethod,
-				out ILInstruction? rootTestedOperand))
+			// Blocks are processed back to front, so the inner parts of a nested deconstruction
+			// are visited before the position its matching starts at; matching them on their own
+			// would consume the pattern piecemeal. Defer to the enclosing attempt where one
+			// exists (see the guard for the precision guarantees).
+			if (IsConsumableByEnclosingDeconstruction(block, pos))
+				return false;
+			if (!MatchDeconstructionSequence(block, startPos, out pos, out var rootCall,
+				out var rootTestedOperand, out var conversionStLocs, out var delayedActions))
 			{
-				pos++;
+				return false;
 			}
-			if (!MatchConversions(block, ref pos, out var conversions, out var conversionStLocs, ref delayedActions))
-				return false;
-
-			if (!MatchAssignments(block, ref pos, conversions, conversionStLocs, ref delayedActions,
-				allowUnrelatedAssignments: deconstructMethod != null))
-				return false;
-			// first tuple element may not be discarded,
-			// otherwise we would run this transform on a suffix of the actual pattern.
-			if (deconstructionResults[0] == null)
-				return false;
 			context.Step("Deconstruction", block.Instructions[startPos]);
 			DeconstructInstruction replacement = new DeconstructInstruction();
+			IMethod? deconstructMethod = rootCall?.Method;
 			IType deconstructedType;
 			if (deconstructMethod == null)
 			{
@@ -229,31 +153,35 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				}
 			}
 			var rootTempVariable = context.Function.RegisterVariable(VariableKind.PatternLocal, deconstructedType);
-			replacement.Pattern = new MatchInstruction(rootTempVariable, deconstructMethod, rootTestedOperand!) {
-				IsDeconstructCall = deconstructMethod != null,
-				IsDeconstructTuple = this.tupleType != null
-			};
-			int index = 0;
-			foreach (ILVariable? v in deconstructionResults)
+			if (rootCall != null)
 			{
-				var result = v;
-				if (result == null)
+				replacement.Pattern = BuildPatternMatch(rootCall, rootTempVariable, rootTestedOperand!);
+			}
+			else
+			{
+				replacement.Pattern = new MatchInstruction(rootTempVariable, method: null, rootTestedOperand!) {
+					IsDeconstructTuple = true
+				};
+				for (int i = 0; i < deconstructionResults.Length; i++)
 				{
-					var freshVar = new ILVariable(VariableKind.PatternLocal, this.tupleType!.ElementTypes[index]) { Name = "E_" + index };
-					context.Function.Variables.Add(freshVar);
-					result = freshVar;
+					var result = deconstructionResults[i];
+					if (result == null)
+					{
+						var freshVar = new ILVariable(VariableKind.PatternLocal, this.tupleType!.ElementTypes[i]) { Name = "E_" + i };
+						context.Function.Variables.Add(freshVar);
+						result = freshVar;
+					}
+					else
+					{
+						result.Kind = VariableKind.PatternLocal;
+					}
+					replacement.Pattern.SubPatterns.Add(
+						new MatchInstruction(
+							result,
+							new DeconstructResultInstruction(i, result.StackType, new LdLoc(rootTempVariable))
+						)
+					);
 				}
-				else
-				{
-					result.Kind = VariableKind.PatternLocal;
-				}
-				replacement.Pattern.SubPatterns.Add(
-					new MatchInstruction(
-						result,
-						new DeconstructResultInstruction(index, result.StackType, new LdLoc(rootTempVariable))
-					)
-				);
-				index++;
 			}
 			replacement.Conversions = new Block(BlockKind.DeconstructionConversions);
 			foreach (var convInst in conversionStLocs)
@@ -268,45 +196,313 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return true;
 		}
 
-		bool MatchDeconstruction(ILInstruction inst, [NotNullWhen(true)] out IMethod? deconstructMethod,
-			[NotNullWhen(true)] out ILInstruction? testedOperand)
+		/// <summary>
+		/// Matches the full statement sequence of one deconstruction, starting at startPos:
+		///   [Deconstruct call + nested calls | nested tuple designation temporaries]
+		///   [conversions]
+		///   [assignments]
+		/// On success, endPos is the position after the last consumed statement.
+		/// The block is not modified; all rewrites are accumulated in delayedActions.
+		/// </summary>
+		bool MatchDeconstructionSequence(Block block, int startPos, out int endPos,
+			out DeconstructionCall? rootCall, out ILInstruction? rootTestedOperand,
+			out List<StLoc> conversionStLocs, out Action<DeconstructInstruction>? delayedActions)
+		{
+			Reset();
+			endPos = startPos;
+			int pos = startPos;
+			delayedActions = null;
+			MatchDeconstruction(block, ref pos, out rootCall, out rootTestedOperand);
+			if (!MatchConversions(block, ref pos, out var conversions, out conversionStLocs, ref delayedActions))
+				return false;
+			if (!MatchAssignments(block, ref pos, conversions, conversionStLocs, ref delayedActions,
+				allowUnrelatedAssignments: rootCall != null, out bool anyAssignments))
+			{
+				return false;
+			}
+			// Without any assignment the statement is a plain Deconstruct call, unless a nested
+			// deconstruction was consumed: then all leaves are single-use elements handled by
+			// the forwarding fixup in MatchAssignments.
+			if (!anyAssignments && !(rootCall != null && rootCall.NestedCalls.Any(c => c != null)))
+				return false;
+			// first tuple element may not be discarded,
+			// otherwise we would run this transform on a suffix of the actual pattern.
+			if (deconstructionResults[0] == null)
+				return false;
+			endPos = pos;
+			return true;
+		}
+
+		/// <summary>
+		/// stloc v(value)
+		/// expr(..., deconstruct { ... }, ...)
+		/// =>
+		/// expr(..., deconstruct { init: stloc v(value) ... }, ...)
+		/// </summary>
+		bool InlineDeconstructionInitializer(Block block, int pos)
+		{
+			if (!block.Instructions[pos].MatchStLoc(out var v, out var value))
+				return false;
+			if (!(v.IsSingleDefinition && v.LoadInstructions is [var loadInst]))
+				return false;
+			if (pos + 1 >= block.Instructions.Count)
+				return false;
+			var result = ILInlining.FindLoadInNext(block.Instructions[pos + 1], v, value, InliningOptions.FindDeconstruction);
+			if (result.Type != ILInlining.FindResultType.Deconstruction)
+				return false;
+			var deconstruction = (DeconstructInstruction)result.LoadInst;
+			if (!loadInst.IsDescendantOf(deconstruction.Assignments))
+				return false;
+			if (loadInst.SlotInfo == StObj.TargetSlot)
+			{
+				if (value.OpCode == OpCode.LdFlda || value.OpCode == OpCode.LdElema)
+					return false;
+			}
+			if (deconstruction.Init.Count > 0)
+			{
+				var a = deconstruction.Init[0].Variable.LoadInstructions.Single();
+				if (!loadInst.IsBefore(a))
+					return false;
+			}
+			context.Step("InlineDeconstructionInitializer", block.Instructions[pos]);
+			deconstruction.Init.Insert(0, (StLoc)block.Instructions[pos]);
+			block.Instructions.RemoveAt(pos);
+			v.Kind = VariableKind.DeconstructionInitTemporary;
+			return true;
+		}
+
+		/// <summary>
+		/// Whether the statement at pos belongs to a deconstruction whose matching starts at an
+		/// earlier position in the block, in either nesting shape:
+		///
+		///   call Deconstruct(..., ldloca inner, ...)             at enclosingPos
+		///   ...
+		///   call Deconstruct(ldloc(a) inner, ...)                at pos
+		///
+		///   stloc temp(ldobj(ldflda ItemN(ldloc(a) outer)))      at enclosingPos
+		///   ...
+		///   stloc x([conv](ldobj(ldflda ItemK(ldloc(a) temp))))  at pos
+		///
+		/// Both shapes are decided by the same dry run of the enclosing match: only a match that
+		/// reaches beyond pos absorbs the statement there. A barrier statement between the two
+		/// positions, an element with uses the nesting cannot consume, or a conversion or
+		/// assignment the enclosing pattern does not account for makes the dry run stop short,
+		/// and the deconstruction at pos is then still transformed on its own. What the dry run
+		/// cannot promise is that the enclosing attempt still matches once the walk reaches it:
+		/// the positions in between are visited first and may rewrite the block. The back-to-front
+		/// walk gives this position no second chance, but losing the match there only costs
+		/// sugar, never correctness.
+		/// </summary>
+		bool IsConsumableByEnclosingDeconstruction(Block block, int pos)
+		{
+			if (!TryFindEnclosingDeconstructionCall(block, pos, out int enclosingPos))
+				return false;
+			// The dry run leaves the matcher state behind, which is safe because it runs before
+			// the attempt at this position, and both that attempt and Run reset it. It does not
+			// modify the block: all rewrites are delayed actions.
+			return MatchDeconstructionSequence(block, enclosingPos, out int endPos, out _, out _, out _, out _)
+				&& endPos > pos;
+		}
+
+		/// <summary>
+		/// call Deconstruct(..., ldloca v, ...)                  at enclosingPos
+		/// [stloc copy(ldloc v)]                                 defensive copy of a struct element
+		/// ...
+		/// call Deconstruct(ldloc(a) v|copy, ...)                at pos
+		/// </summary>
+		static bool TryFindEnclosingDeconstructionCall(Block block, int pos, out int enclosingPos)
+		{
+			enclosingPos = -1;
+			if (!(block.Instructions[pos] is CallInstruction call))
+				return false;
+			if (!MatchInstruction.IsDeconstructMethod(call.Method) || call.Arguments.Count == 0)
+				return false;
+			var target = call.Arguments[0];
+			if (!MatchLdLocOrLdLoca(target, out var v))
+				return false;
+			// look through the defensive copy of a struct element
+			if (v.StoreInstructions is [StLoc copy] && copy.Value.MatchLdLoc(out var copySource))
+			{
+				v = copySource;
+			}
+			// StoreCount also counts the initial value of parameters, on purpose
+			if (v.StoreCount != 0)
+				return false;
+			if (!(v.AddressInstructions is [{ Parent: CallInstruction enclosingCall } addressLoad]
+				&& addressLoad.ChildIndex > 0
+				&& MatchInstruction.IsDeconstructMethod(enclosingCall.Method)))
+			{
+				return false;
+			}
+			if (enclosingCall.Parent != block)
+				return false;
+			enclosingPos = enclosingCall.ChildIndex;
+			return enclosingPos >= 0 && enclosingPos < pos;
+		}
+
+		/// <summary>
+		/// A matched Deconstruct call: one node of the (possibly nested) deconstruction pattern.
+		/// </summary>
+		sealed class DeconstructionCall
+		{
+			public IMethod Method = null!;
+			/// <summary>Pattern variable of this match node; null for the root (which gets a fresh temp).</summary>
+			public ILVariable? Receiver;
+			/// <summary>The out-argument variable per element.</summary>
+			public ILVariable[] Results = null!;
+			/// <summary>Nested deconstruction per element; null = leaf element.</summary>
+			public DeconstructionCall?[] NestedCalls = null!;
+		}
+
+		/// <summary>
+		/// call Deconstruct(target, ldloca x, ldloca inner)      the root call, at pos
+		/// [nested Deconstruct calls, see MatchNestedDeconstructions]
+		/// On success, the leaf out-variables carry flat indices in depth-first order: this is
+		/// the order in which StatementBuilder/ExpressionBuilder pair pattern variables with
+		/// assignments, so the index checks in MatchConversions/MatchAssignments work unchanged
+		/// for nested patterns.
+		/// </summary>
+		void MatchDeconstruction(Block block, ref int pos, out DeconstructionCall? rootCall,
+			out ILInstruction? testedOperand)
+		{
+			rootCall = MatchDeconstructionCall(block.Instructions[pos], out testedOperand);
+			if (rootCall == null)
+				return;
+			pos++;
+			MatchNestedDeconstructions(block, ref pos, rootCall);
+			// Assign flat indices to the leaves in depth-first order: this is the order in which
+			// StatementBuilder/ExpressionBuilder pair pattern variables with assignments, so the
+			// index checks in MatchConversions/MatchAssignments work unchanged for nested patterns.
+			var leaves = new List<ILVariable>();
+			CollectLeaves(rootCall, leaves);
+			deconstructionResults = leaves.ToArray();
+			for (int i = 0; i < deconstructionResults.Length; i++)
+			{
+				deconstructionResultsLookup.Add(deconstructionResults[i]!, i);
+			}
+
+			static void CollectLeaves(DeconstructionCall call, List<ILVariable> leaves)
+			{
+				for (int i = 0; i < call.Results.Length; i++)
+				{
+					if (call.NestedCalls[i] is DeconstructionCall nested)
+						CollectLeaves(nested, leaves);
+					else
+						leaves.Add(call.Results[i]);
+				}
+			}
+		}
+
+		/// <summary>
+		/// call(virt) Deconstruct(target, ldloca out0, ldloca out1, ...)
+		/// where every out-argument is a single-use temporary.
+		/// </summary>
+		DeconstructionCall? MatchDeconstructionCall(ILInstruction inst, out ILInstruction? testedOperand)
 		{
 			testedOperand = null;
-			deconstructMethod = null;
-			deconstructionResults = null!;
 			if (!(inst is CallInstruction call))
-				return false;
+				return null;
 			if (!MatchInstruction.IsDeconstructMethod(call.Method))
-				return false;
+				return null;
 			if (call.Method.IsStatic || call.Method.DeclaringType.IsReferenceType == false)
 			{
 				if (!(call is Call))
-					return false;
+					return null;
 			}
 			else
 			{
 				if (!(call is CallVirt))
-					return false;
+					return null;
 			}
 			if (call.Arguments.Count < 3)
-				return false;
-			deconstructionResults = new ILVariable[call.Arguments.Count - 1];
-			for (int i = 0; i < deconstructionResults.Length; i++)
+				return null;
+			var results = new ILVariable[call.Arguments.Count - 1];
+			for (int i = 0; i < results.Length; i++)
 			{
 				if (!call.Arguments[i + 1].MatchLdLoca(out var v))
-					return false;
+					return null;
 				// TODO v.LoadCount may be 2 if the deconstruction is assigned to a tuple variable
 				// or 0? because of discards
 				if (!(v.StoreCount == 0 && v.AddressCount == 1 && v.LoadCount <= 1))
-					return false;
-				deconstructionResultsLookup.Add(v, i);
-				deconstructionResults[i] = v;
+					return null;
+				results[i] = v;
 			}
 			testedOperand = call.Arguments[0];
-			deconstructMethod = call.Method;
-			return true;
+			return new DeconstructionCall {
+				Method = call.Method,
+				Results = results,
+				NestedCalls = new DeconstructionCall[results.Length]
+			};
 		}
 
+		/// <summary>
+		/// Per element of the parent call, in order:
+		///   [stloc copy(ldloc result)]                          defensive copy for a struct element
+		///   call Deconstruct(ldloc(a) result|copy, ldloca ...)  recursing into its elements
+		/// C# evaluates nested Deconstruct calls left-to-right, directly after the parent call,
+		/// before any conversions or assignments: the elements are visited depth-first, and the
+		/// stack of pending elements takes the place of recursing into a matched nested call.
+		/// </summary>
+		void MatchNestedDeconstructions(Block block, ref int pos, DeconstructionCall rootCall)
+		{
+			var pendingElements = new Stack<(DeconstructionCall Call, int ElementIndex)>();
+			pendingElements.Push((rootCall, 0));
+			while (pendingElements.Count > 0)
+			{
+				var (parent, i) = pendingElements.Pop();
+				if (i + 1 < parent.Results.Length)
+					pendingElements.Push((parent, i + 1));
+				ILVariable result = parent.Results[i];
+				int savedPos = pos;
+				ILVariable receiver = result;
+				var inst = block.Instructions.ElementAtOrDefault(pos);
+				if (inst != null && inst.MatchStLoc(out var copy, out var copiedValue)
+					&& copiedValue.MatchLdLoc(result)
+					&& copy.StoreCount == 1
+					&& copy.LoadCount + copy.AddressCount == 1)
+				{
+					receiver = copy;
+					pos++;
+					inst = block.Instructions.ElementAtOrDefault(pos);
+				}
+				var nested = inst == null ? null : MatchDeconstructionCall(inst, out _);
+				if (nested == null || !IsReceiverReference(((CallInstruction)inst!).Arguments[0], receiver))
+				{
+					pos = savedPos;
+					continue;
+				}
+				if (receiver != result && result.LoadCount != 1)
+				{
+					// the copy must be the element's only use
+					pos = savedPos;
+					continue;
+				}
+				pos++;
+				nested.Receiver = receiver;
+				parent.NestedCalls[i] = nested;
+				// its elements are evaluated before the parent's remaining ones
+				pendingElements.Push((nested, 0));
+			}
+
+			static bool IsReceiverReference(ILInstruction target, ILVariable receiver)
+			{
+				return MatchLdLocOrLdLoca(target, out var v) && v == receiver;
+			}
+		}
+
+		struct ConversionInfo
+		{
+			public IType? inputType;
+			public Conv? conv;
+		}
+
+		/// <summary>
+		/// stloc conv0(conv(FindIndex-resolvable value))
+		/// stloc conv1(conv(...))
+		/// ...
+		/// The run of single-use conversion temporaries following the deconstruction, in flat
+		/// leaf index order.
+		/// </summary>
 		bool MatchConversions(Block block, ref int pos,
 			out Dictionary<ILVariable, ConversionInfo> conversions,
 			out List<StLoc> conversionStLocs,
@@ -334,6 +530,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return true;
 		}
 
+		/// <summary>
+		/// stloc output(conv(input))
+		/// </summary>
 		bool MatchConversion(ILInstruction? inst, [NotNullWhen(true)] out ILInstruction? inputInstruction,
 			[NotNullWhen(true)] out ILVariable? outputVariable, out ConversionInfo info)
 		{
@@ -354,12 +553,21 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return true;
 		}
 
+		/// <summary>
+		/// assignment(FindIndex-resolvable value)                see MatchAssignment
+		/// ...
+		/// The run of assignments following the conversions, in flat leaf index order.
+		/// Single-use elements without an assignment are forwarded through a fresh variable
+		/// assigned inside the deconstruction.
+		/// </summary>
 		bool MatchAssignments(Block block, ref int pos,
 			Dictionary<ILVariable, ConversionInfo> conversions,
 			List<StLoc> conversionStLocs,
 			ref Action<DeconstructInstruction>? delayedActions,
-			bool allowUnrelatedAssignments)
+			bool allowUnrelatedAssignments,
+			out bool anyAssignments)
 		{
+			anyAssignments = false;
 			int previousIndex = -1;
 			int conversionStLocIndex = 0;
 			int startPos = pos;
@@ -450,7 +658,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				}
 			}
 
-			return startPos != pos;
+			anyAssignments = startPos != pos;
+			return true;
 
 			int GetAssignmentIndex(ILInstruction inst)
 			{
@@ -490,6 +699,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 		}
 
+		/// <summary>
+		/// stloc v(value) | stobj(target, value) | call set_Property(target, value)
+		/// or the result-used form
+		///   stloc s(Block CallInlineAssign { call set_Property(target, stloc tmp(value)); final: ldloc tmp })
+		/// where the setter call is moved into the assignments block.
+		/// </summary>
 		bool MatchAssignment(ILInstruction? inst, [NotNullWhen(true)] out IType? targetType, [NotNullWhen(true)] out ILInstruction? valueInst, [NotNullWhen(true)] out Action<DeconstructInstruction>? addAssignment)
 		{
 			targetType = null;
@@ -525,6 +740,50 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 		}
 
+		/// <summary>
+		/// ldloc result                                          a registered result or conversion output
+		/// ldobj(ldflda ItemN(ldloc(a) v))                       an element read of the tuple
+		/// Resolves the value of a conversion or assignment to its element index.
+		/// Returns -1 on failure.
+		/// </summary>
+		int FindIndex(ILInstruction inst, out Action<DeconstructInstruction>? delayedActions)
+		{
+			delayedActions = null;
+			if (inst.MatchLdLoc(out var v))
+			{
+				if (!deconstructionResultsLookup.TryGetValue(v, out int index))
+					return -1;
+				return index;
+			}
+			if (!MatchTupleElementRead(inst, out var container, out var containerType, out int elementIndex))
+				return -1;
+			var normalizedType = TupleType.FromUnderlyingType(context.TypeSystem, containerType);
+			if (this.tupleVariable == null)
+			{
+				this.tupleVariable = container;
+				this.tupleType = (TupleType)normalizedType;
+				this.deconstructionResults = new ILVariable[this.tupleType.Cardinality];
+			}
+			if (this.tupleType!.Cardinality < 2)
+				return -1;
+			if (container != tupleVariable || !this.tupleType.Equals(normalizedType))
+				return -1;
+			if (this.deconstructionResults[elementIndex] == null)
+			{
+				var freshVar = new ILVariable(VariableKind.StackSlot, this.tupleType.ElementTypes[elementIndex]) { Name = "E_" + elementIndex };
+				delayedActions += _ => context.Function.Variables.Add(freshVar);
+				this.deconstructionResults[elementIndex] = freshVar;
+			}
+			delayedActions += _ => {
+				inst.ReplaceWith(new LdLoc(this.deconstructionResults[elementIndex]!));
+			};
+			return elementIndex;
+		}
+
+		/// <summary>
+		/// Gets whether the matched conv instruction (or its absence) is the lowering of the
+		/// implicit conversion from the input type to the assignment's target type.
+		/// </summary>
 		bool IsCompatibleImplicitConversion(IType targetType, ConversionInfo conversionInfo)
 		{
 			var c = CSharpConversions.Get(context.TypeSystem)
@@ -554,6 +813,73 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				}
 			}
 			return false;
+		}
+
+		/// <summary>
+		/// Builds, recursing into nested calls:
+		/// match.deconstruct[Method] (matchVariable = testedOperand) {
+		///     match(result_i = deconstruct.result i(ldloc matchVariable)),
+		///     match.deconstruct[...] (receiver_j = deconstruct.result j(ldloc matchVariable)) { ... }
+		/// }
+		/// </summary>
+		MatchInstruction BuildPatternMatch(DeconstructionCall call, ILVariable matchVariable, ILInstruction testedOperand)
+		{
+			matchVariable.Kind = VariableKind.PatternLocal;
+			var match = new MatchInstruction(matchVariable, call.Method, testedOperand) {
+				IsDeconstructCall = true
+			};
+			for (int i = 0; i < call.Results.Length; i++)
+			{
+				var nested = call.NestedCalls[i];
+				if (nested != null)
+				{
+					var receiver = nested.Receiver!;
+					match.SubPatterns.Add(BuildPatternMatch(nested, receiver,
+						new DeconstructResultInstruction(i, receiver.StackType, new LdLoc(matchVariable))));
+				}
+				else
+				{
+					var result = call.Results[i];
+					result.Kind = VariableKind.PatternLocal;
+					match.SubPatterns.Add(
+						new MatchInstruction(
+							result,
+							new DeconstructResultInstruction(i, result.StackType, new LdLoc(matchVariable))
+						)
+					);
+				}
+			}
+			return match;
+		}
+
+		/// <summary>
+		/// ldobj(ldflda ItemN(ldloc(a) container))
+		/// The returned index is zero-based; Rest chains of long tuples are flattened.
+		/// Non-escaping element reads may have been rewritten from ldloca to ldloc,
+		/// so both load kinds are accepted.
+		/// </summary>
+		static bool MatchTupleElementRead(ILInstruction inst, [NotNullWhen(true)] out ILVariable? container, [NotNullWhen(true)] out IType? containerType, out int index)
+		{
+			container = null;
+			containerType = null;
+			index = -1;
+			if (!(inst is LdObj ldobj && ldobj.Target is LdFlda ldflda))
+				return false;
+			if (ldobj.UnalignedPrefix != 0 || ldobj.IsVolatile)
+				return false;
+			if (!TupleTransform.MatchTupleFieldAccess(ldflda, out containerType, out var target, out int position))
+				return false;
+			// Item fields are one-based, we use zero-based indexing.
+			index = position - 1;
+			return MatchLdLocOrLdLoca(target, out container);
+		}
+
+		/// <summary>
+		/// ldloc variable | ldloca variable
+		/// </summary>
+		static bool MatchLdLocOrLdLoca(ILInstruction inst, [NotNullWhen(true)] out ILVariable? variable)
+		{
+			return inst.MatchLdLoc(out variable) || inst.MatchLdLoca(out variable);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -288,35 +288,49 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		/// earlier position in the block, in either nesting shape:
 		///
 		///   call Deconstruct(..., ldloca inner, ...)             at enclosingPos
-		///   ...
-		///   call Deconstruct(ldloc(a) inner, ...)                at pos
+		///   [stloc copy(ldloc inner)]                            defensive copy of a struct element
+		///   call Deconstruct(ldloc(a) inner|copy, ...)           at pos
 		///
-		///   stloc temp(ldobj(ldflda ItemN(ldloc(a) outer)))      at enclosingPos
+		///   stloc temp(ldobj(ldflda ItemN(ldloc(a) outer)))      earlier in the block
 		///   ...
 		///   stloc x([conv](ldobj(ldflda ItemK(ldloc(a) temp))))  at pos
 		///
-		/// Both shapes are decided by the same dry run of the enclosing match: only a match that
-		/// reaches beyond pos absorbs the statement there. A barrier statement between the two
-		/// positions, an element with uses the nesting cannot consume, or a conversion or
-		/// assignment the enclosing pattern does not account for makes the dry run stop short,
-		/// and the deconstruction at pos is then still transformed on its own. What the dry run
-		/// cannot promise is that the enclosing attempt still matches once the walk reaches it:
-		/// the positions in between are visited first and may rewrite the block. The back-to-front
-		/// walk gives this position no second chance, but losing the match there only costs
-		/// sugar, never correctness.
+		/// The chained calls are emitted back to back, so an enclosing call that is not the
+		/// preceding statement has something between it and pos that stops it from reaching
+		/// here; the deconstruction at pos is then matched on its own. Nested designation
+		/// temporaries are stored before the enclosing run's own element reads, so the two are
+		/// not adjacent and only the store has to be found.
+		///
+		/// Deferring is worth it only if the enclosing attempt can succeed, so the constraint
+		/// MatchDeconstructionCall places on out-parameters is checked here as well: without it
+		/// an element used more than once would defer this position to an attempt that then
+		/// rejects the call, and the back-to-front walk gives it no second chance.
+		///
+		/// Getting this wrong costs sugar, never correctness: the statement at pos is either
+		/// folded into the enclosing deconstruction or decompiled as the explicit calls and
+		/// element reads it came from.
 		/// </summary>
 		bool IsConsumableByEnclosingDeconstruction(Block block, int pos)
 		{
-			if (!TryFindEnclosingDeconstructionCall(block, pos, out int enclosingPos)
-				&& !TryFindEnclosingTupleDesignation(block, pos, out enclosingPos))
+			if (TryFindEnclosingDeconstructionCall(block, pos, out int enclosingPos))
 			{
-				return false;
+				if (enclosingPos != pos - 1
+					&& !(enclosingPos == pos - 2 && block.Instructions[pos - 1] is StLoc { Value: LdLoc }))
+				{
+					return false;
+				}
+				var enclosingCall = (CallInstruction)block.Instructions[enclosingPos];
+				for (int i = 1; i < enclosingCall.Arguments.Count; i++)
+				{
+					if (!enclosingCall.Arguments[i].MatchLdLoca(out var outParam)
+						|| !(outParam.StoreCount == 0 && outParam.AddressCount == 1 && outParam.LoadCount <= 1))
+					{
+						return false;
+					}
+				}
+				return true;
 			}
-			// The dry run leaves the matcher state behind, which is safe because it runs before
-			// the attempt at this position, and both that attempt and Run reset it. It does not
-			// modify the block: all rewrites are delayed actions.
-			return MatchDeconstructionSequence(block, enclosingPos, out int endPos, out _, out _, out _, out _)
-				&& endPos > pos;
+			return HasEnclosingTupleDesignation(block, pos);
 		}
 
 		/// <summary>
@@ -356,17 +370,14 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		}
 
 		/// <summary>
-		/// stloc temp(ldobj(ldflda ItemN(ldloc(a) outer)))       at enclosingPos
+		/// stloc temp(ldobj(ldflda ItemN(ldloc(a) outer)))       earlier in the block
 		/// ...
 		/// stloc x([conv](ldobj(ldflda ItemK(ldloc(a) temp))))   at pos
 		/// The statement at pos reads an element of a tuple stored by an earlier statement that
-		/// is itself an element read, i.e. a candidate nested designation temporary. The
-		/// enclosing pattern's matching starts at the first store of the run that store belongs
-		/// to, because the temporaries of a nested designation are stored back to back.
+		/// is itself an element read, i.e. a candidate nested designation temporary.
 		/// </summary>
-		static bool TryFindEnclosingTupleDesignation(Block block, int pos, out int enclosingPos)
+		static bool HasEnclosingTupleDesignation(Block block, int pos)
 		{
-			enclosingPos = -1;
 			if (!block.Instructions[pos].MatchStLoc(out _, out var value))
 				return false;
 			if (value is Conv conv)
@@ -377,10 +388,18 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return false;
 			if (!MatchTupleElementStore(store, out _, out _, out _, out _))
 				return false;
-			enclosingPos = store.ChildIndex;
-			while (enclosingPos > 0 && MatchTupleElementStore(block.Instructions[enclosingPos - 1], out _, out _, out _, out _))
-				enclosingPos--;
-			return enclosingPos < pos;
+			if (store.ChildIndex >= pos)
+				return false;
+			// The temporaries and element reads of one designation are stored back to back.
+			// A statement of any other kind in between stops the enclosing pattern from
+			// reaching this position, and deferring to it would lose the deconstruction here
+			// as well, because the back-to-front walk does not come back.
+			for (int between = store.ChildIndex + 1; between < pos; between++)
+			{
+				if (!MatchTupleElementStore(block.Instructions[between], out _, out _, out _, out _))
+					return false;
+			}
+			return true;
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -76,9 +76,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 	{
 		StatementTransformContext context = null!;
 		readonly Dictionary<ILVariable, int> deconstructionResultsLookup = new Dictionary<ILVariable, int>();
+		readonly Dictionary<ILVariable, TupleNode> tupleNodes = new Dictionary<ILVariable, TupleNode>();
 		ILVariable?[] deconstructionResults = null!;
-		ILVariable? tupleVariable;
-		TupleType? tupleType;
+		TupleNode? tupleRoot;
 		bool rootedInDeconstructCall;
 
 		void IStatementTransform.Run(Block block, int pos, StatementTransformContext context)
@@ -106,8 +106,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		private void Reset()
 		{
 			this.deconstructionResultsLookup.Clear();
-			this.tupleVariable = null;
-			this.tupleType = null;
+			this.tupleNodes.Clear();
+			this.tupleRoot = null;
 			this.deconstructionResults = null!;
 			this.rootedInDeconstructCall = false;
 		}
@@ -140,8 +140,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			IType deconstructedType;
 			if (deconstructMethod == null)
 			{
-				deconstructedType = this.tupleType!;
-				rootTestedOperand = new LdLoc(this.tupleVariable!);
+				deconstructedType = tupleRoot!.Type;
+				rootTestedOperand = new LdLoc(tupleRoot.Variable);
 			}
 			else
 			{
@@ -161,29 +161,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 			else
 			{
-				replacement.Pattern = new MatchInstruction(rootTempVariable, method: null, rootTestedOperand!) {
-					IsDeconstructTuple = true
-				};
-				for (int i = 0; i < deconstructionResults.Length; i++)
-				{
-					var result = deconstructionResults[i];
-					if (result == null)
-					{
-						var freshVar = new ILVariable(VariableKind.PatternLocal, this.tupleType!.ElementTypes[i]) { Name = "E_" + i };
-						context.Function.Variables.Add(freshVar);
-						result = freshVar;
-					}
-					else
-					{
-						result.Kind = VariableKind.PatternLocal;
-					}
-					replacement.Pattern.SubPatterns.Add(
-						new MatchInstruction(
-							result,
-							new DeconstructResultInstruction(i, result.StackType, new LdLoc(rootTempVariable))
-						)
-					);
-				}
+				replacement.Pattern = BuildTuplePatternMatch(tupleRoot!, rootTempVariable, rootTestedOperand!);
 			}
 			replacement.Conversions = new Block(BlockKind.DeconstructionConversions);
 			foreach (var convInst in conversionStLocs)
@@ -210,29 +188,61 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			out DeconstructionCall? rootCall, out ILInstruction? rootTestedOperand,
 			out List<StLoc> conversionStLocs, out Action<DeconstructInstruction>? delayedActions)
 		{
-			Reset();
-			endPos = startPos;
-			int pos = startPos;
-			delayedActions = null;
-			MatchDeconstruction(block, ref pos, out rootCall, out rootTestedOperand);
-			if (!MatchConversions(block, ref pos, out var conversions, out conversionStLocs, ref delayedActions))
-				return false;
-			if (!MatchAssignments(block, ref pos, conversions, conversionStLocs, ref delayedActions,
-				allowUnrelatedAssignments: rootCall != null, out bool anyAssignments))
+			HashSet<ILVariable>? doNotNest = null;
+			while (true)
 			{
-				return false;
+				Reset();
+				endPos = startPos;
+				int pos = startPos;
+				delayedActions = null;
+				MatchDeconstruction(block, ref pos, out rootCall, out rootTestedOperand);
+				if (rootCall == null)
+					MatchNestedTupleDesignations(block, ref pos, doNotNest);
+				if (!MatchConversions(block, ref pos, out var conversions, out conversionStLocs, ref delayedActions))
+					return false;
+				if (!MatchAssignments(block, ref pos, conversions, conversionStLocs, ref delayedActions,
+					allowUnrelatedAssignments: rootCall != null, out bool anyAssignments))
+				{
+					return false;
+				}
+				// Without any assignment the statement is a plain Deconstruct call, unless a nested
+				// deconstruction was consumed: then all leaves are single-use elements handled by
+				// the forwarding fixup in MatchAssignments.
+				if (!anyAssignments && !(rootCall != null && rootCall.NestedCalls.Any(c => c != null)))
+					return false;
+				// first tuple element may not be discarded,
+				// otherwise we would run this transform on a suffix of the actual pattern.
+				if (deconstructionResults[0] == null)
+					return false;
+				// A nested tuple designation only holds if the pattern consumed every read of
+				// its temporary; a remaining read means the value escapes the designation.
+				// Retry with the variable as a plain designator leaf, which restores the flat
+				// deconstruction the escaping read needs.
+				var escaped = EscapedTupleNodes();
+				if (escaped == null)
+				{
+					endPos = pos;
+					return true;
+				}
+				doNotNest ??= new HashSet<ILVariable>();
+				doNotNest.UnionWith(escaped);
 			}
-			// Without any assignment the statement is a plain Deconstruct call, unless a nested
-			// deconstruction was consumed: then all leaves are single-use elements handled by
-			// the forwarding fixup in MatchAssignments.
-			if (!anyAssignments && !(rootCall != null && rootCall.NestedCalls.Any(c => c != null)))
-				return false;
-			// first tuple element may not be discarded,
-			// otherwise we would run this transform on a suffix of the actual pattern.
-			if (deconstructionResults[0] == null)
-				return false;
-			endPos = pos;
-			return true;
+
+			List<ILVariable>? EscapedTupleNodes()
+			{
+				List<ILVariable>? escaped = null;
+				foreach (var node in tupleNodes.Values)
+				{
+					if (node == tupleRoot)
+						continue;
+					if (node.MatchedAccessCount != node.Variable.LoadCount + node.Variable.AddressCount)
+					{
+						escaped ??= new List<ILVariable>();
+						escaped.Add(node.Variable);
+					}
+				}
+				return escaped;
+			}
 		}
 
 		/// <summary>
@@ -297,8 +307,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		/// </summary>
 		bool IsConsumableByEnclosingDeconstruction(Block block, int pos)
 		{
-			if (!TryFindEnclosingDeconstructionCall(block, pos, out int enclosingPos))
+			if (!TryFindEnclosingDeconstructionCall(block, pos, out int enclosingPos)
+				&& !TryFindEnclosingTupleDesignation(block, pos, out enclosingPos))
+			{
 				return false;
+			}
 			// The dry run leaves the matcher state behind, which is safe because it runs before
 			// the attempt at this position, and both that attempt and Run reset it. It does not
 			// modify the block: all rewrites are delayed actions.
@@ -340,6 +353,34 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return false;
 			enclosingPos = enclosingCall.ChildIndex;
 			return enclosingPos >= 0 && enclosingPos < pos;
+		}
+
+		/// <summary>
+		/// stloc temp(ldobj(ldflda ItemN(ldloc(a) outer)))       at enclosingPos
+		/// ...
+		/// stloc x([conv](ldobj(ldflda ItemK(ldloc(a) temp))))   at pos
+		/// The statement at pos reads an element of a tuple stored by an earlier statement that
+		/// is itself an element read, i.e. a candidate nested designation temporary. The
+		/// enclosing pattern's matching starts at the first store of the run that store belongs
+		/// to, because the temporaries of a nested designation are stored back to back.
+		/// </summary>
+		static bool TryFindEnclosingTupleDesignation(Block block, int pos, out int enclosingPos)
+		{
+			enclosingPos = -1;
+			if (!block.Instructions[pos].MatchStLoc(out _, out var value))
+				return false;
+			if (value is Conv conv)
+				value = conv.Argument;
+			if (!MatchTupleElementRead(value, out var container, out _, out _))
+				return false;
+			if (!(container.StoreInstructions is [StLoc store]) || store.Parent != block)
+				return false;
+			if (!MatchTupleElementStore(store, out _, out _, out _, out _))
+				return false;
+			enclosingPos = store.ChildIndex;
+			while (enclosingPos > 0 && MatchTupleElementStore(block.Instructions[enclosingPos - 1], out _, out _, out _, out _))
+				enclosingPos--;
+			return enclosingPos < pos;
 		}
 
 		/// <summary>
@@ -525,6 +566,137 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				// is only certain when the element type is the receiver type itself.
 				return method.IsStatic
 					&& NormalizeTypeVisitor.TypeErasure.EquivalentTypes(elementType, method.Parameters[0].Type);
+			}
+		}
+
+		/// <summary>
+		/// A tuple variable being deconstructed: one node of the (possibly nested) designation.
+		/// Nested nodes are the temporaries a nested tuple designation is lowered to.
+		/// </summary>
+		sealed class TupleNode
+		{
+			public readonly ILVariable Variable;
+			public readonly TupleType Type;
+			/// <summary>Nested designation per element; null = leaf element.</summary>
+			public readonly TupleNode[] NestedElements;
+			/// <summary>Flat leaf index (depth-first) of each element.</summary>
+			public int[] ElementFlatIndex = null!;
+			/// <summary>Number of element reads of <see cref="Variable"/> consumed by the pattern.</summary>
+			public int MatchedAccessCount;
+
+			public TupleNode(ILVariable variable, TupleType type)
+			{
+				Variable = variable;
+				Type = type;
+				NestedElements = new TupleNode[type.Cardinality];
+			}
+		}
+
+		/// <summary>
+		/// stloc temp(ldobj(ldflda ItemN(ldloc(a) container)))   one per nested designation
+		/// ...
+		/// The temporaries a nested tuple designation is lowered to: parents before children,
+		/// all evaluated before any conversions or assignments. The consumed variables form the
+		/// tuple node tree rooted at the outermost tuple.
+		/// </summary>
+		void MatchNestedTupleDesignations(Block block, ref int pos, HashSet<ILVariable>? doNotNest)
+		{
+			while (MatchTupleElementStore(block.Instructions.ElementAtOrDefault(pos),
+				out var temp, out var container, out var containerType, out int index))
+			{
+				if (doNotNest != null && doNotNest.Contains(temp))
+					break;
+				if (!(temp.StoreCount == 1 && temp.LoadCount + temp.AddressCount >= 1))
+					break;
+				// Every use of the temporary must itself be a tuple element read,
+				// 'ldobj(ldflda ItemK(...temp...))', so that the pattern can consume them all;
+				// reads it does not consume are rejected by the escape check afterwards.
+				if (!AllUsesAreTupleElementReads(temp))
+					break;
+				var containerNode = ResolveTupleContainer(container, containerType);
+				if (containerNode == null)
+					break;
+				if (index >= containerNode.NestedElements.Length || containerNode.NestedElements[index] != null)
+					break;
+				// The container's element type is authoritative for the temporary's tuple type:
+				// a stack slot's own type can be imprecise. A temporary with a precise type must
+				// agree with the element type.
+				var elementType = containerNode.Type.ElementTypes[index];
+				if (TupleType.GetTupleElementTypes(elementType).IsDefaultOrEmpty)
+					break;
+				var tempType = TupleType.FromUnderlyingType(context.TypeSystem, elementType);
+				if (tempType == null || tempType.Cardinality < 2)
+					break;
+				if (!TupleType.GetTupleElementTypes(temp.Type).IsDefaultOrEmpty
+					&& !NormalizeTypeVisitor.TypeErasure.EquivalentTypes(elementType, temp.Type))
+				{
+					break;
+				}
+				var node = new TupleNode(temp, tempType);
+				containerNode.NestedElements[index] = node;
+				// The temporary's store reads one element of the container.
+				containerNode.MatchedAccessCount++;
+				this.tupleNodes.Add(temp, node);
+				InitializeFlatLeafIndices();
+				pos++;
+			}
+
+			static bool AllUsesAreTupleElementReads(ILVariable temp)
+			{
+				foreach (var use in temp.AddressInstructions.Concat<ILInstruction>(temp.LoadInstructions))
+				{
+					if (!(use.Parent is LdFlda elementAccess && elementAccess.Parent is LdObj))
+						return false;
+				}
+				return true;
+			}
+		}
+
+		/// <summary>
+		/// Resolves the container of a tuple element access against the tree of tuple nodes;
+		/// the first access establishes its container as the root. Returns null if the
+		/// container is not part of the tree or its type does not fit a deconstruction.
+		/// </summary>
+		TupleNode? ResolveTupleContainer(ILVariable container, IType containerType)
+		{
+			var normalizedType = TupleType.FromUnderlyingType(context.TypeSystem, containerType);
+			if (normalizedType == null || normalizedType.Cardinality < 2)
+				return null;
+			if (tupleRoot == null)
+			{
+				tupleRoot = new TupleNode(container, normalizedType);
+				tupleNodes.Add(container, tupleRoot);
+				InitializeFlatLeafIndices();
+			}
+			if (!tupleNodes.TryGetValue(container, out var node))
+				return null;
+			return node.Type.Equals(normalizedType) ? node : null;
+		}
+
+		/// <summary>
+		/// Assigns depth-first flat leaf indices to every element of the tuple node tree and
+		/// allocates the flat results array. Depth-first order is the order in which the
+		/// consumers pair pattern variables with conversions and assignments. Called whenever
+		/// the tree grows; the results array is still empty then, because the tree is complete
+		/// before MatchConversions/MatchAssignments start populating it.
+		/// </summary>
+		void InitializeFlatLeafIndices()
+		{
+			int totalLeaves = AssignFlatIndices(tupleRoot!, 0);
+			this.deconstructionResults = new ILVariable[totalLeaves];
+
+			static int AssignFlatIndices(TupleNode node, int nextLeafIndex)
+			{
+				node.ElementFlatIndex = new int[node.Type.Cardinality];
+				for (int i = 0; i < node.Type.Cardinality; i++)
+				{
+					node.ElementFlatIndex[i] = nextLeafIndex;
+					if (node.NestedElements[i] != null)
+						nextLeafIndex = AssignFlatIndices(node.NestedElements[i], nextLeafIndex);
+					else
+						nextLeafIndex++;
+				}
+				return nextLeafIndex;
 			}
 		}
 
@@ -780,8 +952,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		/// <summary>
 		/// ldloc result                                          a registered result or conversion output
-		/// ldobj(ldflda ItemN(ldloc(a) v))                       an element read of the tuple
-		/// Resolves the value of a conversion or assignment to its element index.
+		/// ldobj(ldflda ItemN(ldloc(a) v))                       an element read on the tuple node tree
+		/// Resolves the value of a conversion or assignment to its flat leaf index.
 		/// Returns -1 on failure.
 		/// </summary>
 		int FindIndex(ILInstruction inst, out Action<DeconstructInstruction>? delayedActions)
@@ -793,6 +965,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					return -1;
 				return index;
 			}
+			if (!MatchTupleElementRead(inst, out var container, out var containerType, out int elementIndex))
+				return -1;
 			if (rootedInDeconstructCall)
 			{
 				// A pattern rooted in a Deconstruct call must not absorb tuple element
@@ -800,29 +974,27 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				// bookkeeping and destroy the rewritten tuple access on failure.
 				return -1;
 			}
-			if (!MatchTupleElementRead(inst, out var container, out var containerType, out int elementIndex))
+			var node = ResolveTupleContainer(container, containerType);
+			if (node == null)
 				return -1;
-			var normalizedType = TupleType.FromUnderlyingType(context.TypeSystem, containerType);
-			if (this.tupleVariable == null)
+			if (elementIndex >= node.NestedElements.Length || node.NestedElements[elementIndex] != null)
 			{
-				this.tupleVariable = container;
-				this.tupleType = (TupleType)normalizedType;
-				this.deconstructionResults = new ILVariable[this.tupleType.Cardinality];
+				// The element is bound to a nested designation; a direct read of it would
+				// be a second consumption of the same element.
+				return -1;
 			}
-			if (this.tupleType!.Cardinality < 2)
-				return -1;
-			if (container != tupleVariable || !this.tupleType.Equals(normalizedType))
-				return -1;
-			if (this.deconstructionResults[elementIndex] == null)
+			int flatIndex = node.ElementFlatIndex[elementIndex];
+			node.MatchedAccessCount++;
+			if (this.deconstructionResults[flatIndex] == null)
 			{
-				var freshVar = new ILVariable(VariableKind.StackSlot, this.tupleType.ElementTypes[elementIndex]) { Name = "E_" + elementIndex };
+				var freshVar = new ILVariable(VariableKind.StackSlot, node.Type.ElementTypes[elementIndex]) { Name = "E_" + flatIndex };
 				delayedActions += _ => context.Function.Variables.Add(freshVar);
-				this.deconstructionResults[elementIndex] = freshVar;
+				this.deconstructionResults[flatIndex] = freshVar;
 			}
 			delayedActions += _ => {
-				inst.ReplaceWith(new LdLoc(this.deconstructionResults[elementIndex]!));
+				inst.ReplaceWith(new LdLoc(this.deconstructionResults[flatIndex]!));
 			};
-			return elementIndex;
+			return flatIndex;
 		}
 
 		/// <summary>
@@ -898,6 +1070,57 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		}
 
 		/// <summary>
+		/// Builds, recursing into nested designations:
+		/// match.tuple (matchVariable = testedOperand) {
+		///     match(result_i = deconstruct.result i(ldloc matchVariable)),
+		///     match.tuple (temp_j = deconstruct.result j(ldloc matchVariable)) { ... }
+		/// }
+		/// Unassigned leaf elements get a fresh, load-free pattern variable (a discard).
+		/// </summary>
+		MatchInstruction BuildTuplePatternMatch(TupleNode node, ILVariable matchVariable, ILInstruction testedOperand)
+		{
+			matchVariable.Kind = VariableKind.PatternLocal;
+			var match = new MatchInstruction(matchVariable, method: null, testedOperand) {
+				IsDeconstructTuple = true
+			};
+			for (int i = 0; i < node.Type.Cardinality; i++)
+			{
+				var nested = node.NestedElements[i];
+				if (nested != null)
+				{
+					// A stack-slot temporary can have an imprecise type; the match variable of
+					// a tuple pattern must have the tuple type.
+					if (TupleType.GetTupleElementTypes(nested.Variable.Type).IsDefaultOrEmpty)
+						nested.Variable.Type = nested.Type;
+					match.SubPatterns.Add(BuildTuplePatternMatch(nested, nested.Variable,
+						new DeconstructResultInstruction(i, nested.Variable.StackType, new LdLoc(matchVariable))));
+				}
+				else
+				{
+					int flatIndex = node.ElementFlatIndex[i];
+					var result = deconstructionResults[flatIndex];
+					if (result == null)
+					{
+						var freshVar = new ILVariable(VariableKind.PatternLocal, node.Type.ElementTypes[i]) { Name = "E_" + flatIndex };
+						context.Function.Variables.Add(freshVar);
+						result = freshVar;
+					}
+					else
+					{
+						result.Kind = VariableKind.PatternLocal;
+					}
+					match.SubPatterns.Add(
+						new MatchInstruction(
+							result,
+							new DeconstructResultInstruction(i, result.StackType, new LdLoc(matchVariable))
+						)
+					);
+				}
+			}
+			return match;
+		}
+
+		/// <summary>
 		/// ldobj(ldflda ItemN(ldloc(a) container))
 		/// The returned index is zero-based; Rest chains of long tuples are flattened.
 		/// Non-escaping element reads may have been rewritten from ldloca to ldloc,
@@ -917,6 +1140,24 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			// Item fields are one-based, we use zero-based indexing.
 			index = position - 1;
 			return MatchLdLocOrLdLoca(target, out container);
+		}
+
+		/// <summary>
+		/// stloc temp(ldobj(ldflda ItemN(ldloc(a) container)))
+		/// The store of a nested tuple designation temporary.
+		/// </summary>
+		static bool MatchTupleElementStore(ILInstruction? inst, [NotNullWhen(true)] out ILVariable? temp, [NotNullWhen(true)] out ILVariable? container, [NotNullWhen(true)] out IType? containerType, out int index)
+		{
+			if (inst is StLoc store && MatchTupleElementRead(store.Value, out container, out containerType, out index))
+			{
+				temp = store.Variable;
+				return true;
+			}
+			temp = null;
+			container = null;
+			containerType = null;
+			index = -1;
+			return false;
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -16,10 +16,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Resources;
 
@@ -34,11 +37,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 	/// </summary>
 	class DeconstructionTransform : IStatementTransform
 	{
-		StatementTransformContext context;
+		StatementTransformContext context = null!;
 		readonly Dictionary<ILVariable, int> deconstructionResultsLookup = new Dictionary<ILVariable, int>();
-		ILVariable[] deconstructionResults;
-		ILVariable tupleVariable;
-		TupleType tupleType;
+		ILVariable?[] deconstructionResults = null!;
+		ILVariable? tupleVariable;
+		TupleType? tupleType;
 
 		/*
 			stloc tuple(call MakeIntIntTuple(ldloc this))
@@ -81,7 +84,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 			finally
 			{
-				this.context = null;
+				this.context = null!;
 				Reset();
 			}
 		}
@@ -91,20 +94,20 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			this.deconstructionResultsLookup.Clear();
 			this.tupleVariable = null;
 			this.tupleType = null;
-			this.deconstructionResults = null;
+			this.deconstructionResults = null!;
 		}
 
 		struct ConversionInfo
 		{
-			public IType inputType;
-			public Conv conv;
+			public IType? inputType;
+			public Conv? conv;
 		}
 
 		/// <summary>
 		/// Get index of deconstruction result or tuple element
 		/// Returns -1 on failure.
 		/// </summary>
-		int FindIndex(ILInstruction inst, out Action<DeconstructInstruction> delayedActions)
+		int FindIndex(ILInstruction inst, out Action<DeconstructInstruction>? delayedActions)
 		{
 			delayedActions = null;
 			if (inst.MatchLdLoc(out var v))
@@ -129,7 +132,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					this.tupleType = (TupleType)tupleType;
 					this.deconstructionResults = new ILVariable[this.tupleType.Cardinality];
 				}
-				if (this.tupleType.Cardinality < 2)
+				if (this.tupleType!.Cardinality < 2)
 					return -1;
 				if (v != tupleVariable || !this.tupleType.Equals(tupleType))
 					return -1;
@@ -140,7 +143,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					this.deconstructionResults[index] = freshVar;
 				}
 				delayedActions += _ => {
-					inst.ReplaceWith(new LdLoc(this.deconstructionResults[index]));
+					inst.ReplaceWith(new LdLoc(this.deconstructionResults[index]!));
 				};
 				return index;
 			}
@@ -190,9 +193,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		bool TransformDeconstruction(Block block, int pos)
 		{
 			int startPos = pos;
-			Action<DeconstructInstruction> delayedActions = null;
-			if (MatchDeconstruction(block.Instructions[pos], out IMethod deconstructMethod,
-				out ILInstruction rootTestedOperand))
+			Action<DeconstructInstruction>? delayedActions = null;
+			if (MatchDeconstruction(block.Instructions[pos], out IMethod? deconstructMethod,
+				out ILInstruction? rootTestedOperand))
 			{
 				pos++;
 			}
@@ -210,8 +213,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			IType deconstructedType;
 			if (deconstructMethod == null)
 			{
-				deconstructedType = this.tupleType;
-				rootTestedOperand = new LdLoc(this.tupleVariable);
+				deconstructedType = this.tupleType!;
+				rootTestedOperand = new LdLoc(this.tupleVariable!);
 			}
 			else
 			{
@@ -225,17 +228,17 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				}
 			}
 			var rootTempVariable = context.Function.RegisterVariable(VariableKind.PatternLocal, deconstructedType);
-			replacement.Pattern = new MatchInstruction(rootTempVariable, deconstructMethod, rootTestedOperand) {
+			replacement.Pattern = new MatchInstruction(rootTempVariable, deconstructMethod, rootTestedOperand!) {
 				IsDeconstructCall = deconstructMethod != null,
 				IsDeconstructTuple = this.tupleType != null
 			};
 			int index = 0;
-			foreach (ILVariable v in deconstructionResults)
+			foreach (ILVariable? v in deconstructionResults)
 			{
 				var result = v;
 				if (result == null)
 				{
-					var freshVar = new ILVariable(VariableKind.PatternLocal, this.tupleType.ElementTypes[index]) { Name = "E_" + index };
+					var freshVar = new ILVariable(VariableKind.PatternLocal, this.tupleType!.ElementTypes[index]) { Name = "E_" + index };
 					context.Function.Variables.Add(freshVar);
 					result = freshVar;
 				}
@@ -264,12 +267,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return true;
 		}
 
-		bool MatchDeconstruction(ILInstruction inst, out IMethod deconstructMethod,
-			out ILInstruction testedOperand)
+		bool MatchDeconstruction(ILInstruction inst, [NotNullWhen(true)] out IMethod? deconstructMethod,
+			[NotNullWhen(true)] out ILInstruction? testedOperand)
 		{
 			testedOperand = null;
 			deconstructMethod = null;
-			deconstructionResults = null;
+			deconstructionResults = null!;
 			if (!(inst is CallInstruction call))
 				return false;
 			if (!MatchInstruction.IsDeconstructMethod(call.Method))
@@ -306,7 +309,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		bool MatchConversions(Block block, ref int pos,
 			out Dictionary<ILVariable, ConversionInfo> conversions,
 			out List<StLoc> conversionStLocs,
-			ref Action<DeconstructInstruction> delayedActions)
+			ref Action<DeconstructInstruction>? delayedActions)
 		{
 			conversions = new Dictionary<ILVariable, ConversionInfo>();
 			conversionStLocs = new List<StLoc>();
@@ -330,11 +333,14 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			return true;
 		}
 
-		bool MatchConversion(ILInstruction inst, out ILInstruction inputInstruction,
-			out ILVariable outputVariable, out ConversionInfo info)
+		bool MatchConversion(ILInstruction? inst, [NotNullWhen(true)] out ILInstruction? inputInstruction,
+			[NotNullWhen(true)] out ILVariable? outputVariable, out ConversionInfo info)
 		{
 			info = default;
 			inputInstruction = null;
+			outputVariable = null;
+			if (inst == null)
+				return false;
 			if (!inst.MatchStLoc(out outputVariable, out var value))
 				return false;
 			if (!(value is Conv conv))
@@ -350,7 +356,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		bool MatchAssignments(Block block, ref int pos,
 			Dictionary<ILVariable, ConversionInfo> conversions,
 			List<StLoc> conversionStLocs,
-			ref Action<DeconstructInstruction> delayedActions)
+			ref Action<DeconstructInstruction>? delayedActions)
 		{
 			int previousIndex = -1;
 			int conversionStLocIndex = 0;
@@ -374,7 +380,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					&& conversionInfo.conv == null)
 				{
 					delayedActions += _ => {
-						assignmentTarget.Type = conversionInfo.inputType;
+						assignmentTarget.Type = conversionInfo.inputType!;
 					};
 				}
 				else
@@ -449,7 +455,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return int.MaxValue;
 			}
 
-			void AddMissingAssignmentsForConversions(int index, ref Action<DeconstructInstruction> delayedActions)
+			void AddMissingAssignmentsForConversions(int index, ref Action<DeconstructInstruction>? delayedActions)
 			{
 				while (conversionStLocIndex < conversionStLocs.Count)
 				{
@@ -472,7 +478,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 		}
 
-		bool MatchAssignment(ILInstruction inst, out IType targetType, out ILInstruction valueInst, out Action<DeconstructInstruction> addAssignment)
+		bool MatchAssignment(ILInstruction? inst, [NotNullWhen(true)] out IType? targetType, [NotNullWhen(true)] out ILInstruction? valueInst, [NotNullWhen(true)] out Action<DeconstructInstruction>? addAssignment)
 		{
 			targetType = null;
 			valueInst = null;

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -477,6 +477,14 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					pos = savedPos;
 					continue;
 				}
+				if (!BindsOnElementType(nested.Method, result.Type))
+				{
+					// A nested designation rebinds Deconstruct on the element's static type
+					// when recompiled; if that picks a different method (member hiding), the
+					// call must stay explicit, where a cast can preserve the binding.
+					pos = savedPos;
+					continue;
+				}
 				pos++;
 				nested.Receiver = receiver;
 				parent.NestedCalls[i] = nested;
@@ -487,6 +495,33 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			static bool IsReceiverReference(ILInstruction target, ILVariable receiver)
 			{
 				return MatchLdLocOrLdLoca(target, out var v) && v == receiver;
+			}
+
+			static bool BindsOnElementType(IMethod method, IType elementType)
+			{
+				int outParamCount = method.Parameters.Count - (method.IsStatic ? 1 : 0);
+				IType type = elementType;
+				while (type != null)
+				{
+					if (!method.IsStatic && NormalizeTypeVisitor.TypeErasure.EquivalentTypes(type, method.DeclaringType))
+						return true;
+					if (type.GetMethods(m => m.Name == "Deconstruct", GetMemberOptions.IgnoreInheritedMembers)
+						.Any(m => !m.IsStatic && m.Parameters.Count == outParamCount))
+					{
+						// An instance Deconstruct of the same arity is declared on a type more
+						// derived than the called method's declaring type: it hides the called
+						// method (and wins over a called extension method).
+						return false;
+					}
+					type = type.DirectBaseTypes.FirstOrDefault(t => t.Kind == TypeKind.Class)!;
+				}
+				// The chain ended without seeing the declaring type, so an instance method's
+				// binding cannot be verified. An extension method is reached by its receiver
+				// type, and one declared on a more derived type wins over it; which extensions
+				// are in scope where the output is compiled is not known here, so the binding
+				// is only certain when the element type is the receiver type itself.
+				return method.IsStatic
+					&& NormalizeTypeVisitor.TypeErasure.EquivalentTypes(elementType, method.Parameters[0].Type);
 			}
 		}
 

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -210,22 +210,26 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				// the forwarding fixup in MatchAssignments.
 				if (!anyAssignments && !(rootCall != null && rootCall.NestedCalls.Any(c => c != null)))
 					return false;
+				// A nested tuple designation only holds if the pattern consumed every read of
+				// its temporary; a remaining read means the value escapes the designation.
+				// Retry with the variable as a plain designator leaf, which restores the flat
+				// deconstruction the escaping read needs. This has to be decided before the
+				// leaf check below: every leaf of a wrongly nested first element precedes the
+				// assigned ones, so that check would report the pattern as starting mid-way
+				// and give up on a designation the retry can still make work.
+				var escaped = EscapedTupleNodes();
+				if (escaped != null)
+				{
+					doNotNest ??= new HashSet<ILVariable>();
+					doNotNest.UnionWith(escaped);
+					continue;
+				}
 				// first tuple element may not be discarded,
 				// otherwise we would run this transform on a suffix of the actual pattern.
 				if (deconstructionResults[0] == null)
 					return false;
-				// A nested tuple designation only holds if the pattern consumed every read of
-				// its temporary; a remaining read means the value escapes the designation.
-				// Retry with the variable as a plain designator leaf, which restores the flat
-				// deconstruction the escaping read needs.
-				var escaped = EscapedTupleNodes();
-				if (escaped == null)
-				{
-					endPos = pos;
-					return true;
-				}
-				doNotNest ??= new HashSet<ILVariable>();
-				doNotNest.UnionWith(escaped);
+				endPos = pos;
+				return true;
 			}
 
 			List<ILVariable>? EscapedTupleNodes()

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -79,6 +79,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		ILVariable?[] deconstructionResults = null!;
 		ILVariable? tupleVariable;
 		TupleType? tupleType;
+		bool rootedInDeconstructCall;
 
 		void IStatementTransform.Run(Block block, int pos, StatementTransformContext context)
 		{
@@ -108,6 +109,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			this.tupleVariable = null;
 			this.tupleType = null;
 			this.deconstructionResults = null!;
+			this.rootedInDeconstructCall = false;
 		}
 
 		/// <summary>
@@ -368,6 +370,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			rootCall = MatchDeconstructionCall(block.Instructions[pos], out testedOperand);
 			if (rootCall == null)
 				return;
+			rootedInDeconstructCall = true;
 			pos++;
 			MatchNestedDeconstructions(block, ref pos, rootCall);
 			// Assign flat indices to the leaves in depth-first order: this is the order in which
@@ -789,6 +792,13 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				if (!deconstructionResultsLookup.TryGetValue(v, out int index))
 					return -1;
 				return index;
+			}
+			if (rootedInDeconstructCall)
+			{
+				// A pattern rooted in a Deconstruct call must not absorb tuple element
+				// accesses: discovering the tuple here would overwrite the call's result
+				// bookkeeping and destroy the rewritten tuple access on failure.
+				return -1;
 			}
 			if (!MatchTupleElementRead(inst, out var container, out var containerType, out int elementIndex))
 				return -1;

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -202,7 +202,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			if (!MatchConversions(block, ref pos, out var conversions, out var conversionStLocs, ref delayedActions))
 				return false;
 
-			if (!MatchAssignments(block, ref pos, conversions, conversionStLocs, ref delayedActions))
+			if (!MatchAssignments(block, ref pos, conversions, conversionStLocs, ref delayedActions,
+				allowUnrelatedAssignments: deconstructMethod != null))
 				return false;
 			// first tuple element may not be discarded,
 			// otherwise we would run this transform on a suffix of the actual pattern.
@@ -356,7 +357,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		bool MatchAssignments(Block block, ref int pos,
 			Dictionary<ILVariable, ConversionInfo> conversions,
 			List<StLoc> conversionStLocs,
-			ref Action<DeconstructInstruction>? delayedActions)
+			ref Action<DeconstructInstruction>? delayedActions,
+			bool allowUnrelatedAssignments)
 		{
 			int previousIndex = -1;
 			int conversionStLocIndex = 0;
@@ -364,6 +366,16 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			while (MatchAssignment(block.Instructions.ElementAtOrDefault(pos), out var targetType, out var valueInst, out var addAssignment))
 			{
 				int index = FindIndex(valueInst, out var tupleAccessAdjustment);
+				if (index < 0 && allowUnrelatedAssignments)
+				{
+					// For a Deconstruct call the element list is fixed by the call's
+					// out-arguments, so an assignment whose value is unrelated to the
+					// deconstruction just ends the pattern and stays after the deconstruct
+					// instruction. (For tuples the elements are discovered from the
+					// assignments, so ending early would misread a suffix as the pattern:
+					// keep rejecting there.)
+					break;
+				}
 				if (index <= previousIndex)
 					return false;
 				AddMissingAssignmentsForConversions(index, ref delayedActions);

--- a/ICSharpCode.Decompiler/TypeSystem/TupleType.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TupleType.cs
@@ -115,8 +115,9 @@ namespace ICSharpCode.Decompiler.TypeSystem
 				case TypeKind.Tuple:
 					tupleCardinality = ((TupleType)type).ElementTypes.Length;
 					return true;
-				case TypeKind.Class:
 				case TypeKind.Struct:
+					// C# requires System.ValueTuple to be a struct, so a class of that name is
+					// some other type that happens to share it and must not become tuple syntax.
 					if (type.Namespace == "System" && type.Name == "ValueTuple")
 					{
 						int tpc = type.TypeParameterCount;

--- a/ICSharpCode.Decompiler/TypeSystem/TupleType.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TupleType.cs
@@ -147,7 +147,7 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		public static TupleType FromUnderlyingType(ICompilation compilation, IType type)
 		{
 			var elementTypes = GetTupleElementTypes(type);
-			if (elementTypes.Length > 0)
+			if (!elementTypes.IsDefaultOrEmpty)
 			{
 				return new TupleType(
 					compilation,


### PR DESCRIPTION
Builds on #3949 (merged), rebased onto current master.

After #3949, nested deconstruction decompiled without crashing but unsugared: `var (x, (a, b)) = o;` came out as a flat deconstruction followed by an explicit `inner.Deconstruct(out var a, out var b);` call. The IL pattern node (`MatchInstruction` with `IsDeconstructCall` sub-patterns), its invariants, and the statement/expression builders all already support nested patterns — only `DeconstructionTransform` never built them.

**Change** (two commits — the chain-matching mechanism, then the rule changes that let chains nest): in `DeconstructionTransform`, `MatchDeconstruction` now consumes chained `Deconstruct` calls — including the defensive copy Roslyn emits for struct elements — into nested match patterns, recursively. Leaves get flat indices in depth-first order, which is exactly the order `StatementBuilder`/`ExpressionBuilder` pair assignments with designators, so conversion/assignment matching runs unchanged on top. Three matching-rule adjustments follow from the chain being consumed: a call pattern no longer needs a matched assignment (single-use leaves are covered by the existing forwarding fixup); an unrelated assignment ends a call pattern instead of rejecting it (tuple patterns still reject — their element list is discovered from the assignments, ending early would misread a suffix); and a pattern is not rooted on an element of an enclosing deconstruction (blocks are processed back to front — the inner call is visited first and would otherwise sugar piecemeal, starving the outer call).

The unrelated-assignment rule is keyed on the pattern being call-rooted, not on nesting, so it also fixes *flat* custom deconstructions: `var (a, b) = GetSource(...);` followed by any unrelated assignment previously decompiled as an explicit `Deconstruct` call and now sugars (pinned by the `LocalVariable_NoConversion_Custom_UnrelatedAssignmentAfter` fixture).

One production change lands outside the transform, as its own commit carrying its two pointer-target Pretty fixtures: `DeconstructInstruction.IsAssignment` falls back to `stobj.Type` when a pointer target was materialized through a stack slot (whose type erases to unknown during target evaluation). This independently enables deconstruction into pointer targets — `(*p, value) = tuple;` — including plain tuples with no nesting at all.

**Nested tuples too**: the second half of the series extends the nesting to pure tuple chains (fixtures, then the temporary-consuming mechanism, then the deferral guard) — `var (x, (a, b)) = GetTuple<int, (int, int)>();`, which Roslyn lowers to one temporary per nested designation (parents before children) plus element reads in depth-first leaf order, previously decompiled as a flat deconstruction plus separate element statements. The matcher now consumes the temporaries into a tuple-node tree with flat depth-first leaf indices (the same design as the call nesting). An element variable that escapes the deconstruction (used after the statement) demotes back to a designator leaf via a blacklist-and-retry, and a dry-run guard — the tuple analogue of the call path's — defers inner flat matches to the enclosing attempt. Two IL realities drove the matcher details: earlier transforms rewrite non-escaping element reads from `ldloca` to `ldloc`, and stack-slot temporaries carry imprecise types (the container's element type is authoritative; the match variable is retyped so the `IsDeconstructTuple` invariant holds). One production change again lands outside the transform, in its own commit: `TupleType.FromUnderlyingType` threw `NullReferenceException` on non-tuple input instead of returning null as documented.

**Scope**: call-under-call and tuple-in-tuple nesting, any depth, assignment + foreach forms, discards, conversions on leaves. Mixed containers (a call pattern absorbing tuple elements, or a custom-deconstructed element inside a tuple pattern) intentionally stay flat, as do by-ref extension receivers (`Deconstruct(this in S, ...)`).

**Tests**: each feature's fixtures land ahead of its implementation and are red until it. For the call nesting: 20 Pretty fixtures (the flat unrelated-assignment form, struct/class inners, both-elements-nested, depth 3, inner discard, nested/typed/nullable conversions, `System.Tuple` sources, the two bail-out shapes `ElementDeconstructedAfterBarrier`/`OuterElementUsedTwice`, two foreach forms incl. `KeyValuePair` extension Deconstruct; the two pointer-target forms ride in the pointer commit) and 18 Correctness cases with printed `Deconstruct` calls pinning evaluation order at runtime, including member hiding (`NestedDeconstruction_HiddenDeconstructMethod` pins the `BindsOnElementType` gate), side-effecting LHS targets, checked/nullable conversions, `in`-parameter, conditional and generic-constraint sources, and the tuple-with-custom-element corruption repro. For the tuple nesting: 6 Pretty fixtures (depth 2 and 3, both elements nested, conversions on inner leaves, the escaping-element case pinned per config, foreach) and 5 Correctness cases with runtime-value pins. Every commit in the series builds, and at every point the only failing tests are the not-yet-implemented spec fixtures (verified per intermediate). Full decompiler suite at the head: 3332 tests, 0 failures.

Output polish for #3803/#3388-adjacent cases; closes nothing by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


