### PR TITLE
Fix crash decompiling reference assemblies with stripped method bodies

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -136,6 +136,7 @@
     <None Include="TestCases\ILPretty\FSharpUsing.fs" />
     <None Include="TestCases\ILPretty\FSharpUsing_Debug.il" />
     <None Include="TestCases\ILPretty\DirectCallToExplicitInterfaceImpl.il" />
+    <None Include="TestCases\ILPretty\TruncatedAccessorBody.il" />
     <None Include="TestCases\ILPretty\FSharpUsing_Release.il" />
     <None Include="TestCases\Correctness\BitNot.il" />
     <None Include="TestCases\Correctness\Readme.txt" />
@@ -195,6 +196,8 @@
     <None Include="TestCases\ILPretty\CallIndirect.cs" />
     <Compile Remove="TestCases\ILPretty\EmptyBodies.cs" />
     <None Include="TestCases\ILPretty\EmptyBodies.cs" />
+    <Compile Remove="TestCases\ILPretty\TruncatedAccessorBody.cs" />
+    <None Include="TestCases\ILPretty\TruncatedAccessorBody.cs" />
     <Compile Remove="TestCases\ILPretty\FSharpLoops_Debug.cs" />
     <None Include="TestCases\ILPretty\FSharpLoops_Debug.cs" />
     <Compile Remove="TestCases\ILPretty\FSharpLoops_Release.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -130,6 +130,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task TruncatedAccessorBody()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task EvalOrder()
 		{
 			await Run();

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TruncatedAccessorBody.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TruncatedAccessorBody.cs
@@ -1,0 +1,15 @@
+using System.Runtime.CompilerServices;
+public interface ICancellable
+{
+	bool IsCancellable { get; }
+}
+public class TestClass : ICancellable
+{
+	public bool IsCancellable => false;
+	[SpecialName]
+	bool ICancellable.get_IsCancellable()
+	{
+		_ = IsCancellable;
+		/*Error: End of method reached without returning.*/;
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TruncatedAccessorBody.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/TruncatedAccessorBody.il
@@ -1,0 +1,67 @@
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
+  .ver 4:0:0:0
+}
+.assembly TruncatedAccessorBody
+{
+  .ver 1:0:0:0
+}
+.module TruncatedAccessorBody.dll
+
+.class interface public abstract auto ansi ICancellable
+{
+  .method public hidebysig newslot abstract virtual specialname
+	instance bool get_IsCancellable () cil managed
+  {
+  }
+
+  .property instance bool IsCancellable()
+  {
+    .get instance bool ICancellable::get_IsCancellable()
+  }
+}
+
+.class public auto ansi beforefieldinit TestClass
+	extends [mscorlib]System.Object
+  implements ICancellable
+{
+  // An explicit interface accessor whose body is too short to be the
+  // 'ldarg...; call; ret' forwarding stub. Reference assemblies produce such
+  // bodies, and the accessor-forwarding matcher must reject them instead of
+  // reading past the end of the body.
+  .method private final hidebysig newslot virtual specialname
+	instance bool ICancellable.get_IsCancellable () cil managed
+  {
+    .override method instance bool ICancellable::get_IsCancellable()
+    .maxstack 8
+
+    ldarg.0
+    call instance bool TestClass::get_IsCancellable()
+  }
+
+  .method public hidebysig specialname
+	instance bool get_IsCancellable () cil managed
+  {
+    .maxstack 8
+
+    ldc.i4.0
+    ret
+  }
+
+  .property instance bool IsCancellable()
+  {
+    .get instance bool TestClass::get_IsCancellable()
+  }
+
+  .method public hidebysig specialname rtspecialname
+	instance void .ctor () cil managed
+  {
+    .maxstack 8
+
+    ldarg.0
+    call instance void [mscorlib]System.Object::.ctor()
+    ret
+  }
+
+} // end of class TestClass

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -476,25 +476,38 @@ namespace ICSharpCode.Decompiler.CSharp
 				return false;
 			signature.Reset();
 
+			// The shortest possible forwarding stub loads every argument with a one-byte
+			// ldarg.N; the longest uses the four-byte ldarg form. Both end in call + ret.
+			int minimumMethodSize = 1 * (parameterCount + 1) + 5 + 1;
 			int maximumMethodSize = 4 * (parameterCount + 1) + 5 + 1;
 
 			var body = module.Reader.GetMethodBody(method.RelativeVirtualAddress);
 			var reader = body.GetILReader();
 
-			if (reader.RemainingBytes > maximumMethodSize)
+			// Reference assemblies keep the method RVA but strip the body, so a body far
+			// too short for the stub must be rejected before any of the reads below.
+			if (reader.RemainingBytes < minimumMethodSize || reader.RemainingBytes > maximumMethodSize)
 				return false;
 
 			for (int i = 0; i < parameterCount + 1; i++)
 			{
 				int index;
+				// The long ldarg forms are wider than the one byte per argument that the
+				// minimum size accounts for, so the body can still run out mid-loop.
+				if (reader.RemainingBytes < 1)
+					return false;
 				switch (reader.DecodeOpCode())
 				{
 					case ILOpCode.Ldarg:
+						if (reader.RemainingBytes < 2)
+							return false;
 						index = reader.ReadUInt16();
 						if (index != i)
 							return false;
 						break;
 					case ILOpCode.Ldarg_s:
+						if (reader.RemainingBytes < 1)
+							return false;
 						index = reader.ReadByte();
 						if (index != i)
 							return false;
@@ -519,6 +532,10 @@ namespace ICSharpCode.Decompiler.CSharp
 						return false;
 				}
 			}
+
+			// call <4-byte token> + ret
+			if (reader.RemainingBytes < 6)
+				return false;
 
 			if (reader.DecodeOpCode() != ILOpCode.Call)
 				return false;


### PR DESCRIPTION
## Problem

`CSharpDecompiler.IsAccessorInterfaceImplementationRuntimeHelper` bounds the IL body of a candidate accessor from above, but never from below. Reference assemblies keep the method RVA while stripping the body to zero bytes, so an explicit interface accessor there passes the size check and the very first opcode read runs off the end of the blob. The `BadImageFormatException` escapes `MemberIsHidden` and aborts decompilation of the entire type.

Repro with any `Microsoft.NETFramework.ReferenceAssemblies` pack:

```
ilspycmd .../microsoft.netframework.referenceassemblies.net48/1.0.3/build/.NETFramework/v4.8/System.Web.dll -t System.Web.HttpApplication

---> System.BadImageFormatException: Read out of bounds.
   at ICSharpCode.Decompiler.Disassembler.ILParser.DecodeOpCode(BlobReader& blob)
   at ICSharpCode.Decompiler.CSharp.CSharpDecompiler.IsAccessorInterfaceImplementationRuntimeHelper(...)
   at ICSharpCode.Decompiler.CSharp.CSharpDecompiler.MemberIsHidden(...)
```

## Fix

A `minimumMethodSize` counterpart to the existing `maximumMethodSize`, plus three guards the bound cannot cover on its own: `minimumMethodSize` assumes the one-byte `ldarg.N` encoding, but `ldarg` encodes as four bytes, so a body that passes the bound can still be consumed by the argument loop before the trailing `call`/`ret`.

The sibling fixed-sequence matcher, `TransformDisplayClassUsage.IsCallToObjectCtor`, already guards its lower bound (`reader.Length < 7`) and catches `BadImageFormatException`; this one did not. I audited every `DecodeOpCode` call site: all others are `while (blob.RemainingBytes > 0)` scanners whose opcode read is guarded by the loop condition, so no change is needed there and no bounds-checking overhead is added to normal IL blobs.

## Testing

- New ILPretty fixture `TruncatedAccessorBody`, red before the fix with the same stack trace, green after. ilasm cannot emit a zero-byte body, so the fixture uses the truncated-tail variant of the same defect.
- `System.Web`, `System.Web.Extensions`, `mscorlib`, `System` and `System.Core` from the net48 reference pack now decompile in full with zero errors.
- Full `ILSpy.XPlat.slnf` suite: 3367 tests, 0 failed, 44 skipped (Windows-only).

## How it was found

Fuzzing the nuget.org catalog through the decompiler. Every package whose dependency closure resolved to the `Microsoft.NETFramework.ReferenceAssemblies` packs hit this.

---
_Written by an AI agent (Claude) on Siegfried's behalf._