### PR TITLE
Fix overflow approximating fractions of large negative constants

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/WellKnownConstants.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/WellKnownConstants.cs
@@ -202,5 +202,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public const double Double_Negated_E = -Math.E;
 		public const double Double_Negated_BeforeE = -2.7182818284590446;
 		public const double Double_Negated_AfterE = -2.7182818284590455;
+
+		// Values of either sign whose ratio to PI or E is outside the range expressible as
+		// a fraction must be left alone rather than run through the approximation.
+		public const double Double_TooLargeForFraction = 3085105840164255.5;
+		public const double Double_Negated_TooLargeForFraction = -3085105840164255.5;
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -1724,7 +1724,10 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		// we just keep the last partial product of these matrices.
 		static (long Num, long Den) FractionApprox(double value, int maxDenominator)
 		{
-			if (value > 0x7FFFFFFF)
+			// The range check has to be on the magnitude: the sign is stripped below, so a
+			// large negative value would otherwise reach the continued-fraction loop and
+			// overflow the terms it accumulates.
+			if (Math.Abs(value) > 0x7FFFFFFF)
 				return (0, 0);
 
 			double startValue = value;


### PR DESCRIPTION
## Problem

`TypeSystemAstBuilder.FractionApprox` rejects inputs that cannot be stored as a fraction, but the range check is one-sided and the sign is stripped immediately after it:

```csharp
if (value > 0x7FFFFFFF)          // negatives pass straight through
    return (0, 0);

double startValue = value;
if (value < 0)
    value = -value;              // ...and are then made positive
```

A large negative value therefore reaches the continued-fraction loop and overflows the terms it accumulates. `ICSharpCode.Decompiler` is built with `CheckForOverflowUnderflow`, so this throws rather than wrapping, and the `OverflowException` aborts decompilation of the whole member:

```
System.OverflowException: Arithmetic operation resulted in an overflow.
   at ICSharpCode.Decompiler.CSharp.Syntax.TypeSystemAstBuilder.FractionApprox(Double, Int32)
   at ICSharpCode.Decompiler.CSharp.Syntax.TypeSystemAstBuilder.TryExtractExpression(...)
   at ICSharpCode.Decompiler.CSharp.Syntax.TypeSystemAstBuilder.ConvertFloatingPointLiteral(...)
```

## Fix

Check the magnitude, matching what the surrounding code already assumes.

## Testing

Two constants added to the `WellKnownConstants` fixture, one of each sign. The negative one fails without the fix with the stack above; the positive one is already handled and guards the symmetry.

Note that the trigger has to be non-integral: `ConvertFloatingPointLiteral` short-circuits integral doubles via `Math.Floor(v) == v`, so those never reach the approximation at all. The value used here is an actual constant from MathNet.Numerics, which arrives at `FractionApprox` through its ratio to PI.

Full `ILSpy.XPlat.slnf` suite: 3366 tests, 0 failed, 44 skipped (Windows-only). The complete `MathNet.Numerics` assembly now decompiles with zero errors.

## How it was found

Fuzzing the nuget.org catalog through the decompiler.

---
_Written by an AI agent (Claude) on Siegfried's behalf._