### PR TITLE
Prevent double dark conversion of syntax colors

### DIFF
--- a/ILSpy.Tests/ThemeAwareHighlightingColorizerTests.cs
+++ b/ILSpy.Tests/ThemeAwareHighlightingColorizerTests.cs
@@ -64,6 +64,39 @@ public class ThemeAwareHighlightingColorizerTests
 		public HighlightingColor GetNamedColor(string name) => colors.Find(c => c.Name == name)!;
 	}
 
+	// Mimics AvaloniaEdit's DelayLoadedHighlightingDefinition: every member forwards through
+	// materialization, and materializing runs a load callback that (like
+	// HighlightingService.Load) registers the INNER definition with the theme manager. The
+	// wrapper and the inner definition are distinct objects sharing the same live colours
+	// and Properties dictionary.
+	sealed class LazyLoadedDefinition : IHighlightingDefinition
+	{
+		readonly StubHighlightingDefinition inner;
+		bool materialized;
+
+		public LazyLoadedDefinition(StubHighlightingDefinition inner)
+		{
+			this.inner = inner;
+		}
+
+		StubHighlightingDefinition GetDefinition()
+		{
+			if (!materialized)
+			{
+				materialized = true;
+				ThemeManager.Current.RegisterThemableDefinition(inner);
+			}
+			return inner;
+		}
+
+		public string Name => GetDefinition().Name;
+		public HighlightingRuleSet MainRuleSet => GetDefinition().MainRuleSet;
+		public IEnumerable<HighlightingColor> NamedHighlightingColors => GetDefinition().NamedHighlightingColors;
+		public IDictionary<string, string> Properties => GetDefinition().Properties;
+		public HighlightingRuleSet GetNamedRuleSet(string name) => GetDefinition().GetNamedRuleSet(name);
+		public HighlightingColor GetNamedColor(string name) => GetDefinition().GetNamedColor(name);
+	}
+
 	static HighlightingColor MakeColor(string name, Color foreground)
 		=> new() { Name = name, Foreground = new SimpleHighlightingBrush(foreground) };
 
@@ -74,6 +107,37 @@ public class ThemeAwareHighlightingColorizerTests
 		var settings = new SessionSettings();
 		ThemeManager.Current.Attach(settings);
 		return settings;
+	}
+
+	[AvaloniaTest]
+	public void LazyLoadedDefinitionIsNotDarkenedTwiceAtDarkStartup()
+	{
+		var settings = AttachThemeSettings();
+		try
+		{
+			// Dark is active BEFORE the definition is first touched -- the "dark theme
+			// preselected, session restores a document" startup ordering.
+			settings.Theme = "Dark";
+
+			var color = MakeColor("String", Colors.Red);
+			var pristine = (HighlightingColor)color.Clone();
+			var wrapper = new LazyLoadedDefinition(new StubHighlightingDefinition(color));
+
+			// HighlightingService.GetByExtension registers what the HighlightingManager
+			// returns: the wrapper. Its first member access materializes the inner
+			// definition, whose own registration has then ALREADY darkened the shared
+			// colours in place -- so the wrapper registration must not treat those dark
+			// values as light originals and convert them a second time.
+			ThemeManager.Current.RegisterThemableDefinition(wrapper);
+
+			var singleConversion = ThemeManager.GetColorForDarkTheme(pristine);
+			color.Should().Be(singleConversion,
+				"registering the lazy wrapper after its inner definition must not compound the dark conversion");
+		}
+		finally
+		{
+			settings.Theme = "Light";
+		}
 	}
 
 	[AvaloniaTest]

--- a/ILSpy.Tests/ThemeAwareHighlightingColorizerTests.cs
+++ b/ILSpy.Tests/ThemeAwareHighlightingColorizerTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Christoph Wille
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+
+using Avalonia.Headless.NUnit;
+using Avalonia.Media;
+
+using AvaloniaEdit.Highlighting;
+using AvaloniaEdit.Rendering;
+
+using AwesomeAssertions;
+
+using ICSharpCode.ILSpy;
+using ICSharpCode.ILSpy.TextView;
+using ICSharpCode.ILSpy.Themes;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests;
+
+/// <summary>
+/// Guards the ThemeManager / ThemeAwareHighlightingColorizer contract against double dark
+/// conversion. ThemeManager darkens a REGISTERED definition's named colours in place; the
+/// colorizer per-paint-remaps colours of UNREGISTERED definitions. Both mechanisms active at
+/// once on the same definition converts colours twice (washed-out output), so the colorizer
+/// must observe a registration that happens after it was constructed, and must not serve
+/// cached conversions computed from colour values that a theme switch has since replaced.
+/// </summary>
+[TestFixture]
+public class ThemeAwareHighlightingColorizerTests
+{
+	// Minimal definition stub: real Properties (ThemeManager marks theme-awareness there)
+	// and real named colours (registration snapshots and rewrites them in place).
+	sealed class StubHighlightingDefinition : IHighlightingDefinition
+	{
+		readonly List<HighlightingColor> colors;
+
+		public StubHighlightingDefinition(params HighlightingColor[] colors)
+		{
+			this.colors = new List<HighlightingColor>(colors);
+		}
+
+		public string Name => "ColorizerTestStub";
+		public HighlightingRuleSet MainRuleSet { get; } = new();
+		public IEnumerable<HighlightingColor> NamedHighlightingColors => colors;
+		public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+		public HighlightingRuleSet GetNamedRuleSet(string name) => MainRuleSet;
+		public HighlightingColor GetNamedColor(string name) => colors.Find(c => c.Name == name)!;
+	}
+
+	static HighlightingColor MakeColor(string name, Color foreground)
+		=> new() { Name = name, Foreground = new SimpleHighlightingBrush(foreground) };
+
+	// Drives ThemeManager through its public surface; restores Light afterwards so the
+	// process-lived singleton doesn't leak dark mode into other tests.
+	static SessionSettings AttachThemeSettings()
+	{
+		var settings = new SessionSettings();
+		ThemeManager.Current.Attach(settings);
+		return settings;
+	}
+
+	[AvaloniaTest]
+	public void RegistrationAfterConstructionDisablesPerPaintRemap()
+	{
+		var settings = AttachThemeSettings();
+		try
+		{
+			var color = MakeColor("Keyword", Colors.Blue);
+			var definition = new StubHighlightingDefinition(color);
+			var colorizer = new ThemeAwareHighlightingColorizer(definition);
+
+			settings.Theme = "Dark";
+
+			// Unregistered definition: the colorizer owns the dark conversion.
+			colorizer.GetEffectiveColor(color).Should().NotBeSameAs(color,
+				"an unregistered definition's colours must be remapped per paint in dark mode");
+
+			// Late registration: ThemeManager now darkens the live colours in place. If the
+			// colorizer kept remapping on top of that, every colour would be converted twice.
+			ThemeManager.Current.RegisterThemableDefinition(definition);
+
+			colorizer.GetEffectiveColor(color).Should().BeSameAs(color,
+				"once the definition is theme-managed, a second per-paint conversion would double-darken");
+		}
+		finally
+		{
+			settings.Theme = "Light";
+		}
+	}
+
+	[AvaloniaTest]
+	public void DarkCacheDoesNotSurviveThemeSwitch()
+	{
+		var settings = AttachThemeSettings();
+		try
+		{
+			var color = MakeColor("String", Colors.Red);
+			var definition = new StubHighlightingDefinition(color);
+			var colorizer = new ThemeAwareHighlightingColorizer(definition);
+
+			settings.Theme = "Dark";
+			var beforeSwitch = colorizer.GetEffectiveColor(color);
+
+			// The colour's content changes in place (as ThemeManager does for managed
+			// definitions) with no paint in between. The colorizer's conversion cache is
+			// keyed by HighlightingColor's content-based equality, so the changed content
+			// must miss the cache and reconvert -- serving the conversion of the old values
+			// here would paint stale colours. If HighlightingColor ever moved to reference
+			// equality, this test goes red and the cache needs an explicit flush instead.
+			color.Foreground = new SimpleHighlightingBrush(Colors.Lime);
+			settings.Theme = "Light";
+			settings.Theme = "Dark";
+
+			var afterSwitch = colorizer.GetEffectiveColor(color);
+			afterSwitch.Should().NotBeSameAs(beforeSwitch,
+				"conversions cached from superseded colour values must not be served");
+		}
+		finally
+		{
+			settings.Theme = "Light";
+		}
+	}
+}

--- a/ILSpy.Tests/Themes/DoubleDarkConversionTests.cs
+++ b/ILSpy.Tests/Themes/DoubleDarkConversionTests.cs
@@ -22,28 +22,25 @@ using Avalonia.Headless.NUnit;
 using Avalonia.Media;
 
 using AvaloniaEdit.Highlighting;
-using AvaloniaEdit.Rendering;
 
 using AwesomeAssertions;
 
-using ICSharpCode.ILSpy;
 using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.Themes;
 
 using NUnit.Framework;
 
-namespace ICSharpCode.ILSpy.Tests;
+namespace ICSharpCode.ILSpy.Tests.Themes;
 
 /// <summary>
 /// Guards the ThemeManager / ThemeAwareHighlightingColorizer contract against double dark
 /// conversion. ThemeManager darkens a REGISTERED definition's named colours in place; the
-/// colorizer per-paint-remaps colours of UNREGISTERED definitions. Both mechanisms active at
-/// once on the same definition converts colours twice (washed-out output), so the colorizer
-/// must observe a registration that happens after it was constructed, and must not serve
-/// cached conversions computed from colour values that a theme switch has since replaced.
+/// colorizer per-paint-remaps colours of UNREGISTERED definitions. Both mechanisms active
+/// at once on the same definition -- or the in-place rewrite running twice over one set of
+/// colours -- converts colours twice and washes the palette out.
 /// </summary>
 [TestFixture]
-public class ThemeAwareHighlightingColorizerTests
+public class DoubleDarkConversionTests
 {
 	// Minimal definition stub: real Properties (ThemeManager marks theme-awareness there)
 	// and real named colours (registration snapshots and rewrites them in place).
@@ -120,7 +117,7 @@ public class ThemeAwareHighlightingColorizerTests
 			settings.Theme = "Dark";
 
 			var color = MakeColor("String", Colors.Red);
-			var pristine = (HighlightingColor)color.Clone();
+			var pristine = color.Clone();
 			var wrapper = new LazyLoadedDefinition(new StubHighlightingDefinition(color));
 
 			// HighlightingService.GetByExtension registers what the HighlightingManager
@@ -133,6 +130,36 @@ public class ThemeAwareHighlightingColorizerTests
 			var singleConversion = ThemeManager.GetColorForDarkTheme(pristine);
 			color.Should().Be(singleConversion,
 				"registering the lazy wrapper after its inner definition must not compound the dark conversion");
+		}
+		finally
+		{
+			settings.Theme = "Light";
+		}
+	}
+
+	[AvaloniaTest]
+	public void ThemeSwitchRestoresPristineColorsAfterDarkStartup()
+	{
+		var settings = AttachThemeSettings();
+		try
+		{
+			settings.Theme = "Dark";
+
+			var color = MakeColor("String", Colors.Red);
+			var pristine = color.Clone();
+			var wrapper = new LazyLoadedDefinition(new StubHighlightingDefinition(color));
+			ThemeManager.Current.RegisterThemableDefinition(wrapper);
+
+			// Every later switch must be computed from the pristine snapshot, not from
+			// whatever the colour held after the previous rewrite: Light restores the
+			// .xshd values exactly, and Dark again yields the single conversion.
+			settings.Theme = "Light";
+			color.Should().Be(pristine,
+				"switching to Light must restore the original .xshd colours exactly");
+
+			settings.Theme = "Dark";
+			color.Should().Be(ThemeManager.GetColorForDarkTheme(pristine),
+				"switching back to Dark must convert the pristine colours exactly once");
 		}
 		finally
 		{
@@ -170,7 +197,7 @@ public class ThemeAwareHighlightingColorizerTests
 	}
 
 	[AvaloniaTest]
-	public void DarkCacheDoesNotSurviveThemeSwitch()
+	public void DarkConversionCacheMissesAfterInPlaceRecolor()
 	{
 		var settings = AttachThemeSettings();
 		try
@@ -180,21 +207,17 @@ public class ThemeAwareHighlightingColorizerTests
 			var colorizer = new ThemeAwareHighlightingColorizer(definition);
 
 			settings.Theme = "Dark";
-			var beforeSwitch = colorizer.GetEffectiveColor(color);
+			colorizer.GetEffectiveColor(color); // primes the cache with the conversion of Red
 
-			// The colour's content changes in place (as ThemeManager does for managed
-			// definitions) with no paint in between. The colorizer's conversion cache is
-			// keyed by HighlightingColor's content-based equality, so the changed content
-			// must miss the cache and reconvert -- serving the conversion of the old values
-			// here would paint stale colours. If HighlightingColor ever moved to reference
-			// equality, this test goes red and the cache needs an explicit flush instead.
+			// The colour's content changes in place with no paint in between. The colorizer's
+			// conversion cache is keyed by HighlightingColor's content-based equality, so the
+			// changed content must miss the cache and reconvert -- serving the conversion of
+			// the old values would paint stale colours. If HighlightingColor ever moved to
+			// reference equality, this goes red and the cache needs an explicit flush instead.
 			color.Foreground = new SimpleHighlightingBrush(Colors.Lime);
-			settings.Theme = "Light";
-			settings.Theme = "Dark";
 
-			var afterSwitch = colorizer.GetEffectiveColor(color);
-			afterSwitch.Should().NotBeSameAs(beforeSwitch,
-				"conversions cached from superseded colour values must not be served");
+			colorizer.GetEffectiveColor(color).Should().Be(ThemeManager.GetColorForDarkTheme(color),
+				"the conversion served after an in-place recolour must be computed from the new colour values");
 		}
 		finally
 		{

--- a/ILSpy/TextView/ThemeAwareHighlightingColorizer.cs
+++ b/ILSpy/TextView/ThemeAwareHighlightingColorizer.cs
@@ -27,27 +27,40 @@ namespace ICSharpCode.ILSpy.TextView
 {
 	/// <summary>
 	/// Wraps AvaloniaEdit's default colorizer so colours flip when the active theme is
-	/// Dark. The decision is per-paint and reads <see cref="ThemeManager.IsDarkTheme"/>
-	/// directly, so a theme switch followed by an editor redraw renders in the new
-	/// palette without needing a second colorizer instance. The remapped colours are
-	/// cached per source <see cref="HighlightingColor"/> instance.
+	/// Dark. The whole decision is per-paint: it reads <see cref="ThemeManager.IsDarkTheme"/>
+	/// and <see cref="ThemeManager.IsThemeAware"/> directly, so a theme switch -- or a
+	/// definition getting registered with the theme manager after this colorizer was
+	/// created -- takes effect on the next redraw without needing a second colorizer
+	/// instance. Checking theme-awareness per paint matters for correctness, not just
+	/// freshness: <see cref="ThemeManager"/> darkens a registered definition's named
+	/// colours in place, so remapping them here a second time would wash the palette out.
+	/// The remapped colours are cached per source <see cref="HighlightingColor"/>; the
+	/// cache key is content-based (HighlightingColor overrides Equals/GetHashCode), so an
+	/// in-place recolour of a source colour misses the cache and reconverts instead of
+	/// serving a conversion of the old values.
 	/// </summary>
 	public sealed class ThemeAwareHighlightingColorizer : HighlightingColorizer
 	{
 		readonly Dictionary<HighlightingColor, HighlightingColor> darkColors = new();
-		readonly bool definitionIsThemeAware;
+		readonly IHighlightingDefinition definition;
 
 		public ThemeAwareHighlightingColorizer(IHighlightingDefinition highlightingDefinition)
 			: base(highlightingDefinition)
 		{
-			definitionIsThemeAware = ThemeManager.Current.IsThemeAware(highlightingDefinition);
+			definition = highlightingDefinition;
 		}
 
 		protected override void ApplyColorToElement(VisualLineElement element, HighlightingColor color)
 		{
-			if (!definitionIsThemeAware && ThemeManager.Current.IsDarkTheme)
-				color = GetCachedDarkColor(color);
-			base.ApplyColorToElement(element, color);
+			base.ApplyColorToElement(element, GetEffectiveColor(color));
+		}
+
+		// The per-paint colour decision, split out so tests can drive it without a TextView.
+		internal HighlightingColor GetEffectiveColor(HighlightingColor color)
+		{
+			if (ThemeManager.Current.IsDarkTheme && !ThemeManager.Current.IsThemeAware(definition))
+				return GetCachedDarkColor(color);
+			return color;
 		}
 
 		HighlightingColor GetCachedDarkColor(HighlightingColor lightColor)

--- a/ILSpy/TextView/ThemeAwareHighlightingColorizer.cs
+++ b/ILSpy/TextView/ThemeAwareHighlightingColorizer.cs
@@ -37,7 +37,9 @@ namespace ICSharpCode.ILSpy.TextView
 	/// The remapped colours are cached per source <see cref="HighlightingColor"/>; the
 	/// cache key is content-based (HighlightingColor overrides Equals/GetHashCode), so an
 	/// in-place recolour of a source colour misses the cache and reconverts instead of
-	/// serving a conversion of the old values.
+	/// serving a conversion of the old values. The entry keyed by the old content is
+	/// stranded rather than replaced -- bounded by the definition's colour count per
+	/// recolour, and it dies with the colorizer.
 	/// </summary>
 	public sealed class ThemeAwareHighlightingColorizer : HighlightingColorizer
 	{

--- a/ILSpy/Themes/ThemeManager.cs
+++ b/ILSpy/Themes/ThemeManager.cs
@@ -108,6 +108,17 @@ namespace ICSharpCode.ILSpy.Themes
 		public void RegisterThemableDefinition(IHighlightingDefinition definition)
 		{
 			ArgumentNullException.ThrowIfNull(definition);
+			// An already-theme-aware definition must not be registered again under a second
+			// identity. HighlightingManager hands out a delay-loaded WRAPPER whose members
+			// forward to the inner definition our Load() callback registers, so registering
+			// the wrapper too would snapshot the shared colours AFTER the inner registration
+			// already themed them -- and, when dark is active before the first touch (dark
+			// theme preselected at startup), dark-convert the already-dark values a second
+			// time, washing the palette out. Reading IsThemeAware here also forces the
+			// wrapper to materialize, so the check observes the inner registration's marker.
+			// This equally respects definitions whose XSHD opts out via ILSpy.IsThemeAware.
+			if (IsThemeAware(definition))
+				return;
 			if (!themableDefinitions.Contains(definition))
 				themableDefinitions.Add(definition);
 			ApplyHighlightingColors(definition);

--- a/ILSpy/Themes/ThemeManager.cs
+++ b/ILSpy/Themes/ThemeManager.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 using Avalonia;
 using Avalonia.Media;
@@ -40,11 +41,21 @@ namespace ICSharpCode.ILSpy.Themes
 		// declares its own dark palette in two variants).
 		const string IsThemeAwareKey = "ILSpy.IsThemeAware";
 
-		// Highlighting definitions whose named colours we re-theme on every theme switch, plus a
-		// snapshot of each definition's ORIGINAL (light, .xshd-default) colours so switching back
-		// to Light restores them exactly. Keyed by colour name within each definition.
+		// Highlighting definitions whose named colours we re-theme on every theme switch.
 		readonly List<IHighlightingDefinition> themableDefinitions = new();
-		readonly Dictionary<IHighlightingDefinition, Dictionary<string, HighlightingColor>> originalColors = new();
+
+		// The ORIGINAL (light, .xshd-default) values of every colour ever themed, so switching
+		// back to Light restores them exactly. Keyed by colour INSTANCE: ConditionalWeakTable
+		// compares by reference (unaffected by HighlightingColor's content-based Equals) and
+		// lets snapshots die with their definition. Keying by instance rather than by definition
+		// makes theming idempotent across definition identities -- AvaloniaEdit's
+		// HighlightingManager hands out a delay-loaded wrapper that forwards to the inner
+		// definition ILSpy's load callback registers, so the same colours can arrive here under
+		// two definition objects. A per-definition snapshot taken via the second identity would
+		// capture already-dark values as "originals" and dark-convert them again (washed-out
+		// colours whenever dark is active at first touch); the per-instance snapshot is taken
+		// exactly once, before the first rewrite, no matter which identity triggers it.
+		readonly ConditionalWeakTable<HighlightingColor, HighlightingColor> originalColors = new();
 
 		public static ThemeManager Current { get; } = new();
 
@@ -108,15 +119,13 @@ namespace ICSharpCode.ILSpy.Themes
 		public void RegisterThemableDefinition(IHighlightingDefinition definition)
 		{
 			ArgumentNullException.ThrowIfNull(definition);
-			// An already-theme-aware definition must not be registered again under a second
-			// identity. HighlightingManager hands out a delay-loaded WRAPPER whose members
-			// forward to the inner definition our Load() callback registers, so registering
-			// the wrapper too would snapshot the shared colours AFTER the inner registration
-			// already themed them -- and, when dark is active before the first touch (dark
-			// theme preselected at startup), dark-convert the already-dark values a second
-			// time, washing the palette out. Reading IsThemeAware here also forces the
-			// wrapper to materialize, so the check observes the inner registration's marker.
-			// This equally respects definitions whose XSHD opts out via ILSpy.IsThemeAware.
+			// Skip definitions that are already theme-aware: either their XSHD declares
+			// ILSpy.IsThemeAware (they ship theme-correct colours we must not rewrite), or a
+			// previous registration themed them -- typically the inner definition behind the
+			// delay-loaded wrapper HighlightingManager returns, which materializes (and
+			// registers itself) when the marker is read here. Re-theming would be harmless
+			// either way (the per-instance colour snapshots make it idempotent); there is
+			// simply nothing to do, and no reason to track a second identity in the list.
 			if (IsThemeAware(definition))
 				return;
 			if (!themableDefinitions.Contains(definition))
@@ -132,22 +141,14 @@ namespace ICSharpCode.ILSpy.Themes
 		/// algorithmic conversion elsewhere. Marks the definition theme-aware so the per-paint
 		/// colorizer doesn't additionally remap it.
 		/// </summary>
-		public void ApplyHighlightingColors(IHighlightingDefinition definition)
+		void ApplyHighlightingColors(IHighlightingDefinition definition)
 		{
-			ArgumentNullException.ThrowIfNull(definition);
-			if (!originalColors.TryGetValue(definition, out var snapshot))
-			{
-				snapshot = new Dictionary<string, HighlightingColor>();
-				foreach (var color in definition.NamedHighlightingColors)
-					snapshot[color.Name] = color.Clone();
-				originalColors[definition] = snapshot;
-			}
-
 			var darkPalette = definition.Name == "C#" ? SyntaxColorPalettes.CSharpDark : null;
 			foreach (var color in definition.NamedHighlightingColors)
 			{
-				if (!snapshot.TryGetValue(color.Name, out var original))
-					continue;
+				// Snapshot before the first rewrite; every later visit gets the stored
+				// pristine values back, never the colour's current (possibly dark) content.
+				var original = originalColors.GetValue(color, static c => c.Clone());
 				if (IsDarkTheme)
 				{
 					if (darkPalette is not null && darkPalette.TryGetValue(color.Name, out var syntaxColor))


### PR DESCRIPTION
## What

Fixes and hardens the `ThemeManager` / `ThemeAwareHighlightingColorizer` contract against double dark conversion of syntax colors — including a live, user-visible bug: **with dark theme preselected, the first document of a session rendered washed out** (resources across every token; C# on the tokens outside the hand-authored dark palette).

The two components split responsibility for dark mode: `ThemeManager` darkens a *registered* definition's named `HighlightingColor` instances in place (snapshot-based restore), while the colorizer per-paint-remaps colors of *unregistered* definitions. Any path that runs both mechanisms — or the in-place remap twice — on the same colors washes the palette out.

## Commit 1: check theme-awareness per paint, not at colorizer creation

`ThemeAwareHighlightingColorizer` captured `IsThemeAware(definition)` once, in its constructor, into a readonly field. A colorizer constructed *before* its definition's first `RegisterThemableDefinition` call that survives a *later* registration would keep remapping colors that `ThemeManager` had meanwhile darkened in place. Reachable today only by violating a calling convention (every current path registers before the colorizer exists), but nothing enforced that. Now the flag is read per paint, alongside the existing per-paint `IsDarkTheme` read.

The originally suspected companion hazard — the colorizer's `darkColors` cache serving conversions computed from superseded color values — turned out to be a non-issue: `HighlightingColor` overrides `Equals`/`GetHashCode` with content-based equality, so an in-place recolor changes the key's hash, misses the cache, and reconverts. A characterization test pins that, so an equality-semantics change in AvaloniaEdit surfaces as a red test rather than stale colors.

## Commit 2: fix washed-out colors when dark theme is active at startup

The startup bug had a different mechanism, on the `ThemeManager` side: **the same definition was registered under two identities.** AvaloniaEdit's `HighlightingManager` hands out a `DelayLoadedHighlightingDefinition` *wrapper* whose members all forward to the inner definition; ILSpy's `HighlightingService.Load` registers the *inner* definition during materialization, and `GetByExtension` then registers the *wrapper* it got from the manager. The wrapper registration snapshots the shared live colors **after** the inner registration has already themed them.

- Theme switched in-session: first touch happens in Light, both snapshots are pristine → no visible harm (just double bookkeeping). This is why the bug never reproduced by toggling.
- Dark active at first touch (dark preselected at startup): the wrapper's snapshot captures already-dark values as "light originals", and the rewrite dark-converts them a second time → washed out from the first paint.

The initial fix guarded `RegisterThemableDefinition` on the theme-aware marker; commit 3 (review feedback) replaces the load-bearing part of that guard with something structural.

## Commit 3 (review follow-up): snapshot original colors per color *instance*

Per review: the marker-based guard conflated "XSHD opts out" / "already themed" / "already registered", and leaned on two non-contractual AvaloniaEdit details (the wrapper's `Properties` forwarding, materialize-on-touch). The original-color snapshots are now keyed by `HighlightingColor` instance in a `ConditionalWeakTable` (reference identity — immune to the content-based `Equals`; weak keys die with the definition) instead of by definition. Theming is idempotent no matter how many definition objects expose the same colors or in which order they register, so correctness no longer depends on the marker or registration order. The guard remains only to honor the XSHD `ILSpy.IsThemeAware` opt-out and to skip redundant list entries, and `ApplyHighlightingColors` is now private so nothing can set the marker outside a registration.

## Tests

`ILSpy.Tests/Themes/DoubleDarkConversionTests.cs`, driving the paint decision through an internal seam (`GetEffectiveColor`) and `ThemeManager` through its public surface:

- `LazyLoadedDefinitionIsNotDarkenedTwiceAtDarkStartup` — replicates the delay-loaded-wrapper materialization flow with dark active before first touch; red before the startup fix, green after.
- `ThemeSwitchRestoresPristineColorsAfterDarkStartup` — same dark-startup flow, then Light→Dark round-trip; pins that every switch is computed from the pristine snapshot (Light restores the .xshd values exactly, Dark yields the single conversion).
- `RegistrationAfterConstructionDisablesPerPaintRemap` — red before commit 1 (constructor-cached flag ignored late registration), green after.
- `DarkConversionCacheMissesAfterInPlaceRecolor` — characterization guard for the content-keyed conversion cache: after an in-place recolor, the served conversion must equal the conversion of the *new* values (exists to catch an equality-semantics change in AvaloniaEdit).

Full headless `ILSpy.Tests` suite green (1167 passed, 4 pre-existing environment skips). Verified in the running app: with `<Theme>Dark</Theme>` preselected in the config, the first decompiled document of the session renders with the same vibrant dark palette as an in-session switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
