### PR TITLE
Keep ref-returning switches as statements

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
@@ -282,6 +282,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return ref DefaultInt;
 		}
 
+		public static ref int SwitchRefReturn(int index)
+		{
+			switch (index)
+			{
+				case 0:
+					return ref numbers[0];
+				case 1:
+					return ref numbers[1];
+				default:
+					throw new InvalidOperationException();
+			}
+		}
+
 		public static ref int LastOrDefault()
 		{
 			if (numbers.Length != 0)

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -676,6 +676,8 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			// Exactly one of resultVariable/leaveTarget must be null
 			if ((resultVariable == null) == (leaveTarget == null))
 				return;
+			if (resultType == StackType.Ref)
+				return;
 			if (switchInst.Value is StringToInt str2int)
 			{
 				// validate that each integer is used for exactly one value

--- a/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/ExpressionTransforms.cs
@@ -676,6 +676,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			// Exactly one of resultVariable/leaveTarget must be null
 			if ((resultVariable == null) == (leaveTarget == null))
 				return;
+			// C# has no ref-returning switch expression: an arm cannot be `0 => ref x`.
 			if (resultType == StackType.Ref)
 				return;
 			if (switchInst.Value is StringToInt str2int)


### PR DESCRIPTION
tl;dr: C# has no ref-returning switch expression, so keep these switches as statements.

Fixes #3966

### Problem

`HandleSwitchExpression` also converts switches whose result is `StackType.Ref`. This emits arms such as `0 => ref field`, which C# rejects with CS1525.

### Solution

Skip switch-expression conversion for `StackType.Ref`. The existing statement path then emits a valid switch with `return ref` branches.

The regression case covers a ref-returning switch with multiple branches and a throwing default.

- [x] At least one test covering the code changed
