### PR TITLE
Print the init-only marker after the set keyword again

### DIFF
--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -254,6 +254,8 @@
     <None Include="TestCases\Ugly\NoFieldKeyword.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoForEachStatement.Expected.cs" />
     <None Include="TestCases\Ugly\NoForEachStatement.Expected.cs" />
+    <Compile Remove="TestCases\Ugly\NoInitAccessors.Expected.cs" />
+    <None Include="TestCases\Ugly\NoInitAccessors.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoLocalFunctions.Expected.cs" />
     <None Include="TestCases\Ugly\NoLocalFunctions.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoNewOfT.Expected.cs" />

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoInitAccessors.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoInitAccessors.Expected.cs
@@ -1,0 +1,18 @@
+namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
+{
+	internal class NoInitAccessors
+	{
+		private string name;
+
+		public int AutoInit { get; set/*init*/; }
+
+		public string Name {
+			get {
+				return name;
+			}
+			set/*init*/ {
+				name = value;
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoInitAccessors.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoInitAccessors.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
+{
+	internal class NoInitAccessors
+	{
+		private string name;
+
+		public int AutoInit { get; init; }
+
+		public string Name {
+			get {
+				return name;
+			}
+			init {
+				name = value;
+			}
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
@@ -76,6 +76,15 @@ namespace ICSharpCode.Decompiler.Tests
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		});
 
+		// init accessors require C# 9 and the IsExternalInit marker, which .NET Framework 4.0 lacks
+		static readonly CompilerOptions[] initAccessorOptions = Tester.SupportedOnCurrentPlatform(new[]
+		{
+			CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.UseRoslynLatest,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
+		});
+
 		// top-level statements require C# 9 and cannot target .NET Framework 4.0
 		static readonly CompilerOptions[] topLevelProgramOptions = Tester.SupportedOnCurrentPlatform(new[]
 		{
@@ -125,6 +134,12 @@ namespace ICSharpCode.Decompiler.Tests
 			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings {
 				FieldKeyword = false
 			});
+		}
+
+		[Test]
+		public async Task NoInitAccessors([ValueSource(nameof(initAccessorOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings(CSharp.LanguageVersion.CSharp8_0));
 		}
 
 		[Test]

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -2295,6 +2295,12 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				else
 				{
 					WriteKeyword("set");
+					if (accessor.IsInitOnly)
+					{
+						// The setter is init-only, but the output language version has no init accessor:
+						// mark the keyword, so that the difference is not lost silently.
+						writer.WriteComment(CommentType.MultiLine, "init");
+					}
 				}
 				style = policy.PropertySetBraceStyle;
 			}

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeMembers/Accessor.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeMembers/Accessor.cs
@@ -52,6 +52,16 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		public AccessorKind Kind { get; set; }
 
+		/// <summary>
+		/// True if the underlying setter is init-only. When <see cref="Kind"/> is not
+		/// <see cref="AccessorKind.Init"/>, because the output language version has no init accessors,
+		/// the accessor prints as "set" followed by an /*init*/ comment marking the difference.
+		/// Excluded from pattern matching: a pattern written for a setter has to match an init-only
+		/// setter just the same.
+		/// </summary>
+		[ExcludeFromMatch]
+		public bool IsInitOnly { get; set; }
+
 		// An accessor is printed as its keyword (get/set/init/add/remove), never an identifier, so it
 		// carries no name. The contract members are overridden to no-ops: shared decompiler code sets a
 		// name on every method-like entity (e.g. explicit interface implementations), which is irrelevant

--- a/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/TypeSystemAstBuilder.cs
@@ -228,7 +228,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 
 		/// <summary>
 		/// Controls whether C# 9 "init;" accessors are supported.
-		/// If disabled, emits "set /*init*/;" instead.
+		/// If disabled, emits "set/*init*/;" instead.
 		/// </summary>
 		public bool SupportInitAccessors { get; set; }
 
@@ -2234,10 +2234,7 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 				accessorKind = AccessorKind.Init;
 			}
 			decl.Kind = accessorKind;
-			if (accessor.IsInitOnly && accessorKind != AccessorKind.Init)
-			{
-				decl.AddTrailingTrivia(new Comment("init", CommentType.MultiLine));
-			}
+			decl.IsInitOnly = accessor.IsInitOnly;
 			if (AddResolveResultAnnotations)
 			{
 				decl.AddAnnotation(new MemberResolveResult(null, accessor));


### PR DESCRIPTION
When init accessors are unavailable (e.g. `-lv CSharp8_0`, or the setting turned off), an
init-only setter decompiles as `set` plus an `/*init*/` marker. The marker used to sit right
after the keyword; since the slot AST migration it lands after the accessor body:

```
// 10.1                                     // master
public int Auto { get; set/*init*/; }       public int Auto { get; set; /*init*/}
set/*init*/                                 set
{                                           {
    backing = value;                            backing = value;
}                                           }
                                            /*init*/}
```

Comments used to be child nodes that `InsertSpecialsDecorator` flushed when the next node
started printing; as trailing trivia they are printed in `EndNode`. Moving the marker to the
body's leading trivia would not work either - the auto-property transform drops the body and
would take the marker with it - so the accessor itself carries the init-only fact now and the
printer writes the marker next to the keyword. The flag is `[ExcludeFromMatch]`, because a
pattern written for a setter has to keep matching init-only setters.

Verified against `ilspycmd` built from `release/10.1`: identical output again. Covered by a new
`Ugly` fixture that decompiles with C# 8 settings (red before, green after); the rest of
`ICSharpCode.Decompiler.Tests` stays green (3333 passed, roundtrip excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)