### PR TITLE
Fix #3993, #3994: main-menu shortcuts and dark-mode hover tooltips

### DIFF
--- a/ILSpy.Tests/Editor/DocumentationLinkTests.cs
+++ b/ILSpy.Tests/Editor/DocumentationLinkTests.cs
@@ -80,6 +80,10 @@ public class DocumentationLinkTests
 			.FirstOrDefault(tb => tb.Classes.Contains("doc-link"));
 		link.Should().NotBeNull("a resolvable cref must render as a clickable link");
 		link!.Cursor.Should().NotBeNull("links show the hand cursor as a click affordance");
+		window.TryFindResource("ILSpy.DocLinkForeground", window.ActualThemeVariant, out var linkBrush)
+			.Should().BeTrue("doc links route their colour through a themed brush");
+		link.Foreground.Should().Be(linkBrush,
+			"a hardcoded link colour is unreadable on the dark popup background (issue #3994)");
 
 		object? navigated = null;
 		var linkClickedRaised = false;

--- a/ILSpy.Tests/Editor/DocumentationRendererThemeTests.cs
+++ b/ILSpy.Tests/Editor/DocumentationRendererThemeTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Christoph Wille
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+
+using AvaloniaEdit.Highlighting;
+
+using AwesomeAssertions;
+
+using ICSharpCode.Decompiler.CSharp.OutputVisitor;
+
+using ICSharpCode.ILSpy.TextView;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests.TextView;
+
+/// <summary>
+/// The hover popup's signature text is coloured by the active highlighting theme, so its
+/// chrome must follow the same theme variant: dark-theme (light-on-dark) text on a
+/// hardcoded near-white background is unreadable (issue #3994). Light mode keeps the
+/// established near-white look.
+/// </summary>
+[TestFixture]
+public class DocumentationRendererThemeTests
+{
+	[AvaloniaTest]
+	public void Popup_Chrome_Follows_The_Active_Theme_Variant()
+	{
+		var renderer = new DocumentationRenderer(
+			new CSharpAmbience(),
+			new FontFamily("Consolas, Menlo, Monospace"),
+			12);
+		renderer.AddSignatureBlock(new RichText("(parameter) string matchText"));
+
+		var view = (Border)renderer.CreateView();
+		var window = new Window { Content = view };
+		var app = Application.Current!;
+		var originalVariant = app.RequestedThemeVariant;
+		try
+		{
+			window.Show();
+
+			app.RequestedThemeVariant = ThemeVariant.Dark;
+			Dispatcher.UIThread.RunJobs();
+
+			window.TryFindResource("ILSpy.DocTooltipBackground", ThemeVariant.Dark, out var darkBackground)
+				.Should().BeTrue("the popup chrome must route through themed brushes");
+			view.Background.Should().Be(darkBackground,
+				"dark-theme signature colours are unreadable on a light popup background");
+			window.TryFindResource("ILSpy.DocTooltipBorder", ThemeVariant.Dark, out var darkBorder)
+				.Should().BeTrue();
+			view.BorderBrush.Should().Be(darkBorder);
+
+			app.RequestedThemeVariant = ThemeVariant.Light;
+			Dispatcher.UIThread.RunJobs();
+
+			((ISolidColorBrush)view.Background!).Color.Should().Be(Color.FromRgb(0xFC, 0xFC, 0xFC),
+				"light mode keeps the established near-white popup chrome");
+			((ISolidColorBrush)view.BorderBrush!).Color.Should().Be(Color.FromRgb(0xAA, 0xAA, 0xAA));
+		}
+		finally
+		{
+			window.Close();
+			app.RequestedThemeVariant = originalVariant;
+		}
+	}
+}

--- a/ILSpy.Tests/MainWindow/MainMenuTests.cs
+++ b/ILSpy.Tests/MainWindow/MainMenuTests.cs
@@ -95,6 +95,48 @@ public class MainMenuTests
 		openItem.Gesture!.Should().Be(expected);
 	}
 
+	// NativeMenuItem.Gesture is display-only when NativeMenuBar renders the menu inline
+	// (the managed fallback binds it to MenuItem.InputGesture, which never handles input),
+	// so every menu gesture must also be registered as a window-level KeyBinding or the
+	// shortcut silently does nothing on Windows / Linux (issue #3993: Ctrl+O, Ctrl+S, F5).
+	[AvaloniaTest]
+	public void Menu_Gestures_Are_Registered_As_Window_KeyBindings()
+	{
+		var window = AppComposition.Current.GetExport<MainWindow>();
+		window.Show();
+
+		var nativeMenu = NativeMenu.GetMenu(window)
+			?? throw new InvalidOperationException("MainMenu.Attach should have set NativeMenu on the window");
+
+		var gestureItems = new System.Collections.Generic.List<(string Path, NativeMenuItem Item)>();
+		CollectItemsWithGesture(nativeMenu, parentPath: "", gestureItems);
+
+		gestureItems.Should().NotBeEmpty("File > Open (Ctrl+O), Reload (F5) and Save (Ctrl+S) declare InputGestureText");
+
+		foreach (var (path, item) in gestureItems)
+		{
+			window.KeyBindings.Should().Contain(
+				kb => Equals(kb.Gesture, item.Gesture) && ReferenceEquals(kb.Command, item.Command),
+				$"the gesture {item.Gesture} shown on '{path}' must actually invoke the item's command");
+		}
+	}
+
+	static void CollectItemsWithGesture(NativeMenu menu, string parentPath, System.Collections.Generic.List<(string, NativeMenuItem)> result)
+	{
+		foreach (var element in menu.Items)
+		{
+			if (element is NativeMenuItemSeparator || element is not NativeMenuItem item)
+				continue;
+			var path = string.IsNullOrEmpty(parentPath) ? (item.Header ?? "<unnamed>") : $"{parentPath} > {item.Header}";
+			// Mirrors RegisterGestureKeyBindings: only items with BOTH a gesture and a command
+			// get a key binding, so a display-only gesture must not fail the assertion.
+			if (item.Gesture != null && item.Command != null)
+				result.Add((path, item));
+			if (item.Menu is { Items.Count: > 0 } sub)
+				CollectItemsWithGesture(sub, path, result);
+		}
+	}
+
 	// Avalonia's macOS NativeMenu bridge maps NativeMenuItem to NSMenuItem and sets
 	// NSMenuItem.action ONLY when Command != null. Without it, NSMenuValidation marks
 	// the item disabled (greyed out) and no click ever reaches managed code - which

--- a/ILSpy/App.axaml
+++ b/ILSpy/App.axaml
@@ -54,6 +54,12 @@
                     <SolidColorBrush x:Key="ILSpy.TooltipBackground" Color="#FFFFE1" />
                     <SolidColorBrush x:Key="ILSpy.TooltipForeground" Color="Black" />
                     <SolidColorBrush x:Key="ILSpy.TooltipBorder" Color="#FF767676" />
+                    <!-- Documentation hover popup (signature + XML docs). Kept separate from the
+                         plain ILSpy.Tooltip* brushes: the doc popup uses a near-white surface for
+                         syntax-coloured code, not the classic yellow tooltip fill. -->
+                    <SolidColorBrush x:Key="ILSpy.DocTooltipBackground" Color="#FCFCFC" />
+                    <SolidColorBrush x:Key="ILSpy.DocTooltipBorder" Color="#AAAAAA" />
+                    <SolidColorBrush x:Key="ILSpy.DocLinkForeground" Color="#0066CC" />
                     <SolidColorBrush x:Key="ILSpy.WindowBackground" Color="#F0F0F0" />
                     <SolidColorBrush x:Key="ILSpy.WindowForeground" Color="Black" />
                     <SolidColorBrush x:Key="ILSpy.PaneBackground" Color="White" />
@@ -116,6 +122,12 @@
                     <SolidColorBrush x:Key="ILSpy.TooltipBackground" Color="#252526" />
                     <SolidColorBrush x:Key="ILSpy.TooltipForeground" Color="#DCDCDC" />
                     <SolidColorBrush x:Key="ILSpy.TooltipBorder" Color="#3F3F46" />
+                    <!-- Dark counterpart of the doc hover popup: slightly lighter than the #1E1E1E
+                         editor canvas so the popup reads as a raised surface, with the link blue
+                         brightened for contrast on the dark fill. -->
+                    <SolidColorBrush x:Key="ILSpy.DocTooltipBackground" Color="#252526" />
+                    <SolidColorBrush x:Key="ILSpy.DocTooltipBorder" Color="#3F3F46" />
+                    <SolidColorBrush x:Key="ILSpy.DocLinkForeground" Color="#6FA8DC" />
                     <SolidColorBrush x:Key="ILSpy.WindowBackground" Color="#252526" />
                     <SolidColorBrush x:Key="ILSpy.WindowForeground" Color="#DCDCDC" />
                     <SolidColorBrush x:Key="ILSpy.PaneBackground" Color="#1E1E1E" />
@@ -228,6 +240,12 @@
             <Setter Property="Foreground" Value="{DynamicResource ILSpy.TooltipForeground}" />
             <Setter Property="BorderBrush" Value="{DynamicResource ILSpy.TooltipBorder}" />
             <Setter Property="BorderThickness" Value="1" />
+        </Style>
+
+        <!-- Links inside the documentation hover popup (DocumentationRenderer tags them with
+             the doc-link class). Colour lives here so it swaps with the theme variant. -->
+        <Style Selector="TextBlock.doc-link">
+            <Setter Property="Foreground" Value="{DynamicResource ILSpy.DocLinkForeground}" />
         </Style>
 
         <!-- Window-level chrome: every top-level window picks up these brushes for the

--- a/ILSpy/TextView/DocumentationRenderer.cs
+++ b/ILSpy/TextView/DocumentationRenderer.cs
@@ -48,8 +48,6 @@ namespace ICSharpCode.ILSpy.TextView
 	/// </summary>
 	public sealed class DocumentationRenderer
 	{
-		static readonly IBrush HyperlinkBrush = new SolidColorBrush(Color.FromRgb(0x00, 0x66, 0xCC));
-
 		readonly IAmbience ambience;
 		readonly FontFamily codeFont;
 		readonly double fontSize;
@@ -118,14 +116,18 @@ namespace ICSharpCode.ILSpy.TextView
 				VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
 				MaxHeight = maxHeight,
 			};
-			return new Border {
+			var border = new Border {
 				BorderThickness = new Thickness(1),
-				BorderBrush = new SolidColorBrush(Color.FromRgb(0xAA, 0xAA, 0xAA)),
-				Background = new SolidColorBrush(Color.FromRgb(0xFC, 0xFC, 0xFC)),
 				Padding = new Thickness(6),
 				MaxWidth = maxWidth,
 				Child = scroll,
 			};
+			// The signature text is coloured by the active highlighting theme, so the chrome
+			// must follow the same theme variant: dark-theme text on a fixed light fill is
+			// unreadable. DynamicResource-style bindings keep it in sync on theme switches.
+			border.Bind(Border.BackgroundProperty, border.GetResourceObservable("ILSpy.DocTooltipBackground"));
+			border.Bind(Border.BorderBrushProperty, border.GetResourceObservable("ILSpy.DocTooltipBorder"));
+			return border;
 		}
 
 		public void AddSignatureBlock(RichText signature)
@@ -392,8 +394,8 @@ namespace ICSharpCode.ILSpy.TextView
 		// embedded TextBlock inside an InlineUIContainer.
 		static TextBlock CreateLinkTextBlock()
 		{
+			// Foreground comes from the App.axaml "doc-link" style so it follows the theme.
 			return new TextBlock {
-				Foreground = HyperlinkBrush,
 				TextDecorations = TextDecorations.Underline,
 				Cursor = new Cursor(StandardCursorType.Hand),
 				// A null background makes the TextBlock hit-test invisible — clicks would

--- a/ILSpy/Views/MainMenu.axaml.cs
+++ b/ILSpy/Views/MainMenu.axaml.cs
@@ -76,7 +76,41 @@ public static class MainMenu
 			PromoteHelpToMacAppMenu(menu, topLevelByTag);
 		}
 
+		RegisterGestureKeyBindings(window, menu);
 		NativeMenu.SetMenu(window, menu);
+	}
+
+	// NativeMenuItem.Gesture is display-only when NativeMenuBar renders the menu inline:
+	// the managed fallback binds it to MenuItem.InputGesture, which never handles input.
+	// So each gesture is registered as a window-level KeyBinding too - that is what makes
+	// Ctrl+O / Ctrl+S / F5 actually fire on Windows and Linux. On macOS the system menu
+	// bar consumes its key equivalents before they reach the window, so these bindings
+	// stay dormant there. Runs after TranslateGesturesForMacOS so the bound gesture always
+	// matches the one the menu displays. Duplicates of the KeyBindings declared in
+	// MainWindow.axaml (e.g. Alt+Left) are harmless: KeyboardDevice stops dispatching
+	// once a binding marks the event handled, so only the first match executes.
+	static void RegisterGestureKeyBindings(Window window, NativeMenu menu)
+	{
+		foreach (var element in menu.Items)
+		{
+			if (element is NativeMenuItemSeparator || element is not NativeMenuItem item)
+				continue;
+			if (item.Gesture is { } gesture && item.Command is { } command)
+			{
+				var keyBinding = new KeyBinding {
+					Gesture = gesture,
+					Command = command,
+				};
+				// CommandParameter must track the item's property, not snapshot it: for
+				// IProvideParameterBinding commands the item's parameter is itself a binding
+				// that only resolves once the menu lives in a visual tree, so a value copied
+				// here would be null when the shortcut fires.
+				keyBinding.Bind(KeyBinding.CommandParameterProperty, item.GetObservable(NativeMenuItem.CommandParameterProperty));
+				window.KeyBindings.Add(keyBinding);
+			}
+			if (item.Menu != null)
+				RegisterGestureKeyBindings(window, item.Menu);
+		}
 	}
 
 	// macOS convention puts About / Check for Updates under the bold app-named menu


### PR DESCRIPTION
Fixes #3993
Fixes #3994

Two regressions of the same shape from the Avalonia port: UI affordances that WPF wired up implicitly need explicit wiring in Avalonia, and both fell through the gap.

## Fix 1: Main-menu keyboard shortcuts do nothing on Windows/Linux (#3993)

**Symptom:** Ctrl+O, Ctrl+S, and F5 show next to their File-menu items but pressing them has no effect. Alt+Left/Right and Ctrl+E keep working.

**Root cause:** The main menu is built as a `NativeMenu`, and `NativeMenuItem.Gesture` is display-only outside macOS. Decompiling Avalonia 12.1.1's `NativeMenuBarPresenter` (the managed fallback that renders the menu inline on Windows/Linux) confirms it: the presenter binds `NativeMenuItem.Gesture` to `MenuItem.InputGesture`, which only paints the shortcut text -- it never registers a key handler. Only macOS gets working shortcuts, because there the gestures become real NSMenu key equivalents. The Avalonia docs state this explicitly: *"`InputGesture` only displays the text. You must also register the actual key binding separately for the shortcut to function."* The shortcuts that kept working were exactly the ones hardcoded as `KeyBindings` in `MainWindow.axaml`; everything coming from `[ExportMainMenuCommand(InputGestureText = ...)]` metadata was display-only.

**Fix:** After the menu is built, `MainMenu.RegisterGestureKeyBindings` walks it recursively and adds a window-level `KeyBinding` for every item that has both a gesture and a command. Details:

- It runs after `TranslateGesturesForMacOS`, so the bound gesture always matches the one the menu displays.
- On macOS the system menu bar consumes its key equivalents before they reach the window, so the extra bindings stay dormant there -- no double dispatch.
- Alt+Left/Right exist both in `MainWindow.axaml` and as menu gestures; that duplication is harmless because `KeyboardDevice` stops dispatching key bindings once one marks the event handled (verified in the decompiled Avalonia source), so only the first match executes.
- MEF metadata (`InputGestureText`) stays the single source of truth -- no parallel shortcut list to maintain.

**Test:** `Menu_Gestures_Are_Registered_As_Window_KeyBindings` walks the built menu and asserts every displayed gesture has a matching window `KeyBinding` wired to the same command instance. Red before the fix (failed on Ctrl+O for File > Open), green after.

## Fix 2: Documentation hover tooltip unreadable in dark mode (#3994)

**Symptom:** Hovering a symbol in the decompiled view with the dark theme active shows light-gray/blue text on a near-white box (see issue screenshot). Light mode looks fine.

**Root cause:** The hover popup is not an Avalonia `ToolTip` (those are already themed via the `ToolTip` style in `App.axaml`) -- it is a custom rich `Popup` whose content chrome was hardcoded in `DocumentationRenderer.CreateView`: background `#FCFCFC`, border `#AAAAAA`. The signature text inside it is coloured by the active *highlighting* theme, so in dark mode the light-on-dark syntax colours land on a light box. The hyperlink colour in rendered XML docs was hardcoded too (`#0066CC`), which would be equally unreadable on a dark popup.

**Fix:**

- New theme-variant brushes in `App.axaml`: `ILSpy.DocTooltipBackground` / `ILSpy.DocTooltipBorder` / `ILSpy.DocLinkForeground`. The Light dictionary keeps the exact previous values (`#FCFCFC` / `#AAAAAA` / `#0066CC`), so light mode is pixel-identical. The Dark dictionary uses `#252526` / `#3F3F46` (matching the themed tooltip surface, slightly lighter than the `#1E1E1E` editor canvas so the popup reads as raised) and a brightened link blue `#6FA8DC`.
- These are deliberately separate from the existing `ILSpy.Tooltip*` brushes: the plain tooltip uses the classic yellow `#FFFFE1` fill, which is wrong for a popup showing syntax-coloured code.
- `DocumentationRenderer.CreateView` now binds the popup chrome via `GetResourceObservable` (the same pattern `DecompilerTextEditor` uses for the editor background), and the link colour moved into a `TextBlock.doc-link` style -- both follow live theme switches.

**Tests:** `DocumentationRendererThemeTests.Popup_Chrome_Follows_The_Active_Theme_Variant` pins the dark chrome under `ThemeVariant.Dark` and pins light mode to the unchanged near-white values; the existing `SeeCref` link test gained an assertion that doc links use the themed foreground. Both red before the fix, green after.

Full `ILSpy.Tests` suite green on Windows with both fixes in place: 1176 tests, 0 failed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
