### PR TITLE
Fix pre-commit hook failure when package source mapping is active

### DIFF
--- a/BuildTools/pre-commit
+++ b/BuildTools/pre-commit
@@ -28,7 +28,7 @@ esac
 DOTNET_PATH="$DOTNET_CACHE_ROOT/ICSharpCode/ILSpy/dotnet-format-$DOTNET_FORMAT_VERSION"
 if [ ! -d "$DOTNET_PATH" ]; then
  echo "Downloading dotnet-format $DOTNET_FORMAT_VERSION..."
- dotnet tool install --tool-path "$DOTNET_PATH" dotnet-format --version "$DOTNET_FORMAT_VERSION" --add-source "$DOTNET_FORMAT_SOURCE"
+ dotnet tool install --tool-path "$DOTNET_PATH" dotnet-format --version "$DOTNET_FORMAT_VERSION"
 fi
 
 DOTNET_FORMAT="$DOTNET_PATH/dotnet-format$EXE_SUFFIX"

--- a/BuildTools/pre-commit
+++ b/BuildTools/pre-commit
@@ -36,11 +36,11 @@ DOTNET_FORMAT="$DOTNET_PATH/dotnet-format$EXE_SUFFIX"
 "$DOTNET_FORMAT" --version
 if [ "${1:-}" = "--format" ]; then
 	# called via format.bat
-	"$DOTNET_FORMAT" whitespace --no-restore --verbosity detailed ILSpy.sln
+	"$DOTNET_FORMAT" whitespace --no-restore --verbosity normal ILSpy.sln
 elif git diff --quiet --ignore-submodules; then
-	"$DOTNET_FORMAT" whitespace --no-restore --verbosity detailed ILSpy.sln
+	"$DOTNET_FORMAT" whitespace --no-restore --verbosity normal ILSpy.sln
 	git add -u -- \*\*.cs
 else
 	echo Partial commit: only verifying formatting
-	exec "$DOTNET_FORMAT" whitespace --verify-no-changes --no-restore --verbosity detailed ILSpy.sln
+	exec "$DOTNET_FORMAT" whitespace --verify-no-changes --no-restore --verbosity normal ILSpy.sln
 fi

--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,7 @@
     </packageSource>
     <packageSource key="dotnet10-transport">
       <package pattern="ILCompiler.Reflection.ReadyToRun.Experimental" />
+      <package pattern="dotnet-format" />
     </packageSource>
     <packageSource key="dotnet-tools">
       <package pattern="Microsoft.DiaSymReader.Converter.Xml" />


### PR DESCRIPTION
The hook installs dotnet-format with \--add-source\, which NuGet 6.x+ rejects when \packageSourceMapping\ is configured in \NuGet.config\.

The \dotnet10-transport\ feed is already declared as a package source; adding a \dotnet-format\ entry to its source mapping lets the install succeed without \--add-source\.