### PR TITLE
Fix #3510: keep exporting a project when a member cannot be decompiled

### DIFF
--- a/ICSharpCode.Decompiler.PowerShell/DecompilationErrorReporting.cs
+++ b/ICSharpCode.Decompiler.PowerShell/DecompilationErrorReporting.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Christoph Wille
+// Copyright (c) 2026 Siegfried Pammer
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this
 // software and associated documentation files (the "Software"), to deal in the Software
@@ -16,49 +16,23 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Management.Automation;
-using System.Text;
-
-using ICSharpCode.Decompiler.CSharp;
-using ICSharpCode.Decompiler.TypeSystem;
 
 namespace ICSharpCode.Decompiler.PowerShell
 {
-	[Cmdlet(VerbsCommon.Get, "DecompiledSource")]
-	[OutputType(typeof(string))]
-	public class GetDecompiledSourceCmdlet : PSCmdlet
+	static class DecompilationErrorReporting
 	{
-		[Parameter(Position = 0, Mandatory = true)]
-		public CSharpDecompiler Decompiler { get; set; }
-
-		[Parameter]
-		public string TypeName { get; set; } = string.Empty;
-
-		protected override void ProcessRecord()
+		/// <summary>
+		/// Raises one non-terminating error per member the decompiler could not handle. The output
+		/// is produced either way - with the error text in place of the affected code - so without
+		/// this a script would take known-broken source for a clean decompilation.
+		/// </summary>
+		public static void WriteDecompilationErrors(this Cmdlet cmdlet, IReadOnlyList<DecompilerException> errors)
 		{
-			try
+			foreach (var error in errors)
 			{
-				StringWriter output = new StringWriter();
-				if (TypeName == null)
-				{
-					output.Write(Decompiler.DecompileWholeModuleAsString());
-				}
-				else
-				{
-					var name = new FullTypeName(TypeName);
-					output.Write(Decompiler.DecompileTypeAsString(name));
-				}
-
-				WriteObject(output.ToString());
-				this.WriteDecompilationErrors(Decompiler.Errors);
-			}
-			catch (Exception e)
-			{
-				WriteVerbose(e.ToString());
-				WriteError(new ErrorRecord(e, ErrorIds.DecompilationFailed, ErrorCategory.OperationStopped, null));
+				cmdlet.WriteError(new ErrorRecord(error, ErrorIds.DecompilationFailed, ErrorCategory.NotSpecified, null));
 			}
 		}
 	}

--- a/ICSharpCode.Decompiler.PowerShell/GetDecompiledProjectCmdlet.cs
+++ b/ICSharpCode.Decompiler.PowerShell/GetDecompiledProjectCmdlet.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Threading;
@@ -96,6 +97,7 @@ namespace ICSharpCode.Decompiler.PowerShell
 				task.Wait();
 
 				WriteProgress(new ProgressRecord(1, "Decompiling " + fileName, "Decompilation finished") { RecordType = ProgressRecordType.Completed });
+				this.WriteDecompilationErrors(errors);
 			}
 			catch (Exception e)
 			{
@@ -103,6 +105,8 @@ namespace ICSharpCode.Decompiler.PowerShell
 				WriteError(new ErrorRecord(e, ErrorIds.DecompilationFailed, ErrorCategory.OperationStopped, null));
 			}
 		}
+
+		private IReadOnlyList<DecompilerException> errors = Array.Empty<DecompilerException>();
 
 		private void DoDecompile(string path)
 		{
@@ -112,7 +116,14 @@ namespace ICSharpCode.Decompiler.PowerShell
 			decompiler.ProgressIndicator = this;
 			fileName = module.FileName;
 			completed = 0;
-			decompiler.DecompileProject(module, path);
+			try
+			{
+				decompiler.DecompileProject(module, path);
+			}
+			finally
+			{
+				errors = decompiler.Errors;
+			}
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/DecompilationErrorRecoveryTests.cs
+++ b/ICSharpCode.Decompiler.Tests/DecompilationErrorRecoveryTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Linq;
+
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.IL;
+using ICSharpCode.Decompiler.IL.Transforms;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.Decompiler.Tests
+{
+	/// <summary>
+	/// A method body that cannot be decompiled must not take the surrounding type - or, when
+	/// exporting a project, the surrounding assembly - down with it. The failure is turned into
+	/// output the user can copy into a bug report, and decompilation continues.
+	/// </summary>
+	[TestFixture]
+	public class DecompilationErrorRecoveryTests
+	{
+		const string SimulatedFailure = "Simulated transform failure";
+
+		[Test]
+		public void FailingMethodBodyKeepsTheRestOfTheType()
+		{
+			var decompiler = CreateDecompiler();
+			decompiler.ILTransforms.Add(new ThrowingILTransform("CleanUpFileName"));
+
+			string code = decompiler.DecompileTypeAsString(
+				new FullTypeName("ICSharpCode.Decompiler.CSharp.ProjectDecompiler.WholeProjectDecompiler"));
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(code, Does.Contain(SimulatedFailure), "the exception text must show up in the output");
+				Assert.That(code, Does.Contain(CSharpDecompiler.DecompilationErrorReportUrl), "users need to be told where to report this");
+				Assert.That(code, Does.Contain("public static string CleanUpFileName"), "the failing member keeps its signature");
+				Assert.That(code, Does.Contain("DecompileProject"), "the other members of the type are unaffected");
+			}
+		}
+
+		[Test]
+		public void FailingMethodBodyIsRecordedAsError()
+		{
+			var decompiler = CreateDecompiler();
+			decompiler.ILTransforms.Add(new ThrowingILTransform("CleanUpFileName"));
+
+			decompiler.DecompileTypeAsString(
+				new FullTypeName("ICSharpCode.Decompiler.CSharp.ProjectDecompiler.WholeProjectDecompiler"));
+
+			var error = decompiler.Errors.Single();
+			Assert.That(error.Message, Does.Contain("CleanUpFileName"));
+		}
+
+		/// <summary>
+		/// <see cref="CSharpDecompiler.Errors"/> describes the decompilation that just ran, so a
+		/// reused instance must not report the previous one's failures against it.
+		/// </summary>
+		[Test]
+		public void ErrorsCoverOnlyTheLastDecompilation()
+		{
+			var decompiler = CreateDecompiler();
+			var failing = new ThrowingILTransform("CleanUpFileName");
+			decompiler.ILTransforms.Add(failing);
+			decompiler.DecompileTypeAsString(
+				new FullTypeName("ICSharpCode.Decompiler.CSharp.ProjectDecompiler.WholeProjectDecompiler"));
+
+			decompiler.ILTransforms.Remove(failing);
+			decompiler.DecompileTypeAsString(
+				new FullTypeName("ICSharpCode.Decompiler.CSharp.ProjectDecompiler.WholeProjectDecompiler"));
+
+			Assert.That(decompiler.Errors, Is.Empty);
+		}
+
+		/// <summary>
+		/// A member whose output throws is replaced by the error text, and writing carries on with
+		/// the rest of the type - a file cut off mid-member would leave the braces around it open
+		/// and every later type unreadable.
+		/// </summary>
+		[Test]
+		public void FailingOutputKeepsTheFileWellFormed()
+		{
+			var decompiler = CreateDecompiler();
+			var syntaxTree = decompiler.DecompileType(
+				new FullTypeName("ICSharpCode.Decompiler.CSharp.ProjectDecompiler.WholeProjectDecompiler"));
+
+			// A member that cannot be written: an expression node with no children to write.
+			var victim = syntaxTree.Descendants.OfType<MethodDeclaration>().First(m => m.Name == "CleanUpFileName");
+			victim.Body.Statements.Clear();
+			victim.Body.Statements.Add(new ExpressionStatement(new BinaryOperatorExpression()));
+
+			var writer = new StringWriter();
+			var outputVisitor = new ErrorTolerantOutputVisitor(writer, new DecompilerSettings().CSharpFormattingOptions);
+			syntaxTree.AcceptVisitor(outputVisitor);
+			string code = writer.ToString();
+
+			using (Assert.EnterMultipleScope())
+			{
+				Assert.That(outputVisitor.Errors, Has.Count.EqualTo(1), "the failure is reported to the caller");
+				Assert.That(code, Does.Contain(CSharpDecompiler.DecompilationErrorReportUrl), "and shows up in the file");
+				Assert.That(code, Does.Contain("DecompileProject"), "the members after the failing one are still written");
+				Assert.That(code.Count(c => c == '{'), Is.EqualTo(code.Count(c => c == '}')),
+					"every brace the failed member opened is closed again");
+			}
+		}
+
+		static CSharpDecompiler CreateDecompiler()
+		{
+			var module = new PEFile("ICSharpCode.Decompiler.dll");
+			var settings = new DecompilerSettings();
+			var typeSystem = new DecompilerTypeSystem(module, new UniversalAssemblyResolver(null, false, null), settings);
+			return new CSharpDecompiler(typeSystem, settings);
+		}
+
+		sealed class ThrowingILTransform(string methodName) : IILTransform
+		{
+			public void Run(ILFunction function, ILTransformContext context)
+			{
+				if (function.Parent == null && function.Method?.Name == methodName)
+					throw new InvalidOperationException(SimulatedFailure);
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/ProjectDecompiler/WholeProjectDecompilerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/ProjectDecompiler/WholeProjectDecompilerTests.cs
@@ -19,9 +19,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
+using ICSharpCode.Decompiler.CSharp;
 using ICSharpCode.Decompiler.CSharp.ProjectDecompiler;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.CSharp.Transforms;
 using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
 
 using NUnit.Framework;
 
@@ -68,6 +73,78 @@ public sealed class WholeProjectDecompilerTests
 		}
 	}
 
+	/// <summary>
+	/// Everything an export can fail at - decompiling a source file, creating one, the assembly-info
+	/// file, a resource - is reported and skipped; the export itself always runs to completion, so a
+	/// single unsupported member cannot cost the user the whole project (issue #3510).
+	/// </summary>
+	[Test]
+	public void FailuresDoNotAbortTheExport()
+	{
+		string targetDirectory = Path.Combine(Environment.CurrentDirectory, Path.GetRandomFileName());
+		TestFriendlyProjectDecompiler decompiler = new(new UniversalAssemblyResolver(null, false, null));
+		decompiler.ConfigureDecompiler = d => d.AstTransforms.Add(new ThrowingAstTransform(nameof(WholeProjectDecompiler)));
+		decompiler.FailResourceEnumeration = true;
+		decompiler.FailFileCreationFor = new[] { nameof(TargetServices) + ".cs", "AssemblyInfo.cs" };
+
+		StringWriter projectFileWriter = new();
+		decompiler.DecompileProject(new PEFile("ICSharpCode.Decompiler.dll"), targetDirectory, projectFileWriter);
+		AssertDirectoryDoesntExist(targetDirectory);
+
+		string failedFile = Path.Combine(targetDirectory, "ICSharpCode.Decompiler.CSharp.ProjectDecompiler", $"{nameof(WholeProjectDecompiler)}.cs");
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(decompiler.Errors.Select(e => e.InnerException?.Message), Is.EquivalentTo(new[] {
+				ThrowingAstTransform.Failure,
+				TestFriendlyProjectDecompiler.ResourceFailure,
+				TestFriendlyProjectDecompiler.FileCreationFailure + nameof(TargetServices) + ".cs",
+				TestFriendlyProjectDecompiler.FileCreationFailure + "AssemblyInfo.cs",
+			}));
+			Assert.That(decompiler.Files[failedFile].ToString(), Does.Contain(ThrowingAstTransform.Failure),
+				"the error text takes the place of the file's contents");
+			Assert.That(decompiler.Files, Has.Count.GreaterThan(100), "all other files are still written");
+			Assert.That(projectFileWriter.ToString(), Does.Contain("<Project"), "the project file is still written");
+		}
+	}
+
+	/// <summary>
+	/// A resource that cannot be written must cost that resource alone. Recovering around the
+	/// enumeration cannot do this - an iterator is finished once it throws - so the export has to
+	/// recover per resource, and this pins that.
+	/// </summary>
+	[Test]
+	public void OneFailingResourceDoesNotDropTheOthers()
+	{
+		string targetDirectory = Path.Combine(Environment.CurrentDirectory, Path.GetRandomFileName());
+		TestFriendlyProjectDecompiler decompiler = new(new UniversalAssemblyResolver(null, false, null));
+		decompiler.FailResourceWriting = true;
+
+		StringWriter projectFileWriter = new();
+		// Two embedded .resources containers and nothing else, so both go through WriteResourceToFile
+		// and the test never touches the disk.
+		decompiler.DecompileProject(new PEFile("Microsoft.DiaSymReader.Converter.Xml.dll"), targetDirectory, projectFileWriter);
+		AssertDirectoryDoesntExist(targetDirectory);
+
+		using (Assert.EnterMultipleScope())
+		{
+			Assert.That(decompiler.WrittenResources, Has.Count.EqualTo(2),
+				"the resource after the failing one is still written");
+			Assert.That(decompiler.Errors.Select(e => e.InnerException?.Message),
+				Is.EqualTo(new[] { TestFriendlyProjectDecompiler.ResourceFailure }));
+		}
+	}
+
+	sealed class ThrowingAstTransform(string typeName) : IAstTransform
+	{
+		public const string Failure = "Simulated AST transform failure";
+
+		public void Run(AstNode rootNode, TransformContext context)
+		{
+			if (rootNode.Descendants.OfType<TypeDeclaration>().Any(td => td.Name == typeName))
+				throw new InvalidOperationException(Failure);
+		}
+	}
+
 	static void AssertDirectoryDoesntExist(string directory)
 	{
 		if (Directory.Exists(directory))
@@ -81,9 +158,19 @@ public sealed class WholeProjectDecompilerTests
 	{
 		public Dictionary<string, StringWriter> Files { get; } = [];
 		public HashSet<string> Directories { get; } = [];
+		public Action<CSharpDecompiler>? ConfigureDecompiler { get; set; }
+
+		protected override CSharpDecompiler CreateDecompiler(DecompilerTypeSystem ts)
+		{
+			var decompiler = base.CreateDecompiler(ts);
+			ConfigureDecompiler?.Invoke(decompiler);
+			return decompiler;
+		}
 
 		protected override TextWriter CreateFile(string path)
 		{
+			if (FailFileCreationFor.Any(name => path.EndsWith(name, StringComparison.Ordinal)))
+				throw new IOException(FileCreationFailure + Path.GetFileName(path));
 			StringWriter writer = new();
 			lock (Files)
 			{
@@ -102,6 +189,37 @@ public sealed class WholeProjectDecompilerTests
 
 		protected override IEnumerable<ProjectItemInfo> WriteMiscellaneousFilesInProject(PEFile module) => [];
 
-		protected override IEnumerable<ProjectItemInfo> WriteResourceFilesInProject(MetadataFile module) => [];
+		public const string ResourceFailure = "Simulated resource failure";
+		public const string FileCreationFailure = "Simulated file creation failure: ";
+
+		public bool FailResourceEnumeration { get; set; }
+
+		public bool FailResourceWriting { get; set; }
+
+		public string[] FailFileCreationFor { get; set; } = Array.Empty<string>();
+
+		public List<string> WrittenResources { get; } = [];
+
+		protected override IEnumerable<ProjectItemInfo> WriteResourceFilesInProject(MetadataFile module)
+		{
+			if (FailResourceWriting)
+				return base.WriteResourceFilesInProject(module);
+			return FailResourceEnumeration
+				? Enumerable.Range(0, 1).Select<int, ProjectItemInfo>(_ => throw new InvalidOperationException(ResourceFailure))
+				: [];
+		}
+
+		// Fails on the first resource only, so the test can tell "recovered per resource" from
+		// "gave up on the rest of them".
+		protected override IEnumerable<ProjectItemInfo> WriteResourceToFile(string fileName, string resourceName, Stream entryStream)
+		{
+			if (WrittenResources.Count == 0)
+			{
+				WrittenResources.Add(fileName);
+				throw new InvalidOperationException(ResourceFailure);
+			}
+			WrittenResources.Add(fileName);
+			return new[] { new ProjectItemInfo("EmbeddedResource", fileName) };
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
+++ b/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -204,6 +205,9 @@ namespace ICSharpCode.Decompiler.Roundtrip
 							decompiler.StrongNameKeyFile = Path.Combine(inputDir, snkFilePath);
 						}
 						decompiler.DecompileProject(module, decompiledDir);
+						// The exporter reports what it could not decompile instead of throwing, so
+						// without this a decompiler crash produces a stub and the round trip passes.
+						Assert.That(decompiler.Errors.Select(e => e.ToString()), Is.Empty);
 						Console.WriteLine($"Decompiled {fileToRoundtrip} in {w.Elapsed.TotalSeconds:f2}");
 						projectFile = Path.Combine(decompiledDir, module.Name + ".csproj");
 					}

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -291,6 +291,59 @@ namespace ICSharpCode.Decompiler.CSharp
 		}
 
 		/// <summary>
+		/// Method bodies that could not be decompiled. Instead of aborting the surrounding type,
+		/// such a member is emitted with the error text in place of its body (see
+		/// <see cref="GetErrorCommentLines"/>) and the exception is collected here, so callers
+		/// decompiling many members - the project exporter above all - can tell the user how many
+		/// members are affected.
+		/// </summary>
+		public IReadOnlyList<DecompilerException> Errors => errors;
+
+		readonly List<DecompilerException> errors = new List<DecompilerException>();
+
+		/// <summary>
+		/// Where users are asked to report decompilation failures; part of the error text emitted
+		/// into the output, because a failure nobody reports is a failure nobody fixes.
+		/// </summary>
+		public const string DecompilationErrorReportUrl = "https://github.com/icsharpcode/ILSpy/issues/new";
+
+		/// <summary>
+		/// The headline a front end puts above the list of failures it recovered from. Shared so the
+		/// UI, the command line and any other consumer say the same thing and point at the same URL.
+		/// </summary>
+		public static IEnumerable<string> GetErrorSummaryLines(int errorCount)
+		{
+			yield return $"{errorCount} error(s) occurred; the affected code was replaced by the error text in the output.";
+			yield return $"Please report them at {DecompilationErrorReportUrl}:";
+		}
+
+		/// <summary>
+		/// The one-line description of a single failure, so the UI and the command line name it the
+		/// same way.
+		/// </summary>
+		public static string GetErrorHeadline(DecompilerException error)
+		{
+			if (error == null)
+				throw new ArgumentNullException(nameof(error));
+			return error.InnerException == null ? error.Message : $"{error.Message}: {error.InnerException.Message}";
+		}
+
+		/// <summary>
+		/// Renders <paramref name="error"/> as the lines of a comment block: an explanation, the
+		/// request to report it, and the full exception including its stack trace, which is what
+		/// makes such a report actionable.
+		/// </summary>
+		internal static IEnumerable<string> GetErrorCommentLines(Exception error)
+		{
+			yield return "ILSpy could not decompile this. Please report the exception below,";
+			yield return "along with the assembly it came from, at " + DecompilationErrorReportUrl;
+			foreach (string line in error.ToString().Split('\n'))
+			{
+				yield return line.TrimEnd('\r');
+			}
+		}
+
+		/// <summary>
 		/// Creates a new <see cref="CSharpDecompiler"/> instance from the given <paramref name="fileName"/> using the given <paramref name="settings"/>.
 		/// </summary>
 		public CSharpDecompiler(string fileName, DecompilerSettings settings)
@@ -752,6 +805,10 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		DecompileRun CreateDecompileRun(HashSet<string> namespaces)
 		{
+			// Every public Decompile* entry point starts here, so this is where the failures of the
+			// previous one stop counting - otherwise a reused instance reports them again against
+			// members that decompiled cleanly.
+			errors.Clear();
 			List<INamespace> resolvedNamespaces = new List<INamespace>();
 			foreach (var ns in namespaces)
 			{
@@ -2283,9 +2340,34 @@ namespace ICSharpCode.Decompiler.CSharp
 
 				CleanUpMethodDeclaration(entityDecl, body, function, localSettings.DecompileMemberBodies);
 			}
-			catch (Exception innerException) when (!(innerException is OperationCanceledException || innerException is DecompilerException))
+			catch (Exception innerException) when (!(innerException is OperationCanceledException))
 			{
-				throw new DecompilerException(module, method, innerException);
+				// One method the decompiler cannot handle must not cost the user the type or, when
+				// exporting a project, the assembly around it: keep the signature, put the error in
+				// front of it, and let the remaining members decompile.
+				errors.Add(innerException as DecompilerException ?? new DecompilerException(module, method, innerException));
+				entityDecl.GetChild(Slots.Body)?.Remove();
+				if (settings.DecompileMemberBodies)
+				{
+					// The error goes where the code would have been, the same way a warning about the
+					// code does - and the body keeps the member's shape intact.
+					var errorBody = new BlockStatement();
+					var errorStatement = new EmptyStatement();
+					foreach (string line in GetErrorCommentLines(innerException))
+					{
+						errorStatement.AddTrailingTrivia(new Comment(" " + line));
+					}
+					errorBody.Statements.Add(errorStatement);
+					entityDecl.AddChild(errorBody, Slots.Body);
+				}
+				else
+				{
+					// Definitions-only output has no body to put the error in.
+					foreach (string line in GetErrorCommentLines(innerException))
+					{
+						entityDecl.AddLeadingTrivia(new Comment(" " + line));
+					}
+				}
 			}
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/ErrorTolerantOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/ErrorTolerantOutputVisitor.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using ICSharpCode.Decompiler.CSharp.Syntax;
+
+#nullable enable
+
+namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
+{
+	/// <summary>
+	/// Writes a syntax tree like <see cref="CSharpOutputVisitor"/>, but a member whose output throws
+	/// is replaced by the error text instead of ending the file half-written. Writing resumes with
+	/// the next member, so the reader still gets the rest of the type and a file that closes every
+	/// brace it opened.
+	/// </summary>
+	/// <remarks>
+	/// The failures are collected in <see cref="Errors"/>. An <see cref="IOException"/> from the
+	/// underlying writer is not something to recover from - every following write would fail the
+	/// same way - so it is left to propagate.
+	/// </remarks>
+	public class ErrorTolerantOutputVisitor : CSharpOutputVisitor
+	{
+		readonly List<Exception> errors = new List<Exception>();
+		int braceDepth;
+
+		public ErrorTolerantOutputVisitor(TextWriter textWriter, CSharpFormattingOptions formattingPolicy)
+			: base(textWriter, formattingPolicy)
+		{
+		}
+
+		/// <summary>
+		/// The failures that took the place of a member, in the order they were written.
+		/// </summary>
+		public IReadOnlyList<Exception> Errors => errors;
+
+		protected override void OpenBrace(BraceStyle style, bool newLine = true)
+		{
+			base.OpenBrace(style, newLine);
+			braceDepth++;
+		}
+
+		protected override void CloseBrace(BraceStyle style, bool unindent = true)
+		{
+			base.CloseBrace(style, unindent);
+			braceDepth--;
+		}
+
+		public override void VisitTypeDeclaration(TypeDeclaration typeDeclaration)
+			=> Write(typeDeclaration, base.VisitTypeDeclaration);
+
+		public override void VisitDelegateDeclaration(DelegateDeclaration delegateDeclaration)
+			=> Write(delegateDeclaration, base.VisitDelegateDeclaration);
+
+		public override void VisitConstructorDeclaration(ConstructorDeclaration constructorDeclaration)
+			=> Write(constructorDeclaration, base.VisitConstructorDeclaration);
+
+		public override void VisitDestructorDeclaration(DestructorDeclaration destructorDeclaration)
+			=> Write(destructorDeclaration, base.VisitDestructorDeclaration);
+
+		public override void VisitEnumMemberDeclaration(EnumMemberDeclaration enumMemberDeclaration)
+			=> Write(enumMemberDeclaration, base.VisitEnumMemberDeclaration);
+
+		public override void VisitExtensionDeclaration(ExtensionDeclaration extensionDeclaration)
+			=> Write(extensionDeclaration, base.VisitExtensionDeclaration);
+
+		public override void VisitEventDeclaration(EventDeclaration eventDeclaration)
+			=> Write(eventDeclaration, base.VisitEventDeclaration);
+
+		public override void VisitCustomEventDeclaration(CustomEventDeclaration customEventDeclaration)
+			=> Write(customEventDeclaration, base.VisitCustomEventDeclaration);
+
+		public override void VisitFieldDeclaration(FieldDeclaration fieldDeclaration)
+			=> Write(fieldDeclaration, base.VisitFieldDeclaration);
+
+		public override void VisitFixedFieldDeclaration(FixedFieldDeclaration fixedFieldDeclaration)
+			=> Write(fixedFieldDeclaration, base.VisitFixedFieldDeclaration);
+
+		public override void VisitIndexerDeclaration(IndexerDeclaration indexerDeclaration)
+			=> Write(indexerDeclaration, base.VisitIndexerDeclaration);
+
+		public override void VisitMethodDeclaration(MethodDeclaration methodDeclaration)
+			=> Write(methodDeclaration, base.VisitMethodDeclaration);
+
+		public override void VisitOperatorDeclaration(OperatorDeclaration operatorDeclaration)
+			=> Write(operatorDeclaration, base.VisitOperatorDeclaration);
+
+		public override void VisitPropertyDeclaration(PropertyDeclaration propertyDeclaration)
+			=> Write(propertyDeclaration, base.VisitPropertyDeclaration);
+
+		void Write<T>(T node, Action<T> write) where T : AstNode
+		{
+			int braces = braceDepth;
+			int containers = containerStack.Count;
+			try
+			{
+				write(node);
+			}
+			catch (Exception ex) when (!(ex is OperationCanceledException || ex is IOException))
+			{
+				errors.Add(ex);
+				// The failed member left the writer inside its own nodes and braces: unwind both, so
+				// what follows is written at the level the member started at.
+				while (containerStack.Count > containers)
+				{
+					writer.EndNode(containerStack.Pop());
+				}
+				while (braceDepth > braces)
+				{
+					CloseBrace(BraceStyle.NextLine);
+				}
+				NewLine();
+				foreach (string line in CSharpDecompiler.GetErrorCommentLines(ex))
+				{
+					writer.WriteComment(CommentType.SingleLine, " " + line);
+				}
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/ProjectDecompiler/WholeProjectDecompiler.cs
@@ -151,7 +151,81 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 
 		// per-run members
 		HashSet<string> directories = new HashSet<string>(Platform.FileNameComparer);
+		readonly List<DecompilerException> errors = new List<DecompilerException>();
 		readonly IProjectFileWriter projectWriter;
+
+		/// <summary>
+		/// Everything that went wrong during the last <see cref="DecompileProject(MetadataFile, string, CancellationToken)"/>.
+		/// An export never aborts on a member, file or resource it cannot handle; it writes the
+		/// error text where the content would have gone and continues, so a single unsupported
+		/// method still yields a complete project. Callers should show this list to the user -
+		/// otherwise the failures ship silently and never get reported.
+		/// </summary>
+		public IReadOnlyList<DecompilerException> Errors => errors;
+
+		void RecordError(DecompilerException error)
+		{
+			lock (errors)
+			{
+				errors.Add(error);
+			}
+		}
+
+		/// <summary>
+		/// Yields the items of <paramref name="items"/> until one of them throws; the failure is
+		/// recorded instead of aborting the export.
+		/// </summary>
+		IEnumerable<T> RecordingErrors<T>(IEnumerable<T> items, MetadataFile file, string what)
+		{
+			using var enumerator = items.GetEnumerator();
+			bool lastMoveFailed = false;
+			while (true)
+			{
+				T item;
+				try
+				{
+					if (!enumerator.MoveNext())
+						yield break;
+					item = enumerator.Current;
+				}
+				catch (Exception ex) when (!(ex is OperationCanceledException))
+				{
+					RecordError(ex as DecompilerException ?? new DecompilerException(file, $"Error writing {what}", ex));
+					// Skip the item that failed and try the next one, but give up once two attempts
+					// in a row fail: an enumerator that throws without advancing - which nothing
+					// stops an override from being - would otherwise loop forever.
+					if (lastMoveFailed)
+						yield break;
+					lastMoveFailed = true;
+					continue;
+				}
+				lastMoveFailed = false;
+				yield return item;
+			}
+		}
+
+		/// <summary>
+		/// Puts the error text where the file's contents would have gone. The writer itself may be
+		/// what failed - a full disk, a stream already closed - so a second failure while reporting
+		/// the first is dropped rather than allowed to take the export down.
+		/// </summary>
+		static void WriteErrorComment(TextWriter? writer, Exception error)
+		{
+			if (writer == null)
+				return;
+			try
+			{
+				// The failure may have interrupted the output visitor mid-line.
+				writer.WriteLine();
+				foreach (string line in CSharpDecompiler.GetErrorCommentLines(error))
+				{
+					writer.WriteLine("// " + line);
+				}
+			}
+			catch (Exception ex) when (!(ex is OperationCanceledException))
+			{
+			}
+		}
 
 		public void DecompileProject(MetadataFile file, string targetDirectory, CancellationToken cancellationToken = default(CancellationToken))
 		{
@@ -182,7 +256,8 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 			{
 				TargetDirectory = targetDirectory;
 				directories.Clear();
-				var resources = WriteResourceFilesInProject(file).ToList();
+				errors.Clear();
+				var resources = RecordingErrors(WriteResourceFilesInProject(file), file, "resource files").ToList();
 				resourceFileCount = resources.Count;
 				var files = WriteCodeFilesInProject(file, resources.SelectMany(r => r.PartialTypes ?? Enumerable.Empty<PartialTypeInfo>()).ToList(), cancellationToken).ToList();
 				codeFileCount = files.Count;
@@ -190,7 +265,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 				var module = file as PEFile;
 				if (module != null)
 				{
-					files.AddRange(WriteMiscellaneousFilesInProject(module));
+					files.AddRange(RecordingErrors(WriteMiscellaneousFilesInProject(module), file, "miscellaneous files"));
 				}
 				if (StrongNameKeyFile != null)
 				{
@@ -277,6 +352,7 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 			var progressReporter = ProgressIndicator;
 			var progress = new DecompilationProgress { TotalUnits = files.Count, Title = "Exporting project..." };
 			DecompilerTypeSystem ts = new DecompilerTypeSystem(module, AssemblyResolver, Settings);
+			var missingFiles = new ConcurrentBag<string>();
 			var workList = new HashSet<TypeDefinitionHandle>();
 			var processedTypes = new HashSet<TypeDefinitionHandle>();
 			ProcessFiles(files);
@@ -290,7 +366,21 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 				progress.TotalUnits = files.Count;
 			}
 
-			return files.Select(f => new ProjectItemInfo("Compile", f.Key)).Concat(WriteAssemblyInfo(ts, cancellationToken));
+			// The assembly-level attributes are a single file like any other: failing to decompile
+			// them costs that file, not the export.
+			IEnumerable<ProjectItemInfo> assemblyInfo;
+			try
+			{
+				assemblyInfo = WriteAssemblyInfo(ts, cancellationToken);
+			}
+			catch (Exception ex) when (!(ex is OperationCanceledException))
+			{
+				RecordError(ex as DecompilerException ?? new DecompilerException(module, "Error decompiling the module and assembly attributes", ex));
+				assemblyInfo = Enumerable.Empty<ProjectItemInfo>();
+			}
+
+			return files.Select(f => f.Key).Except(missingFiles, Platform.FileNameComparer)
+				.Select(f => new ProjectItemInfo("Compile", f)).Concat(assemblyInfo);
 
 			string GetFileFileNameForHandle(TypeDefinitionHandle h)
 			{
@@ -325,10 +415,14 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 					delegate (IGrouping<string, TypeDefinitionHandle> file) {
 						var declaredTypes = file.ToArray();
 						DecompilerEventSource.Log.ProjectFileStart(file.Key, declaredTypes.Length);
+						// Everything that can fail for this one file - creating it included, which is
+						// where a path too long for the file system surfaces - belongs inside the try.
+						TextWriter? w = null;
+						CSharpDecompiler? decompiler = null;
 						try
 						{
-							using var w = CreateFile(Path.Combine(TargetDirectory, file.Key));
-							CSharpDecompiler decompiler = CreateDecompiler(ts);
+							w = CreateFile(Path.Combine(TargetDirectory, file.Key));
+							decompiler = CreateDecompiler(ts);
 
 							foreach (var partialType in partialTypes)
 							{
@@ -356,14 +450,44 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 								}
 							}
 
-							syntaxTree.AcceptVisitor(new CSharpOutputVisitor(w, Settings.CSharpFormattingOptions));
+							// A member the output visitor cannot write is replaced by the error text
+							// rather than truncating the file where it failed.
+							var outputVisitor = new ErrorTolerantOutputVisitor(w, Settings.CSharpFormattingOptions);
+							syntaxTree.AcceptVisitor(outputVisitor);
+							foreach (var outputError in outputVisitor.Errors)
+							{
+								RecordError(new DecompilerException(module, $"Error writing '{file.Key}'", outputError));
+							}
 						}
-						catch (Exception innerException) when (!(innerException is OperationCanceledException || innerException is DecompilerException))
+						catch (Exception innerException) when (!(innerException is OperationCanceledException))
 						{
-							throw new DecompilerException(module, $"Error decompiling for '{file.Key}'", innerException);
+							// Whatever the decompiler could not cope with here, the remaining files
+							// are unaffected and the user still gets a complete project; the error
+							// takes the place of the file's contents.
+							RecordError(innerException as DecompilerException ?? new DecompilerException(module, $"Error decompiling for '{file.Key}'", innerException));
+							if (w == null)
+							{
+								// Nothing was written, so nothing can carry the error text - and the
+								// project must not claim a file that is not there.
+								missingFiles.Add(file.Key);
+							}
+							WriteErrorComment(w, innerException);
 						}
 						finally
 						{
+							foreach (var error in decompiler?.Errors ?? (IReadOnlyList<DecompilerException>)Array.Empty<DecompilerException>())
+							{
+								RecordError(error);
+							}
+							try
+							{
+								w?.Dispose();
+							}
+							catch (Exception ex) when (!(ex is OperationCanceledException))
+							{
+								// Dispose flushes: on a full disk this is where the write actually fails.
+								RecordError(new DecompilerException(module, $"Error writing '{file.Key}'", ex));
+							}
 							DecompilerEventSource.Log.ProjectFileStop(file.Key);
 						}
 						progress.Status = file.Key;
@@ -379,76 +503,96 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 		{
 			foreach (var r in module.Resources.Where(r => r.ResourceType == ResourceType.Embedded))
 			{
-				Stream? stream = r.TryOpenStream();
-				if (stream == null)
-					continue;
-
-				stream.Position = 0;
-
-				if (r.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))
+				List<ProjectItemInfo> items;
+				try
 				{
-					bool decodedIntoIndividualFiles;
-					var individualResources = new List<ProjectItemInfo>();
-					try
+					items = WriteResourceFileInProject(r).ToList();
+				}
+				catch (Exception ex) when (!(ex is OperationCanceledException))
+				{
+					// One resource nobody can decode - a mangled .resources blob, a BAML stream the
+					// decompiler chokes on - costs that resource, not the ones behind it.
+					RecordError(ex as DecompilerException ?? new DecompilerException(module, $"Error writing resource '{r.Name}'", ex));
+					continue;
+				}
+				foreach (var item in items)
+				{
+					yield return item;
+				}
+			}
+		}
+
+		IEnumerable<ProjectItemInfo> WriteResourceFileInProject(Resource r)
+		{
+			Stream? stream = r.TryOpenStream();
+			if (stream == null)
+				yield break;
+
+			stream.Position = 0;
+
+			if (r.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))
+			{
+				bool decodedIntoIndividualFiles;
+				var individualResources = new List<ProjectItemInfo>();
+				try
+				{
+					var resourcesFile = new ResourcesFile(stream);
+					if (resourcesFile.AllEntriesAreStreams())
 					{
-						var resourcesFile = new ResourcesFile(stream);
-						if (resourcesFile.AllEntriesAreStreams())
+						foreach (var (name, value) in resourcesFile)
 						{
-							foreach (var (name, value) in resourcesFile)
+							string fileName = SanitizeFileName(name);
+							string? dirName = Path.GetDirectoryName(fileName);
+							if (!string.IsNullOrEmpty(dirName) && directories.Add(dirName))
 							{
-								string fileName = SanitizeFileName(name);
-								string? dirName = Path.GetDirectoryName(fileName);
-								if (!string.IsNullOrEmpty(dirName) && directories.Add(dirName))
-								{
-									CreateDirectory(Path.Combine(TargetDirectory, dirName));
-								}
-								Stream entryStream = (Stream)value!;
-								entryStream.Position = 0;
-								individualResources.AddRange(
-									WriteResourceToFile(fileName, name, entryStream));
+								CreateDirectory(Path.Combine(TargetDirectory, dirName));
 							}
-							decodedIntoIndividualFiles = true;
+							Stream entryStream = (Stream)value!;
+							entryStream.Position = 0;
+							individualResources.AddRange(
+								WriteResourceToFile(fileName, name, entryStream));
 						}
-						else
-						{
-							decodedIntoIndividualFiles = false;
-						}
-					}
-					catch (BadImageFormatException)
-					{
-						decodedIntoIndividualFiles = false;
-					}
-					catch (EndOfStreamException)
-					{
-						decodedIntoIndividualFiles = false;
-					}
-					if (decodedIntoIndividualFiles)
-					{
-						foreach (var entry in individualResources)
-						{
-							yield return entry;
-						}
+						decodedIntoIndividualFiles = true;
 					}
 					else
 					{
-						stream.Position = 0;
-						string fileName = GetFileNameForResource(r.Name);
-						foreach (var entry in WriteResourceToFile(fileName, r.Name, stream))
-						{
-							yield return entry;
-						}
+						decodedIntoIndividualFiles = false;
+					}
+				}
+				catch (BadImageFormatException)
+				{
+					decodedIntoIndividualFiles = false;
+				}
+				catch (EndOfStreamException)
+				{
+					decodedIntoIndividualFiles = false;
+				}
+				if (decodedIntoIndividualFiles)
+				{
+					foreach (var entry in individualResources)
+					{
+						yield return entry;
 					}
 				}
 				else
 				{
+					stream.Position = 0;
 					string fileName = GetFileNameForResource(r.Name);
-					using (FileStream fs = new FileStream(Path.Combine(TargetDirectory, fileName), FileMode.Create, FileAccess.Write))
+					foreach (var entry in WriteResourceToFile(fileName, r.Name, stream))
 					{
-						stream.Position = 0;
-						stream.CopyTo(fs);
+						yield return entry;
 					}
-					yield return new ProjectItemInfo("EmbeddedResource", fileName).With("LogicalName", r.Name);
 				}
+			}
+			else
+			{
+				string fileName = GetFileNameForResource(r.Name);
+				using (FileStream fs = new FileStream(Path.Combine(TargetDirectory, fileName), FileMode.Create, FileAccess.Write))
+				{
+					stream.Position = 0;
+					stream.CopyTo(fs);
+				}
+				yield return new ProjectItemInfo("EmbeddedResource", fileName).With("LogicalName", r.Name);
 			}
 		}
 
@@ -519,25 +663,56 @@ namespace ICSharpCode.Decompiler.CSharp.ProjectDecompiler
 			if (resources == null)
 				yield break;
 
-			byte[]? appIcon = CreateApplicationIcon(resources);
-			if (appIcon != null)
-			{
+			// Each file is written on its own, so the one that fails is the only one lost.
+			foreach (var item in TryWrite(module, "app.ico", () => {
+				byte[]? appIcon = CreateApplicationIcon(resources);
+				if (appIcon == null)
+					return null;
 				File.WriteAllBytes(Path.Combine(TargetDirectory, "app.ico"), appIcon);
-				yield return new ProjectItemInfo("ApplicationIcon", "app.ico");
+				return new ProjectItemInfo("ApplicationIcon", "app.ico");
+			}))
+			{
+				yield return item;
 			}
 
-			byte[]? appManifest = CreateApplicationManifest(resources);
-			if (appManifest != null && !IsDefaultApplicationManifest(appManifest))
-			{
+			foreach (var item in TryWrite(module, "app.manifest", () => {
+				byte[]? appManifest = CreateApplicationManifest(resources);
+				if (appManifest == null || IsDefaultApplicationManifest(appManifest))
+					return null;
 				File.WriteAllBytes(Path.Combine(TargetDirectory, "app.manifest"), appManifest);
-				yield return new ProjectItemInfo("ApplicationManifest", "app.manifest");
+				return new ProjectItemInfo("ApplicationManifest", "app.manifest");
+			}))
+			{
+				yield return item;
 			}
 
-			var appConfig = module.FileName + ".config";
-			if (File.Exists(appConfig))
-			{
+			foreach (var item in TryWrite(module, "app.config", () => {
+				var appConfig = module.FileName + ".config";
+				if (!File.Exists(appConfig))
+					return null;
 				File.Copy(appConfig, Path.Combine(TargetDirectory, "app.config"), overwrite: true);
-				yield return new ProjectItemInfo("ApplicationConfig", Path.GetFileName(appConfig));
+				return new ProjectItemInfo("ApplicationConfig", Path.GetFileName(appConfig));
+			}))
+			{
+				yield return item;
+			}
+		}
+
+		IEnumerable<ProjectItemInfo> TryWrite(MetadataFile module, string what, Func<ProjectItemInfo?> write)
+		{
+			ProjectItemInfo? item;
+			try
+			{
+				item = write();
+			}
+			catch (Exception ex) when (!(ex is OperationCanceledException))
+			{
+				RecordError(ex as DecompilerException ?? new DecompilerException(module, $"Error writing '{what}'", ex));
+				yield break;
+			}
+			if (item.HasValue)
+			{
+				yield return item.Value;
 			}
 		}
 

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -163,6 +163,11 @@ Examples:
 		[Option("-r|--referencepath <path>", "Path to a directory containing dependencies of the assembly that is being decompiled.", CommandOptionType.MultipleValue)]
 		public string[] ReferencePaths { get; }
 
+		[Option("--ignore-decompilation-errors", "Exit with success even when parts of the assembly could not be decompiled. " +
+			"The affected code carries the error text in the output and the failures are listed on stderr either way; " +
+			"only the exit status changes.", CommandOptionType.NoValue)]
+		public bool IgnoreDecompilationErrorsFlag { get; }
+
 		[Option("--no-dead-code", "Remove dead code.", CommandOptionType.NoValue)]
 		public bool RemoveDeadCode { get; }
 
@@ -254,7 +259,7 @@ Examples:
 					{
 						string projectFileName = Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(InputAssemblyNames[0]) + ".csproj");
 						DecompileAsProject(InputAssemblyNames[0], projectFileName);
-						return 0;
+						return ExitCodeForDecompilationErrors();
 					}
 					var projects = new List<ProjectItem>();
 					foreach (var file in InputAssemblyNames)
@@ -265,7 +270,7 @@ Examples:
 						projects.Add(new ProjectItem(projectFileName, projectId.PlatformName, projectId.Guid, projectId.TypeGuid));
 					}
 					SolutionCreator.WriteSolutionFile(Path.Combine(outputDirectory, Path.GetFileNameWithoutExtension(outputDirectory) + ".sln"), projects);
-					return 0;
+					return ExitCodeForDecompilationErrors();
 				}
 				else if (GenerateDiagrammer)
 				{
@@ -295,7 +300,7 @@ Examples:
 						if (result != 0)
 							return result;
 					}
-					return 0;
+					return ExitCodeForDecompilationErrors();
 				}
 			}
 			catch (Exception ex)
@@ -622,6 +627,34 @@ Examples:
 			return 0;
 		}
 
+		readonly List<DecompilerException> decompilationErrors = new();
+
+		/// <summary>
+		/// Lists what the decompiler could not handle. The output was still written - with the error
+		/// text in place of the affected code - so this is the only sign anything went wrong, and
+		/// <see cref="ExitCodeForDecompilationErrors"/> keeps it from passing silently in a script.
+		/// </summary>
+		void ReportDecompilationErrors(string assemblyFileName, IReadOnlyList<DecompilerException> errors)
+		{
+			if (errors.Count == 0)
+				return;
+			decompilationErrors.AddRange(errors);
+			Console.Error.WriteLine($"While decompiling {assemblyFileName}:");
+			foreach (string line in CSharpDecompiler.GetErrorSummaryLines(errors.Count))
+			{
+				Console.Error.WriteLine(line);
+			}
+			foreach (var error in errors)
+			{
+				Console.Error.WriteLine("  " + CSharpDecompiler.GetErrorHeadline(error));
+			}
+		}
+
+		int ExitCodeForDecompilationErrors()
+		{
+			return decompilationErrors.Count == 0 || IgnoreDecompilationErrorsFlag ? 0 : ProgramExitCodes.EX_SOFTWARE;
+		}
+
 		ProjectId DecompileAsProject(string assemblyFileName, string projectFileName)
 		{
 			var module = new PEFile(assemblyFileName);
@@ -645,8 +678,11 @@ Examples:
 			{
 				decompiler = new WholeProjectDecompiler(settings, resolver, null, resolver, debugInfo);
 			}
-			using (var projectFileWriter = new StreamWriter(File.OpenWrite(projectFileName)))
-				return decompiler.DecompileProject(module, Path.GetDirectoryName(projectFileName), projectFileWriter);
+			ProjectId projectId;
+			using (var projectFileWriter = new StreamWriter(File.Create(projectFileName)))
+				projectId = decompiler.DecompileProject(module, Path.GetDirectoryName(projectFileName), projectFileWriter);
+			ReportDecompilationErrors(assemblyFileName, decompiler.Errors);
+			return projectId;
 		}
 
 		int Decompile(string assemblyFileName, TextWriter output, string typeName = null)
@@ -656,6 +692,7 @@ Examples:
 			if (typeName == null)
 			{
 				output.Write(decompiler.DecompileWholeModuleAsString());
+				ReportDecompilationErrors(assemblyFileName, decompiler.Errors);
 				return 0;
 			}
 
@@ -666,6 +703,7 @@ Examples:
 			}
 
 			output.Write(decompiler.DecompileTypeAsString(typeDefinition.FullTypeName));
+			ReportDecompilationErrors(assemblyFileName, decompiler.Errors);
 			return 0;
 		}
 
@@ -680,6 +718,7 @@ Examples:
 			}
 
 			output.Write(decompiler.DecompileAsString(handle));
+			ReportDecompilationErrors(assemblyFileName, decompiler.Errors);
 			return 0;
 		}
 

--- a/ICSharpCode.ILSpyCmd/README.md
+++ b/ICSharpCode.ILSpyCmd/README.md
@@ -57,6 +57,9 @@ Options:
   -ds|--decompiler-setting <value>        Set a decompiler setting. Use multiple times to set multiple settings.
   -r|--referencepath <path>               Path to a directory containing dependencies of the assembly that is being
                                           decompiled.
+  --ignore-decompilation-errors           Exit with success even when parts of the assembly could not be decompiled. The
+                                          affected code carries the error text in the output and the failures are listed
+                                          on stderr either way; only the exit status changes.
   --no-dead-code                          Remove dead code.
   --no-dead-stores                        Remove dead stores.
   -d|--dump-package                       Dump package assemblies into a folder. This requires the output directory

--- a/ILSpy.Tests/Languages/ProjectExportTests.cs
+++ b/ILSpy.Tests/Languages/ProjectExportTests.cs
@@ -25,12 +25,16 @@ using Avalonia.Headless.NUnit;
 using AwesomeAssertions;
 
 using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.Solution;
 
 using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.Commands;
 using ICSharpCode.ILSpy.AssemblyTree;
 using ICSharpCode.ILSpy.Languages;
 using ICSharpCode.ILSpy.ViewModels;
 using ICSharpCode.ILSpy.Views;
+using ICSharpCode.ILSpyX;
 
 using NUnit.Framework;
 
@@ -61,6 +65,69 @@ public class ProjectExportTests
 	{
 		var cs = new CSharpLanguage();
 		cs.ProjectFileExtension.Should().Be(".csproj");
+	}
+
+	/// <summary>
+	/// An export finishes even when parts of the assembly cannot be decompiled, so the failures
+	/// have to reach the result report: the ITextOutput handed to the language is thrown away by
+	/// the export path, and the report is all the user ever sees.
+	/// </summary>
+	[AvaloniaTest]
+	public async Task Export_Report_Names_The_Failures_And_Where_To_Report_Them()
+	{
+		var window = AppComposition.Current.GetExport<MainWindow>();
+		window.Show();
+		var vm = (MainWindowViewModel)window.DataContext!;
+		await vm.AssemblyTreeModel.WaitForAssembliesAsync(minimumCount: 1);
+
+		var loaded = await vm.OpenFixtureAsync();
+		var tempDir = Path.Combine(Path.GetTempPath(), "ILSpyExport_" + System.Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		try
+		{
+			var options = new ProjectExportOptions(tempDir, UseSdkStyleProjectFormat: true,
+				UseNestedDirectoriesForNamespaces: false, RemoveDeadCode: false, RemoveDeadStores: false,
+				UseDebugSymbols: false, StrongNameKeyFile: null, GeneratePdb: false,
+				EmbedSourceFilesInPdb: false);
+
+			var result = await ProjectExporter.ExportAsync([loaded], solutionMode: false, options,
+				new DecompilerSettings(), new FailingLanguage(), progress: null, default);
+
+			var sw = new StringWriter();
+			ProjectExporter.WriteDecompilationErrors(new PlainTextOutput(sw), result.Errors);
+			string written = sw.ToString();
+
+			result.Success.Should().BeTrue("a recovered failure still produces a project");
+			written.Should().Contain("Error decompiling C.M",
+				"the failing member must be named");
+			written.Should().Contain("Simulated failure",
+				"the exception the export recovered from must show up, stack trace and all");
+			written.Should().Contain(CSharpDecompiler.DecompilationErrorReportUrl,
+				"the report is where the user is asked to file the bug");
+		}
+		finally
+		{
+			try
+			{ Directory.Delete(tempDir, recursive: true); }
+			catch { /* best-effort */ }
+		}
+	}
+
+	/// <summary>Stands in for a decompiler that recovered from a failure while exporting.</summary>
+	sealed class FailingLanguage : Language
+	{
+		public override string Name => "Failing";
+
+		public override string FileExtension => ".cs";
+
+		public override string ProjectFileExtension => ".csproj";
+
+		public override ProjectId? DecompileAssembly(LoadedAssembly assembly, ITextOutput output, DecompilationOptions options)
+		{
+			options.DecompilationErrors.Add(new DecompilerException(assembly.GetMetadataFileOrNull()!,
+				"Error decompiling C.M", new System.InvalidOperationException("Simulated failure")));
+			return null;
+		}
 	}
 
 	[AvaloniaTest]

--- a/ILSpy.Tests/SmartTextOutputExtensionsTests.cs
+++ b/ILSpy.Tests/SmartTextOutputExtensionsTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler;
+
+using ICSharpCode.ILSpy.TextView;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests;
+
+[TestFixture]
+public class SmartTextOutputExtensionsTests
+{
+	/// <summary>
+	/// A collapsed fold hides everything up to its end offset, so a fold reaching past the last
+	/// frame takes the line after it - the one the reader needs to see - down with it.
+	/// </summary>
+	[Test]
+	public void Exception_Fold_Stops_At_The_Last_Frame()
+	{
+		var output = new AvaloniaEditTextOutput();
+		output.Write("Something failed:");
+		output.WriteLine();
+		output.WriteExceptionDetails(ExceptionWithTrace());
+		output.Write("this line must stay visible");
+		output.WriteLine();
+
+		string text = output.GetText();
+		var fold = output.Foldings.Should().ContainSingle().Subject;
+		text[fold.StartOffset..fold.EndOffset].Should().NotEndWith("\n",
+			"the fold must end with the last frame, not with the newline behind it");
+		text.Should().Contain("this line must stay visible");
+	}
+
+	static Exception ExceptionWithTrace() => new TrailingNewlineException();
+
+	/// <summary>
+	/// Stands in for the exceptions that actually reach this helper: <see cref="DecompilerException"/>
+	/// renders a trailing newline, which would push the fold one line past the last frame.
+	/// </summary>
+	sealed class TrailingNewlineException : Exception
+	{
+		public override string ToString() => "boom" + Environment.NewLine + "   at Frame1" + Environment.NewLine;
+	}
+}

--- a/ILSpy/Commands/ProjectExport.cs
+++ b/ILSpy/Commands/ProjectExport.cs
@@ -211,6 +211,7 @@ namespace ICSharpCode.ILSpy.Commands
 				var o = new AvaloniaEditTextOutput { Title = title };
 				o.Write(result.StatusText);
 				o.WriteLine();
+				ProjectExporter.WriteDecompilationErrors(o, result.Errors);
 				if (result.Success && Directory.Exists(options.OutputDirectory))
 				{
 					o.AddOpenFolderButton(options.OutputDirectory);

--- a/ILSpy/Commands/ProjectExporter.cs
+++ b/ILSpy/Commands/ProjectExporter.cs
@@ -95,7 +95,7 @@ namespace ICSharpCode.ILSpy.Commands
 						.ConfigureAwait(false);
 				}
 				AppendSkipReport(report, skipReport);
-				return new SolutionExportResult(solution.Success, report.ToString());
+				return new SolutionExportResult(solution.Success, report.ToString()) { Errors = solution.Errors };
 			}
 
 			var projectResult = await Task
@@ -125,6 +125,32 @@ namespace ICSharpCode.ILSpy.Commands
 			return report.ToString();
 		}
 
+		/// <summary>
+		/// Writes what the decompiler could not handle: one headline per failure, each followed by
+		/// the full exception in a collapsed fold. The export replaces the affected code with the
+		/// error text and finishes rather than failing, so this is where the user learns anything
+		/// went wrong - and the trace is right there to paste into the bug report.
+		/// </summary>
+		internal static void WriteDecompilationErrors(ITextOutput output, IReadOnlyList<DecompilerException> errors)
+		{
+			if (errors.Count == 0)
+				return;
+			output.WriteLine();
+			foreach (string line in CSharpDecompiler.GetErrorSummaryLines(errors.Count))
+			{
+				output.WriteLine(line);
+			}
+			foreach (var error in errors)
+			{
+				output.WriteLine();
+				output.WriteLine(CSharpDecompiler.GetErrorHeadline(error));
+				output.WriteExceptionDetails(error);
+			}
+			// Keeps the caller's result button off the last frame's line, the same way the
+			// error-free report ends with a blank line.
+			output.WriteLine();
+		}
+
 		static void AppendSkipReport(StringBuilder report, string skipReport)
 		{
 			if (skipReport.Length == 0)
@@ -138,16 +164,18 @@ namespace ICSharpCode.ILSpy.Commands
 		{
 			var report = new StringBuilder();
 			bool success;
+			// Declared out here because the failures the export recovered from are worth reporting
+			// even when it goes on to fail: their error text is already in the written sources.
+			var decompileOptions = new DecompilationOptions(settingsClone) {
+				FullDecompilation = true,
+				EscapeInvalidIdentifiers = true,
+				CancellationToken = ct,
+				SaveAsProjectDirectory = options.OutputDirectory,
+				StrongNameKeyFile = options.StrongNameKeyFile,
+				ProgressIndicator = progress,
+			};
 			try
 			{
-				var decompileOptions = new DecompilationOptions(settingsClone) {
-					FullDecompilation = true,
-					EscapeInvalidIdentifiers = true,
-					CancellationToken = ct,
-					SaveAsProjectDirectory = options.OutputDirectory,
-					StrongNameKeyFile = options.StrongNameKeyFile,
-					ProgressIndicator = progress,
-				};
 				language.DecompileAssembly(assembly, new PlainTextOutput(new StringWriter()), decompileOptions);
 				report.AppendLine("Project written to " + options.OutputDirectory);
 				success = true;
@@ -165,7 +193,7 @@ namespace ICSharpCode.ILSpy.Commands
 			if (options.GeneratePdb && success)
 				GeneratePdbs(new[] { assembly }, _ => options.OutputDirectory, settingsClone, options, report, ct);
 
-			return new SolutionExportResult(success, report.ToString());
+			return new SolutionExportResult(success, report.ToString()) { Errors = [.. decompileOptions.DecompilationErrors] };
 		}
 
 		static void GeneratePdbs(IReadOnlyList<LoadedAssembly> assemblies,

--- a/ILSpy/DecompilationOptions.cs
+++ b/ILSpy/DecompilationOptions.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 using ICSharpCode.Decompiler;
@@ -81,6 +82,14 @@ namespace ICSharpCode.ILSpy
 		/// file currently being written; ignored on single-member decompiles.
 		/// </summary>
 		public IProgress<DecompilationProgress>? ProgressIndicator { get; set; }
+
+		/// <summary>
+		/// Filled by the project-export path with the members, files and resources the decompiler
+		/// could not handle. The export writes the error text into the affected sources and runs to
+		/// completion instead of failing, so the caller's result report is where the user learns
+		/// that anything went wrong at all - the ITextOutput of an export is discarded.
+		/// </summary>
+		public IList<DecompilerException> DecompilationErrors { get; } = new List<DecompilerException>();
 
 		// Deliberately no parameterless constructor: every decompilation must make an explicit
 		// choice of settings. Callers inside the app want the user's current settings (see

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -555,8 +555,22 @@ namespace ICSharpCode.ILSpy.Languages
 				targetDirectory,
 				WholeProjectDecompiler.CleanUpFileName(module.Name, ProjectFileExtension));
 			ProjectId? id;
-			using (var writer = new System.IO.StreamWriter(projectFileName))
-				id = decompiler.DecompileProject(module, targetDirectory, writer, options.CancellationToken);
+			try
+			{
+				using (var writer = new System.IO.StreamWriter(projectFileName))
+					id = decompiler.DecompileProject(module, targetDirectory, writer, options.CancellationToken);
+			}
+			finally
+			{
+				// The export does not abort on what it cannot decompile; hand the failures to the
+				// caller, whose result report - not this ITextOutput - is what the user sees when it
+				// finishes. Sources carrying error text are already on disk even if the export went
+				// on to fail, so this belongs in the finally.
+				foreach (var error in decompiler.Errors)
+				{
+					options.DecompilationErrors.Add(error);
+				}
+			}
 			output.WriteLine("// Project written to " + targetDirectory);
 			return id;
 		}

--- a/ILSpy/SmartTextOutputExtensions.cs
+++ b/ILSpy/SmartTextOutputExtensions.cs
@@ -52,7 +52,9 @@ namespace ICSharpCode.ILSpy
 			// The fold span is counted in WriteLine() calls, not in the '\n' characters embedded in a
 			// single Write(). Emit the trace one line per WriteLine() so the fold genuinely spans
 			// multiple lines; otherwise it collapses to a single line and is dropped as noise.
-			var lines = ex.ToString().Split('\n');
+			// Trailing newlines would put the fold's end past the last frame, so the collapsed
+			// section would swallow the line after it.
+			var lines = ex.ToString().TrimEnd().Split('\n');
 			for (int i = 0; i < lines.Length; i++)
 			{
 				if (i > 0)

--- a/ILSpy/SolutionWriter.cs
+++ b/ILSpy/SolutionWriter.cs
@@ -38,7 +38,15 @@ namespace ICSharpCode.ILSpy
 	/// solution was produced and the human-readable status report (the same breadcrumb the WPF
 	/// version printed into the decompiler text view).
 	/// </summary>
-	public sealed record SolutionExportResult(bool Success, string StatusText);
+	public sealed record SolutionExportResult(bool Success, string StatusText)
+	{
+		/// <summary>
+		/// What the decompiler could not handle while exporting. These are recovered failures - the
+		/// affected code was replaced by the error text and the export ran to completion - so they
+		/// do not make <see cref="Success"/> false; the caller renders them for the user to report.
+		/// </summary>
+		public IReadOnlyList<DecompilerException> Errors { get; init; } = [];
+	}
 
 	/// <summary>
 	/// Creates a Visual Studio solution containing one decompiled project per assembly. The
@@ -82,6 +90,7 @@ namespace ICSharpCode.ILSpy
 		readonly IProgress<DecompilationProgress>? progress;
 		readonly ConcurrentBag<ProjectItem> projects;
 		readonly ConcurrentBag<string> statusOutput;
+		readonly ConcurrentBag<DecompilerException> decompilationErrors = new();
 
 		// How far each project has got, keyed by assembly short name -- unique, because duplicate names
 		// abort the export before any project runs. The workers fill these in as they decompile and the
@@ -206,7 +215,7 @@ namespace ICSharpCode.ILSpy
 
 			// statusOutput only collects per-assembly failures; an empty bag means every project built.
 			if (statusOutput.Count != 0)
-				return new SolutionExportResult(false, report.ToString());
+				return new SolutionExportResult(false, report.ToString()) { Errors = [.. decompilationErrors] };
 
 			report.AppendLine("Successfully decompiled the following assemblies into Visual Studio projects:");
 			foreach (var n in allAssemblies)
@@ -215,7 +224,7 @@ namespace ICSharpCode.ILSpy
 			if (allAssemblies.Count == projects.Count)
 				report.AppendLine("Created the Visual Studio Solution file.");
 
-			return new SolutionExportResult(true, report.ToString());
+			return new SolutionExportResult(true, report.ToString()) { Errors = [.. decompilationErrors] };
 		}
 
 		// Reports the whole solution's progress: the file counts of every project added up. The projects
@@ -323,6 +332,12 @@ namespace ICSharpCode.ILSpy
 				// The project-export path writes the .csproj into SaveAsProjectDirectory itself; the
 				// ITextOutput only receives a "Project written to ..." breadcrumb, which we discard here.
 				var projectInfo = language.DecompileAssembly(loadedAssembly, new PlainTextOutput(new StringWriter()), options);
+				// Recovered failures travel on the result, not in statusOutput: a non-empty
+				// statusOutput means the solution is incomplete, and these projects did get written.
+				foreach (var error in options.DecompilationErrors)
+				{
+					decompilationErrors.Add(error);
+				}
 				if (projectInfo != null)
 				{
 					// SolutionCreator.FixAllProjectReferences parses each project file off disk, so the

--- a/ILSpy/TextView/DecompilerTabPageModel.cs
+++ b/ILSpy/TextView/DecompilerTabPageModel.cs
@@ -595,8 +595,10 @@ namespace ICSharpCode.ILSpy.TextView
 						catch (Exception ex)
 						{
 							output.WriteLine();
-							output.WriteLine("/* Decompilation failed:");
-							output.WriteLine(ex.ToString());
+							output.WriteLine("/* Decompilation failed: " + ex.Message);
+							// The trace goes in a collapsed fold: what the reader needs is the message,
+							// and the frames only when they go looking for them.
+							output.WriteExceptionDetails(ex);
 							output.WriteLine("*/");
 						}
 						return (output, cts.Token);


### PR DESCRIPTION
### Problem

Save Code / `ilspycmd -p` aborted the entire export on the first member it could not decompile. One unsupported method in a large assembly left the user with nothing: no sources, no `.csproj`, and no way to work around it (#3510).

### What changed

- `CSharpDecompiler.DecompileBody` records the failure instead of throwing. The member keeps its signature and the exception takes the place of its body - a comment with the full trace and where to report it, in the same spot warnings about the code go. The remaining members decompile normally, and the failures are exposed as `CSharpDecompiler.Errors` (reset per decompilation).
- `WholeProjectDecompiler` applies the same rule per file, per resource and around the assembly-info file, so an export always runs to completion. What it recovered from is on `WholeProjectDecompiler.Errors`.
- Those failures are surfaced where the user looks when the export finishes: the export report in ILSpy (one headline per failure, each with its full exception in a collapsed "Exception details" fold) and stderr in `ilspycmd`. The `ITextOutput` handed to the language is discarded by both export callers, so the errors travel on `DecompilationOptions.DecompilationErrors` and are rendered by the caller that owns the report.
- `ErrorTolerantOutputVisitor` keeps a file well-formed when writing a member throws: the error takes that member's place, the braces it opened are closed, and the following members are still written.
- The consumers that relied on the exception keep their failure signal: the PowerShell cmdlets raise one error record per failure, and `RoundtripAssembly` asserts the export reported none - otherwise a decompiler crash on a method the round-trip's own tests never call would ship green.
- **`ilspycmd` keeps its failure signal**: it lists the failures on stderr and exits non-zero, as it did when the decompiler threw. The new `--ignore-decompilation-errors` flag exits with success instead, for automation that wants the partial output to count as a success; the failures are still listed either way.

Recovering silently would trade one bad outcome for a worse one, so the inline comment names `https://github.com/icsharpcode/ILSpy/issues/new` and every summary repeats it.

This also improves the text view: a single bad method used to replace the whole type with an error page; the type is now shown with the error in place of that one member.

### Release notes

> **Project export no longer stops at the first member it cannot decompile.** The affected member is written out with the error text in place of its code and the export runs to completion; ILSpy lists the failures in the export report and `ilspycmd` prints them to stderr. `ilspycmd` exits with a non-zero status when this happens - pass `--ignore-decompilation-errors` to treat such a run as successful.

### Drive-by fixes

- `ilspycmd` wrote the `.csproj` through `File.OpenWrite`, which does not truncate: re-exporting into the same directory could leave a shorter project file with trailing bytes from the previous run.
- `SmartTextOutputExtensions.WriteExceptionDetails` split the exception text without trimming, so for exceptions that render a trailing newline (`DecompilerException` does) the fold reached one line past the last frame and a collapsed fold swallowed the line behind it. That affected the PDB generator and the assembly tree node too.
- `DecompilerTabPageModel`'s decompilation-failure path dumped the raw stack trace into the text view instead of using that folded helper.

### Tests

- `DecompilationErrorRecoveryTests` - a failing method body keeps the rest of the type, is recorded as an error, and does not carry over into the next decompilation.
- `WholeProjectDecompilerTests.FailuresDoNotAbortTheExport` - a failing decompile, two failing file creations (a type file and the assembly-info file) and a failing resource enumeration are all reported, and every other file is still written.
- `WholeProjectDecompilerTests.OneFailingResourceDoesNotDropTheOthers` - a resource that cannot be written costs that resource alone.
- `ProjectExportTests.Export_Report_Names_The_Failures_And_Where_To_Report_Them` - the export report names the failure and the report URL, and the export still counts as successful.
- `DecompilationErrorRecoveryTests.FailingOutputKeepsTheFileWellFormed` - a member whose output throws is replaced in place, the file closes every brace it opens, and the members after it are still written.
- `SmartTextOutputExtensionsTests.Exception_Fold_Stops_At_The_Last_Frame` - the fold does not extend past the last frame.

Failures are injected with a throwing `IILTransform` / `IAstTransform` and an overridden `CreateFile`, so the tests do not depend on a decompiler bug that may get fixed.

Decompiler suite green (3368 tests); `ilspycmd` tests and the affected UI tests green.

---
_Written by an AI agent (Claude) on Siegfried's behalf._

