### PR TITLE
Keep null-conditional LINQ chains in method syntax

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -48,6 +48,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 			public Maybe<int> Value;
 
+#if CS60
+			public Maybe<int> this[int index] => default(Maybe<int>);
+#endif
+
 			public Func<Maybe<int>> Factory()
 			{
 				return () => default(Maybe<int>);
@@ -236,6 +240,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		public Maybe<string>? NullConditionalNestedInvocationQuery(MaybeHolder holder)
 		{
 			return holder?.Factory()().Where((int value) => value > 0).Select((int value) => value.ToString());
+		}
+
+		public Maybe<string>? NullConditionalIndexerQuery(MaybeHolder holder)
+		{
+			return holder?[0].Where((int value) => value > 0).Select((int value) => value.ToString());
 		}
 #endif
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -44,6 +44,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 	public class QueryExpressions
 	{
+		public class MaybeHolder
+		{
+			public Maybe<int> Value;
+
+			public Func<Maybe<int>> Factory()
+			{
+				return () => default(Maybe<int>);
+			}
+		}
+
 		public class HbmParam
 		{
 			public string Name { get; set; }
@@ -216,6 +226,16 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		private List<string> Issue2545(List<string> arglist)
 		{
 			return arglist?.OrderByDescending((string f) => f.Length).ThenBy((string f) => f.ToLower()).ToList();
+		}
+
+		public Maybe<string>? NullConditionalValueTypeQuery(MaybeHolder holder)
+		{
+			return holder?.Value.Where((int value) => value > 0).Select((int value) => value.ToString());
+		}
+
+		public Maybe<string>? NullConditionalNestedInvocationQuery(MaybeHolder holder)
+		{
+			return holder?.Factory()().Where((int value) => value > 0).Select((int value) => value.ToString());
 		}
 #endif
 

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
@@ -380,7 +380,8 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 		bool IsNullConditional(Expression target) => target switch {
 			UnaryOperatorExpression { Operator: UnaryOperatorType.NullConditional } => true,
 			MemberReferenceExpression member => IsNullConditional(member.Target),
-			InvocationExpression { Target: { } invocationTarget } => IsNullConditional(invocationTarget),
+			InvocationExpression invocation => IsNullConditional(invocation.Target),
+			IndexerExpression { Target: { } indexerTarget } => IsNullConditional(indexerTarget),
 			_ => false
 		};
 

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
@@ -377,10 +377,12 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			}
 		}
 
-		bool IsNullConditional(Expression target)
-		{
-			return target is UnaryOperatorExpression uoe && uoe.Operator == UnaryOperatorType.NullConditional;
-		}
+		bool IsNullConditional(Expression target) => target switch {
+			UnaryOperatorExpression { Operator: UnaryOperatorType.NullConditional } => true,
+			MemberReferenceExpression member => IsNullConditional(member.Target),
+			InvocationExpression { Target: { } invocationTarget } => IsNullConditional(invocationTarget),
+			_ => false
+		};
 
 		/// <summary>
 		/// This fixes #437: Decompilation of query expression loses material parentheses


### PR DESCRIPTION
tl;dr: Keep LINQ method syntax when its receiver chain contains a null-conditional access.

Fixes #3968

### Problem

`IntroduceQueryExpressions` only checks the immediate LINQ receiver for `?.`. A chained `Where(...).Select(...)` can therefore be converted to query syntax even when its source contains a null-conditional access over a value type.

The query source is then nullable and does not implement the query pattern.

### Solution

Make `IsNullConditional` inspect the member and invocation receiver chain before introducing query syntax.

- [x] At least one test covering the code changed
