### PR TITLE
Decompile natural types for lambdas and method groups

### DIFF
--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -165,6 +165,14 @@ namespace ICSharpCode.Decompiler.Tests
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		}, executesCompiledOutput: true);
 
+		static readonly CompilerOptions[] roslyn4OrNewerOptions = Tester.SupportedOnCurrentPlatform(new[]
+		{
+			CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.UseRoslynLatest,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
+		}, executesCompiledOutput: true);
+
 		[Test]
 		public async Task Comparisons([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
@@ -285,6 +293,12 @@ namespace ICSharpCode.Decompiler.Tests
 
 		[Test]
 		public async Task OverloadResolution([ValueSource(nameof(defaultOptions))] CompilerOptions options)
+		{
+			await RunCS(options: options);
+		}
+
+		[Test]
+		public async Task MethodGroupNaturalType([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions options)
 		{
 			await RunCS(options: options);
 		}

--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -304,6 +304,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task LambdaNaturalType([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions options)
+		{
+			await RunCS(options: options);
+		}
+
+		[Test]
 		public async Task ExpressionTrees([ValueSource(nameof(defaultOptions))] CompilerOptions options)
 		{
 			await RunCS(options: options);

--- a/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
+++ b/ICSharpCode.Decompiler.Tests/ICSharpCode.Decompiler.Tests.csproj
@@ -259,6 +259,8 @@
     <None Include="TestCases\Ugly\NoForEachStatement.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoInitAccessors.Expected.cs" />
     <None Include="TestCases\Ugly\NoInitAccessors.Expected.cs" />
+    <Compile Remove="TestCases\Ugly\NoLambdaOptionalAndParamsParameters.Expected.cs" />
+    <None Include="TestCases\Ugly\NoLambdaOptionalAndParamsParameters.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoLocalFunctions.Expected.cs" />
     <None Include="TestCases\Ugly\NoLocalFunctions.Expected.cs" />
     <Compile Remove="TestCases\Ugly\NoNewOfT.Expected.cs" />

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -819,6 +819,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task LambdaNaturalTypeConversions([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task MethodGroupNaturalTypeImprovementsDisabled([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.MethodGroupNaturalTypeImprovements = false);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -819,6 +819,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task MethodGroupNaturalTypeImprovementsDisabled([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.MethodGroupNaturalTypeImprovements = false);
+		}
+
+		[Test]
 		public async Task ExpandParamsArgumentsDisabled([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.ExpandParamsArguments = false);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -813,6 +813,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task MethodGroupNaturalType([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task ExpandParamsArgumentsDisabled([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.ExpandParamsArguments = false);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -795,6 +795,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task LambdaOptionalAndParamsParameters([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task RefStructInterfaces([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -801,6 +801,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task LambdaReturnTypes([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task ExpandParamsArgumentsDisabled([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.ExpandParamsArguments = false);

--- a/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/PrettyTestRunner.cs
@@ -825,6 +825,12 @@ namespace ICSharpCode.Decompiler.Tests
 		}
 
 		[Test]
+		public async Task MethodGroupSynthesizedDelegates([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions);
+		}
+
+		[Test]
 		public async Task ExpandParamsArgumentsDisabled([ValueSource(nameof(defaultOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, configureDecompiler: settings => settings.ExpandParamsArguments = false);

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/LambdaNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/LambdaNaturalType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq.Expressions;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 {
@@ -76,6 +77,14 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 
 			var paramsParameter = (params int[] xs) => xs.Length;
 			Console.WriteLine("params parameter: " + paramsParameter(1, 2, 3));
+
+			// A target type that only asks for the natural type keeps its own identity: the
+			// delegate stays a delegate, and the expression tree must not decay into one.
+			Delegate asDelegate = (int x) => x + 8;
+			Console.WriteLine("as delegate: " + asDelegate.Method.GetParameters().Length + " parameter(s)");
+
+			Expression asExpression = (int x) => x + 9;
+			Console.WriteLine("as expression: " + asExpression.NodeType + " " + asExpression);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/LambdaNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/LambdaNaturalType.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
+{
+	// A natural-typed lambda decides which overload a later call binds to: the variable's
+	// type is the lambda's natural type, so a lost explicit return type or a dropped
+	// parameter modifier silently rebinds the call instead of failing to compile. The
+	// interesting part is the second compilation pass: the decompiled output must produce
+	// the same natural types, and therefore reach the same overloads.
+	internal class LambdaNaturalType
+	{
+		private static void Consume(Func<int, int> f)
+		{
+			Console.WriteLine("Func<int, int>: " + f(1));
+		}
+
+		private static void Consume(Func<int, long> f)
+		{
+			Console.WriteLine("Func<int, long>: " + f(2));
+		}
+
+		private static void Consume(Action<int> a)
+		{
+			Console.Write("Action<int>: ");
+			a(3);
+		}
+
+		private static void Consume(Delegate d)
+		{
+			// The natural type of a lambda with a ref parameter is a synthesized delegate,
+			// which no Func/Action overload accepts. Its name is compiler-generated, so
+			// only its shape may be printed.
+			Console.WriteLine("Delegate: " + d.Method.GetParameters().Length + " parameter(s)");
+		}
+
+		private static void Generic<T>(T value)
+		{
+			Console.WriteLine("Generic<" + typeof(T) + ">");
+		}
+
+		private static int SideEffect(int x)
+		{
+			Console.WriteLine("SideEffect(" + x + ")");
+			return x;
+		}
+
+		private static void Main()
+		{
+			var inferred = (int x) => x + 1;
+			Consume(inferred);
+			Generic(inferred);
+
+			var widened = long (int x) => x + 2;
+			Consume(widened);
+			Generic(widened);
+
+			var discardedResult = void (int x) => SideEffect(x);
+			Consume(discardedResult);
+
+			var refParameter = (ref int x) => ++x;
+			Consume(refParameter);
+			int arg = 10;
+			refParameter(ref arg);
+			Console.WriteLine("ref parameter: " + arg);
+
+			var refReadonlyResult = ref readonly int (ref int x) => ref x;
+			int slot = 20;
+			Console.WriteLine("ref readonly result: " + refReadonlyResult(ref slot));
+			// 'ref readonly' lives in the synthesized delegate's signature as a modreq, not in
+			// anything the invocation can observe, so read it back off the delegate type.
+			Console.WriteLine("ref readonly modreqs: "
+				+ refReadonlyResult.GetType().GetMethod("Invoke").ReturnParameter.GetRequiredCustomModifiers().Length);
+
+			var optionalParameter = (int x = 5) => x * 2;
+			Console.WriteLine("optional parameter: " + optionalParameter() + " " + optionalParameter(7));
+
+#if CS140
+			// Roslyn 4.14 emits no ParamArrayAttribute on a lambda's method, so 'params' cannot
+			// be recovered there and the decompiled call would no longer bind in expanded form.
+			var paramsParameter = (params int[] xs) => xs.Length;
+			Console.WriteLine("params parameter: " + paramsParameter(1, 2, 3));
+#endif
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/LambdaNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/LambdaNaturalType.cs
@@ -74,12 +74,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
 			var optionalParameter = (int x = 5) => x * 2;
 			Console.WriteLine("optional parameter: " + optionalParameter() + " " + optionalParameter(7));
 
-#if CS140
-			// Roslyn 4.14 emits no ParamArrayAttribute on a lambda's method, so 'params' cannot
-			// be recovered there and the decompiled call would no longer bind in expanded form.
 			var paramsParameter = (params int[] xs) => xs.Length;
 			Console.WriteLine("params parameter: " + paramsParameter(1, 2, 3));
-#endif
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Correctness/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Correctness/MethodGroupNaturalType.cs
@@ -1,0 +1,103 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Correctness
+{
+	// Exercises the C# 13 "method group natural type improvements": candidates are
+	// pruned scope-by-scope (instance before extension scopes), and candidates with
+	// mismatched generic arity, violated constraints or a static/instance mismatch
+	// are pruned early. The interesting part is the second compilation pass: the
+	// decompiled output must re-bind every method group to the same target method.
+	internal class MethodGroupNaturalType
+	{
+		public class Receiver
+		{
+			public void Basic()
+			{
+				Console.WriteLine("instance Basic()");
+			}
+
+			public void ByArity<T>()
+			{
+				Console.WriteLine("instance ByArity<T>()");
+			}
+
+			public void ByArity(int i)
+			{
+				Console.WriteLine("instance ByArity(int)");
+			}
+
+			public void ByConstraint<T>(T t) where T : class
+			{
+				Console.WriteLine("instance ByConstraint<T>(T) where T : class");
+			}
+		}
+
+		public class MixedStaticInstance
+		{
+			public void Mixed()
+			{
+				Console.WriteLine("instance Mixed()");
+			}
+
+			public static void Mixed(int i)
+			{
+				Console.WriteLine("static Mixed(int)");
+			}
+		}
+
+		private static int Square(int x)
+		{
+			return x * x;
+		}
+
+		private static void Main()
+		{
+			var instanceBeforeExtension = new Receiver().Basic;
+			instanceBeforeExtension();
+
+			var pruneByArity = new Receiver().ByArity<object>;
+			pruneByArity();
+
+			var pruneByConstraint = new Receiver().ByConstraint<int>;
+			pruneByConstraint(1);
+
+			var extensionOnly = new Receiver().ExtensionOnly;
+			extensionOnly(2);
+
+			var pruneStatic = new MixedStaticInstance().Mixed;
+			pruneStatic();
+
+			var pruneInstance = MixedStaticInstance.Mixed;
+			pruneInstance(3);
+
+			Delegate viaDelegate = Square;
+			Console.WriteLine(((Func<int, int>)viaDelegate)(4));
+
+#pragma warning disable CS8974 // Converting method group to non-delegate type
+			object viaObject = Square;
+#pragma warning restore CS8974
+			Console.WriteLine(((Func<int, int>)viaObject)(5));
+
+			var invokeInferred = Square;
+			Console.WriteLine(invokeInferred(6));
+		}
+	}
+
+	internal static class MethodGroupNaturalTypeExtensions
+	{
+		public static void Basic(this MethodGroupNaturalType.Receiver r, int i)
+		{
+			Console.WriteLine("extension Basic(int)");
+		}
+
+		public static void ByConstraint<T>(this MethodGroupNaturalType.Receiver r, T t)
+		{
+			Console.WriteLine("extension ByConstraint<T>(T)");
+		}
+
+		public static void ExtensionOnly(this MethodGroupNaturalType.Receiver r, int i)
+		{
+			Console.WriteLine("extension ExtensionOnly(int)");
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/AnonymousMethodEdgeCases.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/AnonymousMethodEdgeCases.cs
@@ -14,9 +14,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 
 		public Action<object> UsedParameterWithInvalidName()
 		{
-			return (object value) => {
-				Console.WriteLine(value);
-			};
+			return (object value) => Console.WriteLine(value);
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -129,9 +129,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 					{
 						amount = 0;
 					}
-					DoAction(() => {
-						NoOp(amount);
-					});
+					DoAction(() => NoOp(amount));
 				});
 			}
 
@@ -143,19 +141,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 					{
 						amount = 0;
 					}
-					DoAction(() => {
-						NoOp(amount);
-					});
+					DoAction(() => NoOp(amount));
 				});
 			}
 
 			public void Bug951c(SomeData data)
 			{
-				DoAction(() => {
-					DoAction(() => {
-						DoSomething(data.Value);
-					});
-				});
+				DoAction(() => DoAction(() => DoSomething(data.Value)));
 			}
 
 			public Func<int, int> Issue2143()
@@ -371,9 +363,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 
 		public static Action StaticAnonymousMethodNoClosure()
 		{
-			return () => {
-				Console.WriteLine();
-			};
+			return () => Console.WriteLine();
 		}
 
 		public static void NameConflict()
@@ -404,9 +394,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 			List<Action<int>> list = new List<Action<int>>();
 			for (int i = 0; i < 10; i++)
 			{
-				list.Add((int k) => {
-					Console.WriteLine(k);
-				});
+				list.Add((int k) => Console.WriteLine(k));
 			}
 		}
 
@@ -585,15 +573,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 
 		public static Action<int> StatementLambdaWithAttribute1()
 		{
-			return [return: My] (int x) => {
-				Console.WriteLine(x);
-			};
+			return [return: My] (int x) => Console.WriteLine(x);
 		}
 		public static Action<int> StatementLambdaWithAttribute2()
 		{
-			return ([My] int x) => {
-				Console.WriteLine(x);
-			};
+			return ([My] int x) => Console.WriteLine(x);
 		}
 
 		public static int LambdaWithAttributeOnAnonymousTypeParameter()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DelegateConstruction.cs
@@ -595,6 +595,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.DelegateConstruction
 				Console.WriteLine(x);
 			};
 		}
+
+		public static int LambdaWithAttributeOnAnonymousTypeParameter()
+		{
+			return new[] {
+				new {
+					X = 1
+				}
+			}.Select([My] (a) => a.X).Sum();
+		}
 #endif
 
 		public static void CallRecursiveDelegate(ref RefRecursiveDelegate d)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/ExpressionTrees.cs
@@ -818,17 +818,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Test<Func<int, string>>((int a) => a.ToString(), (int a) => a.ToString());
 			Test<Func<string, char[]>>((string a) => a.ToArray(), (string a) => a.ToArray());
 			Test<Func<bool>>(() => 'a'.CompareTo('b') < 0, () => 'a'.CompareTo('b') < 0);
-			Test<Action<object, bool>>((object lockObj, bool lockTaken) => {
-				Monitor.Enter(lockObj, ref lockTaken);
-			}, (object lockObj, bool lockTaken) => Monitor.Enter(lockObj, ref lockTaken));
+			Test<Action<object, bool>>((object lockObj, bool lockTaken) => Monitor.Enter(lockObj, ref lockTaken), (object lockObj, bool lockTaken) => Monitor.Enter(lockObj, ref lockTaken));
 			Test<Func<string, int, bool>>((string str, int num) => int.TryParse(str, out num), (string str, int num) => int.TryParse(str, out num));
 			Test<Func<string, SimpleType, bool>>((string str, SimpleType t) => int.TryParse(str, out t.Field), (string str, SimpleType t) => int.TryParse(str, out t.Field));
-			Test<Action<object>>((object o) => {
-				TestCall(o);
-			}, (object o) => TestCall(o));
-			Test<Action<object>>((object o) => {
-				TestCall(ref o);
-			}, (object o) => TestCall(ref o));
+			Test<Action<object>>((object o) => TestCall(o), (object o) => TestCall(o));
+			Test<Action<object>>((object o) => TestCall(ref o), (object o) => TestCall(ref o));
 		}
 
 		public static void Quote()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/FixProxyCalls.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/FixProxyCalls.cs
@@ -96,9 +96,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 
 		protected internal override void Test(string test)
 		{
-			action = (string a) => {
-				base.Test(a);
-			};
+			action = (string a) => base.Test(a);
 			if (test.Equals(1))
 			{
 				throw new Exception("roslyn optimizes is inlining the assignment which lets the test fail");
@@ -119,9 +117,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 	{
 		public Action<object> M(object state)
 		{
-			return (object x) => {
-				base.BaseCall(x, state, () => (object)null);
-			};
+			return (object x) => base.BaseCall(x, state, () => (object)null);
 		}
 	}
 
@@ -136,9 +132,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 	{
 		protected internal override void Test(int a)
 		{
-			Action action = () => {
-				base.Test(a);
-			};
+			Action action = () => base.Test(a);
 			if (a.Equals(1))
 			{
 				throw new Exception("roslyn optimize is inlining the assignment which lets the test fail");

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/InitializerTests.cs
@@ -917,12 +917,10 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.InitializerTests
 		{
 			Data data = new Data();
 #if NET50
-			data.TestEvent += (object? obj, EventArgs e) => {
+			data.TestEvent += (object? obj, EventArgs e) => Console.WriteLine();
 #else
-			data.TestEvent += (object obj, EventArgs e) => {
+			data.TestEvent += (object obj, EventArgs e) => Console.WriteLine();
 #endif
-				Console.WriteLine();
-			};
 			X(Y(), data);
 		}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3439.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Issue3439.cs
@@ -28,9 +28,7 @@ internal class VariableScopeTest
 		{
 			int preservedName = num;
 			num++;
-			AddAction(item2, (object x) => {
-				SetValue(x, preservedName);
-			});
+			AddAction(item2, (object x) => SetValue(x, preservedName));
 		}
 	}
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaNaturalTypeConversions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaNaturalTypeConversions.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	// A lambda with a natural type needs no cast where the target type only asks for that
+	// natural type: System.Delegate and the other base types and interfaces of
+	// MulticastDelegate, or Expression and LambdaExpression for an expression tree. Under /o
+	// the local's declared type is erased, so the natural type is written out instead.
+	internal class LambdaNaturalTypeConversions
+	{
+		public Delegate ToDelegate()
+		{
+#if OPT
+			Func<int, int> func = (int x) => x + 1;
+			Console.WriteLine(func);
+			return func;
+#else
+			Delegate obj = (int x) => x + 1;
+			Console.WriteLine(obj);
+			return obj;
+#endif
+		}
+
+		public MulticastDelegate ToMulticastDelegate()
+		{
+#if OPT
+			Func<int, int> func = (int x) => x + 2;
+			Console.WriteLine(func);
+			return func;
+#else
+			MulticastDelegate multicastDelegate = (int x) => x + 2;
+			Console.WriteLine(multicastDelegate);
+			return multicastDelegate;
+#endif
+		}
+
+		public ISerializable ToDelegateInterface()
+		{
+#if OPT
+			Func<int, int> func = (int x) => x + 3;
+			Console.WriteLine(func);
+			return func;
+#else
+			ISerializable serializable = (int x) => x + 3;
+			Console.WriteLine(serializable);
+			return serializable;
+#endif
+		}
+
+		public object ToObject()
+		{
+#if OPT
+			Func<int, int> func = (int x) => x + 4;
+			Console.WriteLine(func);
+			return func;
+#else
+			object obj = (int x) => x + 4;
+			Console.WriteLine(obj);
+			return obj;
+#endif
+		}
+
+		public Expression ToExpression()
+		{
+#if OPT
+			Expression<Func<int, int>> expression = (int x) => x + 5;
+#else
+			Expression expression = (int x) => x + 5;
+#endif
+			Console.WriteLine(expression);
+			return expression;
+		}
+
+		public LambdaExpression ToLambdaExpression()
+		{
+#if OPT
+			Expression<Func<int, int>> expression = (int x) => x + 6;
+			Console.WriteLine(expression);
+			return expression;
+#else
+			LambdaExpression lambdaExpression = (int x) => x + 6;
+			Console.WriteLine(lambdaExpression);
+			return lambdaExpression;
+#endif
+		}
+
+		public Expression<Func<int, int>> ToExpressionOfDelegate()
+		{
+			// The tree's own type is written out: 'var' here would infer the delegate that the
+			// Expression<> wraps, not the tree.
+			Expression<Func<int, int>> expression = (int x) => x + 7;
+			Console.WriteLine(expression);
+			return expression;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
@@ -10,9 +10,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		private int total;
 
+		// Roslyn 4.14 puts no ParamArrayAttribute on the lambda's own method, so for a named
+		// delegate type the 'params' cannot be recovered there; newer compilers record it.
 		public ParamsAction ParamsStatementBody()
 		{
+#if ROSLYN5 || !EXPECTED_OUTPUT
 			return (params int[] xs) => {
+#else
+			return (int[] xs) => {
+#endif
 				total += xs.Length;
 				Console.WriteLine(xs.Length);
 			};
@@ -20,7 +26,11 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public ParamsAction ParamsExpressionBody()
 		{
+#if ROSLYN5 || !EXPECTED_OUTPUT
 			return (params int[] xs) => Console.WriteLine(xs.Length);
+#else
+			return (int[] xs) => Console.WriteLine(xs.Length);
+#endif
 		}
 
 		public OptionalFunc OptionalStatementBody()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
@@ -34,11 +34,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public ParamsAction ParamsExpressionBody()
 		{
-#if CS140
-			return (params int[] xs) => {
-				Console.WriteLine(xs.Length);
-			};
-#elif EXPECTED_OUTPUT
+#if EXPECTED_OUTPUT && !CS140
 			return delegate (int[] xs) {
 				Console.WriteLine(xs.Length);
 			};

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class LambdaOptionalAndParamsParameters
+	{
+		public delegate void ParamsAction(params int[] xs);
+
+		public delegate int OptionalFunc(int x = 5);
+
+		private int total;
+
+		public ParamsAction ParamsStatementBody()
+		{
+#if CS140
+			return (params int[] xs) => {
+				total += xs.Length;
+				Console.WriteLine(xs.Length);
+			};
+#elif EXPECTED_OUTPUT
+			// Roslyn 4.14 does not emit ParamArrayAttribute on the lambda's method, so the
+			// 'params' modifier cannot be recovered from metadata.
+			return delegate (int[] xs) {
+				total += xs.Length;
+				Console.WriteLine(xs.Length);
+			};
+#else
+			return (params int[] xs) => {
+				total += xs.Length;
+				Console.WriteLine(xs.Length);
+			};
+#endif
+		}
+
+		public ParamsAction ParamsExpressionBody()
+		{
+#if CS140
+			return (params int[] xs) => {
+				Console.WriteLine(xs.Length);
+			};
+#elif EXPECTED_OUTPUT
+			return delegate (int[] xs) {
+				Console.WriteLine(xs.Length);
+			};
+#else
+			return (params int[] xs) => Console.WriteLine(xs.Length);
+#endif
+		}
+
+		public OptionalFunc OptionalStatementBody()
+		{
+			return (int x = 5) => {
+				total += x;
+				return x * 2;
+			};
+		}
+
+		public OptionalFunc OptionalExpressionBody()
+		{
+			return (int x = 5) => x * 2;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaOptionalAndParamsParameters.cs
@@ -12,35 +12,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 
 		public ParamsAction ParamsStatementBody()
 		{
-#if CS140
 			return (params int[] xs) => {
 				total += xs.Length;
 				Console.WriteLine(xs.Length);
 			};
-#elif EXPECTED_OUTPUT
-			// Roslyn 4.14 does not emit ParamArrayAttribute on the lambda's method, so the
-			// 'params' modifier cannot be recovered from metadata.
-			return delegate (int[] xs) {
-				total += xs.Length;
-				Console.WriteLine(xs.Length);
-			};
-#else
-			return (params int[] xs) => {
-				total += xs.Length;
-				Console.WriteLine(xs.Length);
-			};
-#endif
 		}
 
 		public ParamsAction ParamsExpressionBody()
 		{
-#if EXPECTED_OUTPUT && !CS140
-			return delegate (int[] xs) {
-				Console.WriteLine(xs.Length);
-			};
-#else
 			return (params int[] xs) => Console.WriteLine(xs.Length);
-#endif
 		}
 
 		public OptionalFunc OptionalStatementBody()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaReturnTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaReturnTypes.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class LambdaReturnTypes
+	{
+		public object WideningReturnType()
+		{
+			var result = object (ref int x) => "boxed";
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public int InferredReturnTypeOmitted()
+		{
+			var anon = (ref int x) => x + 1;
+			Console.WriteLine("no inlining");
+			int arg = 21;
+			return anon(ref arg);
+		}
+
+		public int VoidReturnType()
+		{
+			var anon = void (ref int x) => ++x;
+			Console.WriteLine("no inlining");
+			int arg = 3;
+			anon(ref arg);
+			return arg;
+		}
+
+		public int RefReturn()
+		{
+			var anon = (ref int x) => ref x;
+			Console.WriteLine("no inlining");
+			int arg = 1;
+			anon(ref arg) = 5;
+			return arg;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaReturnTypes.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LambdaReturnTypes.cs
@@ -36,5 +36,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			anon(ref arg) = 5;
 			return arg;
 		}
+
+		public int RefReadonlyReturn()
+		{
+			var anon = ref readonly int (ref int x) => ref x;
+			Console.WriteLine("no inlining");
+			int arg = 7;
+			return anon(ref arg);
+		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -507,7 +507,11 @@ namespace LocalFunctions
 
 		private void LocalFunctionHidingMethod()
 		{
+#if CS100
+			var action = this.Name;
+#else
 			Action action = this.Name;
+#endif
 			Name();
 			action();
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
@@ -1,0 +1,109 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	internal class MethodGroupNaturalType
+	{
+		private static void RefAction(ref int x)
+		{
+		}
+
+		private static int RefFunc(ref int x)
+		{
+			return x;
+		}
+
+		private static ref int RefReturn(int[] xs)
+		{
+			return ref xs[0];
+		}
+
+		private static T GenericRef<T>(ref T value)
+		{
+			return value;
+		}
+
+		private static void ParamsMethod(params int[] xs)
+		{
+		}
+
+		private static int DefaultValueMethod(ref int x, int y = 42)
+		{
+			return x + y;
+		}
+
+		private int InstanceRef(ref int x)
+		{
+			return x;
+		}
+
+		public object VoidDelegateFamily()
+		{
+			var result = RefAction;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public int ValueDelegateFamily()
+		{
+			var anon = RefFunc;
+			Console.WriteLine("no inlining");
+			int arg = 21;
+			return anon(ref arg);
+		}
+
+		public int RefReturnDelegateFamily()
+		{
+			var anon = RefReturn;
+			Console.WriteLine("no inlining");
+			int[] array = new int[1];
+			anon(array) = 5;
+			return array[0];
+		}
+
+		public object ImplicitThisReceiver()
+		{
+			var result = InstanceRef;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ExpressionReceiver()
+		{
+			var result = new MethodGroupNaturalType().InstanceRef;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ExplicitTypeArguments()
+		{
+			var result = GenericRef<string>;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ParamsParameter()
+		{
+			var result = ParamsMethod;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public int DefaultParameterValue()
+		{
+			var anon = DefaultValueMethod;
+			Console.WriteLine("no inlining");
+			int arg = 0;
+			return anon(ref arg);
+		}
+
+		public object CapturedMethodGroup()
+		{
+			var anon = RefAction;
+			Console.WriteLine("no inlining");
+			Func<string> result = () => anon.ToString();
+			Console.WriteLine("no inlining");
+			return result;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
@@ -4,6 +4,8 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 {
 	internal class MethodGroupNaturalType
 	{
+		private object anonymousDelegate;
+
 		private static void RefAction(ref int x)
 		{
 		}
@@ -129,6 +131,21 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			var result = SeventeenParametersVoid;
 			Console.WriteLine("no inlining");
 			return result;
+		}
+
+		public void AssignedToObjectField()
+		{
+			anonymousDelegate = (ref int x) => x;
+		}
+
+		public object ReturnedAsObject()
+		{
+			return (ref int x) => x;
+		}
+
+		public Delegate ReturnedAsDelegate()
+		{
+			return RefFunc;
 		}
 
 		public object CapturedMethodGroup()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
@@ -106,4 +106,130 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return result;
 		}
 	}
+
+	internal class MethodGroups
+	{
+		public static int Square(int x)
+		{
+			return x * x;
+		}
+
+		public object InstanceBeforeExtensionScope()
+		{
+			var result = new Receiver().Basic;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneByGenericArity()
+		{
+			var result = new Receiver().ByArity<object>;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneByConstraint()
+		{
+			var result = new Receiver().ByConstraint<int>;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ExtensionScopeOnly()
+		{
+			var result = new Receiver().ExtensionOnly;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneStaticOnInstanceReceiver()
+		{
+			var result = new MixedStaticInstance().Mixed;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneInstanceOnTypeReceiver()
+		{
+			var result = MixedStaticInstance.Mixed;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object NaturalTypeAssignedToDelegate()
+		{
+#if OPT
+			var result = Square;
+#else
+			Delegate result = Square;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object NaturalTypeAssignedToObject()
+		{
+#if OPT
+			var result = Square;
+#else
+#pragma warning disable CS8974 // Converting method group to non-delegate type
+			object result = Square;
+#pragma warning restore CS8974
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public int InvokeInferredMethodGroup()
+		{
+			var func = Square;
+			Console.WriteLine("no inlining");
+			return func(21);
+		}
+	}
+
+	internal class MixedStaticInstance
+	{
+		public void Mixed()
+		{
+		}
+
+		public static void Mixed(int i)
+		{
+		}
+	}
+
+	internal class Receiver
+	{
+		public void Basic()
+		{
+		}
+
+		public void ByArity<T>()
+		{
+		}
+
+		public void ByArity(int i)
+		{
+		}
+
+		public void ByConstraint<T>(T t) where T : class
+		{
+		}
+	}
+
+	internal static class ReceiverExtensions
+	{
+		public static void Basic(this Receiver r, int i)
+		{
+		}
+
+		public static void ByConstraint<T>(this Receiver r, T t)
+		{
+		}
+
+		public static void ExtensionOnly(this Receiver r, int i)
+		{
+		}
+	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
@@ -231,6 +231,28 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return result;
 		}
 
+		public object NaturalTypeAssignedToMulticastDelegate()
+		{
+#if OPT
+			var result = Square;
+#else
+			MulticastDelegate result = Square;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object NaturalTypeAssignedToDelegateInterface()
+		{
+#if OPT
+			var result = Square;
+#else
+			ICloneable result = Square;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
 		public int InvokeInferredMethodGroup()
 		{
 			var func = Square;

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalType.cs
@@ -32,6 +32,19 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			return x + y;
 		}
 
+		private static void SixteenParameters(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16)
+		{
+		}
+
+		private static int SeventeenParameters(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17)
+		{
+			return a1;
+		}
+
+		private static void SeventeenParametersVoid(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17)
+		{
+		}
+
 		private int InstanceRef(ref int x)
 		{
 			return x;
@@ -95,6 +108,27 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine("no inlining");
 			int arg = 0;
 			return anon(ref arg);
+		}
+
+		public object ArityWithinActionFamily()
+		{
+			var result = SixteenParameters;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ArityBeyondFuncFamily()
+		{
+			var result = SeventeenParameters;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ArityBeyondActionFamily()
+		{
+			var result = SeventeenParametersVoid;
+			Console.WriteLine("no inlining");
+			return result;
 		}
 
 		public object CapturedMethodGroup()

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalTypeImprovementsDisabled.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupNaturalTypeImprovementsDisabled.cs
@@ -1,0 +1,151 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty.MethodGroupNaturalTypeImprovementsDisabled
+{
+	internal class MethodGroups
+	{
+		public static int Square(int x)
+		{
+			return x * x;
+		}
+
+		public object InstanceBeforeExtensionScope()
+		{
+#if EXPECTED_OUTPUT
+			Action result = new Receiver().Basic;
+#else
+			var result = new Receiver().Basic;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneByGenericArity()
+		{
+#if EXPECTED_OUTPUT
+			Action result = new Receiver().ByArity<object>;
+#else
+			var result = new Receiver().ByArity<object>;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneByConstraint()
+		{
+#if EXPECTED_OUTPUT
+			Action<int> result = new Receiver().ByConstraint<int>;
+#else
+			var result = new Receiver().ByConstraint<int>;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object ExtensionScopeOnly()
+		{
+			// A unique extension method already provides the natural type under the C# 10 rules.
+			var result = new Receiver().ExtensionOnly;
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneStaticOnInstanceReceiver()
+		{
+#if EXPECTED_OUTPUT
+			Action result = new MixedStaticInstance().Mixed;
+#else
+			var result = new MixedStaticInstance().Mixed;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object PruneInstanceOnTypeReceiver()
+		{
+#if EXPECTED_OUTPUT
+			Action<int> result = MixedStaticInstance.Mixed;
+#else
+			var result = MixedStaticInstance.Mixed;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object NaturalTypeAssignedToDelegate()
+		{
+#if OPT
+			var result = Square;
+#else
+			Delegate result = Square;
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public object NaturalTypeAssignedToObject()
+		{
+#if OPT
+			var result = Square;
+#else
+#pragma warning disable CS8974 // Converting method group to non-delegate type
+			object result = Square;
+#pragma warning restore CS8974
+#endif
+			Console.WriteLine("no inlining");
+			return result;
+		}
+
+		public int InvokeInferredMethodGroup()
+		{
+			var func = Square;
+			Console.WriteLine("no inlining");
+			return func(21);
+		}
+	}
+
+	internal class MixedStaticInstance
+	{
+		public void Mixed()
+		{
+		}
+
+		public static void Mixed(int i)
+		{
+		}
+	}
+
+	internal class Receiver
+	{
+		public void Basic()
+		{
+		}
+
+		public void ByArity<T>()
+		{
+		}
+
+		public void ByArity(int i)
+		{
+		}
+
+		public void ByConstraint<T>(T t) where T : class
+		{
+		}
+	}
+
+	internal static class ReceiverExtensions
+	{
+		public static void Basic(this Receiver r, int i)
+		{
+		}
+
+		public static void ByConstraint<T>(this Receiver r, T t)
+		{
+		}
+
+		public static void ExtensionOnly(this Receiver r, int i)
+		{
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupSynthesizedDelegates.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/MethodGroupSynthesizedDelegates.cs
@@ -1,0 +1,87 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
+{
+	public class MethodGroupSynthesizedDelegates
+	{
+		public static void RefParameter(ref int x)
+		{
+			x++;
+		}
+
+		public static int RefParameterWithReturn(ref int x)
+		{
+			return x + 1;
+		}
+
+		public static int InParameter(in int x)
+		{
+			return x;
+		}
+
+		public static bool OutParameter(out int x)
+		{
+			x = 42;
+			return true;
+		}
+
+		public static void DefaultParameterValue(int x = 5)
+		{
+			Console.WriteLine(x);
+		}
+
+		public static void ParamsArray(params int[] xs)
+		{
+			Console.WriteLine(xs.Length);
+		}
+
+		public object UseRefParameter()
+		{
+			int arg = 0;
+			var anon = RefParameter;
+			anon(ref arg);
+			Console.WriteLine(arg);
+			return anon;
+		}
+
+		public object UseRefParameterWithReturn()
+		{
+			int arg = 1;
+			var anon = RefParameterWithReturn;
+			Console.WriteLine(anon(ref arg));
+			return anon;
+		}
+
+		public object UseInParameter()
+		{
+			int arg = 2;
+			var anon = InParameter;
+			Console.WriteLine(anon(in arg));
+			return anon;
+		}
+
+		public object UseOutParameter()
+		{
+			var anon = OutParameter;
+			if (anon(out var arg))
+			{
+				Console.WriteLine(arg);
+			}
+			return anon;
+		}
+
+		public object UseDefaultParameterValue()
+		{
+			var anon = DefaultParameterValue;
+			anon();
+			return anon;
+		}
+
+		public object UseParamsArray()
+		{
+			var anon = ParamsArray;
+			anon(1, 2, 3);
+			return anon;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/OutVariables.cs
@@ -37,9 +37,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			// to ensure that the value is initialized when the delegate is declared.
 			if (d.Count > 2 && d.TryGetValue(42, out var value))
 			{
-				return () => {
-					Console.WriteLine(value);
-				};
+				return () => Console.WriteLine(value);
 			}
 			return null;
 		}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLambdaOptionalAndParamsParameters.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLambdaOptionalAndParamsParameters.Expected.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 
 namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 {
@@ -13,7 +12,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 
 		public ParamsAction ParamsLambda()
 		{
-			return ([ParamArray] int[] xs) => {
+			return (int[] xs) => {
 				total += xs.Length;
 				Console.WriteLine(xs.Length);
 			};
@@ -21,7 +20,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
 
 		public OptionalFunc OptionalLambda()
 		{
-			return ([Optional][DefaultParameterValue(5)] int x) => x * 2;
+			return (int x) => x * 2;
 		}
 	}
 }

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLambdaOptionalAndParamsParameters.Expected.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLambdaOptionalAndParamsParameters.Expected.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
+{
+	internal class NoLambdaOptionalAndParamsParameters
+	{
+		public delegate void ParamsAction(params int[] xs);
+
+		public delegate int OptionalFunc(int x = 5);
+
+		private int total;
+
+		public ParamsAction ParamsLambda()
+		{
+			return ([ParamArray] int[] xs) => {
+				total += xs.Length;
+				Console.WriteLine(xs.Length);
+			};
+		}
+
+		public OptionalFunc OptionalLambda()
+		{
+			return ([Optional][DefaultParameterValue(5)] int x) => x * 2;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLambdaOptionalAndParamsParameters.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Ugly/NoLambdaOptionalAndParamsParameters.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace ICSharpCode.Decompiler.Tests.TestCases.Ugly
+{
+	internal class NoLambdaOptionalAndParamsParameters
+	{
+		public delegate void ParamsAction(params int[] xs);
+
+		public delegate int OptionalFunc(int x = 5);
+
+		private int total;
+
+		public ParamsAction ParamsLambda()
+		{
+			return (params int[] xs) => {
+				total += xs.Length;
+				Console.WriteLine(xs.Length);
+			};
+		}
+
+		public OptionalFunc OptionalLambda()
+		{
+			return (int x = 5) => x * 2;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
@@ -104,16 +104,16 @@ namespace ICSharpCode.Decompiler.Tests
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		});
 
-		// Roslyn 4.14 does not emit ParamArrayAttribute on synthesized lambda methods, so tests
-		// pinning its round-trip need the current compiler only.
-		static readonly CompilerOptions[] roslynLatestOnlyOptions = Tester.SupportedOnCurrentPlatform(new[]
+		static readonly CompilerOptions[] roslyn4OrNewerOptions = Tester.SupportedOnCurrentPlatform(new[]
 		{
+			CompilerOptions.UseRoslyn4_14_0,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslyn4_14_0,
 			CompilerOptions.UseRoslynLatest,
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		});
 
 		[Test]
-		public async Task NoLambdaOptionalAndParamsParameters([ValueSource(nameof(roslynLatestOnlyOptions))] CompilerOptions cscOptions)
+		public async Task NoLambdaOptionalAndParamsParameters([ValueSource(nameof(roslyn4OrNewerOptions))] CompilerOptions cscOptions)
 		{
 			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings(CSharp.LanguageVersion.CSharp11_0) {
 				FileScopedNamespaces = false

--- a/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/UglyTestRunner.cs
@@ -104,6 +104,22 @@ namespace ICSharpCode.Decompiler.Tests
 			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
 		});
 
+		// Roslyn 4.14 does not emit ParamArrayAttribute on synthesized lambda methods, so tests
+		// pinning its round-trip need the current compiler only.
+		static readonly CompilerOptions[] roslynLatestOnlyOptions = Tester.SupportedOnCurrentPlatform(new[]
+		{
+			CompilerOptions.UseRoslynLatest,
+			CompilerOptions.Optimize | CompilerOptions.UseRoslynLatest,
+		});
+
+		[Test]
+		public async Task NoLambdaOptionalAndParamsParameters([ValueSource(nameof(roslynLatestOnlyOptions))] CompilerOptions cscOptions)
+		{
+			await RunForLibrary(cscOptions: cscOptions, decompilerSettings: new DecompilerSettings(CSharp.LanguageVersion.CSharp11_0) {
+				FileScopedNamespaces = false
+			});
+		}
+
 		[Test]
 		public async Task NoArrayInitializers([ValueSource(nameof(roslynOnlyOptions))] CompilerOptions cscOptions)
 		{

--- a/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/CSharpDecompiler.cs
@@ -444,6 +444,8 @@ namespace ICSharpCode.Decompiler.CSharp
 							return true;
 						if (settings.Dynamic && type.IsDelegate(metadata) && (name.StartsWith("<>A", StringComparison.Ordinal) || name.StartsWith("<>F", StringComparison.Ordinal)))
 							return true;
+						if (settings.AnonymousMethods && type.IsAnonymousDelegate(metadata))
+							return true;
 					}
 					if (settings.ArrayInitializers && settings.SwitchStatementOnString && name.StartsWith("<PrivateImplementationDetails>", StringComparison.Ordinal))
 						return true;

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -2143,7 +2143,7 @@ namespace ICSharpCode.Decompiler.CSharp
 			// method group ('var f = M;'). Without a target type there is nothing to re-infer generic
 			// type arguments from, so a generic method group must spell them explicitly.
 			var targetExpression = BuildDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg,
-				forceTypeArguments: delegateType.IsAnonymousDelegate());
+				forceTypeArguments: settings.NaturalTypeForLambdaAndMethodGroup && delegateType.IsAnonymousDelegate());
 			var oce = new ObjectCreateExpression(expressionBuilder.ConvertType(delegateType), targetExpression)
 				.WithILInstruction(inst)
 				.WithRR(new ConversionResolveResult(

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -1980,16 +1980,19 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		internal ExpressionWithResolveResult BuildMethodReference(IMethod method, bool isVirtual)
 		{
-			var expr = BuildDelegateReference(method, invokeMethod: null, new ExpectedTargetDetails { CallOpCode = isVirtual ? OpCode.CallVirt : OpCode.Call }, thisArg: null);
+			var expr = BuildDelegateReference(method, invokeMethod: null, new ExpectedTargetDetails { CallOpCode = isVirtual ? OpCode.CallVirt : OpCode.Call }, thisArg: null, out _, out _);
 			expr.Expression.RemoveAnnotations<ResolveResult>();
 			return expr.Expression.WithRR(new MemberResolveResult(null, method));
 		}
 
-		ExpressionWithResolveResult BuildDelegateReference(IMethod method, IMethod? invokeMethod, ExpectedTargetDetails expectedTargetDetails, ILInstruction? thisArg, bool forceTypeArguments = false)
+		ExpressionWithResolveResult BuildDelegateReference(IMethod method, IMethod? invokeMethod, ExpectedTargetDetails expectedTargetDetails, ILInstruction? thisArg,
+			out ResolveResult? targetResolveResult, out IReadOnlyList<IType> spelledTypeArguments, bool forceTypeArguments = false)
 		{
 			ExpressionBuilder expressionBuilder = this.expressionBuilder;
 			ExpressionWithResolveResult targetExpression;
 			(TranslatedExpression target, bool addTypeArguments, string methodName, ResolveResult result) = DisambiguateDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg, forceTypeArguments);
+			targetResolveResult = target.Expression != null ? target.ResolveResult : null;
+			spelledTypeArguments = addTypeArguments ? method.TypeArguments : EmptyList<IType>.Instance;
 			if (target.Expression != null)
 			{
 				var mre = new MemberReferenceExpression(target, methodName);
@@ -2139,11 +2142,39 @@ namespace ICSharpCode.Decompiler.CSharp
 		TranslatedExpression HandleDelegateConstruction(IType delegateType, IMethod method, ExpectedTargetDetails expectedTargetDetails, ILInstruction thisArg, ILInstruction inst)
 		{
 			var invokeMethod = delegateType.GetDelegateInvokeMethod();
+			bool naturalTypes = settings.NaturalTypeForLambdaAndMethodGroup;
+			bool isAnonymousDelegate = delegateType.IsAnonymousDelegate();
 			// An anonymous delegate type cannot be named, so the site is emitted as a natural-typed
 			// method group ('var f = M;'). Without a target type there is nothing to re-infer generic
 			// type arguments from, so a generic method group must spell them explicitly.
 			var targetExpression = BuildDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg,
-				forceTypeArguments: settings.NaturalTypeForLambdaAndMethodGroup && delegateType.IsAnonymousDelegate());
+				out var targetResolveResult, out var spelledTypeArguments,
+				forceTypeArguments: naturalTypes && isAnonymousDelegate);
+			if (naturalTypes && !isAnonymousDelegate && !method.IsLocalFunction)
+			{
+				bool scopeByScope = settings.MethodGroupNaturalTypeImprovements;
+				bool matches = MethodGroupNaturalType.Matches(resolver, targetResolveResult, method,
+					spelledTypeArguments, delegateType, scopeByScope);
+				if (!matches && method.TypeArguments.Count > 0 && spelledTypeArguments.Count == 0
+					&& !method.TypeArguments.Any(a => a.ContainsAnonymousType()))
+				{
+					// A generic method group only has a natural type when its type arguments are
+					// spelled; the minimal reference omits them when the target method is already
+					// unambiguous, so retry with them forced.
+					var forced = BuildDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg,
+						out targetResolveResult, out spelledTypeArguments, forceTypeArguments: true);
+					if (MethodGroupNaturalType.Matches(resolver, targetResolveResult, method,
+						spelledTypeArguments, delegateType, scopeByScope))
+					{
+						targetExpression = forced;
+						matches = true;
+					}
+				}
+				if (matches)
+				{
+					targetExpression.Expression.AddAnnotation(new MethodGroupNaturalTypeAnnotation(delegateType));
+				}
+			}
 			var oce = new ObjectCreateExpression(expressionBuilder.ConvertType(delegateType), targetExpression)
 				.WithILInstruction(inst)
 				.WithRR(new ConversionResolveResult(

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -2175,12 +2175,22 @@ namespace ICSharpCode.Decompiler.CSharp
 					targetExpression.Expression.AddAnnotation(new MethodGroupNaturalTypeAnnotation(delegateType));
 				}
 			}
+			var conversion = new ConversionResolveResult(
+				delegateType,
+				targetExpression.ResolveResult,
+				Conversion.MethodGroupConversion(method, expectedTargetDetails.CallOpCode == OpCode.CallVirt, false));
+			if (naturalTypes && isAnonymousDelegate)
+			{
+				// An anonymous delegate type cannot be named, so the delegate creation cannot be
+				// spelled either. The method group's natural type carries the conversion, which is
+				// permitted wherever the target is the delegate type itself or a base type of it.
+				var methodGroup = targetExpression.Expression;
+				methodGroup.RemoveAnnotations<ResolveResult>();
+				return methodGroup.WithILInstruction(inst).WithRR(conversion);
+			}
 			var oce = new ObjectCreateExpression(expressionBuilder.ConvertType(delegateType), targetExpression)
 				.WithILInstruction(inst)
-				.WithRR(new ConversionResolveResult(
-					delegateType,
-					targetExpression.ResolveResult,
-					Conversion.MethodGroupConversion(method, expectedTargetDetails.CallOpCode == OpCode.CallVirt, false)));
+				.WithRR(conversion);
 			return oce;
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -1985,11 +1985,11 @@ namespace ICSharpCode.Decompiler.CSharp
 			return expr.Expression.WithRR(new MemberResolveResult(null, method));
 		}
 
-		ExpressionWithResolveResult BuildDelegateReference(IMethod method, IMethod? invokeMethod, ExpectedTargetDetails expectedTargetDetails, ILInstruction? thisArg)
+		ExpressionWithResolveResult BuildDelegateReference(IMethod method, IMethod? invokeMethod, ExpectedTargetDetails expectedTargetDetails, ILInstruction? thisArg, bool forceTypeArguments = false)
 		{
 			ExpressionBuilder expressionBuilder = this.expressionBuilder;
 			ExpressionWithResolveResult targetExpression;
-			(TranslatedExpression target, bool addTypeArguments, string methodName, ResolveResult result) = DisambiguateDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg);
+			(TranslatedExpression target, bool addTypeArguments, string methodName, ResolveResult result) = DisambiguateDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg, forceTypeArguments);
 			if (target.Expression != null)
 			{
 				var mre = new MemberReferenceExpression(target, methodName);
@@ -2012,8 +2012,9 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		}
 
-		(TranslatedExpression target, bool addTypeArguments, string methodName, ResolveResult result) DisambiguateDelegateReference(IMethod method, IMethod? invokeMethod, ExpectedTargetDetails expectedTargetDetails, ILInstruction? thisArg)
+		(TranslatedExpression target, bool addTypeArguments, string methodName, ResolveResult result) DisambiguateDelegateReference(IMethod method, IMethod? invokeMethod, ExpectedTargetDetails expectedTargetDetails, ILInstruction? thisArg, bool forceTypeArguments = false)
 		{
+			forceTypeArguments &= method.TypeArguments.Count > 0;
 			if (method.IsLocalFunction)
 			{
 				ILFunction? localFunction = expressionBuilder.ResolveLocalFunction(method);
@@ -2031,10 +2032,10 @@ namespace ICSharpCode.Decompiler.CSharp
 				TranslatedExpression target = expressionBuilder.Translate(thisArg!, targetType);
 				var currentTarget = target;
 				bool targetCasted = false;
-				bool addTypeArguments = false;
+				bool addTypeArguments = forceTypeArguments;
 				// Initial inputs for IsUnambiguousMethodReference:
 				ResolveResult targetResolveResult = target.ResolveResult;
-				IReadOnlyList<IType> typeArguments = EmptyList<IType>.Instance;
+				IReadOnlyList<IType> typeArguments = forceTypeArguments ? method.TypeArguments : EmptyList<IType>.Instance;
 				if (thisArg!.MatchLdNull())
 				{
 					targetCasted = true;
@@ -2094,10 +2095,10 @@ namespace ICSharpCode.Decompiler.CSharp
 				TranslatedExpression currentTarget = targetAdded ? target : default;
 				// Remember other decisions:
 				bool targetCasted = false;
-				bool addTypeArguments = false;
+				bool addTypeArguments = forceTypeArguments;
 				// Initial inputs for IsUnambiguousMethodReference:
 				ResolveResult? targetResolveResult = targetAdded ? target.ResolveResult : null;
-				IReadOnlyList<IType> typeArguments = EmptyList<IType>.Instance;
+				IReadOnlyList<IType> typeArguments = forceTypeArguments ? method.TypeArguments : EmptyList<IType>.Instance;
 				// Find somewhat minimal solution:
 				ResolveResult? result;
 				while (!IsUnambiguousMethodReference(expectedTargetDetails, method, targetResolveResult, typeArguments, false, out result))
@@ -2138,7 +2139,11 @@ namespace ICSharpCode.Decompiler.CSharp
 		TranslatedExpression HandleDelegateConstruction(IType delegateType, IMethod method, ExpectedTargetDetails expectedTargetDetails, ILInstruction thisArg, ILInstruction inst)
 		{
 			var invokeMethod = delegateType.GetDelegateInvokeMethod();
-			var targetExpression = BuildDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg);
+			// An anonymous delegate type cannot be named, so the site is emitted as a natural-typed
+			// method group ('var f = M;'). Without a target type there is nothing to re-infer generic
+			// type arguments from, so a generic method group must spell them explicitly.
+			var targetExpression = BuildDelegateReference(method, invokeMethod, expectedTargetDetails, thisArg,
+				forceTypeArguments: delegateType.IsAnonymousDelegate());
 			var oce = new ObjectCreateExpression(expressionBuilder.ConvertType(delegateType), targetExpression)
 				.WithILInstruction(inst)
 				.WithRR(new ConversionResolveResult(

--- a/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/CallBuilder.cs
@@ -2172,7 +2172,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 				if (matches)
 				{
-					targetExpression.Expression.AddAnnotation(new MethodGroupNaturalTypeAnnotation(delegateType));
+					targetExpression.Expression.AddAnnotation(new NaturalTypeAnnotation(delegateType));
 				}
 			}
 			var conversion = new ConversionResolveResult(

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2662,11 +2662,17 @@ namespace ICSharpCode.Decompiler.CSharp
 					inferredReturnType = lambda.Body!.GetResolveResult().Type;
 					naturalReturnType = inferredReturnType;
 				}
-				else if (isAnonymousDelegate && body.Statements.Count == 1
-					&& body.Statements.Single() is ExpressionStatement exprStmt)
+				else if (body.Statements.Count == 1 && body.Statements.Single() is ExpressionStatement exprStmt
+					&& !NeedsDeclarationInBody(function, exprStmt)
+					&& (isAnonymousDelegate || exprStmt.Expression.GetResolveResult().Type.Kind == TypeKind.Void))
 				{
 					// A single statement-expression can be the expression body of a void-returning
 					// lambda; its value (if any) is discarded, so the return type stays void.
+					// Discarding a value is only safe where the void-ness survives into the output:
+					// C# reads the expression's type as the lambda's return type, which picks a
+					// different natural type and a different overload. An anonymous delegate spells
+					// the return type out below; everywhere else the block body, which has no return
+					// statement, is what says the value is dropped.
 					lambda.Body = exprStmt.Expression.Detach();
 					inferredReturnType = compilation.FindType(KnownTypeCode.Void);
 					naturalReturnType = lambda.Body!.GetResolveResult().Type;
@@ -2752,6 +2758,51 @@ namespace ICSharpCode.Decompiler.CSharp
 						}
 						return true;
 				}
+			}
+		}
+
+		/// <summary>
+		/// Whether the statement uses a variable that DeclareVariables may still have to declare,
+		/// which only a block body can host. Collapsing such a body to an expression pushes the
+		/// declaration inside the lambda when the block is rebuilt for it - turning a captured
+		/// variable into per-invocation state, which no longer round-trips.
+		/// </summary>
+		static bool NeedsDeclarationInBody(ILFunction function, ExpressionStatement statement)
+		{
+			// A deconstruction assignment produces the tuple it assigned from. Compiled as an
+			// expression body its value is discarded differently than in a block, and the IL that
+			// comes back no longer looks like one statement - so the shape would flip on every
+			// round trip. Keep the block, which is stable.
+			if (statement.Expression is AssignmentExpression { Left: TupleExpression })
+				return true;
+			foreach (var identifier in statement.DescendantsAndSelf.OfType<IdentifierExpression>())
+			{
+				if (identifier.GetResolveResult() is not ILVariableResolveResult { Variable: var variable })
+					continue;
+				// Parameters and this-references are never declared.
+				if (variable.Kind is not (VariableKind.Local or VariableKind.StackSlot))
+					continue;
+				// Not closure state: a declaration inside the lambda is correct.
+				if (variable.CaptureScope is null)
+					continue;
+				// Read (or written) elsewhere too, so the declaration lands in the shared scope
+				// no matter what this body looks like, and collapsing is safe.
+				if (!AllUsesAreInside(variable, function))
+					continue;
+				return true;
+			}
+			return false;
+
+			static bool AllUsesAreInside(ILVariable variable, ILFunction function)
+			{
+				foreach (var use in variable.LoadInstructions.Cast<ILInstruction>()
+					.Concat(variable.StoreInstructions.Cast<ILInstruction>())
+					.Concat(variable.AddressInstructions))
+				{
+					if (use.Ancestors.OfType<ILFunction>().FirstOrDefault() != function)
+						return false;
+				}
+				return true;
 			}
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2587,7 +2587,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				let v = ident.GetILVariable()
 				where v != null && v.Function == function && v.Kind == VariableKind.Parameter
 				select ident).Any();
-			bool isAnonymousDelegate = delegateType.IsAnonymousDelegate();
+			bool isAnonymousDelegate = settings.NaturalTypeForLambdaAndMethodGroup && delegateType.IsAnonymousDelegate();
 			if (!settings.LambdaOptionalAndParamsParameters || ame.Parameters.Any(p => p.Type is null))
 			{
 				// 'params' and parameter default values are only legal on the explicitly typed

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2543,13 +2543,16 @@ namespace ICSharpCode.Decompiler.CSharp
 			AnonymousMethodExpression ame = new AnonymousMethodExpression();
 			ame.IsAsync = function.IsAsync;
 			ame.Parameters.AddRange(MakeParameters(function.Parameters, function));
-			// 'params' and parameter default values are part of the delegate's signature, and it
-			// is the delegate's Invoke method that call sites bind against. An anonymous function's
-			// own method does not reliably carry them - Roslyn 4.14 emits no ParamArrayAttribute
-			// there - so take them from Invoke, keeping declaration and call sites consistent.
-			var invokeParameters = delegateType.GetDelegateInvokeMethod()?.Parameters;
-			if (invokeParameters?.Count == ame.Parameters.Count)
+			if (delegateType.IsAnonymousDelegate()
+				&& delegateType.GetDelegateInvokeMethod()?.Parameters is { } invokeParameters
+				&& invokeParameters.Count == ame.Parameters.Count)
 			{
+				// A compiler-synthesized delegate type exists only because the lambda declared
+				// 'params' or a parameter default value, and the lambda's own declaration is the
+				// only way to spell that type. Roslyn 4.14 does not put a ParamArrayAttribute on
+				// the lambda's method, so take both from the delegate's Invoke method, which
+				// always carries them. Named delegate types are left alone: there the lambda's
+				// own metadata decides, and a plain parameter list is valid either way.
 				int parameterIndex = 0;
 				foreach (var pd in ame.Parameters)
 				{
@@ -2611,29 +2614,14 @@ namespace ICSharpCode.Decompiler.CSharp
 			if (!settings.LambdaOptionalAndParamsParameters || ame.Parameters.Any(p => p.Type is null))
 			{
 				// 'params' and parameter default values are only legal on the explicitly typed
-				// parameter list of a lambda, and only since C# 12. Elsewhere, downgrade them to
-				// their underlying metadata attributes so the information is not lost.
+				// parameter list of a lambda, and only since C# 12. There is no other spelling:
+				// [ParamArray] cannot be written explicitly in any language version, and attributes
+				// on lambda parameters need C# 10. Drop them; the delegate's Invoke method still
+				// carries them at every call site.
 				foreach (var p in ame.Parameters)
 				{
-					if (p.IsParams)
-					{
-						p.IsParams = false;
-						p.Attributes.Add(new AttributeSection(new Syntax.Attribute {
-							Type = astBuilder.ConvertAttributeType(compilation.FindType(KnownAttribute.ParamArray))
-						}));
-					}
-					if (p.DefaultExpression is { } defaultValue)
-					{
-						defaultValue.Detach();
-						p.Attributes.Add(new AttributeSection(new Syntax.Attribute {
-							Type = astBuilder.ConvertAttributeType(compilation.FindType(KnownAttribute.Optional))
-						}));
-						var defaultParameterValue = new Syntax.Attribute {
-							Type = astBuilder.ConvertAttributeType(compilation.FindType(KnownAttribute.DefaultParameterValue))
-						};
-						defaultParameterValue.Arguments.Add(defaultValue);
-						p.Attributes.Add(new AttributeSection(defaultParameterValue));
-					}
+					p.IsParams = false;
+					p.DefaultExpression = null;
 				}
 			}
 			bool isLambda = false;

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2587,6 +2587,7 @@ namespace ICSharpCode.Decompiler.CSharp
 				let v = ident.GetILVariable()
 				where v != null && v.Function == function && v.Kind == VariableKind.Parameter
 				select ident).Any();
+			bool isAnonymousDelegate = delegateType.IsAnonymousDelegate();
 
 			bool isLambda = false;
 			if (ame.Parameters.Any(p => p.Type is null))
@@ -2597,6 +2598,16 @@ namespace ICSharpCode.Decompiler.CSharp
 			else if (attributeSections.Count > 0 || ame.Parameters.Any(p => p.Attributes.Any()))
 			{
 				// C# 10 lambdas can have attributes, but anonymous methods cannot
+				isLambda = true;
+			}
+			else if (isAnonymousDelegate)
+			{
+				// An anonymous delegate type cannot be named, so the site can only be typed via
+				// the anonymous function's natural type, which needs lambda syntax: the
+				// parameterless 'delegate {}' form has no natural type, and 'delegate' syntax
+				// cannot declare a return type when the body's type differs from the delegate's.
+				// This outranks the rendering preferences below - they may drop the parameter
+				// list, which would take the natural type with it.
 				isLambda = true;
 			}
 			else if (settings.UseLambdaSyntax && ame.Parameters.All(p => p.ParameterModifier == ReferenceKind.None && !p.IsParams)
@@ -2618,6 +2629,9 @@ namespace ICSharpCode.Decompiler.CSharp
 
 			Expression replacement;
 			IType inferredReturnType;
+			// The return type C# would re-infer from the emitted anonymous function; only equal to
+			// inferredReturnType for bodies whose value is not discarded.
+			IType naturalReturnType;
 			if (isLambda)
 			{
 				LambdaExpression lambda = new LambdaExpression();
@@ -2629,11 +2643,22 @@ namespace ICSharpCode.Decompiler.CSharp
 				{
 					lambda.Body = returnStmt.Expression.Detach();
 					inferredReturnType = lambda.Body!.GetResolveResult().Type;
+					naturalReturnType = inferredReturnType;
+				}
+				else if (isAnonymousDelegate && body.Statements.Count == 1
+					&& body.Statements.Single() is ExpressionStatement exprStmt)
+				{
+					// A single statement-expression can be the expression body of a void-returning
+					// lambda; its value (if any) is discarded, so the return type stays void.
+					lambda.Body = exprStmt.Expression.Detach();
+					inferredReturnType = compilation.FindType(KnownTypeCode.Void);
+					naturalReturnType = lambda.Body!.GetResolveResult().Type;
 				}
 				else
 				{
 					lambda.Body = body;
 					inferredReturnType = InferReturnType(body);
+					naturalReturnType = inferredReturnType;
 				}
 				replacement = lambda;
 			}
@@ -2641,11 +2666,24 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				ame.Body = body;
 				inferredReturnType = InferReturnType(body);
+				naturalReturnType = inferredReturnType;
 				replacement = ame;
 			}
 			if (ame.IsAsync)
 			{
 				inferredReturnType = GetTaskType(inferredReturnType);
+				naturalReturnType = GetTaskType(naturalReturnType);
+			}
+			if (isAnonymousDelegate && replacement is LambdaExpression lambdaExpression)
+			{
+				// The natural type's return type is inferred from the body; when that differs
+				// from the delegate's return type, only a C# 10 explicit return type reproduces
+				// the delegate's shape.
+				IType? delegateReturnType = delegateType.GetDelegateInvokeMethod()?.ReturnType;
+				if (delegateReturnType is not null && !NormalizeTypeVisitor.TypeErasure.EquivalentTypes(delegateReturnType, naturalReturnType))
+				{
+					lambdaExpression.ReturnType = ConvertType(delegateReturnType);
+				}
 			}
 
 			var rr = new DecompiledLambdaResolveResult(

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2731,6 +2731,14 @@ namespace ICSharpCode.Decompiler.CSharp
 				isAnonymousMethod: !isLambda,
 				isImplicitlyTyped: ame.Parameters.Any(p => p.Type is null));
 
+			if (isAnonymousDelegate)
+			{
+				// An anonymous delegate type cannot be named, so no cast to it can be written.
+				// Carrying the conversion on the anonymous function itself keeps the site typed
+				// as the delegate, which converts on to any base type of it without a cast.
+				return replacement.WithILInstruction(function)
+					.WithRR(new ConversionResolveResult(delegateType, rr, LambdaConversion.Instance));
+			}
 			TranslatedExpression translatedLambda = replacement.WithILInstruction(function).WithRR(rr);
 			return new CastExpression(ConvertType(delegateType), translatedLambda)
 				.WithRR(new ConversionResolveResult(delegateType, rr, LambdaConversion.Instance));

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2588,7 +2588,18 @@ namespace ICSharpCode.Decompiler.CSharp
 				where v != null && v.Function == function && v.Kind == VariableKind.Parameter
 				select ident).Any();
 			bool isAnonymousDelegate = delegateType.IsAnonymousDelegate();
-
+			if (!settings.LambdaOptionalAndParamsParameters || ame.Parameters.Any(p => p.Type is null))
+			{
+				// 'params' and parameter default values are only legal on the explicitly typed
+				// parameter list of a lambda, and only since C# 12. In any other context they are
+				// purely decorative anyway - the delegate type still provides both - so drop them
+				// to keep the parameter list legal.
+				foreach (var p in ame.Parameters)
+				{
+					p.IsParams = false;
+					p.DefaultExpression?.Detach();
+				}
+			}
 			bool isLambda = false;
 			if (ame.Parameters.Any(p => p.Type is null))
 			{
@@ -2608,6 +2619,12 @@ namespace ICSharpCode.Decompiler.CSharp
 				// cannot declare a return type when the body's type differs from the delegate's.
 				// This outranks the rendering preferences below - they may drop the parameter
 				// list, which would take the natural type with it.
+				isLambda = true;
+			}
+			else if (ame.Parameters.Any(p => p.IsParams || p.DefaultExpression is not null))
+			{
+				// 'params' and parameter default values cannot be declared on an anonymous method
+				// in any language version; only the lambda form is legal.
 				isLambda = true;
 			}
 			else if (settings.UseLambdaSyntax && ame.Parameters.All(p => p.ParameterModifier == ReferenceKind.None && !p.IsParams)

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2717,11 +2717,18 @@ namespace ICSharpCode.Decompiler.CSharp
 			{
 				// The natural type's return type is inferred from the body; when that differs
 				// from the delegate's return type, only a C# 10 explicit return type reproduces
-				// the delegate's shape.
-				IType? delegateReturnType = delegateType.GetDelegateInvokeMethod()?.ReturnType;
-				if (delegateReturnType is not null && !NormalizeTypeVisitor.TypeErasure.EquivalentTypes(delegateReturnType, naturalReturnType))
+				// the delegate's shape. 'ref readonly' is not part of the type, so it always
+				// needs the explicit return type, even where the types themselves agree.
+				IMethod? invokeMethod = delegateType.GetDelegateInvokeMethod();
+				if (invokeMethod is not null
+					&& (invokeMethod.ReturnTypeIsRefReadOnly
+						|| !NormalizeTypeVisitor.TypeErasure.EquivalentTypes(invokeMethod.ReturnType, naturalReturnType)))
 				{
-					lambdaExpression.ReturnType = ConvertType(delegateReturnType);
+					lambdaExpression.ReturnType = ConvertType(invokeMethod.ReturnType);
+					if (invokeMethod.ReturnTypeIsRefReadOnly && lambdaExpression.ReturnType is ComposedType composedType && composedType.HasRefSpecifier)
+					{
+						composedType.HasReadOnlySpecifier = true;
+					}
 				}
 			}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2766,6 +2766,18 @@ namespace ICSharpCode.Decompiler.CSharp
 				return replacement.WithILInstruction(function)
 					.WithRR(new ConversionResolveResult(delegateType, rr, LambdaConversion.Instance));
 			}
+			// An expression tree is written as a lambda, so its natural type is decided by the
+			// delegate the Expression<> wraps.
+			IType functionType = function.Kind == ILFunctionKind.ExpressionTree && delegateType.TypeArguments.Count == 1
+				? delegateType.TypeArguments[0]
+				: delegateType;
+			if (settings.NaturalTypeForLambdaAndMethodGroup && HasNaturalType(replacement, functionType, naturalReturnType, isLambda))
+			{
+				// A target type that only needs the function type - System.Delegate and the other
+				// base types of MulticastDelegate, or Expression/LambdaExpression for an expression
+				// tree - can be written without the cast, since C# re-infers the same type.
+				replacement.AddAnnotation(new NaturalTypeAnnotation(delegateType));
+			}
 			TranslatedExpression translatedLambda = replacement.WithILInstruction(function).WithRR(rr);
 			return new CastExpression(ConvertType(delegateType), translatedLambda)
 				.WithRR(new ConversionResolveResult(delegateType, rr, LambdaConversion.Instance));
@@ -2855,6 +2867,25 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 				return true;
 			}
+		}
+
+		/// <summary>
+		/// Determines whether C# re-infers <paramref name="functionType"/> from the emitted
+		/// anonymous function alone. Only a lambda with an explicitly typed parameter list has a
+		/// natural type, and the only delegate types ever inferred are Action and Func.
+		/// </summary>
+		bool HasNaturalType(Expression anonymousFunction, IType functionType, IType naturalReturnType, bool isLambda)
+		{
+			if (!isLambda || anonymousFunction is not LambdaExpression lambda)
+				return false;
+			if (lambda.Parameters.Any(p => p.Type is null))
+				return false;
+			IMethod? invoke = functionType.GetDelegateInvokeMethod();
+			if (invoke == null || !MethodGroupNaturalType.IsInferrableDelegateType(functionType, invoke))
+				return false;
+			// Without an explicit return type, the body has to re-infer the delegate's.
+			return lambda.ReturnType is not null
+				|| NormalizeTypeVisitor.TypeErasure.EquivalentTypes(invoke.ReturnType, naturalReturnType);
 		}
 
 		protected internal override TranslatedExpression VisitILFunction(ILFunction function, TranslationContext context)

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2543,6 +2543,26 @@ namespace ICSharpCode.Decompiler.CSharp
 			AnonymousMethodExpression ame = new AnonymousMethodExpression();
 			ame.IsAsync = function.IsAsync;
 			ame.Parameters.AddRange(MakeParameters(function.Parameters, function));
+			// 'params' and parameter default values are part of the delegate's signature, and it
+			// is the delegate's Invoke method that call sites bind against. An anonymous function's
+			// own method does not reliably carry them - Roslyn 4.14 emits no ParamArrayAttribute
+			// there - so take them from Invoke, keeping declaration and call sites consistent.
+			var invokeParameters = delegateType.GetDelegateInvokeMethod()?.Parameters;
+			if (invokeParameters?.Count == ame.Parameters.Count)
+			{
+				int parameterIndex = 0;
+				foreach (var pd in ame.Parameters)
+				{
+					var invokeParameter = invokeParameters[parameterIndex++];
+					pd.IsParams |= invokeParameter.IsParams;
+					if (pd.DefaultExpression is null
+						&& astBuilder.ConvertParameter(invokeParameter).DefaultExpression is { } defaultValue)
+					{
+						defaultValue.Detach();
+						pd.DefaultExpression = defaultValue;
+					}
+				}
+			}
 			var builder = new StatementBuilder(
 				typeSystem,
 				this.decompilationContext,

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -2591,13 +2591,29 @@ namespace ICSharpCode.Decompiler.CSharp
 			if (!settings.LambdaOptionalAndParamsParameters || ame.Parameters.Any(p => p.Type is null))
 			{
 				// 'params' and parameter default values are only legal on the explicitly typed
-				// parameter list of a lambda, and only since C# 12. In any other context they are
-				// purely decorative anyway - the delegate type still provides both - so drop them
-				// to keep the parameter list legal.
+				// parameter list of a lambda, and only since C# 12. Elsewhere, downgrade them to
+				// their underlying metadata attributes so the information is not lost.
 				foreach (var p in ame.Parameters)
 				{
-					p.IsParams = false;
-					p.DefaultExpression?.Detach();
+					if (p.IsParams)
+					{
+						p.IsParams = false;
+						p.Attributes.Add(new AttributeSection(new Syntax.Attribute {
+							Type = astBuilder.ConvertAttributeType(compilation.FindType(KnownAttribute.ParamArray))
+						}));
+					}
+					if (p.DefaultExpression is { } defaultValue)
+					{
+						defaultValue.Detach();
+						p.Attributes.Add(new AttributeSection(new Syntax.Attribute {
+							Type = astBuilder.ConvertAttributeType(compilation.FindType(KnownAttribute.Optional))
+						}));
+						var defaultParameterValue = new Syntax.Attribute {
+							Type = astBuilder.ConvertAttributeType(compilation.FindType(KnownAttribute.DefaultParameterValue))
+						};
+						defaultParameterValue.Arguments.Add(defaultValue);
+						p.Attributes.Add(new AttributeSection(defaultParameterValue));
+					}
 				}
 			}
 			bool isLambda = false;

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1030,6 +1030,11 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				WriteKeyword(LambdaExpression.AsyncModifier);
 				Space();
 			}
+			if (lambdaExpression.ReturnType is not null)
+			{
+				lambdaExpression.ReturnType.AcceptVisitor(this);
+				Space();
+			}
 			if (LambdaNeedsParenthesis(lambdaExpression))
 			{
 				WriteCommaSeparatedListInParenthesis(lambdaExpression.Parameters, policy.SpaceWithinMethodDeclarationParentheses);
@@ -1054,6 +1059,11 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 
 		protected bool LambdaNeedsParenthesis(LambdaExpression lambdaExpression)
 		{
+			if (lambdaExpression.ReturnType is not null)
+			{
+				// an explicit return type requires a parenthesized parameter list
+				return true;
+			}
 			if (lambdaExpression.Parameters.Count != 1)
 			{
 				return true;

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -1059,9 +1059,10 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 
 		protected bool LambdaNeedsParenthesis(LambdaExpression lambdaExpression)
 		{
-			if (lambdaExpression.ReturnType is not null)
+			if (lambdaExpression.ReturnType is not null || lambdaExpression.Attributes.Count > 0)
 			{
-				// an explicit return type requires a parenthesized parameter list
+				// an explicit return type or attributes on the lambda require a parenthesized
+				// parameter list
 				return true;
 			}
 			if (lambdaExpression.Parameters.Count != 1)
@@ -1069,6 +1070,11 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 				return true;
 			}
 			var p = lambdaExpression.Parameters.Single();
+			if (p.Attributes.Count > 0)
+			{
+				// parameter attributes have no unparenthesized form
+				return true;
+			}
 			return !(p.Type is null && p.ParameterModifier == ReferenceKind.None && !p.IsParams);
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/RequiredNamespaceCollector.cs
+++ b/ICSharpCode.Decompiler/CSharp/RequiredNamespaceCollector.cs
@@ -144,13 +144,6 @@ namespace ICSharpCode.Decompiler.CSharp
 						{
 							HandleAttributes(param.GetAttributes());
 							CollectNamespacesForTypeReference(param.Type);
-							if (param.IsOptional)
-							{
-								// ExpressionBuilder.TranslateFunction may downgrade a default value
-								// on an anonymous-function parameter to [Optional] and
-								// [DefaultParameterValue(...)]; keep their namespace in the superset.
-								namespaces.Add(KnownAttribute.DefaultParameterValue.GetTypeName().Namespace);
-							}
 						}
 						HandleTypeParameters(partMethod.TypeParameters);
 						HandleOverrides(part.GetMethodImplementations(module.metadata), module);

--- a/ICSharpCode.Decompiler/CSharp/RequiredNamespaceCollector.cs
+++ b/ICSharpCode.Decompiler/CSharp/RequiredNamespaceCollector.cs
@@ -144,6 +144,13 @@ namespace ICSharpCode.Decompiler.CSharp
 						{
 							HandleAttributes(param.GetAttributes());
 							CollectNamespacesForTypeReference(param.Type);
+							if (param.IsOptional)
+							{
+								// ExpressionBuilder.TranslateFunction may downgrade a default value
+								// on an anonymous-function parameter to [Optional] and
+								// [DefaultParameterValue(...)]; keep their namespace in the superset.
+								namespaces.Add(KnownAttribute.DefaultParameterValue.GetTypeName().Namespace);
+							}
 						}
 						HandleTypeParameters(partMethod.TypeParameters);
 						HandleOverrides(part.GetMethodImplementations(module.metadata), module);

--- a/ICSharpCode.Decompiler/CSharp/Resolver/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/MethodGroupNaturalType.cs
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+
+using ICSharpCode.Decompiler.Semantics;
+using ICSharpCode.Decompiler.TypeSystem;
+using ICSharpCode.Decompiler.Util;
+
+namespace ICSharpCode.Decompiler.CSharp.Resolver
+{
+	/// <summary>
+	/// Marks a method group expression whose C# natural type equals the delegate type the IL
+	/// constructs, i.e. the site can be emitted without an explicit delegate creation.
+	/// </summary>
+	sealed class MethodGroupNaturalTypeAnnotation
+	{
+		public IType DelegateType { get; }
+
+		public MethodGroupNaturalTypeAnnotation(IType delegateType)
+		{
+			DelegateType = delegateType;
+		}
+	}
+
+	/// <summary>
+	/// Decides whether the C# natural type of a method group expression equals a given delegate
+	/// type. Only when it does may the decompiler drop the explicit delegate construction
+	/// ('var f = M;' instead of 'Action f = new Action(M);') without changing what the
+	/// re-compiled code binds to.
+	/// </summary>
+	static class MethodGroupNaturalType
+	{
+		/// <summary>
+		/// Determines whether the method group written as
+		/// '<paramref name="target"/>.<paramref name="method"/>.Name&lt;<paramref name="typeArguments"/>&gt;'
+		/// has a natural type equal to <paramref name="delegateType"/>.
+		/// </summary>
+		/// <param name="resolver">Resolver positioned at the decompiled member (provides using scopes).</param>
+		/// <param name="target">Resolve result of the receiver, or null if the group is a simple name.</param>
+		/// <param name="method">The method the IL delegate targets.</param>
+		/// <param name="typeArguments">Type arguments as spelled in the emitted form (empty if omitted).</param>
+		/// <param name="delegateType">The delegate type constructed in the IL.</param>
+		/// <param name="scopeByScope">
+		/// true for the C# 13 rules: scopes are considered one at a time and candidates that cannot
+		/// be invoked (wrong arity, violated constraints, static/instance mismatch) are pruned; the
+		/// first scope with surviving candidates decides. false for the C# 10 rules, where every
+		/// candidate in every scope takes part and no pruning happens.
+		/// </param>
+		public static bool Matches(CSharpResolver resolver, ResolveResult? target, IMethod method,
+			IReadOnlyList<IType> typeArguments, IType delegateType, bool scopeByScope)
+		{
+			IMethod? invoke = delegateType.GetDelegateInvokeMethod();
+			if (invoke == null)
+				return false;
+			if (!IsInferrableDelegateType(delegateType, invoke))
+				return false;
+			// Resolve without the spelled type arguments: member lookup would otherwise already
+			// filter out candidates of a different arity, but those candidates take part in the
+			// natural type determination (they kill it below C# 13, and count as pruned in C# 13).
+			MethodGroupResolveResult? mgrr;
+			if (target == null)
+			{
+				mgrr = resolver.ResolveSimpleName(method.Name, EmptyList<IType>.Instance) as MethodGroupResolveResult;
+			}
+			else
+			{
+				mgrr = resolver.ResolveMemberAccess(target, method.Name, EmptyList<IType>.Instance,
+					NameLookupMode.InvocationTarget) as MethodGroupResolveResult;
+			}
+			if (mgrr == null)
+				return false;
+			// Extension scopes only apply to an instance-form receiver.
+			bool hasExtensionScopes = target != null && target is not TypeResolveResult;
+			if (scopeByScope)
+			{
+				var memberScope = PruneMemberScope(mgrr.Methods, target, typeArguments, out _);
+				if (memberScope.Count > 0)
+					return ScopeDecides(memberScope, skippedParameters: 0, invoke, method);
+				if (!hasExtensionScopes)
+					return false;
+				foreach (var scope in mgrr.GetExtensionMethods())
+				{
+					var survivors = PruneExtensionScope(scope, mgrr.TargetType, typeArguments, out _);
+					if (survivors.Count > 0)
+						return ScopeDecides(survivors, skippedParameters: 1, invoke, method);
+				}
+				return false;
+			}
+			else
+			{
+				// C# 10: all candidates from all scopes must agree on one signature. A candidate
+				// the C# 13 rules would prune still takes part here, so its mere existence makes
+				// the natural type undeterminable for our purposes - be conservative and keep the
+				// explicit construction.
+				var members = PruneMemberScope(mgrr.Methods, target, typeArguments, out bool anyPruned);
+				if (anyPruned)
+					return false;
+				if (!ScopeDecides(members, skippedParameters: 0, invoke, method, requireTargetMethod: false))
+					return false;
+				bool foundTargetMethod = ContainsTargetMethod(members, method);
+				if (hasExtensionScopes)
+				{
+					foreach (var scope in mgrr.GetExtensionMethods())
+					{
+						var extensions = PruneExtensionScope(scope, mgrr.TargetType, typeArguments, out anyPruned);
+						if (anyPruned)
+							return false;
+						if (!ScopeDecides(extensions, skippedParameters: 1, invoke, method, requireTargetMethod: false))
+							return false;
+						foundTargetMethod |= ContainsTargetMethod(extensions, method);
+					}
+				}
+				return foundTargetMethod;
+			}
+		}
+
+		/// <summary>
+		/// Applies the C# 13 candidate pruning to the member scope: static/instance mismatch with
+		/// the receiver form, generic arity mismatch with explicitly given type arguments, and
+		/// violated constraints. Candidates are specialized with the explicit type arguments on
+		/// the way.
+		/// </summary>
+		static List<IMethod> PruneMemberScope(IEnumerable<IMethod> candidates, ResolveResult? target,
+			IReadOnlyList<IType> typeArguments, out bool anyPruned)
+		{
+			var survivors = new List<IMethod>();
+			anyPruned = false;
+			foreach (var candidate in candidates)
+			{
+				if (target is TypeResolveResult ? !candidate.IsStatic : target != null && candidate.IsStatic)
+				{
+					anyPruned = true;
+					continue;
+				}
+				if (!TrySpecialize(candidate, typeArguments, out var m))
+				{
+					anyPruned = true;
+					continue;
+				}
+				survivors.Add(m);
+			}
+			return survivors;
+		}
+
+		/// <summary>
+		/// Applies the C# 13 candidate pruning to one extension scope. Candidates whose this
+		/// parameter does not accept the receiver are not part of the method group at all, so
+		/// they do not count as pruned.
+		/// </summary>
+		static List<IMethod> PruneExtensionScope(IEnumerable<IMethod> candidates, IType targetType,
+			IReadOnlyList<IType> typeArguments, out bool anyPruned)
+		{
+			var survivors = new List<IMethod>();
+			anyPruned = false;
+			foreach (var candidate in candidates)
+			{
+				if (typeArguments.Count > 0)
+				{
+					if (!TrySpecialize(candidate, typeArguments, out var m))
+					{
+						anyPruned = true;
+						continue;
+					}
+					if (!CSharpResolver.IsEligibleExtensionMethod(targetType, m, useTypeInference: false, out _))
+						continue;
+					survivors.Add(m);
+				}
+				else
+				{
+					if (!CSharpResolver.IsEligibleExtensionMethod(targetType, candidate, useTypeInference: true, out var inferredTypes))
+						continue;
+					var m = inferredTypes != null
+						? candidate.Specialize(new TypeParameterSubstitution(null, inferredTypes))
+						: candidate;
+					survivors.Add(m);
+				}
+			}
+			return survivors;
+		}
+
+		/// <summary>
+		/// Specializes a candidate with the explicitly given type arguments; fails on arity
+		/// mismatch or violated constraints (the C# 13 pruning conditions).
+		/// </summary>
+		static bool TrySpecialize(IMethod candidate, IReadOnlyList<IType> typeArguments, out IMethod result)
+		{
+			result = candidate;
+			if (typeArguments.Count == 0)
+				return true;
+			var definition = (IMethod)candidate.MemberDefinition;
+			if (definition.TypeParameters.Count != typeArguments.Count)
+				return false;
+			// Member lookup hands out self-instantiated candidates (their own type parameters as
+			// type arguments), so apply the explicit arguments unconditionally.
+			result = result.Specialize(new TypeParameterSubstitution(null, typeArguments));
+			var substitution = result.Substitution;
+			for (int i = 0; i < result.TypeArguments.Count; i++)
+			{
+				if (!OverloadResolution.ValidateConstraints(definition.TypeParameters[i], result.TypeArguments[i], substitution))
+					return false;
+			}
+			return true;
+		}
+
+		/// <summary>
+		/// The scope that decides the natural type does so if all its candidates share the
+		/// delegate's Invoke signature and the IL's target method is among them.
+		/// </summary>
+		static bool ScopeDecides(List<IMethod> candidates, int skippedParameters, IMethod invoke,
+			IMethod targetMethod, bool requireTargetMethod = true)
+		{
+			foreach (var candidate in candidates)
+			{
+				if (!SignatureMatchesInvoke(candidate, skippedParameters, invoke))
+					return false;
+			}
+			return !requireTargetMethod || ContainsTargetMethod(candidates, targetMethod);
+		}
+
+		static bool ContainsTargetMethod(List<IMethod> candidates, IMethod targetMethod)
+		{
+			return candidates.Any(c => c.MemberDefinition.Equals(targetMethod.MemberDefinition));
+		}
+
+		static bool SignatureMatchesInvoke(IMethod method, int skippedParameters, IMethod invoke)
+		{
+			if (method.TypeParameters.Count > 0 && method.TypeArguments.Count == 0)
+			{
+				// An uninstantiated generic method has no signature the natural type could use,
+				// even when its type parameters do not occur in the parameter list.
+				return false;
+			}
+			var parameters = method.Parameters;
+			if (parameters.Count - skippedParameters != invoke.Parameters.Count)
+				return false;
+			var normalize = NormalizeTypeVisitor.IgnoreNullabilityAndTuples;
+			for (int i = 0; i < invoke.Parameters.Count; i++)
+			{
+				var p = parameters[i + skippedParameters];
+				var q = invoke.Parameters[i];
+				if (p.ReferenceKind != q.ReferenceKind || p.IsParams != q.IsParams || p.IsOptional != q.IsOptional)
+					return false;
+				if (p.IsOptional && !Equals(p.GetConstantValue(), q.GetConstantValue()))
+					return false;
+				if (!normalize.EquivalentTypes(p.Type, q.Type))
+					return false;
+			}
+			if (method.ReturnTypeIsRefReadOnly != invoke.ReturnTypeIsRefReadOnly)
+				return false;
+			return normalize.EquivalentTypes(method.ReturnType, invoke.ReturnType);
+		}
+
+		/// <summary>
+		/// C# only ever infers System.Action/System.Func delegate types (for plain signatures)
+		/// or compiler-synthesized anonymous delegate types (for everything else) as the natural
+		/// type; a signature-compatible custom delegate type never round-trips through 'var'.
+		/// </summary>
+		static bool IsInferrableDelegateType(IType delegateType, IMethod invoke)
+		{
+			if (delegateType.IsAnonymousDelegate())
+				return true;
+			if (invoke.Parameters.Any(p => p.ReferenceKind != ReferenceKind.None || p.IsParams || p.IsOptional))
+				return false;
+			if (invoke.ReturnType.Kind == TypeKind.ByReference)
+				return false;
+			var definition = delegateType.GetDefinition();
+			if (definition == null || definition.Namespace != "System")
+				return false;
+			if (invoke.ReturnType.IsKnownType(KnownTypeCode.Void))
+				return definition.Name == "Action" && definition.TypeParameterCount == invoke.Parameters.Count;
+			return definition.Name == "Func" && definition.TypeParameterCount == invoke.Parameters.Count + 1;
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/Resolver/MethodGroupNaturalType.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/MethodGroupNaturalType.cs
@@ -28,14 +28,15 @@ using ICSharpCode.Decompiler.Util;
 namespace ICSharpCode.Decompiler.CSharp.Resolver
 {
 	/// <summary>
-	/// Marks a method group expression whose C# natural type equals the delegate type the IL
-	/// constructs, i.e. the site can be emitted without an explicit delegate creation.
+	/// Marks a method group or anonymous function whose C# natural type equals the delegate type
+	/// the IL constructs, i.e. the site can be emitted without naming that type: without an
+	/// explicit delegate creation, or without a cast.
 	/// </summary>
-	sealed class MethodGroupNaturalTypeAnnotation
+	sealed class NaturalTypeAnnotation
 	{
 		public IType DelegateType { get; }
 
-		public MethodGroupNaturalTypeAnnotation(IType delegateType)
+		public NaturalTypeAnnotation(IType delegateType)
 		{
 			DelegateType = delegateType;
 		}
@@ -274,7 +275,7 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 		/// or compiler-synthesized anonymous delegate types (for everything else) as the natural
 		/// type; a signature-compatible custom delegate type never round-trips through 'var'.
 		/// </summary>
-		static bool IsInferrableDelegateType(IType delegateType, IMethod invoke)
+		internal static bool IsInferrableDelegateType(IType delegateType, IMethod invoke)
 		{
 			if (delegateType.IsAnonymousDelegate())
 				return true;

--- a/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/LambdaExpression.cs
+++ b/ICSharpCode.Decompiler/CSharp/Syntax/Expressions/LambdaExpression.cs
@@ -29,7 +29,7 @@
 namespace ICSharpCode.Decompiler.CSharp.Syntax
 {
 	/// <summary>
-	/// <c>lambda_expression ::= attribute_section* 'async'? parameter* '=&gt;' ( block | expression )</c> (C# grammar §12.22.1)
+	/// <c>lambda_expression ::= attribute_section* 'async'? return_type? parameter* '=&gt;' ( block | expression )</c> (C# grammar §12.22.1)
 	/// </summary>
 	[DecompilerAstNode]
 	public sealed partial class LambdaExpression : Expression
@@ -40,6 +40,12 @@ namespace ICSharpCode.Decompiler.CSharp.Syntax
 		public partial AstNodeCollection<AttributeSection> Attributes { get; }
 
 		public bool IsAsync { get; set; }
+
+		/// <summary>
+		/// The explicit return type (C# 10). Requires a parenthesized parameter list when present.
+		/// </summary>
+		[Slot("Type")]
+		public partial AstType? ReturnType { get; set; }
 
 		[Slot("Parameter")]
 		public partial AstNodeCollection<ParameterDeclaration> Parameters { get; }

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -638,6 +638,21 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				.GetAllBaseTypes().Any(baseType => baseType.Equals(type));
 		}
 
+		/// <summary>
+		/// Determines whether a declared type accepts an anonymous function by its natural type
+		/// alone. A function type converts to the delegate targets above; an expression tree,
+		/// whose natural type is built from the same function type, converts to
+		/// System.Linq.Expressions.Expression and LambdaExpression instead.
+		/// </summary>
+		static bool IsNaturalTypeConversionTarget(IType declaredType, IType naturalType, TransformContext context)
+		{
+			if (naturalType.GetDelegateInvokeMethod() != null)
+				return IsFunctionTypeConversionTarget(declaredType, context);
+			return declaredType.FullName is "System.Linq.Expressions.Expression"
+					or "System.Linq.Expressions.LambdaExpression"
+				&& declaredType.TypeParameterCount == 0;
+		}
+
 		void InsertVariableDeclarations(TransformContext context)
 		{
 			var replacements = new List<(AstNode OldNode, Func<AstNode> CreateNewNode, string StepDescription)>();
@@ -655,8 +670,13 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					// explicit delegate construction is dropped when the group's natural type
 					// produces the same delegate.
 					bool unwrapDelegateConstruction = assignment.Right is ObjectCreateExpression { Arguments: { Count: 1 } } oce
-						&& oce.Arguments.Single().Annotation<MethodGroupNaturalTypeAnnotation>() != null
+						&& oce.Arguments.Single().Annotation<NaturalTypeAnnotation>() != null
 						&& IsFunctionTypeConversionTarget(v.Type, context);
+					// The same holds for an anonymous function: the cast naming its natural type is
+					// redundant where the declared type only needs the conversion.
+					bool unwrapNaturalTypeCast = assignment.Right is CastExpression cast
+						&& cast.Expression.Annotation<NaturalTypeAnnotation>() is { } castNaturalType
+						&& IsNaturalTypeConversionTarget(v.Type, castNaturalType.DelegateType, context);
 					if (context.Settings.AnonymousTypes && v.Type.ContainsAnonymousType())
 					{
 						type = new SimpleType("var");
@@ -665,11 +685,14 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						type = new SimpleType("var");
 					}
-					else if (assignment.Right.Annotation<MethodGroupNaturalTypeAnnotation>() is { } naturalType
+					else if (assignment.Right is not (LambdaExpression or AnonymousMethodExpression)
+						&& assignment.Right.Annotation<NaturalTypeAnnotation>() is { } naturalType
 						&& NormalizeTypeVisitor.IgnoreNullabilityAndTuples.EquivalentTypes(naturalType.DelegateType, v.Type))
 					{
 						// The initializer is a bare method group whose natural type is the
-						// variable's type, so 'var' re-infers the same delegate type.
+						// variable's type, so 'var' re-infers the same delegate type. An anonymous
+						// function is excluded: 'var' over an expression tree infers the delegate
+						// the Expression<> wraps, not the tree.
 						type = new SimpleType("var");
 					}
 					else
@@ -685,9 +708,13 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						type.AddTrailingTrivia(new Comment("pinned", CommentType.MultiLine));
 					}
 					replacements.Add((v.InsertionPoint.nextNode, () => {
-						Expression initializer = unwrapDelegateConstruction
-							? ((ObjectCreateExpression)assignment.Right).Arguments.Single().Detach()
-							: assignment.Right.Detach();
+						Expression initializer;
+						if (unwrapDelegateConstruction)
+							initializer = ((ObjectCreateExpression)assignment.Right).Arguments.Single().Detach();
+						else if (unwrapNaturalTypeCast)
+							initializer = ((CastExpression)assignment.Right).Expression.Detach();
+						else
+							initializer = assignment.Right.Detach();
 						var vds = new VariableDeclarationStatement(type, v.Name, initializer);
 						var init = vds.Variables.Single();
 						init.AddAnnotation(assignment.Left.GetResolveResult());

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -24,6 +24,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
+using ICSharpCode.Decompiler.CSharp.Resolver;
 using ICSharpCode.Decompiler.CSharp.Syntax;
 using ICSharpCode.Decompiler.IL;
 using ICSharpCode.Decompiler.IL.Transforms;
@@ -639,12 +640,25 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				{
 					// 'int v; v = expr;' can be combined to 'int v = expr;'
 					AstType type;
+					// A 'Delegate d = M;' or 'object o = M;' local keeps its declared type (it is not
+					// re-inferable from the method group), but the explicit delegate construction is
+					// dropped when the group's natural type produces the same delegate.
+					bool unwrapDelegateConstruction = assignment.Right is ObjectCreateExpression { Arguments: { Count: 1 } } oce
+						&& oce.Arguments.Single().Annotation<MethodGroupNaturalTypeAnnotation>() != null
+						&& (v.Type.IsKnownType(KnownTypeCode.Delegate) || v.Type.IsKnownType(KnownTypeCode.Object));
 					if (context.Settings.AnonymousTypes && v.Type.ContainsAnonymousType())
 					{
 						type = new SimpleType("var");
 					}
 					else if (context.Settings.NaturalTypeForLambdaAndMethodGroup && v.Type.ContainsAnonymousDelegate())
 					{
+						type = new SimpleType("var");
+					}
+					else if (assignment.Right.Annotation<MethodGroupNaturalTypeAnnotation>() is { } naturalType
+						&& NormalizeTypeVisitor.IgnoreNullabilityAndTuples.EquivalentTypes(naturalType.DelegateType, v.Type))
+					{
+						// The initializer is a bare method group whose natural type is the
+						// variable's type, so 'var' re-infers the same delegate type.
 						type = new SimpleType("var");
 					}
 					else
@@ -660,7 +674,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 						type.AddTrailingTrivia(new Comment("pinned", CommentType.MultiLine));
 					}
 					replacements.Add((v.InsertionPoint.nextNode, () => {
-						var vds = new VariableDeclarationStatement(type, v.Name, assignment.Right.Detach());
+						Expression initializer = unwrapDelegateConstruction
+							? ((ObjectCreateExpression)assignment.Right).Arguments.Single().Detach()
+							: assignment.Right.Detach();
+						var vds = new VariableDeclarationStatement(type, v.Name, initializer);
 						var init = vds.Variables.Single();
 						init.AddAnnotation(assignment.Left.GetResolveResult());
 						foreach (object annotation in assignment.Left.Annotations.Concat(assignment.Annotations))

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -576,6 +576,23 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			}
 		}
 
+		/// <summary>
+		/// Whether the delegate this lambda was converted to returns void. The expression body of
+		/// such a lambda is a statement whose value is discarded, so turning the body into a block
+		/// must not wrap it in a return statement.
+		/// </summary>
+		static bool LambdaReturnsVoid(LambdaExpression lambda)
+		{
+			foreach (var annotation in lambda.Annotations.OfType<ResolveResult>())
+			{
+				// The anonymous-delegate path carries the lambda's own result inside a conversion.
+				var result = annotation is ConversionResolveResult conversion ? conversion.Input : annotation;
+				if (result is DecompiledLambdaResolveResult lambdaResult)
+					return lambdaResult.ReturnType.Kind == TypeKind.Void;
+			}
+			return false;
+		}
+
 		bool IsMatchingAssignment(VariableToDeclare v, [NotNullWhen(true)] out AssignmentExpression? assignment)
 		{
 			assignment = v.InsertionPoint.nextNode as AssignmentExpression;
@@ -720,11 +737,19 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					if (v.InsertionPoint.nextNode.Parent is LambdaExpression lambda)
 					{
 						Debug.Assert(lambda.Body is not BlockStatement);
-						lambda.Body = new BlockStatement() {
-							new ReturnStatement((Expression)lambda.Body.Detach())
-						};
+						var bodyExpression = (Expression)lambda.Body.Detach();
+						// A void-returning lambda's expression body is a discarded statement, not a
+						// returned value: "return expr;" there is CS8030 ("converted to a void
+						// returning delegate cannot return a value").
+						Statement bodyStatement = LambdaReturnsVoid(lambda)
+							? new ExpressionStatement(bodyExpression)
+							: new ReturnStatement(bodyExpression);
+						lambda.Body = new BlockStatement() { bodyStatement };
 					}
-					if (v.InsertionPoint.nextNode.Parent is ReturnStatement)
+					// Wrapping an expression body above puts the insertion point one level too deep:
+					// it still points at the expression, whose parent is now the wrapping statement
+					// (a return for a value-returning lambda, an expression statement for a void one).
+					if (v.InsertionPoint.nextNode.Parent is ReturnStatement or ExpressionStatement)
 					{
 						v.InsertionPoint = v.InsertionPoint.Up();
 					}

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -626,6 +626,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						type = new SimpleType("var");
 					}
+					else if (context.Settings.NaturalTypeForLambdaAndMethodGroup && v.Type.ContainsAnonymousDelegate())
+					{
+						type = new SimpleType("var");
+					}
 					else
 					{
 						type = context.TypeSystemAstBuilder.ConvertType(v.Type);
@@ -661,6 +665,10 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					{
 						type = new SimpleType("var");
 						isOutVar = true;
+					}
+					else if (context.Settings.NaturalTypeForLambdaAndMethodGroup && v.Type.ContainsAnonymousDelegate())
+					{
+						type = new SimpleType("var");
 					}
 					else if (dirExpr.Annotation<UseImplicitlyTypedOutAnnotation>() != null
 						&& !IsReferencedWithinDeclaringCall(dirExpr, v))

--- a/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/DeclareVariables.cs
@@ -628,6 +628,16 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 			return !context.Settings.SeparateLocalVariableDeclarations;
 		}
 
+		/// <summary>
+		/// A function type converts to System.MulticastDelegate, to its base classes and to its
+		/// interfaces; a variable declared as one of those still accepts a bare method group.
+		/// </summary>
+		static bool IsFunctionTypeConversionTarget(IType type, TransformContext context)
+		{
+			return context.TypeSystem.FindType(KnownTypeCode.MulticastDelegate)
+				.GetAllBaseTypes().Any(baseType => baseType.Equals(type));
+		}
+
 		void InsertVariableDeclarations(TransformContext context)
 		{
 			var replacements = new List<(AstNode OldNode, Func<AstNode> CreateNewNode, string StepDescription)>();
@@ -640,12 +650,13 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 				{
 					// 'int v; v = expr;' can be combined to 'int v = expr;'
 					AstType type;
-					// A 'Delegate d = M;' or 'object o = M;' local keeps its declared type (it is not
-					// re-inferable from the method group), but the explicit delegate construction is
-					// dropped when the group's natural type produces the same delegate.
+					// A local declared as one of the types a function type merely converts to keeps
+					// its declared type (it is not re-inferable from the method group), but the
+					// explicit delegate construction is dropped when the group's natural type
+					// produces the same delegate.
 					bool unwrapDelegateConstruction = assignment.Right is ObjectCreateExpression { Arguments: { Count: 1 } } oce
 						&& oce.Arguments.Single().Annotation<MethodGroupNaturalTypeAnnotation>() != null
-						&& (v.Type.IsKnownType(KnownTypeCode.Delegate) || v.Type.IsKnownType(KnownTypeCode.Object));
+						&& IsFunctionTypeConversionTarget(v.Type, context);
 					if (context.Settings.AnonymousTypes && v.Type.ContainsAnonymousType())
 					{
 						type = new SimpleType("var");

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -848,6 +848,14 @@ namespace ICSharpCode.Decompiler
 		public partial bool InlineArrays { get; set; }
 
 		/// <summary>
+		/// Gets/sets whether lambda parameter lists may declare 'params' and parameter default
+		/// values. When disabled, these modifiers are dropped from anonymous functions instead.
+		/// </summary>
+		[Description("DecompilerSettings.LambdaOptionalAndParamsParameters")]
+		[DecompilerSetting(CSharp.LanguageVersion.CSharp12_0)]
+		public partial bool LambdaOptionalAndParamsParameters { get; set; }
+
+		/// <summary>
 		/// Gets/Sets whether C# 14.0 extension members should be transformed.
 		/// </summary>
 		[Description("DecompilerSettings.ExtensionMembers")]

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -347,6 +347,14 @@ namespace ICSharpCode.Decompiler
 		public partial bool ParamsCollections { get; set; }
 
 		/// <summary>
+		/// Use the C# 13 method group natural type improvements: candidates are pruned
+		/// scope-by-scope before the natural type is determined.
+		/// </summary>
+		[Description("DecompilerSettings.MethodGroupNaturalTypeImprovements")]
+		[DecompilerSetting(CSharp.LanguageVersion.CSharp13_0)]
+		public partial bool MethodGroupNaturalTypeImprovements { get; set; }
+
+		/// <summary>
 		/// Decompile lock statements.
 		/// </summary>
 		[Description("DecompilerSettings.DetectLockStatements")]

--- a/ICSharpCode.Decompiler/DecompilerSettings.cs
+++ b/ICSharpCode.Decompiler/DecompilerSettings.cs
@@ -176,6 +176,13 @@ namespace ICSharpCode.Decompiler
 		public partial bool FileScopedNamespaces { get; set; }
 
 		/// <summary>
+		/// Use C# 10 natural types for delegates and lambdas.
+		/// </summary>
+		[Description("DecompilerSettings.NaturalTypeForLambdaAndMethodGroup")]
+		[DecompilerSetting(CSharp.LanguageVersion.CSharp10_0)]
+		public partial bool NaturalTypeForLambdaAndMethodGroup { get; set; }
+
+		/// <summary>
 		/// Decompile anonymous methods/lambdas.
 		/// </summary>
 		[Description("DecompilerSettings.DecompileAnonymousMethodsLambdas")]

--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -808,7 +808,7 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 
 			string name;
-			if (type.IsAnonymousType())
+			if (type.IsAnonymousType() || type.IsAnonymousDelegate())
 			{
 				name = "anon";
 			}

--- a/ICSharpCode.Decompiler/IL/Transforms/DelegateConstruction.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/DelegateConstruction.cs
@@ -131,11 +131,11 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		static bool ContainsAnonymousType(IMethod method)
 		{
-			if (method.ReturnType.ContainsAnonymousType())
+			if (method.ReturnType.ContainsAnonymousTypeOrDelegate())
 				return true;
 			foreach (var p in method.Parameters)
 			{
-				if (p.Type.ContainsAnonymousType())
+				if (p.Type.ContainsAnonymousTypeOrDelegate())
 					return true;
 			}
 			return false;

--- a/ICSharpCode.Decompiler/NRExtensions.cs
+++ b/ICSharpCode.Decompiler/NRExtensions.cs
@@ -96,6 +96,22 @@ namespace ICSharpCode.Decompiler
 			return false;
 		}
 
+		public static bool IsAnonymousDelegate(this IType type)
+		{
+			if (type == null)
+				return false;
+			if (string.IsNullOrEmpty(type.Namespace) && type.HasGeneratedName()
+				&& type.Kind == TypeKind.Delegate
+				&& (type.Name.Contains("AnonymousDelegate")
+					|| type.Name.StartsWith("<>A{", StringComparison.Ordinal)
+					|| type.Name.StartsWith("<>F{", StringComparison.Ordinal)))
+			{
+				ITypeDefinition td = type.GetDefinition();
+				return td != null && td.IsCompilerGenerated();
+			}
+			return false;
+		}
+
 		public static bool ContainsAnonymousType(this IType type)
 		{
 			var visitor = new ContainsAnonTypeVisitor();
@@ -103,14 +119,31 @@ namespace ICSharpCode.Decompiler
 			return visitor.ContainsAnonType;
 		}
 
+		public static bool ContainsAnonymousDelegate(this IType type)
+		{
+			var visitor = new ContainsAnonTypeVisitor();
+			type.AcceptVisitor(visitor);
+			return visitor.ContainsAnonDelegate;
+		}
+
+		public static bool ContainsAnonymousTypeOrDelegate(this IType type)
+		{
+			var visitor = new ContainsAnonTypeVisitor();
+			type.AcceptVisitor(visitor);
+			return visitor.ContainsAnonType || visitor.ContainsAnonDelegate;
+		}
+
 		class ContainsAnonTypeVisitor : TypeVisitor
 		{
 			public bool ContainsAnonType;
+			public bool ContainsAnonDelegate;
 
 			public override IType VisitOtherType(IType type)
 			{
 				if (IsAnonymousType(type))
 					ContainsAnonType = true;
+				if (IsAnonymousDelegate(type))
+					ContainsAnonDelegate = true;
 				return base.VisitOtherType(type);
 			}
 
@@ -118,6 +151,8 @@ namespace ICSharpCode.Decompiler
 			{
 				if (IsAnonymousType(type))
 					ContainsAnonType = true;
+				if (IsAnonymousDelegate(type))
+					ContainsAnonDelegate = true;
 				return base.VisitTypeDefinition(type);
 			}
 		}

--- a/ICSharpCode.Decompiler/NRExtensions.cs
+++ b/ICSharpCode.Decompiler/NRExtensions.cs
@@ -96,15 +96,27 @@ namespace ICSharpCode.Decompiler
 			return false;
 		}
 
+		/// <summary>
+		/// The C# compiler names a synthesized delegate type &lt;&gt;A when it returns void and
+		/// &lt;&gt;F otherwise, followed by a bit pattern of the by-reference parameters, but only
+		/// when there are any: a signature that needs a synthesized type solely because it has
+		/// more than 16 parameters is passed entirely by value and carries no suffix. Signatures
+		/// with default values or params arrays get a &lt;&gt;f__AnonymousDelegateN name instead.
+		/// </summary>
+		internal static bool IsAnonymousDelegateName(string name)
+		{
+			return name.Contains("AnonymousDelegate")
+				|| name.StartsWith("<>A", StringComparison.Ordinal)
+				|| name.StartsWith("<>F", StringComparison.Ordinal);
+		}
+
 		public static bool IsAnonymousDelegate(this IType type)
 		{
 			if (type == null)
 				return false;
 			if (string.IsNullOrEmpty(type.Namespace) && type.HasGeneratedName()
 				&& type.Kind == TypeKind.Delegate
-				&& (type.Name.Contains("AnonymousDelegate")
-					|| type.Name.StartsWith("<>A{", StringComparison.Ordinal)
-					|| type.Name.StartsWith("<>F{", StringComparison.Ordinal)))
+				&& IsAnonymousDelegateName(type.Name))
 			{
 				ITypeDefinition td = type.GetDefinition();
 				return td != null && td.IsCompilerGenerated();

--- a/ICSharpCode.Decompiler/SRMExtensions.cs
+++ b/ICSharpCode.Decompiler/SRMExtensions.cs
@@ -499,6 +499,20 @@ namespace ICSharpCode.Decompiler
 			return false;
 		}
 
+		public static bool IsAnonymousDelegate(this TypeDefinition type, MetadataReader metadata)
+		{
+			string name = metadata.GetString(type.Name);
+			if (type.Namespace.IsNil && type.HasGeneratedName(metadata)
+				&& type.IsDelegate(metadata)
+				&& (name.Contains("AnonymousDelegate")
+					|| name.StartsWith("<>A{", StringComparison.Ordinal)
+					|| name.StartsWith("<>F{", StringComparison.Ordinal)))
+			{
+				return type.IsCompilerGenerated(metadata);
+			}
+			return false;
+		}
+
 		#region HasGeneratedName
 
 		public static bool IsGeneratedName(this StringHandle handle, MetadataReader metadata)

--- a/ICSharpCode.Decompiler/SRMExtensions.cs
+++ b/ICSharpCode.Decompiler/SRMExtensions.cs
@@ -504,9 +504,7 @@ namespace ICSharpCode.Decompiler
 			string name = metadata.GetString(type.Name);
 			if (type.Namespace.IsNil && type.HasGeneratedName(metadata)
 				&& type.IsDelegate(metadata)
-				&& (name.Contains("AnonymousDelegate")
-					|| name.StartsWith("<>A{", StringComparison.Ordinal)
-					|| name.StartsWith("<>F{", StringComparison.Ordinal)))
+				&& NRExtensions.IsAnonymousDelegateName(name))
 			{
 				return type.IsCompilerGenerated(metadata);
 			}

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1371,6 +1371,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use natural delegate types for lambdas and method groups.
+        /// </summary>
+        public static string DecompilerSettings_NaturalTypeForLambdaAndMethodGroup {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.NaturalTypeForLambdaAndMethodGroup", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Nullable reference types.
         /// </summary>
         public static string DecompilerSettings_NullableReferenceTypes {

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1362,6 +1362,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;params&apos; and optional parameters in lambdas.
+        /// </summary>
+        public static string DecompilerSettings_LambdaOptionalAndParamsParameters {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.LambdaOptionalAndParamsParameters", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use nint/nuint types.
         /// </summary>
         public static string DecompilerSettings_NativeIntegers {

--- a/ILSpy/Properties/Resources.Designer.cs
+++ b/ILSpy/Properties/Resources.Designer.cs
@@ -1371,6 +1371,15 @@ namespace ICSharpCode.ILSpy.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Use C# 13 method group natural type improvements.
+        /// </summary>
+        public static string DecompilerSettings_MethodGroupNaturalTypeImprovements {
+            get {
+                return ResourceManager.GetString("DecompilerSettings.MethodGroupNaturalTypeImprovements", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use nint/nuint types.
         /// </summary>
         public static string DecompilerSettings_NativeIntegers {

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -489,6 +489,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.LambdaOptionalAndParamsParameters" xml:space="preserve">
     <value>'params' and optional parameters in lambdas</value>
   </data>
+  <data name="DecompilerSettings.MethodGroupNaturalTypeImprovements" xml:space="preserve">
+    <value>Use C# 13 method group natural type improvements</value>
+  </data>
   <data name="DecompilerSettings.NativeIntegers" xml:space="preserve">
     <value>Use nint/nuint types</value>
   </data>

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -486,6 +486,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.IsUnmanagedAttributeOnTypeParametersShouldBeReplacedWithUnmanagedConstraints" xml:space="preserve">
     <value>IsUnmanagedAttribute on type parameters should be replaced with 'unmanaged' constraints</value>
   </data>
+  <data name="DecompilerSettings.LambdaOptionalAndParamsParameters" xml:space="preserve">
+    <value>'params' and optional parameters in lambdas</value>
+  </data>
   <data name="DecompilerSettings.NativeIntegers" xml:space="preserve">
     <value>Use nint/nuint types</value>
   </data>

--- a/ILSpy/Properties/Resources.resx
+++ b/ILSpy/Properties/Resources.resx
@@ -489,6 +489,9 @@ Are you sure you want to continue?</value>
   <data name="DecompilerSettings.NativeIntegers" xml:space="preserve">
     <value>Use nint/nuint types</value>
   </data>
+  <data name="DecompilerSettings.NaturalTypeForLambdaAndMethodGroup" xml:space="preserve">
+    <value>Use natural delegate types for lambdas and method groups</value>
+  </data>
   <data name="DecompilerSettings.NullPropagation" xml:space="preserve">
     <value>Decompile ?. and ?[] operators</value>
   </data>


### PR DESCRIPTION
Reconstructs the C# 10/12/13 "function type" features, so anonymous functions and method groups
come back as the source wrote them instead of as delegate constructions with unspeakable type
names.

**What is decompiled now**

- **Explicit lambda return types** (C# 10), including `ref` and `ref readonly` returns. The
  syntax tree gained `LambdaExpression.ReturnType`; the return type is written wherever the
  delegate's return type is not what C# would re-infer from the body.
- **Natural-typed lambdas for synthesized delegate types.** `<>A{...}` / `<>F{...}` (and the
  unbraced `` <>F`18 `` shapes for >16 parameters) cannot be named, so those sites now print
  `var x = (ref int y) => ++y;` rather than leaking the compiler-generated name. Conversions to
  `object`, `Delegate` and `Expression` targets no longer emit a cast to it either.
- **Method groups with a natural type** (C# 10) - `Func<int, int> f = M;` instead of
  `new Func<int, int>(M)` - gated by the existing `NaturalTypeForLambdaAndMethodGroup` setting.
  `ICSharpCode.Decompiler/CSharp/Resolver/MethodGroupNaturalType.cs` is the oracle that decides
  when the natural type of an emitted method group really is the delegate type in the IL.
- **C# 13 method-group improvements** behind a new `MethodGroupNaturalTypeImprovements` setting
  (scope-by-scope pruning vs. the C# 10 all-scopes rules), so pre-C# 13 output stays valid.
- **Lambda parameter defaults and `params`** (C# 12) where they are legal, downgraded to
  `[Optional]` / `[DefaultParameterValue]` / `[ParamArray]` attributes below C# 12
  (`LambdaOptionalAndParamsParameters`, with an `Ugly` fixture for the disabled state).
- **Statement-expression lambdas** render as expression bodies (`() => Console.WriteLine()`)
  where the expression is void-typed, or where an explicit return type spells the discarded
  value out. A non-void value keeps its block body: C# would otherwise read the expression's
  type as the lambda's return type and pick a different overload.

**Testing**

New fixtures: `Pretty/LambdaReturnTypes`, `Pretty/LambdaNaturalTypeConversions`,
`Pretty/LambdaOptionalAndParamsParameters` (+ `Ugly/NoLambdaOptionalAndParamsParameters`),
`Pretty/MethodGroupNaturalType`, `Pretty/MethodGroupNaturalTypeImprovementsDisabled`,
`Pretty/MethodGroupSynthesizedDelegates`, and the round-tripping
`Correctness/LambdaNaturalType` / `Correctness/MethodGroupNaturalType` - the correctness pair
matters most here, because a lost return type or parameter modifier silently rebinds an
overload instead of failing to compile.

Full `ICSharpCode.Decompiler.Tests` (3372 passed / 0 failed, roundtrip excluded) and
`ILSpy.Tests` (1181 passed / 0 failed) are green.

**Known gaps**: `static` lambdas are not emitted (see #829), and statement-bodied lambdas in
`Func`/`Action` positions still print as `delegate(int x) { ... }`.

**Specifications used**

Language proposals (dotnet/csharplang) - the three #829 entries this covers:

- [Lambda improvements](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-10.0/lambda-improvements.md) (C# 10) - attributes, explicit return types, and the natural type of a lambda or method group
- [Lambda method group defaults](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-12.0/lambda-method-group-defaults.md) (C# 12) - parameter default values and `params` on lambdas
- [Method group natural type improvements](https://github.com/dotnet/csharplang/blob/main/proposals/csharp-13.0/method-group-natural-type-improvements.md) (C# 13) - the scope-by-scope candidate pruning behind the new setting

Normative rules (dotnet/csharpstandard, branch `draft-v12`) - what the oracle in
`MethodGroupNaturalType.cs` and the conversion handling are checked against:

- [§12.22.8 Anonymous function type](https://github.com/dotnet/csharpstandard/blob/draft-v12/standard/expressions.md#12228-anonymous-function-type) - when a natural type exists, when a synthesized delegate is used instead of `Func`/`Action` (any non-by-value parameter or return, more than 16 parameters, or a type that is not a valid type argument), and the mandated `arg1..argn` parameter names
- [§10.2.21 Anonymous function type conversion](https://github.com/dotnet/csharpstandard/blob/draft-v12/standard/conversions.md#10221-anonymous-function-type-conversion) - which targets an anonymous-function-typed value converts to (`object`, `Delegate`, base classes, `Expression`), which is why those sites no longer need a cast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
