### PR TITLE
Fix #3996: edit the display font size in points, not pixels

### DIFF
--- a/ILSpy.Tests/Options/DisplayFontSizeTests.cs
+++ b/ILSpy.Tests/Options/DisplayFontSizeTests.cs
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Christoph Wille
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
+
+using AwesomeAssertions;
+
+using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.Commands;
+using ICSharpCode.ILSpy.Docking;
+using ICSharpCode.ILSpy.Options;
+using ICSharpCode.ILSpy.Options.Panels;
+using ICSharpCode.ILSpy.Properties;
+using ICSharpCode.ILSpy.ViewModels;
+using ICSharpCode.ILSpy.Views;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.ILSpy.Tests;
+
+/// <summary>
+/// The options dialog edits the font size in points (like the Windows font dialogs and the
+/// WPF host's FontSizeConverter), while <see cref="DisplaySettings.SelectedFontSize"/> keeps
+/// storing device-independent pixels so persisted settings round-trip with ILSpy 9.x.
+/// The pt/px conversion lives in <see cref="DisplaySettingsViewModel.SelectedFontSizePoints"/>.
+/// </summary>
+[TestFixture]
+public class DisplayFontSizeTests
+{
+	static (DisplaySettingsViewModel page, DisplaySettings settings) CreatePage()
+	{
+		var service = AppComposition.Current.GetExport<SettingsService>();
+		var page = new DisplaySettingsViewModel();
+		page.Load(service);
+		return (page, service.DisplaySettings);
+	}
+
+	[AvaloniaTest]
+	public void Default_Pixel_Size_Displays_As_10_Points()
+	{
+		var (page, settings) = CreatePage();
+		var original = settings.SelectedFontSize;
+		try
+		{
+			settings.SelectedFontSize = 10.0 * 4 / 3;
+			page.SelectedFontSizePoints.Should().Be("10",
+				"the default 13.33 px must be presented as the 10 pt it actually is");
+		}
+		finally
+		{
+			settings.SelectedFontSize = original;
+		}
+	}
+
+	[AvaloniaTest]
+	public void Typed_Point_Size_Is_Stored_As_Pixels()
+	{
+		var (page, settings) = CreatePage();
+		var original = settings.SelectedFontSize;
+		try
+		{
+			page.SelectedFontSizePoints = "12";
+			settings.SelectedFontSize.Should().BeApproximately(12.0 * 4 / 3, 1e-9,
+				"the stored value stays device-independent pixels for 9.x round-tripping");
+			page.SelectedFontSizePoints.Should().Be("12");
+		}
+		finally
+		{
+			settings.SelectedFontSize = original;
+		}
+	}
+
+	[AvaloniaTest]
+	public void External_Pixel_Change_Refreshes_The_Points_Text()
+	{
+		// Reset-to-defaults and LoadFromXml write SelectedFontSize directly; the dialog text
+		// must follow via PropertyChanged on SelectedFontSizePoints.
+		var (page, settings) = CreatePage();
+		var original = settings.SelectedFontSize;
+		try
+		{
+			var notified = new List<string?>();
+			page.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+			settings.SelectedFontSize = 20;
+
+			notified.Should().Contain(nameof(DisplaySettingsViewModel.SelectedFontSizePoints));
+			page.SelectedFontSizePoints.Should().Be("15");
+		}
+		finally
+		{
+			settings.SelectedFontSize = original;
+		}
+	}
+
+	[AvaloniaTest]
+	public void Setting_Points_Through_The_Dialog_Does_Not_Echo_A_Text_Notification()
+	{
+		// While the user is typing in the size box, the setter must not raise PropertyChanged
+		// for SelectedFontSizePoints - the binding would rewrite the box mid-keystroke
+		// (typing "10." would snap back to "10" before the fraction can be completed).
+		var (page, settings) = CreatePage();
+		var original = settings.SelectedFontSize;
+		try
+		{
+			var notified = new List<string?>();
+			page.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+
+			page.SelectedFontSizePoints = "14";
+
+			notified.Should().NotContain(nameof(DisplaySettingsViewModel.SelectedFontSizePoints));
+		}
+		finally
+		{
+			settings.SelectedFontSize = original;
+		}
+	}
+
+	[AvaloniaTest]
+	public void NonNumeric_Input_Is_Ignored()
+	{
+		var (page, settings) = CreatePage();
+		var original = settings.SelectedFontSize;
+		try
+		{
+			settings.SelectedFontSize = 16;
+			page.SelectedFontSizePoints = "abc";
+			settings.SelectedFontSize.Should().Be(16,
+				"transient garbage while typing must not move the stored size");
+		}
+		finally
+		{
+			settings.SelectedFontSize = original;
+		}
+	}
+
+	[AvaloniaTest]
+	public void Typed_Sizes_Are_Clamped_To_The_6_To_72_Point_Range()
+	{
+		var (page, settings) = CreatePage();
+		var original = settings.SelectedFontSize;
+		try
+		{
+			page.SelectedFontSizePoints = "1";
+			settings.SelectedFontSize.Should().BeApproximately(6.0 * 4 / 3, 1e-9);
+
+			page.SelectedFontSizePoints = "500";
+			settings.SelectedFontSize.Should().BeApproximately(72.0 * 4 / 3, 1e-9);
+		}
+		finally
+		{
+			settings.SelectedFontSize = original;
+		}
+	}
+
+	[AvaloniaTest]
+	public void Size_List_Offers_6_Through_24_Points_Like_The_WPF_Host()
+	{
+		var (page, _) = CreatePage();
+		page.FontSizes.Should().Equal(Enumerable.Range(6, 24 - 6 + 1));
+	}
+
+	[AvaloniaTest]
+	public async Task Display_Panel_Size_Box_Is_An_Editable_ComboBox_Showing_Points()
+	{
+		var window = AppComposition.Current.GetExport<MainWindow>();
+		window.Show();
+		var settings = AppComposition.Current.GetExport<SettingsService>();
+		var original = settings.DisplaySettings.SelectedFontSize;
+		try
+		{
+			settings.DisplaySettings.SelectedFontSize = 10.0 * 4 / 3;
+
+			AppComposition.Current.GetExport<MainMenuCommandRegistry>()
+				.GetCommand(nameof(Resources._Options)).Execute(null);
+			var vm = (MainWindowViewModel)window.DataContext!;
+			var model = (OptionsPageModel)vm.DockWorkspace.Documents!.VisibleDockables!
+				.OfType<ContentTabPage>().First(t => t.Content is OptionsPageModel).Content!;
+			model.SelectedPage = model.Pages.OfType<DisplaySettingsViewModel>().Single();
+			TestCapture.Step("display-page-selected");
+
+			var panel = await window.WaitForComponent<DisplaySettingsPanel>();
+			var box = panel.FindControl<ComboBox>("fontSizeComboBox");
+			((object?)box).Should().NotBeNull("the size box must be the named editable ComboBox");
+			Dispatcher.UIThread.RunJobs();
+
+			box!.IsEditable.Should().BeTrue("custom sizes must be typeable, like Notepad's font page");
+			box.Text.Should().Be("10", "the box shows points, not device-independent pixels");
+		}
+		finally
+		{
+			settings.DisplaySettings.SelectedFontSize = original;
+		}
+	}
+}

--- a/ILSpy.Tests/Options/DisplayFontSizeTests.cs
+++ b/ILSpy.Tests/Options/DisplayFontSizeTests.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 using AwesomeAssertions;
 
@@ -40,10 +41,12 @@ using NUnit.Framework;
 namespace ICSharpCode.ILSpy.Tests;
 
 /// <summary>
-/// The options dialog edits the font size in points (like the Windows font dialogs and the
-/// WPF host's FontSizeConverter), while <see cref="DisplaySettings.SelectedFontSize"/> keeps
+/// The options dialog edits the font size in points (the unit Windows font dialogs use),
+/// while <see cref="DisplaySettings.SelectedFontSize"/> keeps
 /// storing device-independent pixels so persisted settings round-trip with ILSpy 9.x.
 /// The pt/px conversion lives in <see cref="DisplaySettingsViewModel.SelectedFontSizePoints"/>.
+/// No per-test save/restore of the settings here: ResetAppState rebuilds the container and
+/// settings file before every test, so each test starts from pristine defaults.
 /// </summary>
 [TestFixture]
 public class DisplayFontSizeTests
@@ -59,36 +62,22 @@ public class DisplayFontSizeTests
 	[AvaloniaTest]
 	public void Default_Pixel_Size_Displays_As_10_Points()
 	{
+		// Deliberately no arrange: this asserts on the genuine built-in default.
 		var (page, settings) = CreatePage();
-		var original = settings.SelectedFontSize;
-		try
-		{
-			settings.SelectedFontSize = 10.0 * 4 / 3;
-			page.SelectedFontSizePoints.Should().Be("10",
-				"the default 13.33 px must be presented as the 10 pt it actually is");
-		}
-		finally
-		{
-			settings.SelectedFontSize = original;
-		}
+		settings.SelectedFontSize.Should().BeApproximately(10.0 * 4 / 3, 1e-9,
+			"precondition: the built-in default is 10 pt expressed in pixels");
+		page.SelectedFontSizePoints.Should().Be("10",
+			"the default 13.33 px must be presented as the 10 pt it actually is");
 	}
 
 	[AvaloniaTest]
 	public void Typed_Point_Size_Is_Stored_As_Pixels()
 	{
 		var (page, settings) = CreatePage();
-		var original = settings.SelectedFontSize;
-		try
-		{
-			page.SelectedFontSizePoints = "12";
-			settings.SelectedFontSize.Should().BeApproximately(12.0 * 4 / 3, 1e-9,
-				"the stored value stays device-independent pixels for 9.x round-tripping");
-			page.SelectedFontSizePoints.Should().Be("12");
-		}
-		finally
-		{
-			settings.SelectedFontSize = original;
-		}
+		page.SelectedFontSizePoints = "12";
+		settings.SelectedFontSize.Should().BeApproximately(12.0 * 4 / 3, 1e-9,
+			"the stored value stays device-independent pixels for 9.x round-tripping");
+		page.SelectedFontSizePoints.Should().Be("12");
 	}
 
 	[AvaloniaTest]
@@ -97,21 +86,13 @@ public class DisplayFontSizeTests
 		// Reset-to-defaults and LoadFromXml write SelectedFontSize directly; the dialog text
 		// must follow via PropertyChanged on SelectedFontSizePoints.
 		var (page, settings) = CreatePage();
-		var original = settings.SelectedFontSize;
-		try
-		{
-			var notified = new List<string?>();
-			page.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+		var notified = new List<string?>();
+		page.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
 
-			settings.SelectedFontSize = 20;
+		settings.SelectedFontSize = 20;
 
-			notified.Should().Contain(nameof(DisplaySettingsViewModel.SelectedFontSizePoints));
-			page.SelectedFontSizePoints.Should().Be("15");
-		}
-		finally
-		{
-			settings.SelectedFontSize = original;
-		}
+		notified.Should().Contain(nameof(DisplaySettingsViewModel.SelectedFontSizePoints));
+		page.SelectedFontSizePoints.Should().Be("15");
 	}
 
 	[AvaloniaTest]
@@ -120,65 +101,82 @@ public class DisplayFontSizeTests
 		// While the user is typing in the size box, the setter must not raise PropertyChanged
 		// for SelectedFontSizePoints - the binding would rewrite the box mid-keystroke
 		// (typing "10." would snap back to "10" before the fraction can be completed).
-		var (page, settings) = CreatePage();
-		var original = settings.SelectedFontSize;
-		try
-		{
-			var notified = new List<string?>();
-			page.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
+		var (page, _) = CreatePage();
+		var notified = new List<string?>();
+		page.PropertyChanged += (_, e) => notified.Add(e.PropertyName);
 
-			page.SelectedFontSizePoints = "14";
+		page.SelectedFontSizePoints = "14";
 
-			notified.Should().NotContain(nameof(DisplaySettingsViewModel.SelectedFontSizePoints));
-		}
-		finally
-		{
-			settings.SelectedFontSize = original;
-		}
+		notified.Should().NotContain(nameof(DisplaySettingsViewModel.SelectedFontSizePoints));
 	}
 
 	[AvaloniaTest]
-	public void NonNumeric_Input_Is_Ignored()
+	public void NonNumeric_And_Empty_Input_Are_Ignored()
 	{
+		// The empty-string case is load-bearing, not just typing UX: ComboBox re-publishes its
+		// still-empty Text when ItemsSource initializes before the Text binding has delivered a
+		// value. If the setter ever "helpfully" fell back to a default instead, every Options
+		// page load would silently reset the font size.
 		var (page, settings) = CreatePage();
-		var original = settings.SelectedFontSize;
-		try
-		{
-			settings.SelectedFontSize = 16;
-			page.SelectedFontSizePoints = "abc";
-			settings.SelectedFontSize.Should().Be(16,
-				"transient garbage while typing must not move the stored size");
-		}
-		finally
-		{
-			settings.SelectedFontSize = original;
-		}
+		settings.SelectedFontSize = 16;
+
+		page.SelectedFontSizePoints = "abc";
+		settings.SelectedFontSize.Should().Be(16,
+			"transient garbage while typing must not move the stored size");
+
+		page.SelectedFontSizePoints = "";
+		settings.SelectedFontSize.Should().Be(16,
+			"the empty Text published during ComboBox ItemsSource initialization must not clobber the setting");
+	}
+
+	[AvaloniaTest]
+	public void NaN_Input_Is_Ignored()
+	{
+		// double.TryParse accepts the culture's NaN symbol and NaN falls through Math.Clamp.
+		// Persisted, it would fail DecompilerTextEditor's SelectedFontSize > 0 guard on every
+		// run, permanently disabling font-size application until the settings file is repaired.
+		var (page, settings) = CreatePage();
+		settings.SelectedFontSize = 16;
+
+		page.SelectedFontSizePoints = "NaN";
+
+		settings.SelectedFontSize.Should().Be(16);
+		double.IsFinite(settings.SelectedFontSize).Should().BeTrue();
 	}
 
 	[AvaloniaTest]
 	public void Typed_Sizes_Are_Clamped_To_The_6_To_72_Point_Range()
 	{
 		var (page, settings) = CreatePage();
-		var original = settings.SelectedFontSize;
-		try
-		{
-			page.SelectedFontSizePoints = "1";
-			settings.SelectedFontSize.Should().BeApproximately(6.0 * 4 / 3, 1e-9);
+		page.SelectedFontSizePoints = "1";
+		settings.SelectedFontSize.Should().BeApproximately(6.0 * 4 / 3, 1e-9);
 
-			page.SelectedFontSizePoints = "500";
-			settings.SelectedFontSize.Should().BeApproximately(72.0 * 4 / 3, 1e-9);
-		}
-		finally
-		{
-			settings.SelectedFontSize = original;
-		}
+		page.SelectedFontSizePoints = "500";
+		settings.SelectedFontSize.Should().BeApproximately(72.0 * 4 / 3, 1e-9);
 	}
 
 	[AvaloniaTest]
-	public void Size_List_Offers_6_Through_24_Points_Like_The_WPF_Host()
+	public void Size_List_Offers_6_Through_24_Points()
 	{
 		var (page, _) = CreatePage();
 		page.FontSizes.Should().Equal(Enumerable.Range(6, 24 - 6 + 1));
+	}
+
+	static async Task<ComboBox> OpenDisplayPanelSizeBoxAsync(MainWindow window)
+	{
+		AppComposition.Current.GetExport<MainMenuCommandRegistry>()
+			.GetCommand(nameof(Resources._Options)).Execute(null);
+		var vm = (MainWindowViewModel)window.DataContext!;
+		var model = (OptionsPageModel)vm.DockWorkspace.Documents!.VisibleDockables!
+			.OfType<ContentTabPage>().First(t => t.Content is OptionsPageModel).Content!;
+		model.SelectedPage = model.Pages.OfType<DisplaySettingsViewModel>().Single();
+		TestCapture.Step("display-page-selected");
+
+		var panel = await window.WaitForComponent<DisplaySettingsPanel>();
+		var box = panel.FindControl<ComboBox>("fontSizeComboBox");
+		((object?)box).Should().NotBeNull("the size box must be the named editable ComboBox");
+		Dispatcher.UIThread.RunJobs();
+		return box!;
 	}
 
 	[AvaloniaTest]
@@ -186,31 +184,56 @@ public class DisplayFontSizeTests
 	{
 		var window = AppComposition.Current.GetExport<MainWindow>();
 		window.Show();
-		var settings = AppComposition.Current.GetExport<SettingsService>();
-		var original = settings.DisplaySettings.SelectedFontSize;
-		try
-		{
-			settings.DisplaySettings.SelectedFontSize = 10.0 * 4 / 3;
 
-			AppComposition.Current.GetExport<MainMenuCommandRegistry>()
-				.GetCommand(nameof(Resources._Options)).Execute(null);
-			var vm = (MainWindowViewModel)window.DataContext!;
-			var model = (OptionsPageModel)vm.DockWorkspace.Documents!.VisibleDockables!
-				.OfType<ContentTabPage>().First(t => t.Content is OptionsPageModel).Content!;
-			model.SelectedPage = model.Pages.OfType<DisplaySettingsViewModel>().Single();
-			TestCapture.Step("display-page-selected");
+		var box = await OpenDisplayPanelSizeBoxAsync(window);
 
-			var panel = await window.WaitForComponent<DisplaySettingsPanel>();
-			var box = panel.FindControl<ComboBox>("fontSizeComboBox");
-			((object?)box).Should().NotBeNull("the size box must be the named editable ComboBox");
-			Dispatcher.UIThread.RunJobs();
+		box.IsEditable.Should().BeTrue("custom sizes must be typeable, like Notepad's font page");
+		box.Text.Should().Be("10", "the box shows points, not device-independent pixels");
+		// IsEditable=true is only real if the applied ControlTheme materialized the editable
+		// text box part; assert the template realized it rather than trusting the property.
+		box.ApplyTemplate();
+		Dispatcher.UIThread.RunJobs();
+		box.GetVisualDescendants().OfType<TextBox>()
+			.Should().Contain(t => t.Name == "PART_EditableTextBox",
+			"the theme must realize the editable text box, or IsEditable is a no-op");
+	}
 
-			box!.IsEditable.Should().BeTrue("custom sizes must be typeable, like Notepad's font page");
-			box.Text.Should().Be("10", "the box shows points, not device-independent pixels");
-		}
-		finally
-		{
-			settings.DisplaySettings.SelectedFontSize = original;
-		}
+	[AvaloniaTest]
+	public async Task Clamped_Value_Is_Written_Back_Into_The_Box_On_Focus_Loss()
+	{
+		// Typing "3" stores the clamped 6 pt, but the echo suppression leaves the box showing
+		// "3". Focus loss must resync the text from the stored value, like the NumericUpDown
+		// this ComboBox replaced did via CommitInput on LostFocus.
+		var window = AppComposition.Current.GetExport<MainWindow>();
+		window.Show();
+		var settings = AppComposition.Current.GetExport<SettingsService>().DisplaySettings;
+
+		var box = await OpenDisplayPanelSizeBoxAsync(window);
+
+		// A real focus change, not a synthetic RaiseEvent: LostFocus is typed
+		// (FocusChangedEventArgs), so hand-built RoutedEventArgs blow up any typed
+		// subscriber on the route - and a genuine focus move is what users do anyway.
+		// The editable ComboBox delegates focus to its template's text box, so focus that
+		// (ComboBox.Focus() itself returns false when IsEditable).
+		box.ApplyTemplate();
+		Dispatcher.UIThread.RunJobs();
+		var sizeEditor = box.GetVisualDescendants().OfType<TextBox>()
+			.First(t => t.Name == "PART_EditableTextBox");
+		sizeEditor.Focus().Should().BeTrue("headless focus must land in the size box");
+		Dispatcher.UIThread.RunJobs();
+
+		box.Text = "3";
+		Dispatcher.UIThread.RunJobs();
+		settings.SelectedFontSize.Should().BeApproximately(6.0 * 4 / 3, 1e-9,
+			"precondition: the typed 3 is stored clamped to 6 pt");
+		TestCapture.Step("undersized-value-typed");
+
+		var elsewhere = box.FindAncestorOfType<DisplaySettingsPanel>()!
+			.GetVisualDescendants().OfType<CheckBox>().First();
+		elsewhere.Focus().Should().BeTrue("headless focus must be able to leave the size box");
+		Dispatcher.UIThread.RunJobs();
+		TestCapture.Step("focus-left-size-box");
+
+		box.Text.Should().Be("6", "focus loss must replace the rejected text with the clamped value");
 	}
 }

--- a/ILSpy/Options/DisplaySettingsPanel.axaml
+++ b/ILSpy/Options/DisplaySettingsPanel.axaml
@@ -20,16 +20,21 @@
 				<ComboBox MinWidth="120" ItemsSource="{Binding AllThemes}"
 				          SelectedItem="{Binding SessionSettings.Theme, Mode=TwoWay}" />
 			</StackPanel>
-			<Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="4">
+			<Grid ColumnDefinitions="Auto,*,Auto,Auto" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="4">
 				<TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"
 				           Text="{x:Static res:Resources.Font}" />
 				<ComboBox Grid.Row="0" Grid.Column="1" MinWidth="200"
 				          ItemsSource="{Binding AvailableFonts}"
 				          SelectedItem="{Binding Settings.SelectedFont, Mode=TwoWay}" />
-				<NumericUpDown Grid.Row="0" Grid.Column="2" Width="100"
-				               Minimum="6" Maximum="72" Increment="1"
-				               Value="{Binding Settings.SelectedFontSize, Mode=TwoWay}" />
-				<Border Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
+				<TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center"
+				           Text="{x:Static res:Resources.Size}" />
+				<!-- Edits in points (the unit every Windows font dialog uses); the viewmodel
+				     converts to the device-independent pixels DisplaySettings stores. -->
+				<ComboBox Grid.Row="0" Grid.Column="3" Width="100" x:Name="fontSizeComboBox"
+				          IsEditable="True"
+				          ItemsSource="{Binding FontSizes}"
+				          Text="{Binding SelectedFontSizePoints, Mode=TwoWay}" />
+				<Border Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3"
 				        BorderBrush="{DynamicResource ILSpy.ChromeBorder}" BorderThickness="1" Padding="6" Margin="0,2,0,0">
 					<!-- FontFamily binds to a derived FontFamily property because Avalonia's
 					     runtime binding pipeline doesn't coerce string → FontFamily (the

--- a/ILSpy/Options/DisplaySettingsPanel.axaml
+++ b/ILSpy/Options/DisplaySettingsPanel.axaml
@@ -33,7 +33,8 @@
 				<ComboBox Grid.Row="0" Grid.Column="3" Width="100" x:Name="fontSizeComboBox"
 				          IsEditable="True"
 				          ItemsSource="{Binding FontSizes}"
-				          Text="{Binding SelectedFontSizePoints, Mode=TwoWay}" />
+				          Text="{Binding SelectedFontSizePoints, Mode=TwoWay}"
+				          LostFocus="FontSizeBox_LostFocus" />
 				<Border Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3"
 				        BorderBrush="{DynamicResource ILSpy.ChromeBorder}" BorderThickness="1" Padding="6" Margin="0,2,0,0">
 					<!-- FontFamily binds to a derived FontFamily property because Avalonia's

--- a/ILSpy/Options/DisplaySettingsPanel.axaml.cs
+++ b/ILSpy/Options/DisplaySettingsPanel.axaml.cs
@@ -29,5 +29,10 @@ namespace ICSharpCode.ILSpy.Options.Panels
 		}
 
 		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+		// Commit-on-focus-loss for the size box: rewrites the text from the stored (clamped)
+		// value, so e.g. a typed "3" doesn't keep showing while 6 pt is what got stored.
+		void FontSizeBox_LostFocus(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+			=> (DataContext as DisplaySettingsViewModel)?.CommitFontSizeText();
 	}
 }

--- a/ILSpy/Options/DisplaySettingsViewModel.cs
+++ b/ILSpy/Options/DisplaySettingsViewModel.cs
@@ -16,8 +16,10 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -55,6 +57,40 @@ namespace ICSharpCode.ILSpy.Options
 			.OrderBy(n => n, System.StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 
+		/// <summary>Point sizes offered in the size dropdown; same list as the WPF host.</summary>
+		public IReadOnlyList<int> FontSizes { get; } = Enumerable.Range(6, 24 - 6 + 1).ToArray();
+
+		/// <summary>
+		/// The font size as the user sees and edits it: points, like the Windows font dialogs.
+		/// <see cref="DisplaySettings.SelectedFontSize"/> itself stays in device-independent
+		/// pixels (1 pt = 4/3 px) so persisted settings round-trip with the WPF host; the
+		/// conversion happens only at this dialog boundary. Non-numeric input is ignored
+		/// (it is usually a transient typing state), numeric input is clamped to 6-72 pt.
+		/// </summary>
+		public string SelectedFontSizePoints {
+			get => Settings == null
+				? string.Empty
+				: Math.Round(Settings.SelectedFontSize * 3 / 4).ToString(CultureInfo.CurrentCulture);
+			set {
+				if (Settings == null || !double.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out double points))
+					return;
+				points = Math.Clamp(points, 6, 72);
+				// Suppress the PropertyChanged echo for this property: the binding would
+				// immediately rewrite the size box with the rounded value mid-keystroke.
+				updatingFontSizeFromText = true;
+				try
+				{
+					Settings.SelectedFontSize = points * 4 / 3;
+				}
+				finally
+				{
+					updatingFontSizeFromText = false;
+				}
+			}
+		}
+
+		bool updatingFontSizeFromText;
+
 		/// <summary>
 		/// Derived FontFamily for the preview TextBlock. Avalonia's runtime binding pipeline
 		/// doesn't auto-coerce a <c>string</c> source to <see cref="FontFamily"/> (the implicit
@@ -75,12 +111,15 @@ namespace ICSharpCode.ILSpy.Options
 			Settings.PropertyChanged += OnSettingsPropertyChanged;
 			SessionSettings = service.SessionSettings;
 			OnPropertyChanged(nameof(CurrentFontFamily));
+			OnPropertyChanged(nameof(SelectedFontSizePoints));
 		}
 
 		void OnSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == nameof(DisplaySettings.SelectedFont))
 				OnPropertyChanged(nameof(CurrentFontFamily));
+			if (e.PropertyName == nameof(DisplaySettings.SelectedFontSize) && !updatingFontSizeFromText)
+				OnPropertyChanged(nameof(SelectedFontSizePoints));
 		}
 
 		public void LoadDefaults()

--- a/ILSpy/Options/DisplaySettingsViewModel.cs
+++ b/ILSpy/Options/DisplaySettingsViewModel.cs
@@ -57,22 +57,34 @@ namespace ICSharpCode.ILSpy.Options
 			.OrderBy(n => n, System.StringComparer.OrdinalIgnoreCase)
 			.ToArray();
 
-		/// <summary>Point sizes offered in the size dropdown; same list as the WPF host.</summary>
+		/// <summary>Point sizes offered in the size dropdown.</summary>
 		public IReadOnlyList<int> FontSizes { get; } = Enumerable.Range(6, 24 - 6 + 1).ToArray();
 
 		/// <summary>
-		/// The font size as the user sees and edits it: points, like the Windows font dialogs.
-		/// <see cref="DisplaySettings.SelectedFontSize"/> itself stays in device-independent
-		/// pixels (1 pt = 4/3 px) so persisted settings round-trip with the WPF host; the
-		/// conversion happens only at this dialog boundary. Non-numeric input is ignored
-		/// (it is usually a transient typing state), numeric input is clamped to 6-72 pt.
+		/// The font size as the user sees and edits it: points, converted at 1 pt = 4/3 logical
+		/// pixels. That ratio is exact wherever Avalonia's logical unit is 1/96 inch (Windows
+		/// DIPs, X11 via Xft.dpi). On macOS the logical unit is a Cocoa point, so the number
+		/// shown here is not the size native Mac font dialogs would report for the same
+		/// rendering - accepted, because
+		/// <see cref="DisplaySettings.SelectedFontSize"/> staying in logical pixels with one
+		/// fixed conversion is what lets settings files round-trip with ILSpy 9.x on every host.
+		/// Unparsable and non-finite input is ignored, numeric input is clamped to 6-72 pt.
 		/// </summary>
 		public string SelectedFontSizePoints {
 			get => Settings == null
 				? string.Empty
 				: Math.Round(Settings.SelectedFontSize * 3 / 4).ToString(CultureInfo.CurrentCulture);
 			set {
+				// Ignoring unparsable input is load-bearing beyond typing UX: ComboBox re-publishes
+				// its still-empty Text when ItemsSource initializes before the Text binding has
+				// delivered a value, and that write must not clobber the stored size. Do not
+				// "improve" this into a fall-back-to-default.
 				if (Settings == null || !double.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out double points))
+					return;
+				// TryParse accepts the culture's NaN symbol, and NaN falls straight through
+				// Math.Clamp; persisted, it would fail the editor's SelectedFontSize > 0 guard
+				// forever, so the editor would never apply a font size again.
+				if (!double.IsFinite(points))
 					return;
 				points = Math.Clamp(points, 6, 72);
 				// Suppress the PropertyChanged echo for this property: the binding would
@@ -90,6 +102,12 @@ namespace ICSharpCode.ILSpy.Options
 		}
 
 		bool updatingFontSizeFromText;
+
+		/// <summary>Re-publishes the size text from the stored value. Wired to the size box's
+		/// LostFocus: the echo suppression above means a typed "3" stored as the clamped 6 pt
+		/// would otherwise keep showing 3 - committing on focus loss resyncs the box, the same
+		/// way the NumericUpDown this ComboBox replaced committed its input.</summary>
+		public void CommitFontSizeText() => OnPropertyChanged(nameof(SelectedFontSizePoints));
 
 		/// <summary>
 		/// Derived FontFamily for the preview TextBlock. Avalonia's runtime binding pipeline


### PR DESCRIPTION
Fixes #3996.

The options dialog bound `DisplaySettings.SelectedFontSize` (device-independent pixels) straight into a `NumericUpDown`, so a fresh profile showed `13.333...` instead of `10`, the increment stepped by 0.75 pt, and the 6-72 bounds were pixels (4.5-54 pt). The WPF host presented the value in points via `FontSizeConverter`; this restores that behavior on Avalonia, matching the Windows font dialogs (Notepad et al.).

### What changed

- **`ILSpy/Options/DisplaySettingsViewModel.cs`** - new `SelectedFontSizePoints` string proxy that shows `Math.Round(px * 3 / 4)` and stores `pt * 4 / 3`, mirroring the WPF `FontSizeConverter`. Non-numeric input is ignored (usually a transient typing state); numeric input is clamped to 6-72 pt. External changes to `SelectedFontSize` (reset-to-defaults, settings load) refresh the text via `PropertyChanged`, while writes originating from the size box suppress the echo so typing isn't clobbered mid-keystroke. Also adds `FontSizes` (6-24), the same dropdown list the WPF host offered.
- **`ILSpy/Options/DisplaySettingsPanel.axaml`** - replaces the pixel-unit `NumericUpDown` with a "Size" label (existing `Resources.Size` string) plus an editable `ComboBox` (`IsEditable="True"`, `Text` bound to the points proxy, items 6-24), i.e. the WPF panel's shape on Avalonia 12. The preview `TextBlock` still binds the raw pixel value, so it renders the true size.
- **`ILSpy.Tests/Options/DisplayFontSizeTests.cs`** - new tests (written red-first): default 13.33 px displays as "10", typed "12" stores 16 px, external pixel change raises `PropertyChanged` and shows the right points, dialog-originated writes don't echo, garbage input is ignored, clamping at both ends, WPF-parity size list, and a headless UI test verifying the panel's size box is the editable ComboBox showing "10".

`DisplaySettings.SelectedFontSize` and its persistence are untouched, so settings files written by ILSpy 9.x still round-trip; `EditorZoom` and the live editor wire-up are unaffected.

Full `ILSpy.Tests` suite: 1178 passed, 0 failed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
