### PR TITLE
Report a call as unresolvable when nothing matched at all

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -196,6 +196,9 @@
     <None Include="TestCases\ILPretty\CS1xSwitch_Release.cs" />
     <Compile Remove="TestCases\ILPretty\CallIndirect.cs" />
     <None Include="TestCases\ILPretty\CallIndirect.cs" />
+    <Compile Remove="TestCases\ILPretty\InstanceOperatorCall.cs" />
+    <None Include="TestCases\ILPretty\InstanceOperatorCall.cs" />
+    <None Include="TestCases\ILPretty\InstanceOperatorCall.il" />
     <Compile Remove="TestCases\ILPretty\EmptyBodies.cs" />
     <None Include="TestCases\ILPretty\EmptyBodies.cs" />
     <Compile Remove="TestCases\ILPretty\TruncatedAccessorBody.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -334,6 +334,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task InstanceOperatorCall()
+		{
+			await Run();
+		}
+
+		[Test]
 		public async Task FSharpLoops_Debug()
 		{
 			CopyFSharpCoreDll();

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/InstanceOperatorCall.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/InstanceOperatorCall.cs
@@ -1,0 +1,24 @@
+public class CallSite
+{
+	public static bool CompareVirtual<T>(Source<T> s, T a, T b)
+	{
+		return a < b;
+	}
+
+	public static bool CompareDirect(Source<int> s, int a, int b)
+	{
+		return a > b;
+	}
+}
+public class Source<T>
+{
+	public virtual bool operator <(T a, T b)
+	{
+		return false;
+	}
+
+	public bool operator >(T a, T b)
+	{
+		return false;
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/InstanceOperatorCall.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/InstanceOperatorCall.il
@@ -1,0 +1,89 @@
+// Metadata version: v4.0.30319
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )                         // .?_....:
+  .ver 11:0:0:0
+}
+.assembly InstanceOperatorCall
+{
+  .ver 1:0:0:0
+}
+.module InstanceOperatorCall.dll
+.imagebase 0x10000000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       // WINDOWS_CUI
+.corflags 0x00000001    //  ILONLY
+
+// F# emits comparison operators as instance members, so operator metadata names appear on
+// methods C# would never bind as operators: the operands are the arguments, and the operator
+// lives on the receiver type rather than on either operand type.
+.class public auto ansi beforefieldinit Source`1<T>
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig specialname newslot virtual
+          instance bool  op_LessThan(!T a,
+                                     !T b) cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldc.i4.0
+    IL_0001:  ret
+  }
+
+  .method public hidebysig specialname
+          instance bool  op_GreaterThan(!T a,
+                                        !T b) cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldc.i4.0
+    IL_0001:  ret
+  }
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  }
+}
+
+.class public auto ansi beforefieldinit CallSite
+       extends [System.Runtime]System.Object
+{
+  .method public hidebysig static bool  CompareVirtual<T>(class Source`1<!!T> s,
+                                                          !!T a,
+                                                          !!T b) cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  ldarg.2
+    IL_0003:  callvirt   instance bool class Source`1<!!T>::op_LessThan(!0,
+                                                                        !0)
+    IL_0008:  ret
+  }
+
+  .method public hidebysig static bool  CompareDirect(class Source`1<int32> s,
+                                                      int32 a,
+                                                      int32 b) cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  ldarg.2
+    IL_0003:  call       instance bool class Source`1<int32>::op_GreaterThan(!0,
+                                                                             !0)
+    IL_0008:  ret
+  }
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  }
+}

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -1643,6 +1643,13 @@ namespace ICSharpCode.Decompiler.CSharp
 			if (or.IsAmbiguous)
 				return OverloadResolutionErrors.AmbiguousMatch;
 			foundMember = or.GetBestCandidateWithSubstitutedTypeArguments();
+			if (foundMember == null)
+			{
+				// Overload resolution reports no error for an empty candidate set - there is no
+				// best candidate to carry one - so a call that matched nothing has to be reported
+				// as unresolvable here.
+				return OverloadResolutionErrors.AmbiguousMatch;
+			}
 			if (!IsAppropriateCallTarget(expectedTargetDetails, method, foundMember))
 				return OverloadResolutionErrors.AmbiguousMatch;
 			var map = or.GetArgumentToParameterMap();


### PR DESCRIPTION
Decompiling `FSharp.DataFrame` from nuget.org crashes with a `NullReferenceException` in `CallBuilder.IsAppropriateCallTarget`.

`OverloadResolution.BestCandidateErrors` returns `None` for an empty candidate set - there is no best candidate to attach an error to - so `IsUnambiguousCall` read the null result of `GetBestCandidateWithSubstitutedTypeArguments()` as success and passed it on to be dereferenced. Only `callvirt` call sites crash: for the other opcodes the null is compared before it is dereferenced.

This PR is that guard: an empty candidate set is reported as unresolvable, so the call keeps its explicit form instead of failing the whole method.

What produces the empty candidate set in that assembly is a separate defect. F# compiles its comparison members to instance methods carrying operator metadata names (`DelayedSource<'T,'U>.op_LessThan(a, b)`), and the operator candidate search looks at the operand types rather than at the receiver type the member belongs to.

The new `InstanceOperatorCall` IL-pretty fixture is built from that shape - a generic instance `op_LessThan` called via `callvirt`, plus a direct `call` variant. Without the guard the `callvirt` method decompiles to the exception text; with it, decompilation completes. The expected output still shows the misclassification: the instance methods render as `operator <` / `operator >` and the call sites drop the receiver, so the fixture will be updated when that is fixed - it pins the crash, not the rendering.

Full ICSharpCode.Decompiler.Tests sweep: 3376 total, 0 failed, 46 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
