### PR TITLE
Add --dump-table metadata dump mode to ilspycmd

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
@@ -350,36 +350,54 @@ namespace ICSharpCode.Decompiler.Metadata
 
 		public static IEnumerable<(Handle Handle, MethodSemanticsAttributes Semantics, MethodDefinitionHandle Method, EntityHandle Association)> GetMethodSemantics(this MetadataReader metadata)
 		{
-			int offset = metadata.GetTableMetadataOffset(TableIndex.MethodSemantics);
-			int rowSize = metadata.GetTableRowSize(TableIndex.MethodSemantics);
 			int rowCount = metadata.GetTableRowCount(TableIndex.MethodSemantics);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.MethodSemantics);
 
-			bool methodSmall = metadata.GetTableRowCount(TableIndex.MethodDef) <= ushort.MaxValue;
-			bool assocSmall = metadata.GetTableRowCount(TableIndex.Property) <= ushort.MaxValue && metadata.GetTableRowCount(TableIndex.Event) <= ushort.MaxValue;
-			int assocOffset = (methodSmall ? 2 : 4) + 2;
-			for (int row = 0; row < rowCount; row++)
+			int methodSize = SimpleIndexSize(metadata, TableIndex.MethodDef);
+			// HasSemantics coded index: 1 tag bit over Event (tag 0) and Property (tag 1).
+			int assocSize = CodedIndexSize(metadata, 1, TableIndex.Event, TableIndex.Property);
+			for (int rid = 1; rid <= rowCount; rid++)
 			{
-				yield return Read(row);
-			}
-
-			(Handle Handle, MethodSemanticsAttributes Semantics, MethodDefinitionHandle Method, EntityHandle Association) Read(int row)
-			{
-				var span = metadata.AsReadOnlySpan();
-				var methodDefSpan = span.Slice(offset + rowSize * row + 2);
-				int methodDef = methodSmall ? BinaryPrimitives.ReadUInt16LittleEndian(methodDefSpan) : (int)BinaryPrimitives.ReadUInt32LittleEndian(methodDefSpan);
-				var assocSpan = span.Slice(assocOffset);
-				int assocDef = assocSmall ? BinaryPrimitives.ReadUInt16LittleEndian(assocSpan) : (int)BinaryPrimitives.ReadUInt32LittleEndian(assocSpan);
+				var semantics = (MethodSemanticsAttributes)reader.ReadUInt16();
+				int methodRow = methodSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int assocTag = assocSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
 				EntityHandle propOrEvent;
-				if ((assocDef & 0x1) == 1)
+				if ((assocTag & 0x1) == 1)
 				{
-					propOrEvent = MetadataTokens.PropertyDefinitionHandle(assocDef >> 1);
+					propOrEvent = MetadataTokens.PropertyDefinitionHandle(assocTag >> 1);
 				}
 				else
 				{
-					propOrEvent = MetadataTokens.EventDefinitionHandle(assocDef >> 1);
+					propOrEvent = MetadataTokens.EventDefinitionHandle(assocTag >> 1);
 				}
-				return (MetadataTokens.Handle(0x18000000 | (row + 1)), (MethodSemanticsAttributes)(BinaryPrimitives.ReadUInt16LittleEndian(span)), MetadataTokens.MethodDefinitionHandle(methodDef), propOrEvent);
+				yield return (MetadataTokens.Handle(((int)TableIndex.MethodSemantics << 24) | rid), semantics, MetadataTokens.MethodDefinitionHandle(methodRow), propOrEvent);
 			}
+		}
+
+		/// <summary>
+		/// Size in bytes of a column indexing <paramref name="table"/> directly
+		/// (ECMA-335 II.24.2.6: 2 bytes while the table has fewer than 2^16 rows).
+		/// </summary>
+		static int SimpleIndexSize(MetadataReader metadata, TableIndex table)
+		{
+			return metadata.GetTableRowCount(table) < (1 << 16) ? 2 : 4;
+		}
+
+		/// <summary>
+		/// Size in bytes of a coded-index column over <paramref name="tables"/> with
+		/// <paramref name="tagBits"/> tag bits (ECMA-335 II.24.2.6: 2 bytes while every
+		/// indexed table has fewer than 2^(16 - tagBits) rows).
+		/// </summary>
+		static int CodedIndexSize(MetadataReader metadata, int tagBits, params TableIndex[] tables)
+		{
+			int smallLimit = 1 << (16 - tagBits);
+			foreach (var table in tables)
+			{
+				if (metadata.GetTableRowCount(table) >= smallLimit)
+					return 4;
+			}
+			return 2;
 		}
 
 		public static IEnumerable<EntityHandle> GetFieldLayouts(this MetadataReader metadata)

--- a/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
+++ b/ICSharpCode.Decompiler/Metadata/MetadataExtensions.cs
@@ -357,6 +357,7 @@ namespace ICSharpCode.Decompiler.Metadata
 			int methodSize = SimpleIndexSize(metadata, TableIndex.MethodDef);
 			// HasSemantics coded index: 1 tag bit over Event (tag 0) and Property (tag 1).
 			int assocSize = CodedIndexSize(metadata, 1, TableIndex.Event, TableIndex.Property);
+			CheckRowSize(metadata, TableIndex.MethodSemantics, 2 + methodSize + assocSize);
 			for (int rid = 1; rid <= rowCount; rid++)
 			{
 				var semantics = (MethodSemanticsAttributes)reader.ReadUInt16();
@@ -398,6 +399,282 @@ namespace ICSharpCode.Decompiler.Metadata
 					return 4;
 			}
 			return 2;
+		}
+
+		/// <summary>
+		/// Size in bytes of the FieldList/MethodList/ParamList member-range columns. SRM's rule
+		/// (MetadataReader.InitializeTableReaders): the column is wide when the *Ptr table itself
+		/// is large; otherwise the member table's row count governs the width, whether or not the
+		/// indirection is present.
+		/// </summary>
+		static int ListColumnSize(MetadataReader metadata, TableIndex ptrTable, TableIndex memberTable)
+		{
+			return SimpleIndexSize(metadata, ptrTable) > 2 ? 4 : SimpleIndexSize(metadata, memberTable);
+		}
+
+		/// <summary>
+		/// Size in bytes of a #Strings heap index column. The width is declared by the HeapSizes
+		/// flags in the tables-stream header, not derived from the heap's size (a producer may set
+		/// the large-heap flag over a small heap). SRM does not expose the flags, but the ModuleRef
+		/// row consists of a single String column, so its computed row size is exactly this width.
+		/// </summary>
+		static int StringIndexSize(MetadataReader metadata)
+		{
+			return metadata.GetTableRowSize(TableIndex.ModuleRef);
+		}
+
+		/// <summary>
+		/// Size in bytes of a #Blob heap index column (see <see cref="StringIndexSize"/>; the
+		/// TypeSpec row consists of a single Blob column).
+		/// </summary>
+		static int BlobIndexSize(MetadataReader metadata)
+		{
+			return metadata.GetTableRowSize(TableIndex.TypeSpec);
+		}
+
+		/// <summary>
+		/// Verifies that the computed column widths sum to the row size SRM derived from the
+		/// tables-stream header. A width bug reads plausible-looking garbage rather than failing,
+		/// and some width rules are not reproducible through public API at all (EnC minimal-delta
+		/// metadata forces every table and coded index to 4 bytes), so fail loudly on mismatch.
+		/// </summary>
+		static void CheckRowSize(MetadataReader metadata, TableIndex table, int computedRowSize)
+		{
+			int actualRowSize = metadata.GetTableRowSize(table);
+			if (computedRowSize != actualRowSize)
+				throw new BadImageFormatException($"Unexpected {table} row size: computed {computedRowSize}, actual {actualRowSize}.");
+		}
+
+		public static IEnumerable<(int PackingSize, uint ClassSize, TypeDefinitionHandle Parent)> GetClassLayouts(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.ClassLayout);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.ClassLayout);
+			int typeDefSize = SimpleIndexSize(metadata, TableIndex.TypeDef);
+			CheckRowSize(metadata, TableIndex.ClassLayout, 2 + 4 + typeDefSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				ushort packingSize = reader.ReadUInt16();
+				uint classSize = reader.ReadUInt32();
+				int parentRow = typeDefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (packingSize, classSize, MetadataTokens.TypeDefinitionHandle(parentRow));
+			}
+		}
+
+		public static IEnumerable<(int Offset, FieldDefinitionHandle Field)> GetFieldLayoutRows(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.FieldLayout);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.FieldLayout);
+			int fieldSize = SimpleIndexSize(metadata, TableIndex.Field);
+			CheckRowSize(metadata, TableIndex.FieldLayout, 4 + fieldSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int offset = reader.ReadInt32();
+				int fieldRow = fieldSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (offset, MetadataTokens.FieldDefinitionHandle(fieldRow));
+			}
+		}
+
+		public static IEnumerable<(TypeDefinitionHandle Parent, EventDefinitionHandle EventList)> GetEventMaps(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.EventMap);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.EventMap);
+			int typeDefSize = SimpleIndexSize(metadata, TableIndex.TypeDef);
+			int eventListSize = ListColumnSize(metadata, TableIndex.EventPtr, TableIndex.Event);
+			CheckRowSize(metadata, TableIndex.EventMap, typeDefSize + eventListSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int parentRow = typeDefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int eventListRow = eventListSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (MetadataTokens.TypeDefinitionHandle(parentRow), MetadataTokens.EventDefinitionHandle(eventListRow));
+			}
+		}
+
+		public static IEnumerable<(TypeDefinitionHandle Parent, PropertyDefinitionHandle PropertyList)> GetPropertyMaps(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.PropertyMap);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.PropertyMap);
+			int typeDefSize = SimpleIndexSize(metadata, TableIndex.TypeDef);
+			int propertyListSize = ListColumnSize(metadata, TableIndex.PropertyPtr, TableIndex.Property);
+			CheckRowSize(metadata, TableIndex.PropertyMap, typeDefSize + propertyListSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int parentRow = typeDefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int propertyListRow = propertyListSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (MetadataTokens.TypeDefinitionHandle(parentRow), MetadataTokens.PropertyDefinitionHandle(propertyListRow));
+			}
+		}
+
+		public static IEnumerable<(TypeDefinitionHandle NestedClass, TypeDefinitionHandle EnclosingClass)> GetNestedClasses(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.NestedClass);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.NestedClass);
+			int typeDefSize = SimpleIndexSize(metadata, TableIndex.TypeDef);
+			CheckRowSize(metadata, TableIndex.NestedClass, 2 * typeDefSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int nestedRow = typeDefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int enclosingRow = typeDefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (MetadataTokens.TypeDefinitionHandle(nestedRow), MetadataTokens.TypeDefinitionHandle(enclosingRow));
+			}
+		}
+
+		public static IEnumerable<(int RelativeVirtualAddress, FieldDefinitionHandle Field)> GetFieldRvas(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.FieldRva);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.FieldRva);
+			int fieldSize = SimpleIndexSize(metadata, TableIndex.Field);
+			CheckRowSize(metadata, TableIndex.FieldRva, 4 + fieldSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int rva = reader.ReadInt32();
+				int fieldRow = fieldSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (rva, MetadataTokens.FieldDefinitionHandle(fieldRow));
+			}
+		}
+
+		public static IEnumerable<(EntityHandle Parent, BlobHandle NativeType)> GetFieldMarshals(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.FieldMarshal);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.FieldMarshal);
+			// HasFieldMarshal coded index: 1 tag bit over Field (tag 0) and Param (tag 1).
+			int parentSize = CodedIndexSize(metadata, 1, TableIndex.Field, TableIndex.Param);
+			int blobSize = BlobIndexSize(metadata);
+			CheckRowSize(metadata, TableIndex.FieldMarshal, parentSize + blobSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int parentTag = parentSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int blobOffset = blobSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				EntityHandle parent = (parentTag & 0x1) == 1
+					? MetadataTokens.ParameterHandle(parentTag >> 1)
+					: MetadataTokens.FieldDefinitionHandle(parentTag >> 1);
+				yield return (parent, MetadataTokens.BlobHandle(blobOffset));
+			}
+		}
+
+		public static IEnumerable<(System.Reflection.MethodImportAttributes MappingFlags, EntityHandle MemberForwarded, StringHandle ImportName, ModuleReferenceHandle ImportScope)> GetImplMaps(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.ImplMap);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.ImplMap);
+			// MemberForwarded coded index: 1 tag bit over Field (tag 0) and MethodDef (tag 1).
+			int memberForwardedSize = CodedIndexSize(metadata, 1, TableIndex.Field, TableIndex.MethodDef);
+			int stringSize = StringIndexSize(metadata);
+			int moduleRefSize = SimpleIndexSize(metadata, TableIndex.ModuleRef);
+			CheckRowSize(metadata, TableIndex.ImplMap, 2 + memberForwardedSize + stringSize + moduleRefSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				var mappingFlags = (System.Reflection.MethodImportAttributes)reader.ReadUInt16();
+				int memberForwardedTag = memberForwardedSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int importNameOffset = stringSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int importScopeRow = moduleRefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				EntityHandle memberForwarded = (memberForwardedTag & 0x1) == 1
+					? MetadataTokens.MethodDefinitionHandle(memberForwardedTag >> 1)
+					: MetadataTokens.FieldDefinitionHandle(memberForwardedTag >> 1);
+				yield return (mappingFlags, memberForwarded, MetadataTokens.StringHandle(importNameOffset), MetadataTokens.ModuleReferenceHandle(importScopeRow));
+			}
+		}
+
+		public static IEnumerable<(TypeDefinitionHandle Class, EntityHandle Interface)> GetInterfaceImplRows(this MetadataReader metadata)
+		{
+			int rowCount = metadata.GetTableRowCount(TableIndex.InterfaceImpl);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.InterfaceImpl);
+			int typeDefSize = SimpleIndexSize(metadata, TableIndex.TypeDef);
+			// TypeDefOrRef coded index: 2 tag bits over TypeDef (0), TypeRef (1) and TypeSpec (2).
+			int interfaceSize = CodedIndexSize(metadata, 2, TableIndex.TypeDef, TableIndex.TypeRef, TableIndex.TypeSpec);
+			CheckRowSize(metadata, TableIndex.InterfaceImpl, typeDefSize + interfaceSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int classRow = typeDefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int interfaceTag = interfaceSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				EntityHandle iface = (interfaceTag & 0x3) switch {
+					0 => MetadataTokens.TypeDefinitionHandle(interfaceTag >> 2),
+					1 => MetadataTokens.TypeReferenceHandle(interfaceTag >> 2),
+					_ => MetadataTokens.TypeSpecificationHandle(interfaceTag >> 2),
+				};
+				yield return (MetadataTokens.TypeDefinitionHandle(classRow), iface);
+			}
+		}
+
+		/// <summary>
+		/// Enumerates one of the five *Ptr indirection tables (EventPtr, FieldPtr, MethodPtr,
+		/// ParamPtr, PropertyPtr), yielding the referenced entity of each row.
+		/// </summary>
+		public static IEnumerable<EntityHandle> GetPtrRows(this MetadataReader metadata, TableIndex ptrTable)
+		{
+			TableIndex referencedTable = ptrTable switch {
+				TableIndex.EventPtr => TableIndex.Event,
+				TableIndex.FieldPtr => TableIndex.Field,
+				TableIndex.MethodPtr => TableIndex.MethodDef,
+				TableIndex.ParamPtr => TableIndex.Param,
+				TableIndex.PropertyPtr => TableIndex.Property,
+				_ => throw new ArgumentOutOfRangeException(nameof(ptrTable)),
+			};
+			int rowCount = metadata.GetTableRowCount(ptrTable);
+			var reader = metadata.AsBlobReader();
+			reader.Offset = metadata.GetTableMetadataOffset(ptrTable);
+			int handleSize = SimpleIndexSize(metadata, referencedTable);
+			CheckRowSize(metadata, ptrTable, handleSize);
+			for (int rid = 1; rid <= rowCount; rid++)
+			{
+				int row = handleSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return MetadataTokens.EntityHandle(((int)referencedTable << 24) | row);
+			}
+		}
+
+		/// <summary>
+		/// Reads the FieldList/MethodList columns of the TypeDef table, which SRM does not expose:
+		/// the stored value is the running list position (the next type's first member row, or one
+		/// past the member table's end), never 0. The columns sit at the end of the row, so they are
+		/// read relative to the row end to avoid re-deriving the widths of the preceding columns.
+		/// </summary>
+		public static IEnumerable<(TypeDefinitionHandle Type, int FieldList, int MethodList)> GetTypeDefListColumns(this MetadataReader metadata)
+		{
+			int fieldListSize = ListColumnSize(metadata, TableIndex.FieldPtr, TableIndex.Field);
+			int methodListSize = ListColumnSize(metadata, TableIndex.MethodPtr, TableIndex.MethodDef);
+			// Flags + Name + Namespace + Extends (TypeDefOrRef coded index) precede the list columns.
+			CheckRowSize(metadata, TableIndex.TypeDef,
+				4 + 2 * StringIndexSize(metadata)
+				+ CodedIndexSize(metadata, 2, TableIndex.TypeDef, TableIndex.TypeRef, TableIndex.TypeSpec)
+				+ fieldListSize + methodListSize);
+			int rowSize = metadata.GetTableRowSize(TableIndex.TypeDef);
+			int tableOffset = metadata.GetTableMetadataOffset(TableIndex.TypeDef);
+			var reader = metadata.AsBlobReader();
+			foreach (var handle in metadata.TypeDefinitions)
+			{
+				reader.Offset = tableOffset + rowSize * MetadataTokens.GetRowNumber(handle) - fieldListSize - methodListSize;
+				int fieldList = fieldListSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				int methodList = methodListSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (handle, fieldList, methodList);
+			}
+		}
+
+		/// <summary>
+		/// Reads the ParamList column of the MethodDef table (see <see cref="GetTypeDefListColumns"/>
+		/// for why SRM cannot provide it).
+		/// </summary>
+		public static IEnumerable<(MethodDefinitionHandle Method, int ParamList)> GetMethodDefParamLists(this MetadataReader metadata)
+		{
+			int paramListSize = ListColumnSize(metadata, TableIndex.ParamPtr, TableIndex.Param);
+			// RVA + ImplFlags + Flags + Name + Signature precede the ParamList column.
+			CheckRowSize(metadata, TableIndex.MethodDef,
+				4 + 2 + 2 + StringIndexSize(metadata) + BlobIndexSize(metadata) + paramListSize);
+			int rowSize = metadata.GetTableRowSize(TableIndex.MethodDef);
+			int tableOffset = metadata.GetTableMetadataOffset(TableIndex.MethodDef);
+			var reader = metadata.AsBlobReader();
+			foreach (var handle in metadata.MethodDefinitions)
+			{
+				reader.Offset = tableOffset + rowSize * MetadataTokens.GetRowNumber(handle) - paramListSize;
+				int paramList = paramListSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
+				yield return (handle, paramList);
+			}
 		}
 
 		public static IEnumerable<EntityHandle> GetFieldLayouts(this MetadataReader metadata)

--- a/ICSharpCode.ILSpyCmd.Tests/CliTestRunner.cs
+++ b/ICSharpCode.ILSpyCmd.Tests/CliTestRunner.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ICSharpCode.ILSpyCmd.Tests
+{
+	/// <summary>
+	/// Runs ilspycmd in-process with captured console streams.
+	/// </summary>
+	internal static class CliTestRunner
+	{
+		public static async Task<(int ExitCode, string Output, string Error)> RunAsync(params string[] args)
+		{
+			var originalOut = Console.Out;
+			var originalError = Console.Error;
+			var stdout = new StringWriter();
+			var stderr = new StringWriter();
+			try
+			{
+				Console.SetOut(stdout);
+				Console.SetError(stderr);
+				int exitCode = await ILSpyCmdProgram.Main(args);
+				return (exitCode, stdout.ToString(), stderr.ToString());
+			}
+			finally
+			{
+				Console.SetOut(originalOut);
+				Console.SetError(originalError);
+			}
+		}
+	}
+}

--- a/ICSharpCode.ILSpyCmd.Tests/DumpTableOptionTests.cs
+++ b/ICSharpCode.ILSpyCmd.Tests/DumpTableOptionTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+using static ICSharpCode.ILSpyCmd.Tests.CliTestRunner;
+
+namespace ICSharpCode.ILSpyCmd.Tests
+{
+	[TestFixture]
+	public class DumpTableOptionTests
+	{
+		static readonly string testAssemblyPath = typeof(DumpTableOptionTests).Assembly.Location;
+
+		[Test]
+		public async Task TypeDefTableContainsSampleType()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "TypeDef");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain("RID"));
+			Assert.That(result.Output, Does.Contain("Token"));
+			Assert.That(result.Output, Does.Contain(nameof(DumpTableSample)));
+			// the FieldList/MethodList columns SRM hides must be part of the dump
+			Assert.That(result.Output, Does.Contain("FieldList"));
+			Assert.That(result.Output, Does.Contain("MethodList"));
+		}
+
+		[Test]
+		public async Task PropertyTableContainsSampleProperty()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "Property");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain(nameof(DumpTableSample.SampleProperty)));
+		}
+
+		[Test]
+		public async Task MethodSemanticsTableShowsAccessors()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "MethodSemantics");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain("Getter"));
+		}
+
+		[Test]
+		public async Task NestedClassTableHasRows()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "NestedClass");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain("NestedClass"));
+			// at least one row beyond the header: RID 1 must be present
+			Assert.That(result.Output, Does.Match(@"(?m)^\s*1\s"));
+		}
+
+		[Test]
+		public async Task ClassLayoutTableHasRows()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "ClassLayout");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain("PackingSize"));
+			Assert.That(result.Output, Does.Contain("ClassSize"));
+			Assert.That(result.Output, Does.Match(@"(?m)^\s*1\s"));
+		}
+
+		[Test]
+		public async Task JsonOutputIsParseableAndContainsRows()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "Property", "--json");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			using var doc = JsonDocument.Parse(result.Output);
+			var root = doc.RootElement;
+			Assert.That(root.GetProperty("table").GetString(), Is.EqualTo("Property"));
+			Assert.That(root.GetProperty("rowCount").GetInt32(), Is.GreaterThan(0));
+			bool foundSample = false;
+			foreach (var row in root.GetProperty("rows").EnumerateArray())
+			{
+				Assert.That(row.GetProperty("RID").ValueKind, Is.EqualTo(JsonValueKind.Number));
+				if (row.GetProperty("Name").GetString() == nameof(DumpTableSample.SampleProperty))
+					foundSample = true;
+			}
+			Assert.That(foundSample, Is.True, "expected a Property row named SampleProperty");
+		}
+
+		[Test]
+		public async Task UnknownTableNameReportsUsageError()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "Bogus");
+
+			Assert.That(result.ExitCode, Is.EqualTo(ProgramExitCodes.EX_USAGE));
+			Assert.That(result.Error, Does.Contain("Bogus"));
+			Assert.That(result.Error, Does.Contain("TypeDef"), "the error should list valid table names");
+		}
+
+		[Test]
+		public async Task JsonWithoutDumpTableReportsUsageError()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--json");
+
+			Assert.That(result.ExitCode, Is.EqualTo(ProgramExitCodes.EX_USAGE));
+			Assert.That(result.Error, Does.Contain("--json"));
+		}
+
+		[Test]
+		public async Task TableByDecimalNumber()
+		{
+			// 23 == 0x17 == Property
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "23");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain(nameof(DumpTableSample.SampleProperty)));
+		}
+
+		[Test]
+		public async Task TableByHexNumber()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "0x17");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain(nameof(DumpTableSample.SampleProperty)));
+		}
+
+		[Test]
+		public async Task OutOfRangeTableNumberReportsUsageError()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "0x40");
+
+			Assert.That(result.ExitCode, Is.EqualTo(ProgramExitCodes.EX_USAGE));
+			Assert.That(result.Error, Does.Contain("0x40"));
+		}
+
+		[Test]
+		public async Task OutputDirWritesEveryAssemblyCompletely()
+		{
+			// Two input assemblies, so the per-file output writer is swapped between files;
+			// a writer that is replaced without being flushed truncates the earlier file.
+			string ilspyCmdAssemblyPath = typeof(ILSpyCmdProgram).Assembly.Location;
+			string outputDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			Directory.CreateDirectory(outputDir);
+			try
+			{
+				var result = await RunAsync(testAssemblyPath, ilspyCmdAssemblyPath,
+					"--disable-updatecheck", "--dump-table", "TypeDef", "--json", "-o", outputDir);
+
+				Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+				foreach (string assemblyPath in new[] { testAssemblyPath, ilspyCmdAssemblyPath })
+				{
+					string outputFile = Path.Combine(outputDir, Path.GetFileNameWithoutExtension(assemblyPath) + ".TypeDef.json");
+					Assert.That(File.Exists(outputFile), Is.True, outputFile);
+					// a truncated file is not parseable JSON
+					using var doc = JsonDocument.Parse(File.ReadAllText(outputFile));
+					Assert.That(doc.RootElement.GetProperty("rowCount").GetInt32(), Is.GreaterThan(0), outputFile);
+				}
+			}
+			finally
+			{
+				Directory.Delete(outputDir, recursive: true);
+			}
+		}
+
+		[Test]
+		public async Task TableNameIsCaseInsensitive()
+		{
+			var result = await RunAsync(testAssemblyPath, "--disable-updatecheck", "--dump-table", "property");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain(nameof(DumpTableSample.SampleProperty)));
+		}
+	}
+
+	public class DumpTableSample
+	{
+		public string SampleProperty => "sample";
+
+		public class NestedSample
+		{
+		}
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 4, Size = 16)]
+	public struct ExplicitLayoutSample
+	{
+		public int A;
+	}
+}

--- a/ICSharpCode.ILSpyCmd.Tests/MemberOptionTests.cs
+++ b/ICSharpCode.ILSpyCmd.Tests/MemberOptionTests.cs
@@ -22,32 +22,14 @@ using System.Threading.Tasks;
 
 using NUnit.Framework;
 
+using static ICSharpCode.ILSpyCmd.Tests.CliTestRunner;
+
 namespace ICSharpCode.ILSpyCmd.Tests
 {
 	[TestFixture]
 	public class ILSpyCmdMemberOptionTests
 	{
 		static readonly string testAssemblyPath = typeof(ILSpyCmdMemberOptionTests).Assembly.Location;
-
-		static async Task<(int ExitCode, string Output, string Error)> RunAsync(params string[] args)
-		{
-			var originalOut = Console.Out;
-			var originalError = Console.Error;
-			var stdout = new StringWriter();
-			var stderr = new StringWriter();
-			try
-			{
-				Console.SetOut(stdout);
-				Console.SetError(stderr);
-				int exitCode = await ILSpyCmdProgram.Main(args);
-				return (exitCode, stdout.ToString(), stderr.ToString());
-			}
-			finally
-			{
-				Console.SetOut(originalOut);
-				Console.SetError(originalError);
-			}
-		}
 
 		[Test]
 		public async Task MethodByDocumentationIdString()

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -136,6 +136,12 @@ Examples:
 		[Option("--decompile-baml", "When used with -p, decompile BAML resources to XAML files (Page items) instead of leaving them as raw byte streams.", CommandOptionType.NoValue)]
 		public bool DecompileBamlFlag { get; }
 
+		[Option("--dump-table <table>", "Dump a metadata table: prints RID, token, names, heap offsets and coded indexes of every row. <table> is the ECMA-335 table name (e.g. TypeDef, Property, MethodSemantics; case-insensitive) or table number (decimal or 0x-prefixed hex, e.g. 0x17).", CommandOptionType.SingleValue)]
+		public string DumpTableName { get; }
+
+		[Option("--json", "Output as JSON. Currently only supported together with --dump-table.", CommandOptionType.NoValue)]
+		public bool JsonOutputFlag { get; }
+
 		public string DecompilerVersion => "ilspycmd: " + typeof(ILSpyCmdProgram).Assembly.GetName().Version.ToString() +
 				Environment.NewLine
 				+ "ICSharpCode.Decompiler: " +
@@ -232,6 +238,12 @@ Examples:
 			if (outputDirectory != null)
 			{
 				Directory.CreateDirectory(outputDirectory);
+			}
+
+			if (JsonOutputFlag && DumpTableName == null)
+			{
+				app.Error.WriteLine("The --json option is currently only supported together with --dump-table.");
+				return ProgramExitCodes.EX_USAGE;
 			}
 
 			try
@@ -362,6 +374,27 @@ Examples:
 				else if (ResourceName != null)
 				{
 					return ExtractResource(fileName, ResourceName, output, outputDirectory, app);
+				}
+				else if (DumpTableName != null)
+				{
+					if (!MetadataTableDumper.TryParseTableName(DumpTableName, out var table))
+					{
+						app.Error.WriteLine($"Unknown metadata table '{DumpTableName}'.");
+						app.Error.WriteLine($"Supported tables: {MetadataTableDumper.SupportedTableNames}");
+						return ProgramExitCodes.EX_USAGE;
+					}
+
+					if (outputDirectory != null)
+					{
+						// per-file writer, disposed here: the shared 'output' is only closed once
+						// at the end of the run, which would lose the buffered tail of every file
+						// but the last when dumping multiple assemblies
+						string outputName = Path.GetFileNameWithoutExtension(fileName);
+						using var tableOutput = File.CreateText(Path.Combine(outputDirectory, outputName) + $".{table}.{(JsonOutputFlag ? "json" : "txt")}");
+						return MetadataTableDumper.DumpTable(fileName, tableOutput, table, JsonOutputFlag);
+					}
+
+					return MetadataTableDumper.DumpTable(fileName, output, table, JsonOutputFlag);
 				}
 				else
 				{

--- a/ICSharpCode.ILSpyCmd/MetadataTableDumper.cs
+++ b/ICSharpCode.ILSpyCmd/MetadataTableDumper.cs
@@ -1,0 +1,544 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Text.Json;
+
+using ICSharpCode.Decompiler.Metadata;
+
+namespace ICSharpCode.ILSpyCmd
+{
+	/// <summary>
+	/// Implements the --dump-table mode: prints every row of a metadata table (RID, token,
+	/// resolved names, heap offsets and coded indexes) as an aligned console table or as JSON.
+	/// The columns of every table are spelled out explicitly (in ECMA-335 declaration order)
+	/// so the output stays deterministic across runtime versions.
+	/// </summary>
+	internal static class MetadataTableDumper
+	{
+		// The Cor tables the GUI's metadata view supports; EnC and Portable-PDB tables are out of scope.
+		static readonly TableIndex[] supportedTables = {
+			TableIndex.Module, TableIndex.TypeRef, TableIndex.TypeDef, TableIndex.FieldPtr,
+			TableIndex.Field, TableIndex.MethodPtr, TableIndex.MethodDef, TableIndex.ParamPtr,
+			TableIndex.Param, TableIndex.InterfaceImpl, TableIndex.MemberRef, TableIndex.Constant,
+			TableIndex.CustomAttribute, TableIndex.FieldMarshal, TableIndex.DeclSecurity,
+			TableIndex.ClassLayout, TableIndex.FieldLayout, TableIndex.StandAloneSig,
+			TableIndex.EventMap, TableIndex.EventPtr, TableIndex.Event, TableIndex.PropertyMap,
+			TableIndex.PropertyPtr, TableIndex.Property, TableIndex.MethodSemantics,
+			TableIndex.MethodImpl, TableIndex.ModuleRef, TableIndex.TypeSpec, TableIndex.ImplMap,
+			TableIndex.FieldRva, TableIndex.Assembly, TableIndex.AssemblyRef, TableIndex.File,
+			TableIndex.ExportedType, TableIndex.ManifestResource, TableIndex.NestedClass,
+			TableIndex.GenericParam, TableIndex.MethodSpec, TableIndex.GenericParamConstraint,
+		};
+
+		public static string SupportedTableNames => string.Join(", ",
+			supportedTables.Select(t => $"{t} (0x{(int)t:X2})"));
+
+		public static bool TryParseTableName(string name, out TableIndex table)
+		{
+			// accept the ECMA-335 table number, decimal or 0x-prefixed hex, as an
+			// alternative to the table name
+			bool isNumber = name.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+				? int.TryParse(name.AsSpan(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int number)
+				: int.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out number);
+			if (isNumber)
+			{
+				table = (TableIndex)number;
+				return supportedTables.Contains(table);
+			}
+			return Enum.TryParse(name, ignoreCase: true, out table)
+				&& supportedTables.Contains(table);
+		}
+
+		public static int DumpTable(string assemblyFileName, TextWriter output, TableIndex table, bool asJson)
+		{
+			using var module = new PEFile(assemblyFileName);
+			var metadata = module.Metadata;
+			var rows = LoadRows(metadata, table);
+			if (asJson)
+			{
+				WriteJson(output, assemblyFileName, table, rows);
+			}
+			else
+			{
+				WriteConsoleTable(output, rows);
+			}
+			return 0;
+		}
+
+		/// <summary>
+		/// A row is an ordered list of (column, value) pairs; values are either int (RID)
+		/// or already-formatted strings, so the console and JSON writers stay in sync.
+		/// </summary>
+		static List<List<(string Column, object Value)>> LoadRows(MetadataReader metadata, TableIndex table)
+		{
+			var rows = new List<List<(string, object)>>();
+			int rid = 0;
+
+			switch (table)
+			{
+				case TableIndex.Module:
+					if (metadata.GetTableRowCount(TableIndex.Module) > 0)
+					{
+						var module = metadata.GetModuleDefinition();
+						rows.Add(Row(metadata, 1, MetadataTokens.EntityHandle(TableIndex.Module, 1),
+							("Generation", module.Generation),
+							("Name", module.Name),
+							("Mvid", module.Mvid),
+							("GenerationId", module.GenerationId),
+							("BaseGenerationId", module.BaseGenerationId)));
+					}
+					break;
+				case TableIndex.TypeRef:
+					foreach (var h in metadata.TypeReferences)
+					{
+						var typeRef = metadata.GetTypeReference(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("ResolutionScope", typeRef.ResolutionScope),
+							("Name", typeRef.Name),
+							("Namespace", typeRef.Namespace)));
+					}
+					break;
+				case TableIndex.TypeDef:
+					var listColumns = metadata.GetTypeDefListColumns().ToDictionary(r => r.Type, r => (r.FieldList, r.MethodList));
+					foreach (var h in metadata.TypeDefinitions)
+					{
+						var typeDef = metadata.GetTypeDefinition(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Attributes", typeDef.Attributes),
+							("Name", typeDef.Name),
+							("Namespace", typeDef.Namespace),
+							("BaseType", typeDef.BaseType),
+							("FieldList", FormatRid(listColumns[h].FieldList)),
+							("MethodList", FormatRid(listColumns[h].MethodList))));
+					}
+					break;
+				case TableIndex.Field:
+					foreach (var h in metadata.FieldDefinitions)
+					{
+						var field = metadata.GetFieldDefinition(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Attributes", field.Attributes),
+							("Name", field.Name),
+							("Signature", field.Signature)));
+					}
+					break;
+				case TableIndex.MethodDef:
+					var paramLists = metadata.GetMethodDefParamLists().ToDictionary(r => r.Method, r => r.ParamList);
+					foreach (var h in metadata.MethodDefinitions)
+					{
+						var method = metadata.GetMethodDefinition(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("RVA", FormatHex(method.RelativeVirtualAddress)),
+							("ImplAttributes", method.ImplAttributes),
+							("Attributes", method.Attributes),
+							("Name", method.Name),
+							("Signature", method.Signature),
+							("ParamList", FormatRid(paramLists[h]))));
+					}
+					break;
+				case TableIndex.Param:
+					foreach (int r in RidRange(metadata, table))
+					{
+						var param = metadata.GetParameter(MetadataTokens.ParameterHandle(r));
+						rows.Add(Row(metadata, r, MetadataTokens.EntityHandle(table, r),
+							("Attributes", param.Attributes),
+							("SequenceNumber", param.SequenceNumber),
+							("Name", param.Name)));
+					}
+					break;
+				case TableIndex.InterfaceImpl:
+					foreach (var (cls, iface) in metadata.GetInterfaceImplRows())
+						rows.Add(Row(metadata, ++rid, table, ("Class", cls), ("Interface", iface)));
+					break;
+				case TableIndex.MemberRef:
+					foreach (var h in metadata.MemberReferences)
+					{
+						var memberRef = metadata.GetMemberReference(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Parent", memberRef.Parent),
+							("Name", memberRef.Name),
+							("Signature", memberRef.Signature)));
+					}
+					break;
+				case TableIndex.Constant:
+					foreach (int r in RidRange(metadata, table))
+					{
+						var constant = metadata.GetConstant(MetadataTokens.ConstantHandle(r));
+						rows.Add(Row(metadata, r, MetadataTokens.EntityHandle(table, r),
+							("TypeCode", constant.TypeCode),
+							("Parent", constant.Parent),
+							("Value", constant.Value)));
+					}
+					break;
+				case TableIndex.CustomAttribute:
+					foreach (var h in metadata.CustomAttributes)
+					{
+						var attribute = metadata.GetCustomAttribute(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Parent", attribute.Parent),
+							("Constructor", attribute.Constructor),
+							("Value", attribute.Value)));
+					}
+					break;
+				case TableIndex.FieldMarshal:
+					foreach (var (parent, nativeType) in metadata.GetFieldMarshals())
+						rows.Add(Row(metadata, ++rid, table, ("Parent", parent), ("NativeType", nativeType)));
+					break;
+				case TableIndex.DeclSecurity:
+					foreach (var h in metadata.DeclarativeSecurityAttributes)
+					{
+						var declSecurity = metadata.GetDeclarativeSecurityAttribute(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Action", declSecurity.Action),
+							("Parent", declSecurity.Parent),
+							("PermissionSet", declSecurity.PermissionSet)));
+					}
+					break;
+				case TableIndex.ClassLayout:
+					foreach (var (packingSize, classSize, parent) in metadata.GetClassLayouts())
+						rows.Add(Row(metadata, ++rid, table, ("PackingSize", packingSize), ("ClassSize", classSize), ("Parent", parent)));
+					break;
+				case TableIndex.FieldLayout:
+					foreach (var (offset, field) in metadata.GetFieldLayoutRows())
+						rows.Add(Row(metadata, ++rid, table, ("Offset", offset), ("Field", field)));
+					break;
+				case TableIndex.StandAloneSig:
+					foreach (int r in RidRange(metadata, table))
+					{
+						var signature = metadata.GetStandaloneSignature(MetadataTokens.StandaloneSignatureHandle(r));
+						rows.Add(Row(metadata, r, MetadataTokens.EntityHandle(table, r),
+							("Signature", signature.Signature)));
+					}
+					break;
+				case TableIndex.EventMap:
+					foreach (var (parent, eventList) in metadata.GetEventMaps())
+						rows.Add(Row(metadata, ++rid, table, ("Parent", parent), ("EventList", eventList)));
+					break;
+				case TableIndex.Event:
+					foreach (var h in metadata.EventDefinitions)
+					{
+						var eventDef = metadata.GetEventDefinition(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Attributes", eventDef.Attributes),
+							("Name", eventDef.Name),
+							("Type", eventDef.Type)));
+					}
+					break;
+				case TableIndex.PropertyMap:
+					foreach (var (parent, propertyList) in metadata.GetPropertyMaps())
+						rows.Add(Row(metadata, ++rid, table, ("Parent", parent), ("PropertyList", propertyList)));
+					break;
+				case TableIndex.Property:
+					foreach (var h in metadata.PropertyDefinitions)
+					{
+						var property = metadata.GetPropertyDefinition(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Attributes", property.Attributes),
+							("Name", property.Name),
+							("Signature", property.Signature)));
+					}
+					break;
+				case TableIndex.MethodSemantics:
+					foreach (var (_, semantics, method, association) in metadata.GetMethodSemantics())
+						rows.Add(Row(metadata, ++rid, table, ("Semantics", semantics), ("Method", method), ("Association", association)));
+					break;
+				case TableIndex.MethodImpl:
+					foreach (int r in RidRange(metadata, table))
+					{
+						var methodImpl = metadata.GetMethodImplementation(MetadataTokens.MethodImplementationHandle(r));
+						rows.Add(Row(metadata, r, MetadataTokens.EntityHandle(table, r),
+							("Class", methodImpl.Type),
+							("MethodBody", methodImpl.MethodBody),
+							("MethodDeclaration", methodImpl.MethodDeclaration)));
+					}
+					break;
+				case TableIndex.ModuleRef:
+					foreach (var h in metadata.GetModuleReferences())
+					{
+						var moduleRef = metadata.GetModuleReference(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Name", moduleRef.Name)));
+					}
+					break;
+				case TableIndex.TypeSpec:
+					foreach (var h in metadata.GetTypeSpecifications())
+					{
+						var typeSpec = metadata.GetTypeSpecification(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Signature", typeSpec.Signature)));
+					}
+					break;
+				case TableIndex.ImplMap:
+					foreach (var (mappingFlags, memberForwarded, importName, importScope) in metadata.GetImplMaps())
+						rows.Add(Row(metadata, ++rid, table, ("MappingFlags", mappingFlags), ("MemberForwarded", memberForwarded), ("ImportName", importName), ("ImportScope", importScope)));
+					break;
+				case TableIndex.FieldRva:
+					foreach (var (rva, field) in metadata.GetFieldRvas())
+						rows.Add(Row(metadata, ++rid, table, ("RVA", FormatHex(rva)), ("Field", field)));
+					break;
+				case TableIndex.Assembly:
+					if (metadata.IsAssembly)
+					{
+						var assembly = metadata.GetAssemblyDefinition();
+						rows.Add(Row(metadata, 1, MetadataTokens.EntityHandle(TableIndex.Assembly, 1),
+							("HashAlgorithm", assembly.HashAlgorithm),
+							("Version", assembly.Version),
+							("Flags", assembly.Flags),
+							("PublicKey", assembly.PublicKey),
+							("Name", assembly.Name),
+							("Culture", assembly.Culture)));
+					}
+					break;
+				case TableIndex.AssemblyRef:
+					foreach (var h in metadata.AssemblyReferences)
+					{
+						var assemblyRef = metadata.GetAssemblyReference(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Version", assemblyRef.Version),
+							("Flags", assemblyRef.Flags),
+							("PublicKeyOrToken", assemblyRef.PublicKeyOrToken),
+							("Name", assemblyRef.Name),
+							("Culture", assemblyRef.Culture),
+							("HashValue", assemblyRef.HashValue)));
+					}
+					break;
+				case TableIndex.File:
+					foreach (var h in metadata.AssemblyFiles)
+					{
+						var file = metadata.GetAssemblyFile(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("ContainsMetadata", file.ContainsMetadata),
+							("Name", file.Name),
+							("HashValue", file.HashValue)));
+					}
+					break;
+				case TableIndex.ExportedType:
+					foreach (var h in metadata.ExportedTypes)
+					{
+						var exportedType = metadata.GetExportedType(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Attributes", exportedType.Attributes),
+							("Name", exportedType.Name),
+							("Namespace", exportedType.Namespace),
+							("Implementation", exportedType.Implementation),
+							("IsForwarder", exportedType.IsForwarder)));
+					}
+					break;
+				case TableIndex.ManifestResource:
+					foreach (var h in metadata.ManifestResources)
+					{
+						var resource = metadata.GetManifestResource(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Offset", resource.Offset),
+							("Attributes", resource.Attributes),
+							("Name", resource.Name),
+							("Implementation", resource.Implementation)));
+					}
+					break;
+				case TableIndex.NestedClass:
+					foreach (var (nested, enclosing) in metadata.GetNestedClasses())
+						rows.Add(Row(metadata, ++rid, table, ("NestedClass", nested), ("EnclosingClass", enclosing)));
+					break;
+				case TableIndex.GenericParam:
+					foreach (int r in RidRange(metadata, table))
+					{
+						var genericParam = metadata.GetGenericParameter(MetadataTokens.GenericParameterHandle(r));
+						rows.Add(Row(metadata, r, MetadataTokens.EntityHandle(table, r),
+							("Number", genericParam.Index),
+							("Attributes", genericParam.Attributes),
+							("Owner", genericParam.Parent),
+							("Name", genericParam.Name)));
+					}
+					break;
+				case TableIndex.MethodSpec:
+					foreach (var h in metadata.GetMethodSpecifications())
+					{
+						var methodSpec = metadata.GetMethodSpecification(h);
+						rows.Add(Row(metadata, MetadataTokens.GetRowNumber(h), h,
+							("Method", methodSpec.Method),
+							("Instantiation", methodSpec.Signature)));
+					}
+					break;
+				case TableIndex.GenericParamConstraint:
+					foreach (int r in RidRange(metadata, table))
+					{
+						var constraint = metadata.GetGenericParameterConstraint(MetadataTokens.GenericParameterConstraintHandle(r));
+						rows.Add(Row(metadata, r, MetadataTokens.EntityHandle(table, r),
+							("Owner", (EntityHandle)constraint.Parameter),
+							("Constraint", constraint.Type)));
+					}
+					break;
+				case TableIndex.EventPtr:
+				case TableIndex.FieldPtr:
+				case TableIndex.MethodPtr:
+				case TableIndex.ParamPtr:
+				case TableIndex.PropertyPtr:
+					foreach (var target in metadata.GetPtrRows(table))
+						rows.Add(Row(metadata, ++rid, table, ("Target", target)));
+					break;
+				default:
+					throw new InvalidOperationException($"Table {table} is listed as supported but has no loader.");
+			}
+			return rows;
+		}
+
+		static IEnumerable<int> RidRange(MetadataReader metadata, TableIndex table)
+		{
+			return Enumerable.Range(1, metadata.GetTableRowCount(table));
+		}
+
+		static List<(string, object)> Row(MetadataReader metadata, int rid, EntityHandle handle, params (string Column, object Value)[] columns)
+		{
+			return BuildRow(metadata, rid, MetadataTokens.GetToken(handle), columns);
+		}
+
+		static List<(string, object)> Row(MetadataReader metadata, int rid, TableIndex table, params (string Column, object Value)[] columns)
+		{
+			// tables without an SRM handle type get their token synthesized from table id and RID
+			return BuildRow(metadata, rid, ((int)table << 24) | rid, columns);
+		}
+
+		static List<(string, object)> BuildRow(MetadataReader metadata, int rid, int token, (string Column, object Value)[] columns)
+		{
+			var row = new List<(string, object)> {
+				("RID", rid),
+				("Token", FormatHex(token)),
+			};
+			foreach (var (column, value) in columns)
+			{
+				row.Add((column, FormatValue(metadata, value)));
+			}
+			return row;
+		}
+
+		static string FormatValue(MetadataReader metadata, object value)
+		{
+			switch (value)
+			{
+				case null:
+					return "";
+				case string s:
+					return s;
+				case StringHandle sh:
+					return sh.IsNil ? "" : metadata.GetString(sh);
+				case BlobHandle bh:
+					return bh.IsNil ? "nil" : FormatHex(MetadataTokens.GetHeapOffset(bh));
+				case GuidHandle gh:
+					return gh.IsNil ? "nil" : metadata.GetGuid(gh).ToString();
+				case EntityHandle eh:
+					return eh.IsNil ? "nil" : FormatHex(MetadataTokens.GetToken(eh));
+				// The concrete handle cases below are not dead code: pattern matching tests the
+				// runtime type of the boxed value and ignores SRM's user-defined conversions, so
+				// a boxed MethodDefinitionHandle does not match the EntityHandle case above.
+				case MethodDefinitionHandle mdh:
+					return FormatValue(metadata, (EntityHandle)mdh);
+				case FieldDefinitionHandle fdh:
+					return FormatValue(metadata, (EntityHandle)fdh);
+				case TypeDefinitionHandle tdh:
+					return FormatValue(metadata, (EntityHandle)tdh);
+				case EventDefinitionHandle edh:
+					return FormatValue(metadata, (EntityHandle)edh);
+				case PropertyDefinitionHandle pdh:
+					return FormatValue(metadata, (EntityHandle)pdh);
+				case ModuleReferenceHandle mrh:
+					return FormatValue(metadata, (EntityHandle)mrh);
+				case Enum e:
+					return e.ToString();
+				case bool b:
+					return b ? "true" : "false";
+				case Version v:
+					return v.ToString();
+				default:
+					// Reject unlisted handle types instead of letting Convert.ToString render
+					// them as their type name; cast handles to EntityHandle at the call site.
+					if (value.GetType().Namespace == "System.Reflection.Metadata")
+						throw new InvalidOperationException($"Unhandled metadata handle type {value.GetType().Name}.");
+					return Convert.ToString(value, CultureInfo.InvariantCulture) ?? "";
+			}
+		}
+
+		static string FormatHex(int value)
+		{
+			return "0x" + value.ToString("X8", CultureInfo.InvariantCulture);
+		}
+
+		static string FormatRid(int value)
+		{
+			return value.ToString(CultureInfo.InvariantCulture);
+		}
+
+		static void WriteConsoleTable(TextWriter output, List<List<(string Column, object Value)>> rows)
+		{
+			if (rows.Count == 0)
+			{
+				output.WriteLine("0 rows");
+				return;
+			}
+			var columns = rows[0].Select(c => c.Column).ToArray();
+			int[] widths = columns.Select(c => c.Length).ToArray();
+			foreach (var row in rows)
+			{
+				for (int i = 0; i < row.Count; i++)
+				{
+					widths[i] = Math.Max(widths[i], Convert.ToString(row[i].Value, CultureInfo.InvariantCulture)!.Length);
+				}
+			}
+			output.WriteLine(string.Join("  ", columns.Select((c, i) => c.PadRight(widths[i]))).TrimEnd());
+			output.WriteLine(string.Join("  ", widths.Select(w => new string('-', w))));
+			foreach (var row in rows)
+			{
+				output.WriteLine(string.Join("  ", row.Select((c, i) => Convert.ToString(c.Value, CultureInfo.InvariantCulture)!.PadRight(widths[i]))).TrimEnd());
+			}
+		}
+
+		static void WriteJson(TextWriter output, string assemblyFileName, TableIndex table, List<List<(string Column, object Value)>> rows)
+		{
+			using var stream = new MemoryStream();
+			using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+			{
+				writer.WriteStartObject();
+				writer.WriteString("assembly", assemblyFileName);
+				writer.WriteString("table", table.ToString());
+				writer.WriteNumber("rowCount", rows.Count);
+				writer.WriteStartArray("rows");
+				foreach (var row in rows)
+				{
+					writer.WriteStartObject();
+					foreach (var (column, value) in row)
+					{
+						if (value is int i)
+							writer.WriteNumber(column, i);
+						else
+							writer.WriteString(column, (string)value);
+					}
+					writer.WriteEndObject();
+				}
+				writer.WriteEndArray();
+				writer.WriteEndObject();
+			}
+			output.WriteLine(System.Text.Encoding.UTF8.GetString(stream.ToArray()));
+		}
+	}
+}

--- a/ICSharpCode.ILSpyCmd/README.md
+++ b/ICSharpCode.ILSpyCmd/README.md
@@ -41,6 +41,11 @@ Options:
                                           whose name ends with '.baml' are decompiled to XAML.
   --decompile-baml                        When used with -p, decompile BAML resources to XAML files (Page items) instead
                                           of leaving them as raw byte streams.
+  --dump-table <table>                    Dump a metadata table: prints RID, token, names, heap offsets and coded
+                                          indexes of every row. <table> is the ECMA-335 table name (e.g. TypeDef,
+                                          Property, MethodSemantics; case-insensitive) or table number (decimal or
+                                          0x-prefixed hex, e.g. 0x17).
+  --json                                  Output as JSON. Currently only supported together with --dump-table.
   -lv|--languageversion <version>         C# Language version: CSharp1, CSharp2, CSharp3, CSharp4, CSharp5, CSharp6,
                                           CSharp7, CSharp7_1, CSharp7_2, CSharp7_3, CSharp8_0, CSharp9_0, CSharp10_0,
                                           CSharp11_0, CSharp12_0, CSharp13_0, Preview or Latest

--- a/ILSpy/Metadata/CorTables/FieldMarshalTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/FieldMarshalTableTreeNode.cs
@@ -39,19 +39,10 @@ namespace ICSharpCode.ILSpy.Metadata.CorTables
 		protected override IReadOnlyList<FieldMarshalEntry> LoadTable()
 		{
 			var list = new List<FieldMarshalEntry>();
-			var metadata = metadataFile.Metadata;
-			var length = metadata.GetTableRowCount(TableIndex.FieldMarshal);
-			var reader = metadata.AsBlobReader();
-			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.FieldMarshal);
-			int hasFieldMarshalRefSize = metadata.ComputeCodedTokenSize(32768, TableMask.Field | TableMask.Param);
-			int blobHeapSize = metadata.GetHeapSize(HeapIndex.Blob) < ushort.MaxValue ? 2 : 4;
-			for (int rid = 1; rid <= length; rid++)
+			int rid = 0;
+			foreach (var (parent, nativeType) in metadataFile.Metadata.GetFieldMarshals())
 			{
-				uint parentTag = (uint)(hasFieldMarshalRefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32());
-				int blobOffset = blobHeapSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
-				list.Add(new FieldMarshalEntry(metadataFile, rid,
-					MetadataReaderHelpers.FromHasFieldMarshalTag(parentTag),
-					MetadataTokens.BlobHandle(blobOffset)));
+				list.Add(new FieldMarshalEntry(metadataFile, ++rid, parent, nativeType));
 			}
 			return list;
 		}

--- a/ILSpy/Metadata/CorTables/ImplMapTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/ImplMapTableTreeNode.cs
@@ -40,23 +40,10 @@ namespace ICSharpCode.ILSpy.Metadata.CorTables
 		protected override IReadOnlyList<ImplMapEntry> LoadTable()
 		{
 			var list = new List<ImplMapEntry>();
-			var metadata = metadataFile.Metadata;
-			var length = metadata.GetTableRowCount(TableIndex.ImplMap);
-			var reader = metadata.AsBlobReader();
-			reader.Offset = metadata.GetTableMetadataOffset(TableIndex.ImplMap);
-			int moduleRefSize = metadata.GetTableRowCount(TableIndex.ModuleRef) < ushort.MaxValue ? 2 : 4;
-			int memberForwardedTagSize = metadata.ComputeCodedTokenSize(32768, TableMask.MethodDef | TableMask.Field);
-			int stringHandleSize = metadata.GetHeapSize(HeapIndex.String) < ushort.MaxValue ? 2 : 4;
-			for (int rid = 1; rid <= length; rid++)
+			int rid = 0;
+			foreach (var (mappingFlags, memberForwarded, importName, importScope) in metadataFile.Metadata.GetImplMaps())
 			{
-				MethodImportAttributes mappingFlags = (MethodImportAttributes)reader.ReadUInt16();
-				uint memberForwardedTag = (uint)(memberForwardedTagSize == 2 ? reader.ReadUInt16() : reader.ReadInt32());
-				int importNameOffset = stringHandleSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
-				int importScopeRow = moduleRefSize == 2 ? reader.ReadUInt16() : reader.ReadInt32();
-				list.Add(new ImplMapEntry(metadataFile, rid, mappingFlags,
-					MetadataReaderHelpers.FromMemberForwardedTag(memberForwardedTag),
-					MetadataTokens.StringHandle(importNameOffset),
-					MetadataTokens.ModuleReferenceHandle(importScopeRow)));
+				list.Add(new ImplMapEntry(metadataFile, ++rid, mappingFlags, memberForwarded, importName, importScope));
 			}
 			return list;
 		}

--- a/ILSpy/Metadata/CorTables/MethodTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/MethodTableTreeNode.cs
@@ -41,23 +41,13 @@ namespace ICSharpCode.ILSpy.Metadata.CorTables
 		protected override IReadOnlyList<MethodDefEntry> LoadTable()
 		{
 			var list = new List<MethodDefEntry>();
-			var metadata = metadataFile.Metadata;
-			// ParamList is read from the raw row: the computed range (GetParameters) is empty
-			// for a parameterless method, but the stored value is the running list position
-			// (the next method's first Param row, or one past the Param table's end), never 0.
-			// It is the last column, so it sits at the end of the row; with a ParamPtr
-			// indirection present, the column indexes the pointer table, whose row count also
-			// governs the column width.
-			var indexedTable = metadata.GetTableRowCount(TableIndex.ParamPtr) > 0 ? TableIndex.ParamPtr : TableIndex.Param;
-			int paramListWidth = metadata.GetTableRowCount(indexedTable) <= ushort.MaxValue ? 2 : 4;
-			int rowSize = metadata.GetTableRowSize(TableIndex.MethodDef);
-			int tableOffset = metadata.GetTableMetadataOffset(TableIndex.MethodDef);
-			var reader = metadata.AsBlobReader();
-			foreach (var row in metadata.MethodDefinitions)
+			// ParamList comes from the raw row (GetMethodDefParamLists): the computed range
+			// (GetParameters) is empty for a parameterless method, but the stored value is the
+			// running list position (the next method's first Param row, or one past the Param
+			// table's end), never 0.
+			foreach (var (handle, paramList) in metadataFile.Metadata.GetMethodDefParamLists())
 			{
-				reader.Offset = tableOffset + rowSize * MetadataTokens.GetRowNumber(row) - paramListWidth;
-				int paramList = paramListWidth == 2 ? reader.ReadUInt16() : reader.ReadInt32();
-				list.Add(new MethodDefEntry(metadataFile, row, paramList));
+				list.Add(new MethodDefEntry(metadataFile, handle, paramList));
 			}
 			return list;
 		}

--- a/ILSpy/Metadata/CorTables/TypeDefTableTreeNode.cs
+++ b/ILSpy/Metadata/CorTables/TypeDefTableTreeNode.cs
@@ -44,33 +44,15 @@ namespace ICSharpCode.ILSpy.Metadata.CorTables
 		protected override IReadOnlyList<TypeDefEntry> LoadTable()
 		{
 			var list = new List<TypeDefEntry>();
-			var metadata = metadataFile.Metadata;
-			// FieldList/MethodList are read from the raw rows: the computed member ranges
-			// (TypeDefinition.GetFields/GetMethods) are empty for a memberless type, but the
-			// stored column value is the running list position (the next type's first member
-			// row, or one past the member table's end), never 0. Reading relative to the row
-			// end avoids re-deriving the widths of the preceding string-heap and coded-index
-			// columns. With a FieldPtr/MethodPtr indirection present, the list columns index
-			// the pointer table, whose row count also governs the column width.
-			int fieldListWidth = ListColumnWidth(metadata, TableIndex.FieldPtr, TableIndex.Field);
-			int methodListWidth = ListColumnWidth(metadata, TableIndex.MethodPtr, TableIndex.MethodDef);
-			int rowSize = metadata.GetTableRowSize(TableIndex.TypeDef);
-			int tableOffset = metadata.GetTableMetadataOffset(TableIndex.TypeDef);
-			var reader = metadata.AsBlobReader();
-			foreach (var row in metadata.TypeDefinitions)
+			// FieldList/MethodList come from the raw rows (GetTypeDefListColumns): the computed
+			// member ranges (TypeDefinition.GetFields/GetMethods) are empty for a memberless type,
+			// but the stored column value is the running list position (the next type's first
+			// member row, or one past the member table's end), never 0.
+			foreach (var (handle, fieldList, methodList) in metadataFile.Metadata.GetTypeDefListColumns())
 			{
-				reader.Offset = tableOffset + rowSize * MetadataTokens.GetRowNumber(row) - fieldListWidth - methodListWidth;
-				int fieldList = fieldListWidth == 2 ? reader.ReadUInt16() : reader.ReadInt32();
-				int methodList = methodListWidth == 2 ? reader.ReadUInt16() : reader.ReadInt32();
-				list.Add(new TypeDefEntry(metadataFile, row, fieldList, methodList));
+				list.Add(new TypeDefEntry(metadataFile, handle, fieldList, methodList));
 			}
 			return list;
-
-			static int ListColumnWidth(MetadataReader metadata, TableIndex ptrTable, TableIndex memberTable)
-			{
-				var indexed = metadata.GetTableRowCount(ptrTable) > 0 ? ptrTable : memberTable;
-				return metadata.GetTableRowCount(indexed) <= ushort.MaxValue ? 2 : 4;
-			}
 		}
 
 		public sealed class TypeDefEntry


### PR DESCRIPTION
The GUI has the metadata-tables view; the CLI had nothing, so questions like "which MethodSemantics rows reference this Property row" required hand-written System.Reflection.Metadata scripts (item 2 of the internal ilspycmd agent-workflow wishlist).

`ilspycmd --dump-table <table> assembly.dll` prints every row of a metadata table - RID, token, resolved names, heap offsets, coded indexes - for the same 39 Cor tables the GUI shows. `<table>` is the ECMA-335 table name (case-insensitive) or the table number, decimal or `0x`-prefixed hex.

Output of `--dump-table TypeDef` against an F# sample assembly (aligned text table, default):

```
RID  Token       Attributes                  Name                Namespace                                           BaseType    FieldList  MethodList
---  ----------  --------------------------  ------------------  --------------------------------------------------  ----------  ---------  ----------
1    0x02000001  NotPublic                   <Module>                                                                0x01000001  1          1
2    0x02000002  Public, Abstract, Sealed    Repro3652                                                               0x01000001  1          1
3    0x02000003  NestedPublic, Serializable  Config                                                                  0x01000001  1          3
4    0x02000004  Abstract, Sealed            $Repro3652          <StartupCode$Repro3652>                             0x01000001  2          7
```

`--dump-table 0x18` (numeric form of MethodSemantics) - the motivating "which accessors belong to this property" query:

```
RID  Token       Semantics  Method      Association
---  ----------  ---------  ----------  -----------
1    0x18000001  Setter     0x06000005  0x17000001
2    0x18000002  Getter     0x06000004  0x17000001
```

`--dump-table Property --json`:

```json
{
  "assembly": "Repro3652.dll",
  "table": "Property",
  "rowCount": 1,
  "rows": [
    {
      "RID": 1,
      "Token": "0x17000001",
      "Attributes": "None",
      "Name": "Value'",
      "Signature": "0x000000CB"
    }
  ]
}
```

Design notes:
- Row enumeration for tables without public SRM row access (ClassLayout, EventMap, PropertyMap, NestedClass, FieldRVA, FieldMarshal, ImplMap, InterfaceImpl, the five *Ptr tables, and the SRM-hidden FieldList/MethodList/ParamList columns) lives in `MetadataExtensions` next to the existing `GetMethodSemantics` helper. The four GUI table nodes whose width rules diverged from SRM (TypeDef, MethodDef, ImplMap, FieldMarshal) already consume these shared readers; the remaining raw-reading nodes only use plain simple-index widths and can be folded in a follow-up.
- Every raw reader verifies that its computed column widths sum to the row size SRM derived from the tables-stream header and throws `BadImageFormatException` on mismatch, so a width bug (a large-heap flag over a small heap, EnC minimal-delta metadata) fails loudly instead of dumping plausible-looking garbage. String/Blob index widths are taken from SRM's computed row sizes of the single-column ModuleRef/TypeSpec tables, i.e. from the HeapSizes flags rather than the heap byte size.
- Every table's columns are spelled out explicitly in ECMA-335 declaration order; no reflection over SRM row structs, so the output is deterministic across runtime versions and trim/AOT-safe.
- JSON uses System.Text.Json from the shared framework - no new package reference, no lock-file changes. The `--json` flag is deliberately generic so it can later serve `-l` as well; for now it is gated to `--dump-table`.
- Unknown table names/numbers exit with EX_USAGE and list the supported tables with their numbers (`TypeDef (0x02), ...`); `-o` writes `.<table>.txt`/`.json`.

Also fixes a real bug found en route (own commit): `MetadataExtensions.GetMethodSemantics` read the Semantics and Association columns from metadata-root-relative offsets instead of per-row offsets, and used the plain-index width threshold for the coded Association column - the GUI's MethodSemantics table view was displaying garbage for both columns.

Tests: `DumpTableOptionTests` (red-first) in ICSharpCode.ILSpyCmd.Tests covering console and JSON output, the raw-read tiers (NestedClass, ClassLayout), the MethodSemantics accessor query, numeric addressing (decimal, hex, out-of-range), error paths, case-insensitivity and the `-o` multi-assembly output path; full CLI suite green (22/22), XPlat solution family builds warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

