### PR TITLE
Fix overflow computing the element count of a multi-dim array initializer

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MultidimensionalArray.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MultidimensionalArray.cs
@@ -52,5 +52,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			return new int[10][,];
 		}
+
+		// The dimensions multiply to more than int.MaxValue; the initializer transform
+		// must cope with that instead of overflowing while sizing its element list.
+		public int[,] DimensionsExceedingIntRange()
+		{
+			int[,] array = new int[65536, 65536];
+			array[0, 0] = 1;
+			array[0, 1] = 2;
+			return array;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/TransformArrayInitializers.cs
@@ -594,7 +594,9 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		{
 			instructionsToRemove = 0;
 			int elementCount = 0;
-			int length = arrayLength.Aggregate(1, (t, l) => t * l);
+			// The dimensions come from the IL and need not multiply within int range.
+			// This is only a capacity hint, so saturate rather than overflow.
+			int length = arrayLength.Aggregate(1, (t, l) => (int)Math.Min((long)t * l, int.MaxValue));
 			// Cannot pre-allocate the result array, because we do not know yet,
 			// whether there is in fact an array initializer.
 			// To prevent excessive allocations, use min(|block|, arraySize) als initial capacity.


### PR DESCRIPTION
## Problem

`TransformArrayInitializers.HandleSimpleArrayInitializer` multiplies the array dimensions to size the list it collects elements into:

```csharp
int length = arrayLength.Aggregate(1, (t, l) => t * l);
```

The dimensions come from the input assembly and need not multiply within `int` range. `ICSharpCode.Decompiler` is built with `CheckForOverflowUnderflow`, so this throws instead of wrapping, and the `OverflowException` aborts decompilation of the whole member:

```
System.OverflowException: Arithmetic operation resulted in an overflow.
   at ...TransformArrayInitializers.<>c.<HandleSimpleArrayInitializer>b__22_0(Int32 t, Int32 l)
   at System.Linq.Enumerable.Aggregate[TSource,TAccumulate](...)
   at ...TransformArrayInitializers.HandleSimpleArrayInitializer(...)
   at ...TransformArrayInitializers.DoTransformMultiDim(...)
```

## Fix

The product is used only as the initial capacity of `valuesList` and has no bearing on the result, so it can saturate instead of overflowing.

## Testing

A `new int[65536, 65536]` case added to the `MultidimensionalArray` fixture, whose dimensions multiply to more than `int.MaxValue`. It fails without the fix with the stack above.

Full `ILSpy.XPlat.slnf` suite: 3366 tests, 0 failed, 44 skipped (Windows-only).

## How it was found

Fuzzing the nuget.org catalog through the decompiler; the original hit was an obfuscated assembly.

---
_Written by an AI agent (Claude) on Siegfried's behalf._