### PR TITLE
Fix #3954: name the entry point of a top-level program 'Main'

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -247,6 +247,16 @@
     <None Include="TestCases\Ugly\NoNewOfT.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoPropertiesAndEvents.Expected.cs" />
     <None Include="TestCases\Ugly\NoPropertiesAndEvents.Expected.cs" />
+    <!-- top-level statements: neither the input nor the expected output can be compiled
+         into the test assembly, which is a library and has its own entry point rules -->
+    <Compile Remove="TestCases\Ugly\TopLevelProgram.cs" />
+    <None Include="TestCases\Ugly\TopLevelProgram.cs" />
+    <Compile Remove="TestCases\Ugly\TopLevelProgram.Expected.cs" />
+    <None Include="TestCases\Ugly\TopLevelProgram.Expected.cs" />
+    <Compile Remove="TestCases\Ugly\TopLevelProgramAsync.cs" />
+    <None Include="TestCases\Ugly\TopLevelProgramAsync.cs" />
+    <Compile Remove="TestCases\Ugly\TopLevelProgramAsync.Expected.cs" />
+    <None Include="TestCases\Ugly\TopLevelProgramAsync.Expected.cs" />
     <Compile Remove="TestCases\VBPretty\VBCompoundAssign.cs" />
     <None Include="TestCases\VBPretty\VBCompoundAssign.cs" />
   </ItemGroup>

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgram.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgram.Expected.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Runtime.CompilerServices;
+
+[CompilerGenerated]
+internal class Program
+{
+	private static void Main(string[] args)
+	{
+		Console.WriteLine("Hello, World!");
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgram.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgram.cs
@@ -1,0 +1,3 @@
+using System;
+
+Console.WriteLine("Hello, World!");

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgramAsync.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgramAsync.Expected.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+[CompilerGenerated]
+internal class Program
+{
+	private static async Task Main(string[] args)
+	{
+		await Task.Yield();
+		Console.WriteLine("Hello, World!");
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgramAsync.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/TopLevelProgramAsync.cs
@@ -1,0 +1,5 @@
+using System;
+using System.Threading.Tasks;
+
+await Task.Yield();
+Console.WriteLine("Hello, World!");

--- a/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
@@ -69,6 +69,15 @@ namespace ICSharpCode.Decompiler.Tests
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		});
 
+		// top-level statements require C# 9 and cannot target .NET Framework 4.0
+		static readonly CompilerOptions[] topLevelProgramOptions = Tester.SupportedOnCurrentPlatform(new[]
+		{
+			CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.UseRoslynLatest,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
+		});
+
 		static readonly CompilerOptions[] defaultOptions = Tester.SupportedOnCurrentPlatform(new[]
 		{
 			CompilerOptions.None,
@@ -139,6 +148,22 @@ namespace ICSharpCode.Decompiler.Tests
 		public async Task NoNewOfT([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings(CSharp.LanguageVersion.CSharp1));
+		}
+
+		// Top-level statements are not reconstructed; the entry point becomes an ordinary method,
+		// which C# only accepts as an entry point if it is called 'Main'. Compiled as executables,
+		// because top-level statements require one and the entry point token has to be set.
+
+		[Test]
+		public async Task TopLevelProgram([ValueSource(nameof(topLevelProgramOptions))] CompilerOptions cscOptions)
+		{
+			await Run(cscOptions: cscOptions);
+		}
+
+		[Test]
+		public async Task TopLevelProgramAsync([ValueSource(nameof(topLevelProgramOptions))] CompilerOptions cscOptions)
+		{
+			await Run(cscOptions: cscOptions);
 		}
 
 		async Task RunForLibrary([CallerMemberName] string testName = null, CompilerOptions cscOptions = CompilerOptions.None, DecompilerSettings decompilerSettings = null)

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1613,6 +1613,35 @@ namespace ICSharpCode.Decompiler.CSharp
 			}
 		}
 
+		/// <summary>
+		/// Gets whether the method is the managed entry point of the module, or - for an async
+		/// top-level program - the method holding the top-level statements, which the
+		/// compiler-generated entry point only awaits.
+		/// </summary>
+		bool IsEntryPoint(IMethod method)
+		{
+			var corHeader = module.MetadataFile.CorHeader;
+			if (corHeader == null)
+				return false;
+			// the entry point of a multi-module assembly is in another module, and the token is
+			// then a File token instead of a method definition
+			var entryPoint = MetadataTokenHelpers.EntityHandleOrNil(corHeader.EntryPointTokenOrRelativeVirtualAddress);
+			if (entryPoint.IsNil || entryPoint.Kind != HandleKind.MethodDefinition)
+				return false;
+			if (method.MetadataToken == entryPoint)
+				return true;
+			// An async top-level program compiles to '<Main>$' holding the statements plus a
+			// '<Main>' entry point that awaits it. The latter is hidden, so the name has to be
+			// given to the former; without AsyncAwait it stays visible and keeps the name.
+			if (!settings.AsyncAwait
+				|| !AsyncAwaitDecompiler.IsCompilerGeneratedMainMethod(module.MetadataFile, (MethodDefinitionHandle)entryPoint))
+			{
+				return false;
+			}
+			return method.Name == "<Main>$"
+				&& method.DeclaringTypeDefinition?.MetadataToken == metadata.GetMethodDefinition((MethodDefinitionHandle)entryPoint).GetDeclaringType();
+		}
+
 		void FixParameterNames(EntityDeclaration entity)
 		{
 			int i = 0;
@@ -2045,6 +2074,13 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (methodDecl is not OperatorDeclaration && method.IsExplicitInterfaceImplementation && lastDot >= 0)
 				{
 					methodDecl.Name = method.Name.Substring(lastDot + 1);
+				}
+				if (method.HasGeneratedName() && IsEntryPoint(method))
+				{
+					// Roslyn names the entry point of a top-level program '<Main>$', which cannot be
+					// declared in C#. Only a method called 'Main' is accepted as an entry point, so
+					// without this the decompiled program does not compile (CS5001).
+					methodDecl.Name = "Main";
 				}
 				FixParameterNames(methodDecl);
 				var methodDefinition = metadata.GetMethodDefinition((MethodDefinitionHandle)method.MetadataToken);


### PR DESCRIPTION
Fixes #3954.

Roslyn compiles top-level statements into a synthesized `Program` class whose entry point is called `<Main>$` — a name that cannot be declared in C#. The decompiled output kept it verbatim (escaped to `_003CMain_003E_0024` when exporting a project), and since C# accepts only a method called `Main` as an entry point, the exported executable did not compile:

```
CSC : error CS5001: Program does not contain a static 'Main' method suitable for an entry point
```

**Change**: `CSharpDecompiler.DoDecompile(IMethod)` gives that method the name `Main`, next to the existing explicit-interface-implementation rename. The new `IsEntryPoint` helper resolves the entry point from `CorHeader.EntryPointTokenOrRelativeVirtualAddress` via `MetadataTokenHelpers.EntityHandleOrNil` and requires a `MethodDefinition` handle — per ECMA-335 II.25.3.3 that field is a MethodDef *or* a File token, the latter when the entry point lives in another module of a multi-module assembly. Per the decision recorded in #829 top-level statements are not reconstructed — this is just the level of support the output needs in order to compile.

**Async top-level programs need the name in a different place.** They compile to `<Main>$` holding the statements *plus* a `<Main>` wrapper that only awaits it. The wrapper carries the `.entrypoint` marker, but it is hidden from the output (`MemberIsHidden` via `AsyncAwaitDecompiler.IsCompilerGeneratedMainMethod`), so renaming strictly the method marked `.entrypoint` would leave every `await`-using program emitting `<Main>$` and still not compiling. `IsEntryPoint` therefore also maps the hidden wrapper to the method it awaits, guarded by `settings.AsyncAwait` — the same condition under which the wrapper is hidden — so the two can never both end up named `Main`. A classic `static async Task Main` is unaffected: its wrapper is hidden and its own name is already speakable.

**Not a regression**: the same `<Main>$` output comes out of release/10.1, v9.1, and the NuGet `ilspycmd` 8.2.0 (2023) and 7.2.1 (2022) — the case has simply never been handled since top-level statements arrived in C# 9.

**Tests**: `Ugly/TopLevelProgram` and `Ugly/TopLevelProgramAsync` — the input is valid C#, and the `.Expected.cs` records the output we intentionally do not reproduce faithfully, which is what the Ugly suite is for. They use `Run` rather than `RunForLibrary`, because top-level statements require an executable and the entry-point token has to be set. All 8 configurations are red before the change (emitting `_003CMain_003E_0024`) and green after; full decompiler suite 3340 tests, 0 failures.

Beyond the fixtures, `dotnet new console` and an `await`-using variant were decompiled with the rebuilt `ilspycmd`: both exported projects now compile *and* run, where the first previously failed with CS5001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
