### PR TITLE
Fix #3952: decompile VB.NET anonymous types and queries to valid C#

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -149,6 +149,7 @@
     <None Include="TestCases\VBPretty\Issue1906.vb" />
     <None Include="TestCases\VBPretty\Issue2192.vb" />
     <None Include="TestCases\VBPretty\Select.vb" />
+    <None Include="TestCases\VBPretty\VBAnonymousTypes.vb" />
     <None Include="TestCases\VBPretty\ParameterizedProperties.vb" />
     <None Include="TestCases\ILPretty\Unsafe.il" />
     <None Include="TestCases\ILPretty\Issue1389.il" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLocalFunctions.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLocalFunctions.Expected.cs
@@ -44,9 +44,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 
 		private static void SimpleCapture()
 		{
-			_003C_003Ec__DisplayClass1_0 _003C_003Ec__DisplayClass1_1 = default(_003C_003Ec__DisplayClass1_0);
-			_003C_003Ec__DisplayClass1_1.x = 1;
-			_003CSimpleCapture_003Eg__F_007C1_0(ref _003C_003Ec__DisplayClass1_1);
+			_003C_003Ec__DisplayClass1_0 obj = default(_003C_003Ec__DisplayClass1_0);
+			obj.x = 1;
+			_003CSimpleCapture_003Eg__F_007C1_0(ref obj);
 		}
 
 		private static void SimpleCaptureWithRef()
@@ -56,9 +56,9 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 			obj.x = 1;
 			new Handle(new Func<int>(obj._003CSimpleCaptureWithRef_003Eg__F_007C0));
 #else
-			_003C_003Ec__DisplayClass2_0 _003C_003Ec__DisplayClass2_1 = new _003C_003Ec__DisplayClass2_0();
-			_003C_003Ec__DisplayClass2_1.x = 1;
-			Handle handle = new Handle(new Func<int>(_003C_003Ec__DisplayClass2_1._003CSimpleCaptureWithRef_003Eg__F_007C0));
+			_003C_003Ec__DisplayClass2_0 obj = new _003C_003Ec__DisplayClass2_0();
+			obj.x = 1;
+			Handle handle = new Handle(new Func<int>(obj._003CSimpleCaptureWithRef_003Eg__F_007C0));
 #endif
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+using Microsoft.VisualBasic.CompilerServices;
+
+[StandardModule]
+public sealed class VBAnonymousTypes
+{
+	public static void MutableAnonymousType()
+	{
+		var anon = new {
+			Value = 1,
+			Name = "test"
+		};
+		Console.WriteLine(anon.Value);
+		Console.WriteLine(anon.Name);
+	}
+
+	public static void KeyAnonymousType()
+	{
+		var anon = new {
+			Value = 1,
+			Name = "test"
+		};
+		Console.WriteLine(anon.Value);
+		Console.WriteLine(anon.Name);
+	}
+
+	public static void AnonymousTypeAsArgument()
+	{
+		Console.WriteLine(new {
+			Value = 1,
+			Name = "test"
+		}.ToString());
+	}
+
+	public static void SelectAnonymousType(IEnumerable<int> items)
+	{
+		var enumerable = items.Select([SpecialName] (int i) => new {
+			Value = i,
+			Square = checked(i * i)
+		});
+		foreach (var item in enumerable)
+		{
+			Console.WriteLine(item.Value);
+			Console.WriteLine(item.Square);
+		}
+	}
+
+	public static void LetWhereSelect(IEnumerable<int> items)
+	{
+		var enumerable = from i in items
+						 let square = checked(i * i)
+						 where square > 4
+						 select new { i, square };
+		foreach (var item in enumerable)
+		{
+			Console.WriteLine(item.i);
+			Console.WriteLine(item.square);
+		}
+	}
+
+	public static void JoinSelect(IEnumerable<int> left, IEnumerable<int> right)
+	{
+		var enumerable = from x in left
+						 join y in right on x equals y
+						 select new { x, y };
+		foreach (var item in enumerable)
+		{
+			Console.WriteLine(item.x);
+			Console.WriteLine(item.y);
+		}
+	}
+
+	public static void OrderBySelect(IEnumerable<int> items)
+	{
+		var enumerable = from i in items
+						 let doubled = checked(i * 2)
+						 orderby doubled
+						 select new { i, doubled };
+		foreach (var item in enumerable)
+		{
+			Console.WriteLine(item.i);
+			Console.WriteLine(item.doubled);
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.cs
@@ -3,22 +3,30 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+#if LEGACY_VBC
+using System.Text;
+#endif
 
 using Microsoft.VisualBasic.CompilerServices;
 
 // A VB anonymous type. Its properties are settable and only those declared 'Key'
 // take part in Equals and GetHashCode, so it cannot be written as a C# anonymous
 // type and is declared here instead.
+#if LEGACY_VBC && OPT
+[DebuggerDisplay("Value={Value}, Name={Name}")]
+[CompilerGenerated]
+#else
 [CompilerGenerated]
 [DebuggerDisplay("Value={Value}, Name={Name}")]
+#endif
 internal sealed class VB_AnonymousType_0<T0, T1>
 {
-#if !OPT
+#if !OPT && !LEGACY_VBC
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 #endif
 	private T0 _Value;
 
-#if !OPT
+#if !OPT && !LEGACY_VBC
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
 #endif
 	private T1 _Name;
@@ -41,7 +49,7 @@ internal sealed class VB_AnonymousType_0<T0, T1>
 		}
 	}
 
-#if !OPT
+#if !OPT && !LEGACY_VBC
 	[DebuggerHidden]
 #endif
 	public VB_AnonymousType_0(T0 Value, T1 Name)
@@ -50,12 +58,21 @@ internal sealed class VB_AnonymousType_0<T0, T1>
 		_Name = Name;
 	}
 
-#if !OPT
+#if !OPT && !LEGACY_VBC
 	[DebuggerHidden]
 #endif
 	public override string ToString()
 	{
+#if LEGACY_VBC
+		StringBuilder stringBuilder = new StringBuilder();
+		stringBuilder.Append("{ ");
+		stringBuilder.AppendFormat("{0} = {1}, ", "Value", _Value);
+		stringBuilder.AppendFormat("{0} = {1} ", "Name", _Name);
+		stringBuilder.Append("}");
+		return stringBuilder.ToString();
+#else
 		return string.Format(null, "{{ Value = {0}, Name = {1} }}", new object[2] { _Value, _Name });
+#endif
 	}
 }
 [StandardModule]

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.cs
@@ -1,21 +1,71 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Microsoft.VisualBasic.CompilerServices;
 
+// A VB anonymous type. Its properties are settable and only those declared 'Key'
+// take part in Equals and GetHashCode, so it cannot be written as a C# anonymous
+// type and is declared here instead.
+[CompilerGenerated]
+[DebuggerDisplay("Value={Value}, Name={Name}")]
+internal sealed class VB_AnonymousType_0<T0, T1>
+{
+#if !OPT
+	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+#endif
+	private T0 _Value;
+
+#if !OPT
+	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+#endif
+	private T1 _Name;
+
+	public T0 Value {
+		get {
+			return _Value;
+		}
+		set {
+			_Value = value;
+		}
+	}
+
+	public T1 Name {
+		get {
+			return _Name;
+		}
+		set {
+			_Name = value;
+		}
+	}
+
+#if !OPT
+	[DebuggerHidden]
+#endif
+	public VB_AnonymousType_0(T0 Value, T1 Name)
+	{
+		_Value = Value;
+		_Name = Name;
+	}
+
+#if !OPT
+	[DebuggerHidden]
+#endif
+	public override string ToString()
+	{
+		return string.Format(null, "{{ Value = {0}, Name = {1} }}", new object[2] { _Value, _Name });
+	}
+}
 [StandardModule]
 public sealed class VBAnonymousTypes
 {
 	public static void MutableAnonymousType()
 	{
-		var anon = new {
-			Value = 1,
-			Name = "test"
-		};
-		Console.WriteLine(anon.Value);
-		Console.WriteLine(anon.Name);
+		VB_AnonymousType_0<int, string> obj = new VB_AnonymousType_0<int, string>(1, "test");
+		Console.WriteLine(obj.Value);
+		Console.WriteLine(obj.Name);
 	}
 
 	public static void KeyAnonymousType()

--- a/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.vb
+++ b/ICSharpCode.Decompiler.Tests/TestCases/VBPretty/VBAnonymousTypes.vb
@@ -1,0 +1,62 @@
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Public Module VBAnonymousTypes
+	Public Sub MutableAnonymousType()
+		Dim value = New With {.Value = 1, .Name = "test"}
+		Console.WriteLine(value.Value)
+		Console.WriteLine(value.Name)
+	End Sub
+
+	Public Sub KeyAnonymousType()
+		Dim value = New With {Key .Value = 1, Key .Name = "test"}
+		Console.WriteLine(value.Value)
+		Console.WriteLine(value.Name)
+	End Sub
+
+	Public Sub AnonymousTypeAsArgument()
+		Console.WriteLine(New With {Key .Value = 1, Key .Name = "test"}.ToString())
+	End Sub
+
+	Public Sub SelectAnonymousType(items As IEnumerable(Of Integer))
+		Dim query = From i In items
+					Select New With {Key .Value = i, Key .Square = i * i}
+		For Each item In query
+			Console.WriteLine(item.Value)
+			Console.WriteLine(item.Square)
+		Next
+	End Sub
+
+	Public Sub LetWhereSelect(items As IEnumerable(Of Integer))
+		Dim query = From i In items
+					Let square = i * i
+					Where square > 4
+					Select i, square
+		For Each item In query
+			Console.WriteLine(item.i)
+			Console.WriteLine(item.square)
+		Next
+	End Sub
+
+	Public Sub JoinSelect(left As IEnumerable(Of Integer), right As IEnumerable(Of Integer))
+		Dim query = From x In left
+					Join y In right On x Equals y
+					Select x, y
+		For Each item In query
+			Console.WriteLine(item.x)
+			Console.WriteLine(item.y)
+		Next
+	End Sub
+
+	Public Sub OrderBySelect(items As IEnumerable(Of Integer))
+		Dim query = From i In items
+					Let doubled = i * 2
+					Order By doubled
+					Select i, doubled
+		For Each item In query
+			Console.WriteLine(item.i)
+			Console.WriteLine(item.doubled)
+		Next
+	End Sub
+End Module

--- a/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/VBPrettyTestRunner.cs
@@ -126,6 +126,13 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task VBAnonymousTypes([ValueSource(nameof(defaultOptions))] CompilerOptions options)
+		{
+			IgnoreIfVbRuntimeSubstituted(options);
+			await Run(options: options | CompilerOptions.Library);
+		}
+
+		[Test]
 		public async Task Issue1906([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
 			await Run(options: options | CompilerOptions.Library);

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -250,6 +250,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				new CombineQueryExpressions(),
 				new NormalizeBlockStatements(),
 				new FlattenSwitchBlocks(),
+				new RenameVisualBasicAnonymousTypes(), // must run before FixNameCollisions
 				new FixNameCollisions(),
 				new AddXmlDocumentationTransform(),
 			};

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -645,8 +645,13 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		internal static bool IsTransparentIdentifier(string identifier)
 		{
-			return identifier.StartsWith("<>", StringComparison.Ordinal)
-				&& (identifier.Contains("TransparentIdentifier") || identifier.Contains("TranspIdent"));
+			if (identifier.StartsWith("<>", StringComparison.Ordinal))
+			{
+				return identifier.Contains("TransparentIdentifier") || identifier.Contains("TranspIdent");
+			}
+			// The VB compiler names the carriers of its query range variables
+			// $VB$It, $VB$It1, $VB$It2 and $VB$ItAnonymous.
+			return identifier.StartsWith("$VB$It", StringComparison.Ordinal);
 		}
 		#endregion
 

--- a/ICSharpCode.Decompiler/CSharp/Transforms/RenameVisualBasicAnonymousTypes.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/RenameVisualBasicAnonymousTypes.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
+
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace ICSharpCode.Decompiler.CSharp.Transforms
+{
+	/// <summary>
+	/// Gives the anonymous types of a VB assembly that are declared rather than written as C#
+	/// anonymous types a name that is legal in C#.
+	/// </summary>
+	/// <remarks>
+	/// An anonymous type with a settable property has no C# anonymous type equivalent
+	/// (see <see cref="NRExtensions.IsAnonymousType(IType)"/>), so its declaration is emitted and
+	/// referred to by name. The VB compiler separates the parts of that name with '$', which is
+	/// not a legal identifier character in C#, and does the same for the backing fields.
+	/// Renaming happens per identifier via its symbol, so a reference is renamed the same way
+	/// whether or not the declaration is part of the same output.
+	/// </remarks>
+	public class RenameVisualBasicAnonymousTypes : IAstTransform
+	{
+		public void Run(AstNode rootNode, TransformContext context)
+		{
+			foreach (var identifier in rootNode.DescendantsAndSelf.OfType<Identifier>())
+			{
+				if (!identifier.Name.Contains("$"))
+					continue;
+				// A field declaration carries its symbol on the FieldDeclaration, not on the
+				// VariableInitializer holding the name.
+				if (FindEntity(identifier.Parent) is not IEntity entity || entity.Name != identifier.Name)
+					continue;
+				var declaringType = entity as ITypeDefinition ?? entity.DeclaringTypeDefinition;
+				if (declaringType == null || !declaringType.IsAnonymousTypeDeclaredAsNamedType())
+					continue;
+				identifier.Name = identifier.Name.Replace('$', '_');
+			}
+
+			foreach (var typeDeclaration in rootNode.DescendantsAndSelf.OfType<TypeDeclaration>())
+			{
+				if (typeDeclaration.GetSymbol() is not ITypeDefinition type
+					|| !type.IsAnonymousTypeDeclaredAsNamedType())
+				{
+					continue;
+				}
+				typeDeclaration.AddLeadingTrivia(new Comment(
+					" A VB anonymous type. Its properties are settable and only those declared 'Key'"));
+				typeDeclaration.AddLeadingTrivia(new Comment(
+					" take part in Equals and GetHashCode, so it cannot be written as a C# anonymous"));
+				typeDeclaration.AddLeadingTrivia(new Comment(
+					" type and is declared here instead."));
+			}
+
+			static IEntity FindEntity(AstNode node)
+			{
+				return node?.GetSymbol() as IEntity ?? node?.Parent?.GetSymbol() as IEntity;
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -882,6 +882,12 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 			if (name.Length == 0)
 				return "obj";
+			if (!IsValidName(name))
+			{
+				// A name taken from metadata may be legal there but not in C#; VB, for one,
+				// separates the parts of its generated names with '$'.
+				return null;
+			}
 			string lowerCaseName = char.ToLower(name[0]) + name.Substring(1);
 			if (CSharp.OutputVisitor.CSharpOutputVisitor.IsKeyword(lowerCaseName))
 				return null;

--- a/ICSharpCode.Decompiler/NRExtensions.cs
+++ b/ICSharpCode.Decompiler/NRExtensions.cs
@@ -50,7 +50,7 @@ namespace ICSharpCode.Decompiler
 
 		public static bool HasGeneratedName(this IType type)
 		{
-			return type.Name.StartsWith("<", StringComparison.Ordinal) || type.Name.Contains("<");
+			return SRMExtensions.IsGeneratedName(type.Name);
 		}
 
 		public static bool IsAnonymousType(this IType type)

--- a/ICSharpCode.Decompiler/NRExtensions.cs
+++ b/ICSharpCode.Decompiler/NRExtensions.cs
@@ -53,6 +53,36 @@ namespace ICSharpCode.Decompiler
 			return SRMExtensions.IsGeneratedName(type.Name);
 		}
 
+		/// <summary>
+		/// A C# anonymous type is immutable and compares all of its members, so only an anonymous
+		/// type with no settable property can be written as one. The C# compiler emits nothing
+		/// else, but VB's properties are settable unless declared 'Key', and only 'Key' members
+		/// take part in Equals/GetHashCode: those types keep their own declaration.
+		/// </summary>
+		static bool HasOnlyReadOnlyProperties(ITypeDefinition type)
+		{
+			foreach (var property in type.Properties)
+			{
+				if (property.CanSet)
+					return false;
+			}
+			return true;
+		}
+
+		/// <summary>
+		/// An anonymous type that keeps its own declaration because it cannot be written as a C#
+		/// anonymous type: a VB anonymous type with at least one settable, non-'Key' property.
+		/// </summary>
+		public static bool IsAnonymousTypeDeclaredAsNamedType(this ITypeDefinition type)
+		{
+			return type != null
+				&& string.IsNullOrEmpty(type.Namespace)
+				&& type.HasGeneratedName()
+				&& (type.Name.Contains("AnonType") || type.Name.Contains("AnonymousType"))
+				&& type.IsCompilerGenerated()
+				&& !HasOnlyReadOnlyProperties(type);
+		}
+
 		public static bool IsAnonymousType(this IType type)
 		{
 			if (type == null)
@@ -61,7 +91,7 @@ namespace ICSharpCode.Decompiler
 				&& (type.Name.Contains("AnonType") || type.Name.Contains("AnonymousType")))
 			{
 				ITypeDefinition td = type.GetDefinition();
-				return td != null && td.IsCompilerGenerated();
+				return td != null && td.IsCompilerGenerated() && HasOnlyReadOnlyProperties(td);
 			}
 			return false;
 		}

--- a/ICSharpCode.Decompiler/SRMExtensions.cs
+++ b/ICSharpCode.Decompiler/SRMExtensions.cs
@@ -489,9 +489,20 @@ namespace ICSharpCode.Decompiler
 
 		public static bool IsGeneratedName(this StringHandle handle, MetadataReader metadata)
 		{
-			return !handle.IsNil
-				&& (metadata.GetString(handle).StartsWith("<", StringComparison.Ordinal)
-				|| metadata.GetString(handle).Contains("$"));
+			return !handle.IsNil && IsGeneratedName(metadata.GetString(handle));
+		}
+
+		/// <summary>
+		/// Detects the mangled names compilers give to entities that have no user-written
+		/// declaration. The C# compiler prefixes them with '&lt;', the VB compiler separates
+		/// the parts with '$' (VB$AnonymousType_0, VB$StateMachine_1_Foo). Neither character
+		/// is legal in a C# or VB identifier.
+		/// Note that a name may legitimately contain '&lt;' without being generated: explicit
+		/// implementations of generic interface members are named after the interface.
+		/// </summary>
+		internal static bool IsGeneratedName(string name)
+		{
+			return name.StartsWith("<", StringComparison.Ordinal) || name.Contains("$");
 		}
 
 		public static bool HasGeneratedName(this MethodDefinitionHandle handle, MetadataReader metadata)

--- a/ICSharpCode.Decompiler/SRMExtensions.cs
+++ b/ICSharpCode.Decompiler/SRMExtensions.cs
@@ -474,13 +474,27 @@ namespace ICSharpCode.Decompiler
 			}
 		}
 
+		/// <summary>
+		/// See NRExtensions.HasOnlyReadOnlyProperties: an anonymous type with a settable property
+		/// cannot be written as a C# anonymous type, so its declaration must not be hidden.
+		/// </summary>
+		static bool HasOnlyReadOnlyProperties(TypeDefinition type, MetadataReader metadata)
+		{
+			foreach (var handle in type.GetProperties())
+			{
+				if (!metadata.GetPropertyDefinition(handle).GetAccessors().Setter.IsNil)
+					return false;
+			}
+			return true;
+		}
+
 		public static bool IsAnonymousType(this TypeDefinition type, MetadataReader metadata)
 		{
 			string name = metadata.GetString(type.Name);
 			if (type.Namespace.IsNil && type.HasGeneratedName(metadata)
 				&& (name.Contains("AnonType") || name.Contains("AnonymousType")))
 			{
-				return type.IsCompilerGenerated(metadata);
+				return type.IsCompilerGenerated(metadata) && HasOnlyReadOnlyProperties(type, metadata);
 			}
 			return false;
 		}

--- a/ILSpy.Tests/Bookmarks/BookmarkNavigationViewTests.cs
+++ b/ILSpy.Tests/Bookmarks/BookmarkNavigationViewTests.cs
@@ -23,8 +23,6 @@ using Avalonia.Headless.NUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 
-using AvaloniaEdit.Rendering;
-
 using AwesomeAssertions;
 
 using ICSharpCode.ILSpy.AppEnv;
@@ -97,11 +95,11 @@ public class BookmarkNavigationViewTests
 		await vm.DockWorkspace.WaitForDecompiledTextAsync();
 
 		view = await window.WaitForComponent<DecompilerTextView>();
-		// Wait until the one-shot highlight has registered, then assert without any further delay: the
-		// adorner self-dismisses after an ~800 ms lifetime, so a fixed-length pump on a loaded CI runner
-		// can outlast it and observe an empty collection. The same deferred apply also lands the caret.
-		await Waiters.WaitForAsync(() => view.Editor.TextArea.TextView.BackgroundRenderers
-			.OfType<LineHighlightAdorner>().Any());
+		// Wait until the one-shot highlight has played. The adorner itself self-dismisses after an
+		// ~800 ms lifetime and a stalled CI dispatcher can register and dismiss it inside a single
+		// pump, so polling the renderer collection can miss the entire play; LastHighlightPlayedLine
+		// is the view's persistent record of it. The same deferred apply also lands the caret.
+		await Waiters.WaitForAsync(() => view.LastHighlightPlayedLine != null);
 
 		int targetLine = view.GetLineForBookmark(bookmark) ?? -1;
 		targetLine.Should().BeGreaterThan(1, "the bookmark resolves to a line below the top in the freshly shown document");
@@ -110,9 +108,9 @@ public class BookmarkNavigationViewTests
 		view.Editor.TextArea.Caret.Line.Should().Be(targetLine,
 			"bookmark navigation from non-decompiler content must scroll to the saved line");
 
-		// P2: the one-shot line highlight is playing on the freshly shown view.
-		view.Editor.TextArea.TextView.BackgroundRenderers.OfType<LineHighlightAdorner>()
-			.Should().ContainSingle("the destination line must be highlighted after the content switch");
+		// P2: the one-shot line highlight played on the freshly shown view, on the right line.
+		view.LastHighlightPlayedLine.Should().Be(targetLine,
+			"the destination line must be highlighted after the content switch");
 	}
 
 	// Regression: when the active tab is frozen, navigating to a bookmark in a different node must
@@ -160,21 +158,21 @@ public class BookmarkNavigationViewTests
 		var activeModel = vm.DockWorkspace.ActiveDecompilerTab;
 		activeModel.Should().NotBeNull("navigation must surface a decompiler tab");
 
-		// Wait until the fresh preview's view exists and its one-shot highlight has registered, then
-		// assert without any further delay: the adorner self-dismisses after an ~800 ms lifetime, so a
-		// fixed-length pump on a loaded CI runner can outlast it and observe an empty collection.
+		// Wait until the fresh preview's view exists and its one-shot highlight has played. The
+		// adorner itself self-dismisses after an ~800 ms lifetime and a stalled CI dispatcher can
+		// register and dismiss it inside a single pump, so polling the renderer collection can miss
+		// the entire play; LastHighlightPlayedLine is the view's persistent record of it.
 		DecompilerTextView? ActiveView() => window.GetVisualDescendants().OfType<DecompilerTextView>()
 			.FirstOrDefault(v => ReferenceEquals(v.DataContext, activeModel));
-		await Waiters.WaitForAsync(() => ActiveView()?.Editor.TextArea.TextView.BackgroundRenderers
-			.OfType<LineHighlightAdorner>().Any() == true);
+		await Waiters.WaitForAsync(() => ActiveView()?.LastHighlightPlayedLine != null);
 		var activeView = ActiveView()!;
 
 		int targetLine = activeView.GetLineForBookmark(bookmark) ?? -1;
 		targetLine.Should().BeGreaterThan(1, "the fresh preview shows System.String with the bookmarked line below the top");
 		activeView.Editor.TextArea.Caret.Line.Should().Be(targetLine,
 			"opening a fresh preview for a frozen-tab navigation must still scroll to the bookmark");
-		activeView.Editor.TextArea.TextView.BackgroundRenderers.OfType<LineHighlightAdorner>()
-			.Should().ContainSingle("the destination line must be highlighted in the fresh preview");
+		activeView.LastHighlightPlayedLine.Should().Be(targetLine,
+			"the destination line must be highlighted in the fresh preview");
 	}
 
 	// Regression: a bookmark re-anchors by token/IL offset, so a decompiler-setting change that

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -843,6 +843,13 @@ namespace ICSharpCode.ILSpy.TextView
 			return false;
 		}
 
+		// The last line the one-shot navigation highlight was played on in this view, or null when
+		// none has played yet. The adorner itself self-dismisses after its ~800 ms lifetime, so an
+		// observer polling the renderer collection can miss the entire play when the dispatcher
+		// stalls (a headless test on a loaded CI runner); this record is the persistent evidence
+		// that the highlight ran, and where.
+		internal int? LastHighlightPlayedLine { get; private set; }
+
 		void ScrollToLine(int line, Bookmarks.BookmarkViewState? viewState = null)
 		{
 			var document = Editor.Document;
@@ -862,6 +869,7 @@ namespace ICSharpCode.ILSpy.TextView
 					RestoreBookmarkFoldings(viewState);
 				CenterLineInView(document, line);
 				LineHighlightAdorner.DisplayLineHighlight(Editor.TextArea, line);
+				LastHighlightPlayedLine = line;
 				bookmarkMargin?.PulseLine(line);
 			}, DispatcherPriority.Background);
 		}


### PR DESCRIPTION
Fixes #3952.

## The bug

Two predicates disagreed about what a compiler-generated name looks like:

- `SRMExtensions.IsGeneratedName` (metadata level) counts a `$` in the name, so
  `SRMExtensions.IsAnonymousType` matched `VB$AnonymousType_*` and `MemberIsHidden`
  dropped the definitions from the output.
- `NRExtensions.HasGeneratedName(IType)` (type system level) only looked for `<`, so
  `NRExtensions.IsAnonymousType` returned false and none of the anonymous-type
  translations in `CallBuilder`/`ExpressionBuilder` fired.

VB assemblies therefore lost the type definitions *and* kept the raw metadata names at
every use site — output that cannot be recompiled, since `$` is not a legal C# identifier
character.

## The fix

1. **One shared predicate** for both levels, so they cannot drift apart again. The
   metadata-level behaviour is kept exactly as it was: counting every name that merely
   *contains* `<` would newly capture explicit implementations of generic interface members.
2. **VB transparent identifiers.** The VB compiler carries query range variables in
   `$VB$It`, `$VB$It1`, `$VB$It2` and `$VB$ItAnonymous` (Roslyn's `GeneratedNameConstants`),
   the counterpart to C#'s `<>h__TransparentIdentifier`. Unrecognized, they survived into
   the output and left the queries uncompilable even once the anonymous types were fixed.

Without the second change the first one alone still yields invalid identifiers for every VB
query with more than one range variable, which is the shape the reported assembly is full of.

## Effect

A VB `From i In items Let square = i * i Where square > 4 Select i, square` went from

```csharp
IEnumerable<VB$AnonymousType_3<int, int>> enumerable = from i in items
    select new VB$AnonymousType_3<int, int>(i, checked(i * i)) into $VB$It
    where $VB$It.square > 4
    select new VB$AnonymousType_3<int, int>($VB$It.i, $VB$It.square);
```

to

```csharp
var enumerable = from i in items
                 let square = checked(i * i)
                 where square > 4
                 select new { i, square };
```

On the assembly from the issue (`QuartzNetWebConsole.Views` 1.0.2) every `VB$AnonymousType_*`
reference is gone.

## Tests

New `VBPretty/VBAnonymousTypes` fixture (20 configurations) covering mutable and `Key`
anonymous types, an anonymous type as an argument, and `Select`/`Let`+`Where`/`Join`/`Order By`
queries. Committed fixtures-first: the expected output fails on the first commit and passes on
the last. Full `ICSharpCode.Decompiler.Tests` suite green (3314 passed, 46 skipped, 0 failed).

The Roslyn 2.10 / .NET Core 2.2 configuration is branched with `#if`: there the query operator
calls are not restored to extension-method syntax, so no query expression is formed at all.
That is a pre-existing, config-specific gap unrelated to this change.

## Deliberately not in scope

- `VB$AnonymousDelegate_*` types (already called out in the issue as separate work). These
  are *not* a VB-only construct: a natural-typed C# lambda or method group that `Func`/`Action`
  cannot express makes Roslyn synthesize a delegate type too, and decompiling those is what
  the `natural-type-lambdas-methods` branch adds. Its `IsAnonymousDelegate` predicate matches
  on `Name.Contains("AnonymousDelegate")` through the same `HasGeneratedName()` this PR fixes,
  and VB's synthesized delegates satisfy its other conditions as well (empty namespace,
  `TypeKind.Delegate`, `[CompilerGenerated]`), so the two compose: this PR is what makes that
  machinery reachable for VB rather than something that has to be duplicated for it.
- Transparent identifiers that survive because the query transform bails, e.g. for lambdas
  with statement bodies (common in VB XML-literal code). This is **not** VB-specific: with
  `QueryExpressions` disabled, C# output emits 35 `<>h__TransparentIdentifier` references
  for the existing `QueryExpressions` fixture today. ILSpy applies `EscapeInvalidIdentifiers`
  only in the test harness, not in the default pipeline.
- VB closure display classes (`_Closure$__N-M`, `$VB$Local_*`) are still not recognized as
  such.

---

*This pull request was prepared by an AI agent (Claude) on Siegfried's behalf.*

