### PR TITLE
Fix the remaining deconstruction issues

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -996,6 +996,20 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return a + b;
 		}
 
+		public void NestedDesignation_RestChainedInnerTuple()
+		{
+			var (value, (value2, value3, value4, value5, value6, value7, value8, value9)) = GetTuple<int, (int, int, int, int, int, int, int, int)>();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+			Console.WriteLine(value4);
+			Console.WriteLine(value5);
+			Console.WriteLine(value6);
+			Console.WriteLine(value7);
+			Console.WriteLine(value8);
+			Console.WriteLine(value9);
+		}
+
 		public bool DeconstructStructParameter(StructDeconstructionSource<int, string> point)
 		{
 			var (num2, value) = point;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
@@ -417,6 +418,26 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value);
 			Console.WriteLine(myInt4);
 			Console.WriteLine(value2);
+		}
+
+		public void LocalVariable_Nested_StructInnerFirstElement()
+		{
+			var ((value, value2), value3) = GetSource<StructDeconstructionSource<int, string>, int>();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
+		}
+
+		public void LocalVariable_ElementOfElementRead_ThenDeconstruct()
+		{
+			((StructDeconstructionSource<int, string>, int), int) tuple = GetTuple<(StructDeconstructionSource<int, string>, int), int>();
+			(StructDeconstructionSource<int, string>, int) item = tuple.Item1;
+			StructDeconstructionSource<int, string> item2 = item.Item1;
+			var (value, value2) = item2;
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(item.Item2);
+			Console.WriteLine(tuple.Item2);
 		}
 
 		public void LocalVariable_Nested_Depth3()
@@ -963,6 +984,30 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			{
 				Console.WriteLine(text + ": " + num);
 			}
+		}
+
+		public async Task<int> DeconstructionAssignmentToCapturedLocals(string file)
+		{
+			int a = 0;
+			int b = 0;
+			await Task.Run(delegate {
+				(a, b) = GetTuple<int, int>();
+			});
+			return a + b;
+		}
+
+		public bool DeconstructStructParameter(StructDeconstructionSource<int, string> point)
+		{
+			var (num2, value) = point;
+			Console.WriteLine(value);
+			return num2 >= 0;
+		}
+
+		public void DeconstructStructLocal()
+		{
+			StructDeconstructionSource<int, string> structSource = GetStructSource<int, string>();
+			var (num2, text2) = structSource;
+			Console.WriteLine(num2 + text2 + structSource.Dummy);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Records.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Records.cs
@@ -285,6 +285,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public record struct PairWithPrimaryCtor<A, B>(A First, B Second);
 
+		public readonly record struct BoundsInfo(int Profile, Bounds Bounds);
+
+		public readonly record struct Bounds(ulong Small, ulong Large);
+
 		public record struct PrimaryCtor(int A, string B);
 
 		public record struct MultipleCtorsNoPrimaryCtor
@@ -446,6 +450,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			{
 				C = 1.41;
 			}
+		}
+
+		private static BoundsInfo GetInfo()
+		{
+			return new BoundsInfo(1, new Bounds(2uL, 3uL));
+		}
+
+		public static void NestedDeconstruction()
+		{
+			var (value, (value2, value3)) = GetInfo();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			Console.WriteLine(value3);
 		}
 	}
 

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -129,6 +129,17 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			// exists (see the guard for the precision guarantees).
 			if (IsConsumableByEnclosingDeconstruction(block, pos))
 				return false;
+			// Same idea for the value-semantics copy before a root Deconstruct call: blocks are
+			// processed back to front, so defer the call-only match to the attempt starting at
+			// the copy, which can consume both (see MatchDeconstruction). Defer only when that
+			// attempt actually reaches its match: an attempt that is itself deferred to an
+			// enclosing pattern bails without consuming this position, and the back-to-front
+			// walk never comes back, which would lose the deconstruction at both positions.
+			if (pos > 0 && IsRootDeconstructionCopy(block, pos - 1, out _, out _)
+				&& !IsConsumableByEnclosingDeconstruction(block, pos - 1))
+			{
+				return false;
+			}
 			if (!MatchDeconstructionSequence(block, startPos, out pos, out var rootCall,
 				out var rootTestedOperand, out var conversionStLocs, out var delayedActions))
 			{
@@ -431,7 +442,19 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 		void MatchDeconstruction(Block block, ref int pos, out DeconstructionCall? rootCall,
 			out ILInstruction? testedOperand)
 		{
-			rootCall = MatchDeconstructionCall(block.Instructions[pos], out testedOperand);
+			// Deconstruction assignment has value semantics, so Roslyn copies the deconstructed
+			// value into a temporary and calls Deconstruct on that. When the value is a call
+			// result, inlining already folds the temporary away; when it is a local or parameter,
+			// the copy survives to here. Consume it into the pattern: rendering the copied value
+			// as the deconstruction target recompiles to the identical temporary.
+			rootCall = null;
+			testedOperand = null;
+			if (IsRootDeconstructionCopy(block, pos, out var copiedValue, out rootCall))
+			{
+				testedOperand = copiedValue;
+				pos++;
+			}
+			rootCall ??= MatchDeconstructionCall(block.Instructions[pos], out testedOperand);
 			if (rootCall == null)
 				return;
 			rootedInDeconstructCall = true;
@@ -458,6 +481,46 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 						leaves.Add(call.Results[i]);
 				}
 			}
+		}
+
+		/// <summary>
+		/// stloc copy(value)                          at pos
+		/// call Deconstruct(ldloc(a) copy, ...)       a root Deconstruct call on the copy
+		/// where the copy has no other use: the value-semantics temporary Roslyn emits for a
+		/// deconstruction whose right-hand side is not already a temporary. On success,
+		/// <paramref name="copiedValue"/> is the deconstructed value and <paramref name="call"/>
+		/// the matched call, so callers need not re-match either.
+		/// </summary>
+		bool IsRootDeconstructionCopy(Block block, int pos, out ILInstruction? copiedValue,
+			out DeconstructionCall? call)
+		{
+			copiedValue = null;
+			call = null;
+			if (pos + 1 >= block.Instructions.Count)
+				return false;
+			if (!block.Instructions[pos].MatchStLoc(out var copy, out var value))
+				return false;
+			if (copy.Kind is not (VariableKind.Local or VariableKind.StackSlot))
+				return false;
+			// A byref temporary is not a copy: Deconstruct called through it acts on the original,
+			// which is not what a value-semantics deconstruction of the referenced expression does.
+			if (copy.StackType == StackType.Ref)
+				return false;
+			if (!(copy.StoreCount == 1 && copy.LoadCount + copy.AddressCount == 1))
+				return false;
+			// The defensive copy of a struct element of an enclosing Deconstruct call has this
+			// exact shape. It belongs to the enclosing call's nested designation, so consuming it
+			// here would commit the inner call on its own and break the designation for good.
+			if (TryFindEnclosingDeconstructionCall(block, pos + 1, out _))
+				return false;
+			var matchedCall = MatchDeconstructionCall(block.Instructions[pos + 1], out var testedOperand);
+			if (matchedCall == null)
+				return false;
+			if (!MatchLdLocOrLdLoca(testedOperand!, out var receiver) || receiver != copy)
+				return false;
+			copiedValue = value;
+			call = matchedCall;
+			return true;
 		}
 
 		/// <summary>

--- a/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DeconstructionTransform.cs
@@ -731,7 +731,16 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			{
 				foreach (var use in temp.AddressInstructions.Concat<ILInstruction>(temp.LoadInstructions))
 				{
-					if (!(use.Parent is LdFlda elementAccess && elementAccess.Parent is LdObj))
+					// Walk the ldflda chain up to the reading ldobj: element 8+ of a long tuple
+					// is accessed through the Rest field, i.e. through more than one ldflda.
+					// Whether each read is really a tuple element access (and consumed by the
+					// pattern) is verified by MatchTupleElementRead and the escape check.
+					ILInstruction? node = use.Parent;
+					if (node is not LdFlda)
+						return false;
+					while (node is LdFlda ldflda)
+						node = ldflda.Parent;
+					if (node is not LdObj)
 						return false;
 				}
 				return true;

--- a/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/EarlyExpressionTransforms.cs
@@ -163,17 +163,37 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				temp = ldfldaTarget;
 				range = range.Concat(temp.ILRanges);
 			}
-			if (temp.MatchAddressOf(out var addressOfTarget, out _) && addressOfTarget.MatchLdLoc(out var v))
+			if (!temp.MatchAddressOf(out var addressOfTarget, out var addressOfType))
+				return;
+			ILInstruction replacement;
+			switch (addressOfTarget)
 			{
-				context.Step($"ldobj(...(addressof(ldloca {v.Name}))) => ldobj(...(ldloca {v.Name}))", inst);
-				var replacement = new LdLoca(v).WithILRange(addressOfTarget);
-				foreach (var r in range)
-				{
-					replacement = replacement.WithILRange(r);
-				}
-				temp.ReplaceWith(replacement);
-				context.EndStep(replacement);
+				case LdLoc { Variable: var v }:
+					context.Step($"ldobj(...(addressof(ldloca {v.Name}))) => ldobj(...(ldloca {v.Name}))", inst);
+					replacement = new LdLoca(v).WithILRange(addressOfTarget);
+					break;
+				// The enclosing ldobj only reads through the temporary the addressof creates, so
+				// the copy can be elided and the read go directly through the inner address.
+				// This shape arises when a struct field chain is read by value (ldfld, then a
+				// field of the loaded value), e.g. reading element 8+ of a long tuple via Rest.
+				// The type check keeps the elision on that shape: re-rooting a read of an
+				// incompatible type onto the inner address would read memory behind it that the
+				// copy never covered.
+				case LdObj { UnalignedPrefix: 0, IsVolatile: false } innerLdObj
+					when TypeUtils.IsCompatibleTypeForMemoryAccess(innerLdObj.Type, addressOfType):
+					context.Step("ldobj(...(addressof(ldobj(addr)))) => ldobj(...(addr))", inst);
+					replacement = innerLdObj.Target;
+					range = range.Concat(addressOfTarget.ILRanges);
+					break;
+				default:
+					return;
 			}
+			foreach (var r in range)
+			{
+				replacement = replacement.WithILRange(r);
+			}
+			temp.ReplaceWith(replacement);
+			context.EndStep(replacement);
 		}
 
 		protected internal override void VisitCall(Call inst)


### PR DESCRIPTION
Fixes #3208, fixes #3453, fixes #3962. Closes #2322, closes #3037, closes #3275: those three no longer reproduce on master (#3275 was fixed by #3949), and this PR adds the missing regression fixtures for them, so they can be closed with it.

Triage first: each issue's repro was compiled and decompiled against current master. The three crashes/wrong-code reports (#2322, #3037, #3275) are already fixed - #2322 is covered by the existing `DeconstructDictionaryForEach` fixture, and this PR adds fixtures for #3037 (deconstruction assignment to locals captured by a lambda in an async method) and #3275 (nested deconstruction of readonly record structs). What remained collapses into two defects:

**Value-semantics copy left behind (#3453, #3208).** Deconstruction assignment copies the right-hand side into a temporary before calling `Deconstruct`. When the RHS is a call, inlining folds the temporary; for a local or parameter it survived into the output as a separate statement (`CalibrationPoint calibrationPoint = point; var (num, num2) = calibrationPoint;`). `DeconstructionTransform` now consumes the copy into the pattern - rendering the copied value as the RHS recompiles to the identical temporary. Because blocks are matched back to front, the call-position match defers to the attempt starting at the copy, mirroring the existing nested-deconstruction defer guard.

**`Rest`-chained inner tuple designation (#3962).** Element 8+ of a long tuple is read through the `Rest` field, which Roslyn loads *by value*; ILSpy rendered that as an `addressof(ldobj(...))` sandwich that hid the tuple field chain from every downstream matcher (including the existing `Rest` flattening in `MatchTupleFieldAccess`). Two-part fix at the failure origin: `EarlyExpressionTransforms` elides the copy when the enclosing expression only reads through it, and the deconstruction transform's use-shape guard walks the resulting `ldflda` chain instead of requiring exactly one field access. `var (x, (a, b, c, d, e, f, g, h)) = ...` now reconstructs fully; as a side effect, plain reads render as `item.Item8` instead of `item.Rest.Item1`.

Each fix was developed fixture-first (red on master, green after); the full decompiler suite passes on every commit.

---
*This PR description was written by the Claude Code agent session that authored the change.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)