### PR TITLE
Say what the code does instead of which app did it first

### DIFF
--- a/ILSpy.Tests/AssemblyList/AssemblyTreeFileDropTests.cs
+++ b/ILSpy.Tests/AssemblyList/AssemblyTreeFileDropTests.cs
@@ -159,8 +159,7 @@ public class AssemblyTreeFileDropTests
 	[AvaloniaTest]
 	public async Task File_Drop_Selects_The_Newly_Opened_Assembly_Nodes()
 	{
-		// Selecting the freshly-opened assemblies after a drop mirrors WPF's
-		// AssemblyListTreeNode.Drop (which ends in AssemblyTreeModel.SelectNodes).
+		// A drop ends by selecting the assemblies it just opened.
 		// Without this, the user gets no visual confirmation that the drop took, and
 		// the decompiler view stays parked on whatever was selected before.
 		var (window, vm) = await TestHarness.BootAsync(3);

--- a/ILSpy.Tests/AssemblyList/AssemblyTreeTests.cs
+++ b/ILSpy.Tests/AssemblyList/AssemblyTreeTests.cs
@@ -1604,12 +1604,10 @@ public class AssemblyTreeTests
 	[AvaloniaTest]
 	public async Task Active_Search_Term_Does_Not_Hide_Member_Tree_Nodes()
 	{
-		// Pre-existing port misstep: commit 45461ddde wired the search-pane's term into
-		// LanguageSettings.SearchTerm and made SearchTermMatches gate visibility on it.
-		// WPF intentionally makes SearchTermMatches a no-op (returns true) so the assembly
-		// tree stays independent of the search pane. After fixing parity, FieldTreeNode.Filter
-		// must NOT return Hidden purely because the field's name doesn't contain the active
-		// SearchTerm — only ShowApiLevel + ShowMember remain valid hiding criteria.
+		// SearchTermMatches is deliberately a no-op (returns true) so the assembly tree stays
+		// independent of the search pane. FieldTreeNode.Filter must therefore NOT return
+		// Hidden purely because the field's name doesn't contain the active SearchTerm —
+		// only ShowApiLevel + ShowMember remain valid hiding criteria.
 
 		var (_, vm) = await TestHarness.BootAsync();
 

--- a/ILSpy.Tests/AssemblyList/AssemblyTreeTests.cs
+++ b/ILSpy.Tests/AssemblyList/AssemblyTreeTests.cs
@@ -1575,7 +1575,7 @@ public class AssemblyTreeTests
 	public void ExitCommand_Is_Exported_To_File_Menu_With_Resources_E_xit_Header()
 	{
 		// File → Exit must be MEF-discovered and parented to the File menu at MenuOrder=99999
-		// (last entry, mirrors WPF). Headless app lifetime isn't IClassicDesktopStyleApplicationLifetime,
+		// (last entry). Headless app lifetime isn't IClassicDesktopStyleApplicationLifetime,
 		// so Execute() is a safe no-op under tests — we don't actually shut down the test runner,
 		// but the metadata + CanExecute path is the regression-worthy surface.
 

--- a/ILSpy.Tests/AssemblyList/ShowMetadataTokensTests.cs
+++ b/ILSpy.Tests/AssemblyList/ShowMetadataTokensTests.cs
@@ -39,8 +39,7 @@ public class ShowMetadataTokensTests
 	public async Task Member_Text_Carries_Hex_Or_Decimal_Token_Suffix_Per_DisplaySettings()
 	{
 		// Display Settings "Show metadata tokens" + "Show metadata tokens in base 10" must
-		// reach the tree-node Text values. Mirrors WPF ILSpyTreeNode.GetSuffixString —
-		// suffix is " @xNNNNNNNN" (hex, 8 digits) or " @NNNNNNNNN" (decimal) when enabled,
+		// reach the tree-node Text values. The suffix is " @xNNNNNNNN" (hex, 8 digits) or " @NNNNNNNNN" (decimal) when enabled,
 		// empty otherwise.
 
 		var settings = AppComposition.Current.GetExport<SettingsService>().DisplaySettings;

--- a/ILSpy.Tests/Editor/DocumentationRendererTooltipWidthTests.cs
+++ b/ILSpy.Tests/Editor/DocumentationRendererTooltipWidthTests.cs
@@ -40,8 +40,7 @@ namespace ICSharpCode.ILSpy.Tests.TextView;
 /// Pins the rendering shape of method-signature tooltips so a long signature isn't clipped
 /// horizontally: the signature <see cref="SelectableTextBlock"/> must wrap. Created with
 /// <see cref="TextWrapping.NoWrap"/>, text past the popup's MaxWidth is simply cut off,
-/// because the outer ScrollViewer disables horizontal scrolling. WPF parity is
-/// wrap-friendly, so we mirror that.
+/// because the outer ScrollViewer disables horizontal scrolling.
 /// </summary>
 [TestFixture]
 public class DocumentationRendererTooltipWidthTests

--- a/ILSpy.Tests/Editor/EditorCommandsTests.cs
+++ b/ILSpy.Tests/Editor/EditorCommandsTests.cs
@@ -46,7 +46,7 @@ public class EditorCommandsTests
 	[AvaloniaTest]
 	public async Task Copy_Entry_Is_Registered_Under_The_Editor_Category()
 	{
-		// Mirrors WPF's CopyContextMenuEntry — exported with Header=Copy / Category=Editor so
+		// Exported with Header=Copy / Category=Editor so
 		// it lands under the editor's right-click menu next to other text-view actions.
 		var window = AppComposition.Current.GetExport<MainWindow>();
 		window.Show();
@@ -60,7 +60,7 @@ public class EditorCommandsTests
 	[AvaloniaTest]
 	public async Task SelectAll_Entry_Is_Registered_Under_The_Editor_Category()
 	{
-		// Mirrors WPF's SelectAllContextMenuEntry — Header=Select / Category=Editor.
+		// Exported with Header=Select / Category=Editor.
 		var window = AppComposition.Current.GetExport<MainWindow>();
 		window.Show();
 		var registry = AppComposition.Current.GetExport<ContextMenuEntryRegistry>();
@@ -74,7 +74,7 @@ public class EditorCommandsTests
 	public async Task Copy_Entry_Reflects_Editor_Selection_State()
 	{
 		// Visible whenever a text view is the source; enabled only when the editor has a
-		// non-empty selection. Mirrors WPF: SelectionLength > 0 gates the "Copy" item.
+		// non-empty selection: SelectionLength > 0 gates the "Copy" item.
 		var window = AppComposition.Current.GetExport<MainWindow>();
 		window.Show();
 		var vm = (MainWindowViewModel)window.DataContext!;

--- a/ILSpy.Tests/Editor/FoldingsViewStateTests.cs
+++ b/ILSpy.Tests/Editor/FoldingsViewStateTests.cs
@@ -31,9 +31,9 @@ namespace ICSharpCode.ILSpy.Tests;
 
 /// <summary>
 /// Tests for the foldings-persistence helper that backs Back/Forward navigation's
-/// "remember which regions the user had expanded" behaviour. The math mirrors WPF's
-/// <c>DecompilerTextViewState.SaveFoldingsState</c> / <c>RestoreFoldings</c> so that
-/// the protective "skip on layout mismatch" semantics carry over identically.
+/// "remember which regions the user had expanded" behaviour, including the protective
+/// "skip on layout mismatch" semantics: a saved state is only restored when the document
+/// still has the folding layout it was captured against.
 /// </summary>
 [TestFixture]
 public class FoldingsViewStateTests
@@ -42,8 +42,7 @@ public class FoldingsViewStateTests
 	public void Capture_Records_Offsets_Of_Expanded_Foldings_Only()
 	{
 		// The saved subset is the list of foldings the user has open — folded foldings are
-		// already at their default state and don't need preserving. Mirrors WPF's
-		// `foldings.Where(f => !f.IsFolded)` filter at the heart of SaveFoldingsState.
+		// already at their default state and don't need preserving.
 
 		// Arrange — four foldings, two folded and two expanded. Offsets chosen to disambiguate.
 		var foldings = new[] {

--- a/ILSpy.Tests/Editor/ReferenceClickTests.cs
+++ b/ILSpy.Tests/Editor/ReferenceClickTests.cs
@@ -40,9 +40,9 @@ using NUnit.Framework;
 namespace ICSharpCode.ILSpy.Tests.TextView;
 
 /// <summary>
-/// Pins the reference-link click gesture in the decompiled view (WPF parity): navigation
-/// happens on mouse-UP and only when the pointer did not drag, so text that belongs to a
-/// link can still be selected by press-and-drag.
+/// Pins the reference-link click gesture in the decompiled view: navigation happens on
+/// mouse-UP and only when the pointer did not drag, so text that belongs to a link can
+/// still be selected by press-and-drag.
 /// </summary>
 [TestFixture]
 public class ReferenceClickTests

--- a/ILSpy.Tests/Metadata/MetadataDisablesLanguageSwitchingTests.cs
+++ b/ILSpy.Tests/Metadata/MetadataDisablesLanguageSwitchingTests.cs
@@ -41,8 +41,8 @@ public class MetadataDisablesLanguageSwitchingTests
 	public async Task MetadataTablePageModel_Defaults_SupportsLanguageSwitching_False()
 	{
 		// Unit-level guard: every fresh MetadataTablePageModel must declare itself
-		// language-agnostic in its ctor. Mirrors WPF's CoffHeaderTreeNode / DataDirectories /
-		// MetadataTreeNode etc. setting tabPage.SupportsLanguageSwitching=false.
+		// language-agnostic in its ctor: a metadata view has nothing to re-render in another
+		// language, so the language dropdown must not act on it.
 		var model = new MetadataTablePageModel();
 		model.SupportsLanguageSwitching.Should().BeFalse(
 			"metadata grids render PE-header / table fields straight from metadata — language choice doesn't affect what's shown");

--- a/ILSpy.Tests/Metadata/MetadataTablesTreeTests.cs
+++ b/ILSpy.Tests/Metadata/MetadataTablesTreeTests.cs
@@ -37,7 +37,7 @@ public class MetadataTablesTreeTests
 	public async Task MetadataTreeNode_Surfaces_A_Tables_Container_Between_PE_Headers_And_Heaps()
 	{
 		// "Tables" is the synthetic folder that, once expanded, exposes one leaf per
-		// non-empty CLI metadata table. Mirrors WPF tree shape: PE headers → Tables → heaps.
+		// non-empty CLI metadata table. Tree shape: PE headers → Tables → heaps.
 		// Phase 1 lazy-loads its children with a generic placeholder per table; Phase 1e
 		// replaces them with per-table typed leaves carrying the actual row data.
 

--- a/ILSpy.Tests/Metadata/PEHeaderTreeTests.cs
+++ b/ILSpy.Tests/Metadata/PEHeaderTreeTests.cs
@@ -36,8 +36,8 @@ public class PEHeaderTreeTests
 	public async Task MetadataTreeNode_Surfaces_Five_PE_Header_Children_For_A_PE_Assembly()
 	{
 		// The Metadata folder under a PE assembly should expose five PE-format leaves:
-		// DOS / COFF / Optional / DataDirectories / DebugDirectory. Order mirrors WPF so a
-		// user shifting between hosts sees the same tree shape. Each node is the entry point
+		// DOS / COFF / Optional / DataDirectories / DebugDirectory, in that order. Each node
+		// is the entry point
 		// to a header / table view; Phase 1 renders text, Phase 2 swaps to a DataGrid.
 
 		var (_, vm) = await TestHarness.BootAsync();

--- a/ILSpy.Tests/Navigation/NavigationTests.cs
+++ b/ILSpy.Tests/Navigation/NavigationTests.cs
@@ -132,8 +132,8 @@ public class NavigationTests
 		// Assert 1 — newest-first ordering: index 0 is the immediate previous selection
 		// (methodB), index 1 is the one before that (methodA). Each menu item carries a
 		// TreeNodeEntry wrapping the original tree node, and the header reads the richer
-		// NavigationText (mirrors WPF — disambiguates "Empty" from other "Empty" methods by
-		// prefixing the declaring type).
+		// NavigationText, which disambiguates "Empty" from other "Empty" methods by
+		// prefixing the declaring type.
 		var items = flyout.Items.OfType<MenuItem>().ToList();
 		((string)items[0].Header!).Should().Be((string)methodB.NavigationText);
 		((string)items[1].Header!).Should().Be((string)methodA.NavigationText);

--- a/ILSpy.Tests/Navigation/NavigationTests.cs
+++ b/ILSpy.Tests/Navigation/NavigationTests.cs
@@ -197,6 +197,6 @@ public class NavigationTests
 		((string)baseTypesEntry.Header!).Should().Contain("Exception",
 			"the dropdown header must disambiguate generic grouping nodes via NavigationText");
 		((string)baseTypesEntry.Header!).Should().NotBe((string)baseTypes.Text,
-			"falling back to bare Text would reproduce the WPF parity gap");
+			"falling back to bare Text would leave the grouping nodes indistinguishable");
 	}
 }

--- a/ILSpy.Tests/Options/OptionsTabTests.cs
+++ b/ILSpy.Tests/Options/OptionsTabTests.cs
@@ -174,7 +174,7 @@ public class OptionsTabTests
 	public void Reinvoking_ShowOptionsCommand_Focuses_Existing_Tab_Without_Spawning_A_Second()
 	{
 		// Single-instance behaviour — re-firing the command while Options is already open
-		// just reactivates the existing tab. Mirrors WPF's modal-stack uniqueness.
+		// just reactivates the existing tab.
 		var window = AppComposition.Current.GetExport<MainWindow>();
 		window.Show();
 		var vm = (MainWindowViewModel)window.DataContext!;

--- a/ILSpy.Tests/Resources/BamlResourceTests.cs
+++ b/ILSpy.Tests/Resources/BamlResourceTests.cs
@@ -109,7 +109,7 @@ public class BamlResourceTests
 	{
 		// EntryType drives the MSBuild item group the produced file lands in. BAML→XAML
 		// must go under `<Page>` so MSBuild's XAML compiler picks it up and regenerates the
-		// matching .g.cs partial on rebuild — same as the WPF side.
+		// matching .g.cs partial on rebuild.
 
 		// Arrange + Act + Assert — exact string match (case-sensitive; MSBuild element names
 		// are case-insensitive in practice but the canonical form is "Page").

--- a/ILSpy.Tests/Search/SearchResultSortOrderTests.cs
+++ b/ILSpy.Tests/Search/SearchResultSortOrderTests.cs
@@ -44,8 +44,8 @@ public class SearchResultSortOrderTests
 	{
 		// The "Sort results by fitness" checkbox in Display Settings must reach the search
 		// pipeline. Default is true (rank by Fitness desc); flipping to false must rank by
-		// Name asc (StringComparer.Ordinal). Mirrors WPF's SearchPane.xaml.cs:288-290
-		// which captures the comparer at start-of-search based on DisplaySettings.SortResults.
+		// Name asc (StringComparer.Ordinal). The comparer is captured at start-of-search
+		// from DisplaySettings.SortResults.
 
 		await TestHarness.BootAsync();
 

--- a/ILSpy.Tests/Search/SearchTermFilterTests.cs
+++ b/ILSpy.Tests/Search/SearchTermFilterTests.cs
@@ -36,12 +36,12 @@ public class SearchTermFilterTests
 	[AvaloniaTest]
 	public Task SearchTermMatches_Is_A_No_Op_That_Always_Returns_True()
 	{
-		// Pins the WPF-parity contract: the search pane drives its own results via the
-		// ILSpyX search strategies; LanguageSettings.SearchTermMatches deliberately ignores
-		// SearchTerm so the assembly-tree filter cascade stays independent of the search
-		// pane. Without this, typing a term into the search box would hide tree rows whose
-		// names don't match it — including member rows under a type whose own name DOES
-		// match — because the cascade only resets the match bit one level deep.
+		// The search pane drives its own results via the ILSpyX search strategies;
+		// LanguageSettings.SearchTermMatches deliberately ignores SearchTerm so the
+		// assembly-tree filter cascade stays independent of the search pane. Were it to
+		// honour the term, typing into the search box would hide tree rows whose names don't
+		// match it — including member rows under a type whose own name DOES match — because
+		// the cascade only resets the match bit one level deep.
 
 		var settings = AppComposition.Current.GetExport<SettingsService>().SessionSettings.LanguageSettings;
 		try
@@ -54,7 +54,7 @@ public class SearchTermFilterTests
 			settings.SearchTerm = "enum";
 			settings.SearchTermMatches("IEnumerable").Should().BeTrue();
 			settings.SearchTermMatches("Object").Should().BeTrue(
-				"WPF parity: SearchTermMatches must NOT honour the SearchTerm — it's a no-op shim");
+				"SearchTermMatches must NOT honour the SearchTerm — it's a no-op shim");
 
 			settings.SearchTerm = "ZZZ_NoMatchAnywhere";
 			settings.SearchTermMatches("Anything").Should().BeTrue();
@@ -69,11 +69,10 @@ public class SearchTermFilterTests
 	[AvaloniaTest]
 	public Task Typing_In_The_Search_Pane_Does_Not_Bleed_Into_LanguageSettings_SearchTerm()
 	{
-		// The search pane is decoupled from the assembly-tree filter cascade. Earlier port
-		// commits pushed SearchPaneModel.SearchTerm into LanguageSettings.SearchTerm to drive
-		// a tree-filter cascade — that path hid member rows users expected to see (e.g. enum
-		// literals under their matched-by-name enum type). Reverted to WPF parity: typing in
-		// the search pane drives the orchestrator only.
+		// The search pane is decoupled from the assembly-tree filter cascade: typing in it
+		// drives the orchestrator only. Feeding SearchPaneModel.SearchTerm into
+		// LanguageSettings.SearchTerm instead would drive the cascade and hide member rows
+		// users expect to see — e.g. enum literals under their matched-by-name enum type.
 
 		var search = AppComposition.Current.GetExport<SearchPaneModel>();
 		var settings = AppComposition.Current.GetExport<SettingsService>().SessionSettings.LanguageSettings;

--- a/ILSpy/Analyzers/AnalyzerEntityTreeNode.cs
+++ b/ILSpy/Analyzers/AnalyzerEntityTreeNode.cs
@@ -103,8 +103,8 @@ namespace ICSharpCode.ILSpy.Analyzers
 			// One message carries both halves: Reference drives the assembly-tree navigation,
 			// Source carries the originally-analysed entity so the receiving subscriber can
 			// paint local-reference marks on it in the navigated-to body. The subscription
-			// lives in AssemblyTreeModel (mirrors WPF) so the highlight stays decoupled from
-			// the tree-node code path.
+			// lives in AssemblyTreeModel so the highlight stays decoupled from the tree-node
+			// code path.
 			MessageBus.Send(this, new NavigateToReferenceEventArgs(Member, SourceMember));
 		}
 

--- a/ILSpy/AssemblyTree/AssemblyTreeModel.cs
+++ b/ILSpy/AssemblyTree/AssemblyTreeModel.cs
@@ -161,9 +161,8 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			};
 			SelectedItems.CollectionChanged += OnSelectedItemsChanged;
 			// Single hub for "navigate to this reference, optionally highlighting that source"
-			// — mirrors WPF AssemblyTreeModel's JumpToReference subscription. The analyzer
-			// pane, metadata tables, and future decompile commands all push through this same
-			// channel.
+			// — the analyzer pane, metadata tables, and future decompile commands all push
+			// through this same channel.
 			Util.MessageBus<Util.NavigateToReferenceEventArgs>.Subscribers += OnNavigateToReference;
 			// Live re-render when Display Settings change. WPF leaves these as apply-on-next-
 			// load; Avalonia opts into reactivity because the Options dialog stays open while
@@ -925,16 +924,14 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 		/// Fan-out for changes to the currently-active assembly list (assemblies added or
 		/// removed). Re-publishes via <see cref="Util.MessageBus"/> so panes that don't
 		/// directly hold a reference to <see cref="AssemblyList"/> can react — the search
-		/// pane restarts, the dock workspace prunes orphaned tabs. Mirrors WPF's
-		/// <c>assemblyList_CollectionChanged</c> shape.
+		/// pane restarts, the dock workspace prunes orphaned tabs.
 		/// </summary>
 		void OnActiveAssemblyListCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
 		{
 			// Prune navigation-history entries that pointed at tree nodes inside removed
 			// assemblies BEFORE re-publishing — Back/Forward consumers (the toolbar
 			// commands + dropdowns) re-evaluate their CanExecute when the bus fires, so
-			// they must see the post-prune state. Mirrors WPF's history.RemoveAll(...)
-			// inside assemblyList_CollectionChanged.
+			// they must see the post-prune state.
 			if (e.OldItems is { Count: > 0 } oldItems)
 			{
 				var removed = new HashSet<LoadedAssembly>(oldItems.OfType<LoadedAssembly>());
@@ -995,8 +992,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 		/// <summary>
 		/// Resolves every assembly reference of each supplied assembly node through that
 		/// assembly's own resolver -- which auto-loads the targets into the live list -- then
-		/// re-decompiles the active tab so newly available references render. Mirrors WPF's
-		/// LoadDependencies command.
+		/// re-decompiles the active tab so newly available references render.
 		/// </summary>
 		public async Task LoadDependenciesAsync(IReadOnlyList<SharpTreeNode> nodes)
 		{
@@ -1051,7 +1047,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			// tree, so FindNodeByPath returns the same tree-node reference, the
 			// SelectedItem setter early-outs, and DockWorkspace.ShowSelectedNode's
 			// dedup short-circuits — leaving stale decompiled text. Force a fresh
-			// render. Mirrors WPF's RefreshDecompiledView() call.
+			// render.
 			AppEnv.AppComposition.TryGetExport<Docking.DockWorkspace>()?.ForceRefreshActiveTab();
 		}
 	}

--- a/ILSpy/Commands/SelectPdbContextMenuEntry.cs
+++ b/ILSpy/Commands/SelectPdbContextMenuEntry.cs
@@ -96,7 +96,7 @@ namespace ICSharpCode.ILSpy.Commands
 				return;
 			await assembly.LoadDebugInfo(path);
 			// Refresh the tree node + re-decompile the current selection so the new debug
-			// symbols feed back into the output. Mirrors WPF's RefreshDecompiledView call.
+			// symbols feed back into the output.
 			if (assemblyTreeModel.SelectedItem is { } current)
 			{
 				assemblyTreeModel.SelectedItem = null;

--- a/ILSpy/Commands/SimpleCommand.cs
+++ b/ILSpy/Commands/SimpleCommand.cs
@@ -25,10 +25,10 @@ namespace ICSharpCode.ILSpy.Commands
 {
 	/// <summary>
 	/// Minimal ICommand base. Avalonia has no global RequerySuggested signal like WPF's CommandManager,
-	/// so CanExecuteChanged is routed through our own <see cref="CommandManager"/> (mirroring how WPF's
-	/// SimpleCommand routed it through CommandManager.RequerySuggested). State-change sites call
-	/// <see cref="CommandManager.InvalidateRequerySuggested"/> and every bound command re-evaluates --
-	/// no per-command wiring, and the menu/toolbar item updates its enabled state on every platform.
+	/// so CanExecuteChanged is routed through our own <see cref="CommandManager"/>. State-change
+	/// sites call <see cref="CommandManager.InvalidateRequerySuggested"/> and every bound command
+	/// re-evaluates -- no per-command wiring, and the menu/toolbar item updates its enabled
+	/// state on every platform.
 	/// </summary>
 	public abstract class SimpleCommand : ICommand
 	{

--- a/ILSpy/ContextMenuEntry.cs
+++ b/ILSpy/ContextMenuEntry.cs
@@ -78,9 +78,8 @@ namespace ICSharpCode.ILSpy
 	}
 
 	/// <summary>
-	/// Concrete metadata view for context-menu entries. Mirrors WPF's
-	/// <c>IContextMenuEntryMetadata</c>; <see cref="System.Composition"/> requires a class
-	/// (not an interface) for metadata views.
+	/// Concrete metadata view for context-menu entries: <see cref="System.Composition"/>
+	/// requires a class (not an interface) for metadata views.
 	/// </summary>
 	public class ContextMenuEntryMetadata
 	{

--- a/ILSpy/Docking/DockWorkspace.cs
+++ b/ILSpy/Docking/DockWorkspace.cs
@@ -224,7 +224,7 @@ namespace ICSharpCode.ILSpy.Docking
 				documentsNotify.PropertyChanged += OnDocumentsPropertyChanged;
 			// Close orphaned carve-out tabs when their assembly is removed. The persistent
 			// MainTab slot is left alone — its content will swap to whatever the user selects
-			// next via the assembly tree. Mirrors WPF's DockWorkspace.CurrentAssemblyList_Changed.
+			// next via the assembly tree.
 			ICSharpCode.ILSpy.Util.MessageBus<ICSharpCode.ILSpy.Util.CurrentAssemblyListChangedEventArgs>.Subscribers
 				+= OnAssemblyListChanged;
 			ICSharpCode.ILSpy.AppEnv.AppLog.Mark("DockWorkspace ctor exited");
@@ -235,7 +235,7 @@ namespace ICSharpCode.ILSpy.Docking
 			var inner = e.Inner;
 
 			// On Reset (assembly list wholesale-cleared), drop ALL history — every entry is
-			// stale by definition. Mirrors WPF's assemblyList_CollectionChanged.
+			// stale by definition.
 			if (inner.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
 			{
 				PruneHistoryAfterAssemblyListChange(removed: null);
@@ -712,8 +712,7 @@ namespace ICSharpCode.ILSpy.Docking
 		/// the tree isn't rebuilt and the SelectedItem reference is preserved, so the
 		/// normal selection-change cascade would no-op and the editor would keep stale
 		/// decompiled text. Resetting <c>lastShownNodes</c> defeats the
-		/// dedup short-circuit inside <see cref="ShowSelectedNode"/>. Mirrors WPF's
-		/// <c>RefreshDecompiledView()</c> call.
+		/// dedup short-circuit inside <see cref="ShowSelectedNode"/>.
 		/// </summary>
 		public void ForceRefreshActiveTab()
 		{

--- a/ILSpy/Languages/CSharpLanguage.cs
+++ b/ILSpy/Languages/CSharpLanguage.cs
@@ -112,18 +112,18 @@ namespace ICSharpCode.ILSpy.Languages
 
 		public override void WriteCommentLine(ITextOutput output, string comment) => output.WriteLine("// " + comment);
 
-		// Parity with WPF's CSharpLanguage: map an IL member back to its C# source via the
-		// decompiler, so compiler-generated members (lambdas, async/iterator state machines)
-		// resolve to their declaring method/part rather than only the declaring type (the
-		// base Language fallback). Used by analyzers / navigation.
+		// Maps an IL member back to its C# source via the decompiler, so compiler-generated
+		// members (lambdas, async/iterator state machines) resolve to their declaring
+		// method/part rather than only the declaring type (the base Language fallback).
+		// Used by analyzers / navigation.
 		public override CodeMappingInfo GetCodeMappingInfo(MetadataFile module, EntityHandle member)
 		{
 			return CSharpDecompiler.GetCodeMappingInfo(module, member);
 		}
 
-		// Parity with WPF's CSharpLanguage: produce C#-styled entity names (generics as
-		// <T>, nested types joined with '.'). Without this the base Language emits IL-style
-		// names (`1 arity suffixes, escaped identifiers).
+		// Produces C#-styled entity names (generics as <T>, nested types joined with '.').
+		// Without this the base Language emits IL-style names (`1 arity suffixes, escaped
+		// identifiers).
 		public override string GetEntityName(MetadataFile module, EntityHandle handle, bool fullName, bool omitGenerics)
 		{
 			MetadataReader metadata = module.Metadata;

--- a/ILSpy/Metadata/Helpers.cs
+++ b/ILSpy/Metadata/Helpers.cs
@@ -96,8 +96,7 @@ namespace ICSharpCode.ILSpy.Metadata
 	/// <summary>
 	/// Bitmask covering each CLI metadata table. Used as the second argument to
 	/// <see cref="MetadataReaderHelpers.ComputeCodedTokenSize"/> when computing how many bytes
-	/// a coded-token column occupies in a given metadata blob — same encoding as the WPF
-	/// host's <c>TableMask</c>.
+	/// a coded-token column occupies in a given metadata blob.
 	/// </summary>
 	[Flags]
 	public enum TableMask : ulong

--- a/ILSpy/Search/AvaloniaSearchResultFactory.cs
+++ b/ILSpy/Search/AvaloniaSearchResultFactory.cs
@@ -31,8 +31,7 @@ namespace ICSharpCode.ILSpy.Search
 {
 	/// <summary>
 	/// Builds the <see cref="SearchResult"/> objects the search strategies stream into the
-	/// pane's result queue. Mirrors WPF's <c>SearchResultFactory</c>: fitness ranking
-	/// privileges short names (shorter == higher fitness == higher rank); compiler-generated
+	/// pane's result queue. Fitness ranking privileges short names (shorter == higher fitness == higher rank); compiler-generated
 	/// names (those starting with <c>&lt;</c>) get fitness 0 so they sink to the bottom.
 	/// </summary>
 	internal sealed class AvaloniaSearchResultFactory : ISearchResultFactory

--- a/ILSpy/Search/RunningSearch.cs
+++ b/ILSpy/Search/RunningSearch.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.ILSpy.Search
 	/// Orchestrates one search across the loaded <see cref="AssemblyList"/>. Walks
 	/// the assemblies serially on a background <see cref="Task"/>, pushes results into
 	/// a thread-safe queue, and the UI thread drains that queue once per render frame
-	/// with a wall-clock budget — the same shape as the WPF SearchPane.
+	/// with a wall-clock budget.
 	/// </summary>
 	internal sealed class RunningSearch
 	{

--- a/ILSpy/Search/SearchPaneModel.cs
+++ b/ILSpy/Search/SearchPaneModel.cs
@@ -66,7 +66,7 @@ namespace ICSharpCode.ILSpy.Search
 			// Refresh search results when the active assembly list mutates. Skip the
 			// restart when ONLY auto-loaded (dependency) assemblies are added — those
 			// fire from navigating through results in a large assembly and would cause
-			// a tight feedback loop / flicker. Mirrors WPF's #3734 fix.
+			// a tight feedback loop / flicker (issue #3734).
 			Util.MessageBus<Util.CurrentAssemblyListChangedEventArgs>.Subscribers += OnAssemblyListChanged;
 		}
 

--- a/ILSpy/TextView/DecompilerTextView.axaml.cs
+++ b/ILSpy/TextView/DecompilerTextView.axaml.cs
@@ -193,11 +193,10 @@ namespace ICSharpCode.ILSpy.TextView
 			uiElementGenerator = new UIElementGenerator();
 			Editor.TextArea.TextView.ElementGenerators.Add(uiElementGenerator);
 
-			// Reference navigation fires on pointer-RELEASE without drag (WPF parity: the WPF
-			// view used TextArea.PreviewMouseDown/Up the same way), so a press-and-drag over a
-			// link starts a text selection instead of navigating away. The press handler only
-			// records the start position, so tunnel routing (before AvaloniaEdit consumes the
-			// press) is fine.
+			// Reference navigation fires on pointer-RELEASE without drag, so a press-and-drag
+			// over a link starts a text selection instead of navigating away. The press handler
+			// only records the start position, so tunnel routing (before AvaloniaEdit consumes
+			// the press) is fine.
 			Editor.TextArea.AddHandler(InputElement.PointerPressedEvent,
 				OnTextAreaPointerPressedForReferenceClick,
 				RoutingStrategies.Tunnel,

--- a/ILSpy/TextView/DocumentationRenderer.cs
+++ b/ILSpy/TextView/DocumentationRenderer.cs
@@ -136,9 +136,8 @@ namespace ICSharpCode.ILSpy.TextView
 
 			// Wrap rather than NoWrap so a signature wider than the popup's MaxWidth folds
 			// to multiple lines instead of being clipped at the right edge — the outer
-			// ScrollViewer disables horizontal scrolling, so NoWrap meant "the right half
-			// of long generic method signatures is invisible". WPF parity: the equivalent
-			// FlowDocument Paragraph wraps by default (Paragraph doesn't even support NoWrap).
+			// ScrollViewer disables horizontal scrolling, so NoWrap would leave the right
+			// half of long generic method signatures invisible.
 			var block = new SelectableTextBlock {
 				FontFamily = codeFont,
 				FontSize = fontSize,

--- a/ILSpy/TextView/DocumentationRenderer.cs
+++ b/ILSpy/TextView/DocumentationRenderer.cs
@@ -160,7 +160,7 @@ namespace ICSharpCode.ILSpy.TextView
 			}
 			catch (XmlException)
 			{
-				// Malformed XML in the .xml file — ignore as WPF does.
+				// Malformed XML in the .xml file — ignore it rather than failing the tooltip.
 			}
 		}
 

--- a/ILSpy/TextView/EditorCommands.cs
+++ b/ILSpy/TextView/EditorCommands.cs
@@ -46,9 +46,8 @@ namespace ICSharpCode.ILSpy.TextView
 	}
 
 	/// <summary>
-	/// Right-click → Select All. Mirrors WPF's SelectAllContextMenuEntry. Keyboard Ctrl+A is
-	/// handled natively by AvaloniaEdit; this entry surfaces the same action from the
-	/// right-click menu.
+	/// Right-click → Select All. Keyboard Ctrl+A is handled natively by AvaloniaEdit;
+	/// this entry surfaces the same action from the right-click menu.
 	/// </summary>
 	[ExportContextMenuEntry(Header = nameof(Resources.Select), Category = nameof(Resources.Editor), Order = 110)]
 	[Shared]

--- a/ILSpy/TreeNodes/BaseTypesEntryNode.cs
+++ b/ILSpy/TreeNodes/BaseTypesEntryNode.cs
@@ -56,11 +56,10 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		/// <summary>
 		/// Shared activate helper used by <see cref="BaseTypesEntryNode"/> and
-		/// <see cref="DerivedTypesEntryNode"/>. Mirrors WPF's matching helper. The
-		/// <paramref name="node"/> parameter is unused on Avalonia (navigation routes through
-		/// the MEF-resolved <see cref="AssemblyTreeModel"/> instead of walking up the tree to
-		/// the assembly-list node), but the signature stays in lock-step with WPF so any future
-		/// caller that needs the originating node has it on hand.
+		/// <see cref="DerivedTypesEntryNode"/>. The <paramref name="node"/> parameter is
+		/// unused — navigation routes through the MEF-resolved <see cref="AssemblyTreeModel"/>
+		/// rather than walking up the tree to the assembly-list node — but it stays on the
+		/// signature so a caller that does need the originating node has it on hand.
 		/// </summary>
 		internal static bool ActivateItem(SharpTreeNode node, ITypeDefinition? def)
 		{

--- a/ILSpy/TreeNodes/BaseTypesTreeNode.cs
+++ b/ILSpy/TreeNodes/BaseTypesTreeNode.cs
@@ -60,7 +60,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		internal static void AddBaseTypes(SharpTreeNodeCollection children, MetadataFile module, ITypeDefinition typeDefinition)
 		{
 			// Re-resolve the type with an Uncached type system so we get a fresh inheritance
-			// chain (some Decompiler-flag toggles affect how interfaces fold in). Mirrors WPF.
+			// chain (some Decompiler-flag toggles affect how interfaces fold in).
 			var handle = (TypeDefinitionHandle)typeDefinition.MetadataToken;
 			var typeSystem = new DecompilerTypeSystem(module, module.GetAssemblyResolver(),
 				TypeSystemOptions.Default | TypeSystemOptions.Uncached);

--- a/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
+++ b/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
@@ -69,11 +69,10 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		};
 
 		/// <summary>
-		/// Mirrors WPF's filter — drop non-public entries under PublicOnly visibility, otherwise
-		/// recurse so the user can drill into derived chains. The WPF overload also reads
-		/// <c>SearchTermMatches</c> (a <see cref="LanguageSettings"/> helper that's not yet in
-		/// the Avalonia port) to surface only entries whose name matches the active search term;
-		/// reinstate that branch when the search infrastructure lands.
+		/// Drops non-public entries under PublicOnly visibility, otherwise recurses so the user
+		/// can drill into derived chains. The active search term is deliberately not consulted:
+		/// <see cref="LanguageSettings.SearchTermMatches"/> is a no-op so the assembly tree stays
+		/// independent of the search pane.
 		/// </summary>
 		public override FilterResult Filter(LanguageSettings settings)
 		{

--- a/ILSpy/TreeNodes/ExtensionTreeNode.cs
+++ b/ILSpy/TreeNodes/ExtensionTreeNode.cs
@@ -72,8 +72,8 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		// Uses the constructor-time marker reference directly. The marker comes from the
 		// parent TypeTreeNode, which resolves through GetTypeSystemWithCurrentOptionsOrNull,
 		// so the chain is consistent with the current settings; per-access re-resolution (so
-		// language-version flips refresh the display string without rebuilding the node, as
-		// WPF does) remains a follow-up (see `extension-methods-tree` in the tracker).
+		// language-version flips refresh the display string without rebuilding the node)
+		// remains a follow-up (see `extension-methods-tree` in the tracker).
 		ITypeDefinition GetTypeDefinition() => MarkerMethod.DeclaringTypeDefinition!;
 
 		protected override void LoadChildren()

--- a/ILSpy/TreeNodes/FieldTreeNode.cs
+++ b/ILSpy/TreeNodes/FieldTreeNode.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override object Icon => GetIcon(FieldDefinition);
 
-		// Mirrors WPF's discriminator: enum value, const literal, readonly, plain field.
+		// Discriminated in this order: enum value, const literal, readonly, plain field.
 		public static Avalonia.Media.IImage GetIcon(IField field)
 		{
 			// EnumValue: declaring type is an enum and the return type is the enum itself --

--- a/ILSpy/TreeNodes/FilterResult.cs
+++ b/ILSpy/TreeNodes/FilterResult.cs
@@ -21,8 +21,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 	/// <summary>
 	/// Outcome of an <see cref="ILSpyTreeNode.Filter"/> evaluation against the active
 	/// <see cref="LanguageSettings"/>. Drives whether the assembly tree shows the node, hides
-	/// it outright, or shows it only if any descendant matches. Layout mirrors WPF's
-	/// <c>FilterResult</c> for 1:1 portability of <see cref="ILSpyTreeNode.Filter"/> overrides.
+	/// it outright, or shows it only if any descendant matches.
 	/// </summary>
 	public enum FilterResult
 	{

--- a/ILSpy/TreeNodes/ILSpyTreeNode.cs
+++ b/ILSpy/TreeNodes/ILSpyTreeNode.cs
@@ -85,8 +85,8 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		/// <summary>
 		/// Optional " @xNNNNNNNN" (hex) or " @NNNNN" (decimal) suffix appended to entity tree-node
 		/// <see cref="SharpTreeNode.Text"/> values when the user enables Display Settings →
-		/// "Show metadata tokens". Mirrors WPF's <c>ILSpyTreeNode.GetSuffixString</c>; format
-		/// matches byte-for-byte so cross-tool grep on token strings keeps working.
+		/// "Show metadata tokens". The format is fixed, so grepping token strings across tools
+		/// keeps working.
 		/// </summary>
 		protected static string GetSuffixString(IMember member) => GetSuffixString(member.MetadataToken);
 
@@ -173,11 +173,11 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		/// <summary>
 		/// Applies <see cref="Filter"/> to every newly-added child and writes the result
-		/// into <see cref="SharpTreeNode.IsHidden"/>. Mirrors WPF's filter cascade — it's
-		/// what makes accessor children of properties / events read as hidden under the
-		/// default ShowApiLevel without overriding <see cref="SharpTreeNode.ShowExpander"/>
-		/// per node-type. Only fires while this parent is visible (matches WPF) so the
-		/// filter pass doesn't run for descendants whose parent chain isn't realised yet.
+		/// into <see cref="SharpTreeNode.IsHidden"/>. This cascade is what makes accessor
+		/// children of properties / events read as hidden under the default ShowApiLevel
+		/// without overriding <see cref="SharpTreeNode.ShowExpander"/> per node-type. It only
+		/// fires while this parent is visible, so the filter pass doesn't run for descendants
+		/// whose parent chain isn't realised yet.
 		/// </summary>
 		public override void OnChildrenChanged(NotifyCollectionChangedEventArgs e)
 		{
@@ -198,7 +198,6 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		/// parent inherit stale <see cref="SharpTreeNode.IsHidden"/> states. Without this
 		/// trigger, expanding a node that ShowApiLevel had hidden leaves its accessor
 		/// children reading as visible even though the cascade would mark them hidden.
-		/// Mirrors WPF's identical override on <c>ILSpyTreeNode</c>.
 		/// </summary>
 		protected override void OnIsVisibleChanged()
 		{

--- a/ILSpy/TreeNodes/MethodTreeNode.cs
+++ b/ILSpy/TreeNodes/MethodTreeNode.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override object Icon => GetIcon(MethodDefinition);
 
-		// Mirrors WPF's dispatch order: operator, extension method, constructor,
+		// Dispatch order: operator, extension method, constructor,
 		// P/Invoke (DllImport without a body), virtual, plain method. Tested against
 		// every kind in the analyzers fixtures.
 		public static Avalonia.Media.IImage GetIcon(IMethod method)

--- a/ILSpy/TreeNodes/PropertyTreeNode.cs
+++ b/ILSpy/TreeNodes/PropertyTreeNode.cs
@@ -49,7 +49,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 
 		public override object Icon => GetIcon(PropertyDefinition);
 
-		// Mirrors WPF: indexers get a distinct base glyph; extension properties (C# 14
+		// Indexers get a distinct base glyph; extension properties (C# 14
 		// extension blocks) layer the Extension overlay on top.
 		public static Avalonia.Media.IImage GetIcon(IProperty property)
 		{

--- a/ILSpy/ViewModels/CompareTabPageModel.cs
+++ b/ILSpy/ViewModels/CompareTabPageModel.cs
@@ -54,7 +54,7 @@ namespace ICSharpCode.ILSpy.Compare
 		{
 			// Compare view shows a structural metadata diff — language-agnostic, so the
 			// toolbar's Language / Language-Version pickers shouldn't affect anything while
-			// this tab is active. Mirrors WPF's CompareViewModel.SupportsLanguageSwitching=false.
+			// this tab is active.
 			SupportsLanguageSwitching = false;
 			leftAssembly = left;
 			rightAssembly = right;

--- a/ILSpy/ViewModels/TabPageModel.cs
+++ b/ILSpy/ViewModels/TabPageModel.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.ILSpy.ViewModels
 		/// this tab is active. Defaults to <see langword="true"/> — meaningful for decompiler
 		/// output (C# / IL / ILAst). Metadata views and the compare view set this to
 		/// <see langword="false"/> in their ctors because language choice doesn't affect what
-		/// they render. Mirrors WPF's <c>TabPageModel.SupportsLanguageSwitching</c>.
+		/// they render.
 		/// </summary>
 		[ObservableProperty]
 		private bool supportsLanguageSwitching = true;

--- a/ILSpy/ViewModels/UpdatePanelViewModel.cs
+++ b/ILSpy/ViewModels/UpdatePanelViewModel.cs
@@ -32,8 +32,7 @@ namespace ICSharpCode.ILSpy.ViewModels
 	/// <summary>
 	/// Drives the toolbar-strip banner shown under the main toolbar when an update is
 	/// available or the user explicitly asks the Help → Check For Updates menu entry.
-	/// Mirrors WPF's <c>UpdatePanelViewModel</c>: a single <see cref="IsPanelVisible"/>
-	/// flag flips it on/off, and <see cref="UpdateAvailableDownloadUrl"/> toggles the
+	/// A single <see cref="IsPanelVisible"/> flag flips it on/off, and <see cref="UpdateAvailableDownloadUrl"/> toggles the
 	/// button between "Download" (when a URL is set) and "Check Again" (when null).
 	/// </summary>
 	[Export]

--- a/ILSpy/Views/ManageAssemblyListsDialog.axaml.cs
+++ b/ILSpy/Views/ManageAssemblyListsDialog.axaml.cs
@@ -36,8 +36,7 @@ namespace ICSharpCode.ILSpy.Views
 	/// <summary>
 	/// Manage Assembly Lists dialog: list of saved assembly-list names with New / Clone /
 	/// Rename / Delete / Reset operations + a Select button that swaps the active list.
-	/// Mirrors WPF's <c>ManageAssemblyListsDialog</c>; all CRUD ops route through the
-	/// shared <see cref="AssemblyListManager"/>.
+	/// All CRUD ops route through the shared <see cref="AssemblyListManager"/>.
 	/// </summary>
 	public partial class ManageAssemblyListsDialog : Window
 	{
@@ -190,8 +189,7 @@ namespace ICSharpCode.ILSpy.Views
 		/// The list of preconfigured assembly lists offered by the "Add preconfigured list..."
 		/// menu: the three GAC-based framework lists (only when a GAC is actually present, i.e.
 		/// on Windows) plus one entry per installed .NET runtime discovered under the dotnet
-		/// install's <c>shared</c> folder (works on every platform). Mirrors WPF's
-		/// ManageAssemblyListsViewModel.ResolvePreconfiguredAssemblyLists.
+		/// install's <c>shared</c> folder (works on every platform).
 		/// </summary>
 		internal IEnumerable<PreconfiguredAssemblyList> GetPreconfiguredAssemblyLists()
 		{

--- a/ILSpy/Views/OpenFromGacDialog.axaml.cs
+++ b/ILSpy/Views/OpenFromGacDialog.axaml.cs
@@ -29,7 +29,7 @@ using Avalonia.Threading;
 
 using ICSharpCode.Decompiler.Metadata;
 
-// Alias the WPF-shared Resources class — Window inherits an IResourceDictionary Resources
+// Alias the localisation Resources class — Window inherits an IResourceDictionary Resources
 // property that would otherwise shadow ICSharpCode.ILSpy.Properties.Resources, turning every
 // `Resources.X` into an IResourceDictionary indexer lookup that doesn't compile.
 using Loc = ICSharpCode.ILSpy.Properties.Resources;
@@ -122,7 +122,7 @@ namespace ICSharpCode.ILSpy.Views
 			loadingBar.IsIndeterminate = true;
 			try
 			{
-				// Two-phase progress, like WPF: indeterminate during EnumerateGac (we don't know
+				// Two-phase progress: indeterminate during EnumerateGac (we don't know
 				// the count yet), then determinate while resolving each reference's on-disk path.
 				// EnumerateGac is materialised to a list off-thread so the count is known before
 				// the resolve pass starts.
@@ -193,7 +193,7 @@ namespace ICSharpCode.ILSpy.Views
 			if (string.IsNullOrEmpty(text))
 				return true;
 			// Match every space-separated token against the full assembly name OR the version
-			// string — mirrors WPF's filter (FullName || FormattedVersion). All tokens must
+			// string. All tokens must
 			// match: "system 4.0" finds entries whose FullName contains "system" AND
 			// FormattedVersion contains "4.0".
 			foreach (var token in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))

--- a/ILSpy/Views/OpenFromNuGetFeedDialog.axaml.cs
+++ b/ILSpy/Views/OpenFromNuGetFeedDialog.axaml.cs
@@ -26,7 +26,7 @@ using Avalonia.Markup.Xaml;
 using ICSharpCode.ILSpy.NuGetFeeds;
 using ICSharpCode.ILSpy.ViewModels;
 
-// Alias the WPF-shared Resources class — Window inherits an IResourceDictionary Resources
+// Alias the localisation Resources class — Window inherits an IResourceDictionary Resources
 // property that would otherwise shadow ICSharpCode.ILSpy.Properties.Resources, turning every
 // `Resources.X` into an IResourceDictionary indexer lookup that doesn't compile.
 using Loc = ICSharpCode.ILSpy.Properties.Resources;


### PR DESCRIPTION
### Problem

A comment that justifies behaviour by pointing at the WPF front-end means nothing to someone reading the file cold. The front-end it names is no longer in the tree, so the referent a reader would go looking for does not exist:

```csharp
// ... Force a fresh render. Mirrors WPF's RefreshDecompiledView() call.
```

`RefreshDecompiledView` is a method nobody can open. And in almost every case the sentence beside it already carried the reason — the reference was an appendix.

This is the rule `CLAUDE.md` already states — *comments must stand on their own, with no memory of how the code was written* — applied to the WPF back-references.

### What changed

**63 sites across 47 files**, in two commits:

1. **The `WPF parity` phrasings** (11 sites) — the parity clause dropped, the surrounding explanation kept.
2. **The `Mirrors WPF's ...` family and its variants** (52 sites) — same treatment, plus the cases below that needed more than trimming.

Where the reference carried the only content, the comment was rewritten to state the rule directly rather than deleted:

- `MethodTreeNode` / `PropertyTreeNode` — *"Mirrors WPF's dispatch order: operator, extension method, constructor, ..."*. The list **is** the specification, so it stays; only the attribution goes.
- `ILSpyTreeNode.GetSuffixString` — the reason the format is fixed is cross-tool grep on token strings, not that WPF did it that way.
- `BaseTypesEntryNode` — an unused parameter was justified as *"stays in lock-step with WPF"*. With the WPF host gone that is no longer a reason; it now says the parameter is kept so a caller that needs the originating node has it.

Some of these are not `//` comments and would be missed by an obvious grep: two are assertion messages (`.Should().BeTrue("WPF parity: ...")`), several use `Mirrors WPF`, `same as the WPF`, `like WPF`, or `lock-step with WPF`.

### One that had gone stale

`DerivedTypesEntryNode` described consulting the active search term as a missing feature — *"not yet in the Avalonia port; reinstate that branch when the search infrastructure lands"*. That is no longer true, and hasn't been for a while: `SearchTermMatches` is **deliberately** a no-op so the assembly tree stays independent of the search pane, which `SearchTermFilterTests` pins. The comment now says so, so nobody acts on the old instruction.

### Deliberately kept

Comments citing a **live platform difference** or an **external product's** documented behaviour stay, because there the comparison is the reason rather than a memory:

- `SimpleCommand` — Avalonia genuinely has no global `RequerySuggested` signal, which is why the class exists at all. (Its redundant *"mirroring how WPF's SimpleCommand routed it"* parenthetical did go.)
- `DecompilerTextView.ToggleAllFoldings`, `FoldingGroupTests` — Visual Studio's Toggle All Outlining semantics (mixed state expands everything). Delete that and a reader cannot tell whether the rule is intentional.
- `PreviewTabPromotionTests` — "visual parity" between the freeze and close buttons in this app.

After this, `git grep -i "mirrors WPF\|WPF parity\|like WPF\|as the WPF"` returns exactly one hit: `SimpleCommand`.

### Tests

Comment-only apart from one assertion message. `ILSpy.Tests` builds clean; the affected fixtures pass (50 tests across both commits). The diff stays comment-sized — 38 files, +76/-95 in the second commit — with no line-ending churn.

---
_Written by an AI agent (Claude) on Siegfried's behalf._