### PR TITLE
Fix #3451: qualify an explicit implementation as the type implements it

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullableRefTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullableRefTypes.cs
@@ -144,8 +144,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 	public class T06_ExplicitInterfaceImplementation : IEnumerable<KeyValuePair<string, string?>>, IEnumerable
 	{
-		// TODO: declaring type is not yet rendered with nullability annotations from the base type
-		IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
+		IEnumerator<KeyValuePair<string, string?>> IEnumerable<KeyValuePair<string, string?>>.GetEnumerator()
 		{
 			yield return new KeyValuePair<string, string>("a", "b");
 		}
@@ -158,7 +157,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 	public class T07_ExplicitInterfaceImplementation : IEnumerator<KeyValuePair<string, string?>>, IEnumerator, IDisposable
 	{
-		KeyValuePair<string, string?> IEnumerator<KeyValuePair<string, string>>.Current {
+		KeyValuePair<string, string?> IEnumerator<KeyValuePair<string, string?>>.Current {
 			get {
 				throw new NotImplementedException();
 			}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TupleTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/TupleTests.cs
@@ -25,6 +25,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
 	public class TupleTests
 	{
+		private interface I1<T>
+		{
+			void Test();
+		}
+
+		private class ExplicitInterfaceImpl : I1<(int V1, int V2)>
+		{
+			void I1<(int V1, int V2)>.Test()
+			{
+			}
+		}
+
 		private abstract class OverloadResolution
 		{
 			public abstract void M1((long, long) a);

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -1576,7 +1576,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				// slot is empty; leave the forwarder's (already empty) return-type slot untouched in that case.
 				if (memberDecl.ReturnType is { } memberReturnType)
 					methodDecl.ReturnType = memberReturnType.Clone();
-				methodDecl.PrivateImplementationType = astBuilder.ConvertType(m.DeclaringType);
+				methodDecl.PrivateImplementationType = astBuilder.ConvertType(m.DeclaringType.GetInterfaceAsImplementedBy(method.DeclaringType));
 				methodDecl.Name = m.Name;
 				methodDecl.TypeParameters.AddRange(memberDecl.GetChildren(Slots.TypeParameter)
 												   .Select(n => (TypeParameterDeclaration)n.Clone()));

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpAmbience.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpAmbience.cs
@@ -493,7 +493,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			{
 				var baseMember = member.ExplicitlyImplementedInterfaceMembers.FirstOrDefault();
 				if (baseMember != null)
-					return baseMember.DeclaringType;
+					return baseMember.DeclaringType.GetInterfaceAsImplementedBy(member.DeclaringType);
 			}
 			return null;
 		}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -2774,7 +2774,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 			{
 				var baseMember = member.ExplicitlyImplementedInterfaceMembers.FirstOrDefault();
 				if (baseMember != null)
-					return ConvertType(baseMember.DeclaringType);
+					return ConvertType(baseMember.DeclaringType.GetInterfaceAsImplementedBy(member.DeclaringType));
 			}
 			return null;
 		}

--- a/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/TypeSystemExtensions.cs
@@ -55,6 +55,31 @@ namespace ICSharpCode.Decompiler.TypeSystem
 		}
 
 		/// <summary>
+		/// Returns <paramref name="interfaceType"/> as <paramref name="implementingType"/> implements it -
+		/// the entry from its base-type list - falling back to <paramref name="interfaceType"/> itself.
+		/// </summary>
+		/// <remarks>
+		/// Tuple element names and nullability are not part of a type's identity, so an interface resolved
+		/// through one of its members carries neither; the implementing type's base-type list is where they
+		/// are recorded. Naming an explicit interface implementation requires the spelling from that list -
+		/// C# rejects <c>void I&lt;(int, int)&gt;.M()</c> on a type declared as <c>I&lt;(int A, int B)&gt;</c>
+		/// with CS0540. At most one base type can match, because implementing two interfaces that differ
+		/// only in tuple element names or nullability is itself an error (CS8140, CS8645).
+		/// </remarks>
+		internal static IType GetInterfaceAsImplementedBy(this IType interfaceType, IType implementingType)
+		{
+			foreach (var baseType in implementingType.GetAllBaseTypes())
+			{
+				if (baseType.Kind == TypeKind.Interface
+					&& NormalizeTypeVisitor.IgnoreNullabilityAndTuples.EquivalentTypes(baseType, interfaceType))
+				{
+					return baseType;
+				}
+			}
+			return interfaceType;
+		}
+
+		/// <summary>
 		/// Gets all non-interface base types.
 		/// </summary>
 		/// <remarks>


### PR DESCRIPTION
Fixes #3451.

### Problem

Tuple element names and nullability are not part of a type's identity, so an interface resolved through one of its members carries neither. Naming an explicit interface implementation from that type therefore dropped them:

```csharp
private class C1 : I1<(int V1, int V2)>
{
	void I1<(int, int)>.Test()   // names lost
	{
	}
}
```

That output does not build - `error CS0540: containing type does not implement interface 'I1<(int, int)>'`, exactly as reported.

The same rule applies to nullability, where the mismatch costs a CS8643 warning rather than an error. That half was already recorded as a `// TODO: declaring type is not yet rendered with nullability annotations from the base type` in the `NullableRefTypes` fixture; this change resolves it, so the TODO and the two expectations it guarded are updated.

### Solution

The implementing type's base-type list is the only place those annotations are recorded, so the qualifier is looked up there via the new `TypeSystemExtensions.GetInterfaceAsImplementedBy` (internal - no public API change).

Three call sites derived the qualifier independently and all three had the bug; they now share the helper:

- `TypeSystemAstBuilder.GetExplicitInterfaceType` - methods, properties, indexers, events and operators
- `CSharpAmbience.GetExplicitInterfaceType` - tooltips and tree labels
- `CSharpDecompiler.AddInterfaceImplHelpers` - the forwarders synthesized for MethodImpls

Matching while ignoring tuple names and nullability cannot be ambiguous: implementing two interfaces that differ only in those is itself an error (CS8140, CS8645).

### Tests

- `TupleTests` gains the issue's repro as a Pretty fixture, which fails without the fix.
- `NullableRefTypes` T06/T07 now expect the annotated qualifier.

The forwarder path has no new test: reaching it needs a MethodImpl that is not expressible as a C# explicit implementation, so it would take an IL fixture, and all five member kinds route through the one helper the tuple fixture already covers.

Decompiler suite green (3369), `ilspycmd` tests and the ILSpy tree/tooltip tests that consume the ambience green.

---
_Written by an AI agent (Claude) on Siegfried's behalf._