### PR TITLE
Fix #3729: recognize value-type ctor call on unresolved declaring type

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -202,6 +202,9 @@
     <None Include="TestCases\ILPretty\TruncatedAccessorBody.cs" />
     <Compile Remove="TestCases\ILPretty\SealedRecordProtectedCopyCtor.cs" />
     <None Include="TestCases\ILPretty\SealedRecordProtectedCopyCtor.cs" />
+    <Compile Remove="TestCases\ILPretty\Issue3729.cs" />
+    <None Include="TestCases\ILPretty\Issue3729.cs" />
+    <None Include="TestCases\ILPretty\Issue3729.il" />
     <Compile Remove="TestCases\ILPretty\FSharpLoops_Debug.cs" />
     <None Include="TestCases\ILPretty\FSharpLoops_Debug.cs" />
     <Compile Remove="TestCases\ILPretty\FSharpLoops_Release.cs" />

--- a/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/ILPrettyTestRunner.cs
@@ -405,6 +405,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await Run(settings: new DecompilerSettings { SortSwitchSections = true, FileScopedNamespaces = false });
 		}
 
+		[Test]
+		public async Task Issue3729()
+		{
+			await Run();
+		}
+
 		async Task Run([CallerMemberName] string testName = null, DecompilerSettings settings = null,
 			AssemblerOptions assemblerOptions = AssemblerOptions.Library)
 		{

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3729.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3729.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Runtime.CompilerServices;
+using Library1;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
+{
+	public class Issue3729
+	{
+		private MyStruct structField;
+
+		public void TestSingleArgCtor()
+		{
+			//IL_0003: Unknown result type (might be due to invalid IL or missing references)
+			Console.WriteLine("Test new struct: " + ((object)new MyStruct(4)/*cast due to constrained. prefix*/).ToString());
+		}
+
+		public void TestParameterlessCtor()
+		{
+			//IL_0002: Unknown result type (might be due to invalid IL or missing references)
+			//IL_0007: Unknown result type (might be due to invalid IL or missing references)
+			MyEmptyStruct val = new MyEmptyStruct();
+			Console.WriteLine(val);
+		}
+
+		public void TestMultiArgCtor()
+		{
+			//IL_0011: Unknown result type (might be due to invalid IL or missing references)
+			//IL_0016: Unknown result type (might be due to invalid IL or missing references)
+			MyBigStruct val = new MyBigStruct(1, "hello", 3.14);
+			Console.WriteLine(val);
+		}
+
+		public void TestFieldCtor()
+		{
+			//IL_0007: Unknown result type (might be due to invalid IL or missing references)
+			ref MyStruct reference = ref structField;
+			reference = new MyStruct(5);
+		}
+
+		public unsafe static void TestPointerCtor(void* ptr)
+		{
+			//IL_0002: Unknown result type (might be due to invalid IL or missing references)
+			System.Runtime.CompilerServices.Unsafe.Write(ptr, new MyStruct(6));
+		}
+
+		public void TestArrayElemCtor()
+		{
+			//IL_000f: Unknown result type (might be due to invalid IL or missing references)
+			MyStruct[] array = (MyStruct[])(object)new MyStruct[1] {
+				new MyStruct(7)
+			};
+		}
+
+		public void TestGenericStructCtor()
+		{
+			//IL_0003: Unknown result type (might be due to invalid IL or missing references)
+			//IL_0008: Unknown result type (might be due to invalid IL or missing references)
+			MyGenericStruct<int> val = new MyGenericStruct<int>(4);
+			Console.WriteLine(val);
+		}
+
+		public void TestRefTypeNewobj()
+		{
+			//IL_0000: Unknown result type (might be due to invalid IL or missing references)
+			//IL_0006: Expected O, but got Unknown
+			MyClass value = new MyClass();
+			Console.WriteLine(value);
+		}
+	}
+	public class Issue3729_DerivedFromUnknown : MissingBase
+	{
+	}
+	public class Issue3729_DerivedFromUnknownWithArgs : MissingBase
+	{
+		public Issue3729_DerivedFromUnknownWithArgs()
+			: base(42)
+		{
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3729.il
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3729.il
@@ -1,0 +1,228 @@
+// Reproducer for issue #3729:
+// Decompilation of a struct constructor call where the struct's defining
+// assembly (Library1) cannot be resolved at decompile time.
+// Mirrors what csc emits for `new Library1.MyStruct(4)` followed by
+// string concat with the struct value.
+
+.assembly extern Library1
+{
+}
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly Issue3729
+{
+  .ver 1:0:0:0
+}
+.module Issue3729.dll
+
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.ILPretty.Issue3729
+    extends [System.Runtime]System.Object
+{
+    .field private valuetype [Library1]Library1.MyStruct structField
+
+    // single-int-arg struct ctor with subsequent constrained.callvirt ToString()
+    .method public hidebysig
+        instance void TestSingleArgCtor () cil managed
+    {
+        .maxstack 2
+        .locals init (
+            [0] valuetype [Library1]Library1.MyStruct
+        )
+
+        IL_0000: ldloca.s 0
+        IL_0002: ldc.i4.4
+        IL_0003: call instance void [Library1]Library1.MyStruct::.ctor(int32)
+        IL_0008: ldstr "Test new struct: "
+        IL_000d: ldloca.s 0
+        IL_000f: constrained. [Library1]Library1.MyStruct
+        IL_0015: callvirt instance string [System.Runtime]System.Object::ToString()
+        IL_001a: call string [System.Runtime]System.String::Concat(string, string)
+        IL_001f: call void [System.Console]System.Console::WriteLine(string)
+        IL_0024: ret
+    }
+
+    // explicit parameterless struct ctor (C# 10+ feature in source)
+    // Single-argument ctor: the receiver sits directly below the argument.
+    .method public hidebysig
+        instance void TestParameterlessCtor () cil managed
+    {
+        .maxstack 1
+        .locals init (
+            [0] valuetype [Library1]Library1.MyEmptyStruct
+        )
+
+        IL_0000: ldloca.s 0
+        IL_0002: call instance void [Library1]Library1.MyEmptyStruct::.ctor()
+        IL_0007: ldloc.0
+        IL_0008: box [Library1]Library1.MyEmptyStruct
+        IL_000d: call void [System.Console]System.Console::WriteLine(object)
+        IL_0012: ret
+    }
+
+    // Multi-argument ctor with mixed parameter types: the receiver sits below three arguments
+    .method public hidebysig
+        instance void TestMultiArgCtor () cil managed
+    {
+        .maxstack 5
+        .locals init (
+            [0] valuetype [Library1]Library1.MyBigStruct
+        )
+
+        IL_0000: ldloca.s 0
+        IL_0002: ldc.i4.1
+        IL_0003: ldstr "hello"
+        IL_0008: ldc.r8 3.14
+        IL_0011: call instance void [Library1]Library1.MyBigStruct::.ctor(int32, string, float64)
+        IL_0016: ldloc.0
+        IL_0017: box [Library1]Library1.MyBigStruct
+        IL_001c: call void [System.Console]System.Console::WriteLine(object)
+        IL_0021: ret
+    }
+
+    // struct field init via `ldflda + call .ctor`. Receiver is the field
+    // address (StackType.Ref) - same shape as `ldloca`, just sourced from
+    // an instance field instead of a local.
+    .method public hidebysig
+        instance void TestFieldCtor () cil managed
+    {
+        .maxstack 2
+
+        IL_0000: ldarg.0
+        IL_0001: ldflda valuetype [Library1]Library1.MyStruct ICSharpCode.Decompiler.Tests.TestCases.ILPretty.Issue3729::structField
+        IL_0006: ldc.i4.5
+        IL_0007: call instance void [Library1]Library1.MyStruct::.ctor(int32)
+        IL_000c: ret
+    }
+
+    // Unsafe code passes the target as a pointer, so the receiver is a native
+    // pointer (StackType.I) rather than a managed reference.
+    .method public hidebysig static
+        void TestPointerCtor (
+            void* ptr
+        ) cil managed
+    {
+        .maxstack 2
+
+        IL_0000: ldarg.0
+        IL_0001: ldc.i4.6
+        IL_0002: call instance void [Library1]Library1.MyStruct::.ctor(int32)
+        IL_0007: ret
+    }
+
+    // struct array element init via `ldelema + call .ctor`. Receiver is the
+    // element address (StackType.Ref) - again the same shape.
+    .method public hidebysig
+        instance void TestArrayElemCtor () cil managed
+    {
+        .maxstack 4
+        .locals init (
+            [0] valuetype [Library1]Library1.MyStruct[]
+        )
+
+        IL_0000: ldc.i4.1
+        IL_0001: newarr [Library1]Library1.MyStruct
+        IL_0006: stloc.0
+        IL_0007: ldloc.0
+        IL_0008: ldc.i4.0
+        IL_0009: ldelema [Library1]Library1.MyStruct
+        IL_000e: ldc.i4.7
+        IL_000f: call instance void [Library1]Library1.MyStruct::.ctor(int32)
+        IL_0014: ret
+    }
+
+    // generic struct instantiation `new MyGenericStruct<int>(4)`. Declaring
+    // type at the call site is a ParameterizedType wrapping the unresolved
+    // generic def - its Kind delegates to the underlying UnknownType.Kind,
+    // so a constructed generic type is unresolved in the same way.
+    .method public hidebysig
+        instance void TestGenericStructCtor () cil managed
+    {
+        .maxstack 2
+        .locals init (
+            [0] valuetype [Library1]Library1.MyGenericStruct`1<int32>
+        )
+
+        IL_0000: ldloca.s 0
+        IL_0002: ldc.i4.4
+        IL_0003: call instance void valuetype [Library1]Library1.MyGenericStruct`1<int32>::.ctor(!0)
+        IL_0008: ldloc.0
+        IL_0009: box valuetype [Library1]Library1.MyGenericStruct`1<int32>
+        IL_000e: call void [System.Console]System.Console::WriteLine(object)
+        IL_0013: ret
+    }
+
+    // newobj on an unresolved reference type - uses OpCode.NewObj, a different
+    // IL path that already produces correct C# (HandleConstructorCall in CallBuilder).
+    // Included as a control case for the value-type ctor handling above.
+    .method public hidebysig
+        instance void TestRefTypeNewobj () cil managed
+    {
+        .maxstack 1
+        .locals init (
+            [0] class [Library1]Library1.MyClass
+        )
+
+        IL_0000: newobj instance void [Library1]Library1.MyClass::.ctor()
+        IL_0005: stloc.0
+        IL_0006: ldloc.0
+        IL_0007: call void [System.Console]System.Console::WriteLine(object)
+        IL_000c: ret
+    }
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+        IL_0006: ret
+    }
+}
+
+// Classes deriving from an unresolved base class. The synthesized .ctor
+// calls `[Library1]Library1.MissingBase::.ctor(...)` with `this`
+// (StackType.O) as the receiver - exercises the StackType.Ref guard on
+// a reference-typed receiver, which has to keep falling through to the
+// default call path so the C# decompiler can render it as a normal
+// `: base(...)` constructor initializer.
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.ILPretty.Issue3729_DerivedFromUnknown
+    extends [Library1]Library1.MissingBase
+{
+    // parameterless base ctor - the implicit ctor would normally be elided.
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .maxstack 8
+
+        IL_0000: ldarg.0
+        IL_0001: call instance void [Library1]Library1.MissingBase::.ctor()
+        IL_0006: ret
+    }
+}
+
+// Same as above but the base ctor takes an argument - receiver is at
+// depth 1 (one parameter on the stack above it). Output should render
+// the explicit `: base(<arg>)` initializer.
+.class public auto ansi beforefieldinit ICSharpCode.Decompiler.Tests.TestCases.ILPretty.Issue3729_DerivedFromUnknownWithArgs
+    extends [Library1]Library1.MissingBase
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .maxstack 2
+
+        IL_0000: ldarg.0
+        IL_0001: ldc.i4.s 42
+        IL_0003: call instance void [Library1]Library1.MissingBase::.ctor(int32)
+        IL_0008: ret
+    }
+}

--- a/ICSharpCode.Decompiler/IL/ILReader.cs
+++ b/ICSharpCode.Decompiler/IL/ILReader.cs
@@ -1276,14 +1276,24 @@ namespace ICSharpCode.Decompiler.IL
 			}
 		}
 
-		StackType PeekStackType()
+		StackType PeekStackType() => PeekStackTypeAtDepth(0);
+
+		StackType PeekStackTypeAtDepth(int depth)
 		{
-			if (expressionStack.Count > 0)
-				return expressionStack.Last().ResultType;
-			if (currentStack.IsEmpty)
+			// depth 0 = top of stack, depth N = N-th item below the top.
+			if (depth < expressionStack.Count)
+				return expressionStack[expressionStack.Count - 1 - depth].ResultType;
+			int skip = depth - expressionStack.Count;
+			var stack = currentStack;
+			for (int i = 0; i < skip; i++)
+			{
+				if (stack.IsEmpty)
+					return StackType.Unknown;
+				stack = stack.Pop();
+			}
+			if (stack.IsEmpty)
 				return StackType.Unknown;
-			else
-				return currentStack.Peek().StackType;
+			return stack.Peek().StackType;
 		}
 
 		sealed class CollectStackVariablesVisitor : ILVisitor<ILInstruction>
@@ -1765,14 +1775,17 @@ namespace ICSharpCode.Decompiler.IL
 					Warn("Unknown method called on array type: " + method.Name);
 					goto default;
 				}
-				case TypeKind.Struct when method.IsConstructor && !method.IsStatic && opCode == OpCode.Call
-					&& method.ReturnType.Kind == TypeKind.Void:
+				case TypeKind.Struct when IsValueTypeCtorCall():
+				case TypeKind.Unknown when IsValueTypeCtorCall() && ReceiverLooksLikeValueTypeTarget():
 				{
 					// "call Struct.ctor(target, ...)" doesn't exist in C#,
 					// the next best equivalent is an assignment `*target = new Struct(...);`.
 					// So we represent this call as "stobj Struct(target, newobj Struct.ctor(...))".
 					// This needs to happen early (not as a transform) because the StObj.TargetSlot has
 					// restricted inlining (doesn't accept ldflda when exceptions aren't delayed).
+					// The declaring type's kind is unavailable when its assembly is missing, so the
+					// receiver decides: a constructor invoked with "call" on an address is the shape
+					// only a value type can have.
 					arguments = PrepareArguments(firstArgumentIsStObjTarget: true);
 					var newobj = new NewObj(method);
 					newobj.ILStackWasEmpty = CurrentStackIsEmpty();
@@ -1789,6 +1802,23 @@ namespace ICSharpCode.Decompiler.IL
 					if (call.ResultType != StackType.Void)
 						return Push(call);
 					return call;
+			}
+
+			// A value type's constructor is invoked with "call" on the address of the target,
+			// unlike a reference type's, which is invoked with "newobj".
+			bool IsValueTypeCtorCall()
+			{
+				return method.IsConstructor && !method.IsStatic && opCode == OpCode.Call
+					&& method.ReturnType.Kind == TypeKind.Void;
+			}
+
+			// Used when the declaring type could not be resolved, so its kind is unknown: the
+			// receiver is an address (a managed reference, or a pointer in unsafe code), and
+			// metadata that does say the type is a reference type rules the rewrite out.
+			bool ReceiverLooksLikeValueTypeTarget()
+			{
+				return PeekStackTypeAtDepth(method.Parameters.Count) is StackType.Ref or StackType.I
+					&& method.DeclaringType.IsReferenceType != true;
 			}
 
 			ILInstruction[] PrepareArguments(bool firstArgumentIsStObjTarget)


### PR DESCRIPTION
Fixes #3729.

A `call` to a value-type constructor is rewritten early in `ILReader.DecodeCall` into `stobj Struct(target, newobj Struct.ctor(...))`, because `Struct.ctor(target, ...)` has no C# equivalent. That rewrite only fired for `TypeKind.Struct`, so when the declaring type comes from an assembly that is not available, the type resolves as `TypeKind.Unknown` and the call fell through to the ordinary call path - the decompiled method then failed with a stack-type mismatch instead of producing `new MyStruct(4)`.

The declaring type's kind is unavailable in that situation, but the IL shape is not: a value-type constructor call is the only case where the receiver of a `call` to a `.ctor` is a managed reference. `TypeKind.Unknown` now takes the same branch when the receiver at stack depth `method.Parameters.Count` is a `ref`, which keeps the rewrite off unresolved *reference*-type constructors (they arrive as `newobj`, and their receiver is not a `ref` anyway).

The check needs to inspect the receiver without consuming it, since `PrepareArguments` runs afterwards, so `PeekStackTypeAtDepth` looks through the expression stack first and then walks the immutable stack behind it, reporting `StackType.Unknown` rather than throwing if the stack is shorter than expected.

New IL-pretty fixture `Issue3729` covers a single-argument ctor, a parameterless one, a multi-argument one, and a ctor called on a field target, all on structs from a missing assembly. Full ICSharpCode.Decompiler.Tests sweep: 3378 total, 0 failed, 46 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
