### PR TITLE
Make ThisResolveResult an ILVariableResolveResult of the this parameter

### DIFF
--- a/ICSharpCode.Decompiler.Tests/Semantics/ThisResolveResultTests.cs
+++ b/ICSharpCode.Decompiler.Tests/Semantics/ThisResolveResultTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Christoph Wille
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Linq;
+
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.IL;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.Semantics;
+using ICSharpCode.Decompiler.Tests.TypeSystem;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.Decompiler.Tests.Semantics
+{
+	// Sample hierarchy decompiled by ThisResolveResultTests: every way of naming the current
+	// instance (unqualified member, explicit 'this', 'base', a struct's by-ref 'this') has to
+	// end up annotated with the same 'this' parameter of the method being decompiled.
+	internal class ThisReferenceBase
+	{
+		public virtual int Get() => 0;
+	}
+
+	internal class ThisReferenceSample : ThisReferenceBase
+	{
+		public int value;
+
+		public ThisReferenceSample(int value)
+		{
+			// The parameter shadows the field, so this access keeps its qualifier.
+			this.value = value;
+		}
+
+		public int Unqualified() => value;
+
+		public override int Get() => base.Get();
+	}
+
+	internal struct ThisReferenceStructSample
+	{
+		public int value;
+
+		public int Unqualified() => value;
+	}
+
+	[TestFixture]
+	public class ThisResolveResultTests
+	{
+		// All samples live in this test assembly, so a single decompiler (and the PE file
+		// shared with the other fixtures) serves every test here. CSharpDecompiler is not
+		// safe for concurrent decompilations, so this fixture must stay non-parallelizable;
+		// marking it [Parallelizable] requires a decompiler per test.
+		static readonly Lazy<CSharpDecompiler> decompiler = new Lazy<CSharpDecompiler>(
+			delegate {
+				var module = TypeSystemLoaderTests.TestAssembly;
+				var resolver = new UniversalAssemblyResolver(module.FileName, false, module.Metadata.DetectTargetFrameworkId());
+				return new CSharpDecompiler(module, resolver, new DecompilerSettings());
+			});
+
+		static SyntaxTree Decompile(System.Type type)
+		{
+			return decompiler.Value.DecompileType(new FullTypeName(type.FullName));
+		}
+
+		static ILVariable AssertIsThisParameter(ResolveResult rr, string what)
+		{
+			Assert.That(rr, Is.InstanceOf<ThisResolveResult>(), what);
+			var variable = (rr as ILVariableResolveResult)?.Variable;
+			Assert.That(variable, Is.Not.Null, what);
+			Assert.That(variable.IsThis(), Is.True, what);
+			return variable;
+		}
+
+		static ResolveResult ResolveResultOf(SyntaxTree tree, string methodName, System.Func<MethodDeclaration, Expression> select)
+		{
+			var method = tree.Descendants.OfType<MethodDeclaration>().Single(m => m.Name == methodName);
+			return select(method).GetResolveResult();
+		}
+
+		[Test]
+		public void ExplicitThisIsTheThisParameter()
+		{
+			var tree = Decompile(typeof(ThisReferenceSample));
+			var ctor = tree.Descendants.OfType<ConstructorDeclaration>().Single();
+			var thisRef = ctor.Descendants.OfType<ThisReferenceExpression>().Single();
+			var variable = AssertIsThisParameter(thisRef.GetResolveResult(), "this");
+			Assert.That(variable.Type.FullName, Is.EqualTo(typeof(ThisReferenceSample).FullName));
+		}
+
+		[Test]
+		public void UnqualifiedFieldAccessTargetsTheThisParameter()
+		{
+			var tree = Decompile(typeof(ThisReferenceSample));
+			var rr = ResolveResultOf(tree, "Unqualified", m => m.Descendants.OfType<IdentifierExpression>().Single(id => id.Identifier == "value"));
+			var mrr = rr as MemberResolveResult;
+			Assert.That(mrr, Is.Not.Null, "unqualified field access");
+			AssertIsThisParameter(mrr.TargetResult, "target of unqualified field access");
+		}
+
+		[Test]
+		public void BaseReferenceIsTheThisParameterWithTheBaseType()
+		{
+			var tree = Decompile(typeof(ThisReferenceSample));
+			var rr = ResolveResultOf(tree, "Get", m => m.Descendants.OfType<BaseReferenceExpression>().Single());
+			var variable = AssertIsThisParameter(rr, "base");
+			Assert.That(rr.Type.FullName, Is.EqualTo(typeof(ThisReferenceBase).FullName));
+			Assert.That(variable.Type.FullName, Is.EqualTo(typeof(ThisReferenceSample).FullName));
+			Assert.That(((ThisResolveResult)rr).CausesNonVirtualInvocation, Is.True);
+		}
+
+		[Test]
+		public void StructUnqualifiedFieldAccessTargetsTheByRefThisParameter()
+		{
+			var tree = Decompile(typeof(ThisReferenceStructSample));
+			var rr = ResolveResultOf(tree, "Unqualified", m => m.Descendants.OfType<IdentifierExpression>().Single(id => id.Identifier == "value"));
+			var mrr = rr as MemberResolveResult;
+			Assert.That(mrr, Is.Not.Null, "unqualified field access");
+			var variable = AssertIsThisParameter(mrr.TargetResult, "target of unqualified field access");
+			Assert.That(variable.Type, Is.InstanceOf<ByReferenceType>());
+			Assert.That(mrr.TargetResult.Type.Kind, Is.Not.EqualTo(TypeKind.ByReference), "the reference is spelled as the struct itself");
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -423,8 +423,11 @@ namespace ICSharpCode.Decompiler.CSharp
 				}
 			}
 
-			if (mrr == null)
+			if (mrr == null || !requireTarget)
 			{
+				// The resolver looked the unqualified name up against the current type, so its
+				// result does not carry the translated target; annotate the same this/base or
+				// type target the qualified spelling gets.
 				mrr = new MemberResolveResult(target.ResolveResult, field);
 			}
 
@@ -2831,13 +2834,13 @@ namespace ICSharpCode.Decompiler.CSharp
 			// Additionally check target for null, in order to avoid a crash.
 			if (!memberStatic && target != null)
 			{
-				if (ShouldUseBaseReference())
+				if (ShouldUseBaseReference(out var baseThisVariable))
 				{
 					var baseReferenceType = resolver.CurrentTypeDefinition.DirectBaseTypes
 						.FirstOrDefault(t => t.Kind != TypeKind.Interface);
 					return new BaseReferenceExpression()
 						.WithILInstruction(target)
-						.WithRR(new ThisResolveResult(baseReferenceType ?? memberDeclaringType, nonVirtualInvocation));
+						.WithRR(new ThisResolveResult(baseThisVariable, baseReferenceType ?? memberDeclaringType, nonVirtualInvocation));
 				}
 				else
 				{
@@ -2881,11 +2884,11 @@ namespace ICSharpCode.Decompiler.CSharp
 							.WithoutILInstruction();
 					}
 					translatedTarget = EnsureTargetNotNullable(translatedTarget, target);
-					if (translatedTarget.Expression is ThisReferenceExpression)
+					if (translatedTarget.Expression is ThisReferenceExpression
+						&& translatedTarget.ResolveResult is ILVariableResolveResult { Variable: var thisVariable })
 					{
 						// Give an explicit `this` the same resolve result the base-reference branch
-						// above gives `base`, and that the resolver gives the unqualified spelling of
-						// the same access. ConvertVariable annotates it as an ordinary local, so
+						// above gives `base`. ConvertVariable annotates it as an ordinary local, so
 						// without this a consumer asking "does this expression reach instance state"
 						// gets a different answer depending on whether the qualifier happened to be
 						// printed - and the qualifier is printed for reasons (a parameter of the same
@@ -2893,7 +2896,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						// question being asked.
 						translatedTarget = new ThisReferenceExpression()
 							.WithILInstruction(target)
-							.WithRR(new ThisResolveResult(translatedTarget.Type, nonVirtualInvocation));
+							.WithRR(new ThisResolveResult(thisVariable, translatedTarget.Type, nonVirtualInvocation));
 					}
 					return translatedTarget;
 				}
@@ -2905,21 +2908,22 @@ namespace ICSharpCode.Decompiler.CSharp
 					.WithRR(new TypeResolveResult(constrainedTo ?? memberDeclaringType));
 			}
 
-			bool ShouldUseBaseReference()
+			bool ShouldUseBaseReference([NotNullWhen(true)] out ILVariable? thisVariable)
 			{
+				thisVariable = null;
 				if (!nonVirtualInvocation)
 					return false;
-				if (!MatchLdThis(target))
+				if (!MatchLdThis(target, out thisVariable))
 					return false;
 				if ((constrainedTo ?? memberDeclaringType).GetDefinition() == resolver.CurrentTypeDefinition)
 					return false;
 				return true;
 			}
 
-			bool MatchLdThis(ILInstruction inst)
+			bool MatchLdThis(ILInstruction inst, [NotNullWhen(true)] out ILVariable? thisVariable)
 			{
 				// ldloc this
-				if (inst.MatchLdThis())
+				if (inst.MatchLdThis(out thisVariable))
 					return true;
 				if (resolver.CurrentTypeDefinition.Kind == TypeKind.Struct)
 				{
@@ -2930,7 +2934,7 @@ namespace ICSharpCode.Decompiler.CSharp
 						return false;
 					if (!type.Equals(type2) || !type.Equals(resolver.CurrentTypeDefinition))
 						return false;
-					return arg2.MatchLdThis();
+					return arg2.MatchLdThis(out thisVariable);
 				}
 				return false;
 			}

--- a/ICSharpCode.Decompiler/CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.Decompiler/CSharp/Resolver/CSharpResolver.cs
@@ -1640,8 +1640,15 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 				ResolveResult r;
 				if (lookupMode == NameLookupMode.Expression || lookupMode == NameLookupMode.InvocationTarget)
 				{
-					var targetResolveResult = (t == this.CurrentTypeDefinition ? ResolveThisReference() : new TypeResolveResult(t));
-					r = lookup.Lookup(targetResolveResult, identifier, typeArguments, lookupMode == NameLookupMode.InvocationTarget);
+					// A ThisResolveResult names the 'this' parameter of an ILFunction, which the
+					// resolver does not know; the lookup on the current type does not need one,
+					// as it accepts protected members of the current type on its own. The type
+					// is self-parameterized so that its members come out specialized, matching
+					// the members that references from inside the type resolve to.
+					IType targetType = t == this.CurrentTypeDefinition && t.TypeParameterCount != 0
+						? new ParameterizedType(t, t.TypeParameters)
+						: t;
+					r = lookup.Lookup(new TypeResolveResult(targetType), identifier, typeArguments, lookupMode == NameLookupMode.InvocationTarget);
 				}
 				else
 				{
@@ -2618,48 +2625,6 @@ namespace ICSharpCode.Decompiler.CSharp.Resolver
 					break;
 			}
 			return new SizeOfResolveResult(int32, type, size);
-		}
-		#endregion
-
-		#region Resolve This/Base Reference
-		/// <summary>
-		/// Resolves 'this'.
-		/// </summary>
-		public ResolveResult ResolveThisReference()
-		{
-			ITypeDefinition t = CurrentTypeDefinition;
-			if (t != null)
-			{
-				if (t.TypeParameterCount != 0)
-				{
-					// Self-parameterize the type
-					return new ThisResolveResult(new ParameterizedType(t, t.TypeParameters));
-				}
-				else
-				{
-					return new ThisResolveResult(t);
-				}
-			}
-			return ErrorResult;
-		}
-
-		/// <summary>
-		/// Resolves 'base'.
-		/// </summary>
-		public ResolveResult ResolveBaseReference()
-		{
-			ITypeDefinition t = CurrentTypeDefinition;
-			if (t != null)
-			{
-				foreach (IType baseType in t.DirectBaseTypes)
-				{
-					if (baseType.Kind != TypeKind.Unknown && baseType.Kind != TypeKind.Interface)
-					{
-						return new ThisResolveResult(baseType, causesNonVirtualInvocation: true);
-					}
-				}
-			}
-			return ErrorResult;
 		}
 		#endregion
 

--- a/ICSharpCode.Decompiler/IL/Instructions/PatternMatching.cs
+++ b/ICSharpCode.Decompiler/IL/Instructions/PatternMatching.cs
@@ -116,8 +116,18 @@ namespace ICSharpCode.Decompiler.IL
 
 		public bool MatchLdThis()
 		{
-			var inst = this as LdLoc;
-			return inst != null && inst.Variable.Kind == VariableKind.Parameter && inst.Variable.Index < 0;
+			return MatchLdThis(out _);
+		}
+
+		public bool MatchLdThis([NotNullWhen(true)] out ILVariable? variable)
+		{
+			if (this is LdLoc inst && inst.Variable.IsThis())
+			{
+				variable = inst.Variable;
+				return true;
+			}
+			variable = null;
+			return false;
 		}
 
 		public bool MatchStLoc([NotNullWhen(true)] out ILVariable? variable)

--- a/ICSharpCode.Decompiler/Semantics/ThisResolveResult.cs
+++ b/ICSharpCode.Decompiler/Semantics/ThisResolveResult.cs
@@ -16,6 +16,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.IL;
 using ICSharpCode.Decompiler.TypeSystem;
 
 namespace ICSharpCode.Decompiler.Semantics
@@ -23,12 +25,15 @@ namespace ICSharpCode.Decompiler.Semantics
 	/// <summary>
 	/// Represents the 'this' reference.
 	/// Also used for the 'base' reference.
+	/// Both read the 'this' parameter of the current function, so this is also the
+	/// <see cref="ILVariableResolveResult"/> of that variable. The type is the one the
+	/// reference is spelled with: 'base' carries the base type, not the variable's type.
 	/// </summary>
-	public class ThisResolveResult : ResolveResult
+	public class ThisResolveResult : ILVariableResolveResult
 	{
 		bool causesNonVirtualInvocation;
 
-		public ThisResolveResult(IType type, bool causesNonVirtualInvocation = false) : base(type)
+		public ThisResolveResult(ILVariable thisVariable, IType type, bool causesNonVirtualInvocation = false) : base(thisVariable, type)
 		{
 			this.causesNonVirtualInvocation = causesNonVirtualInvocation;
 		}


### PR DESCRIPTION
## Summary

`ThisResolveResult` now inherits from `ILVariableResolveResult` and carries the `this` parameter (`ILVariable` with `Kind == Parameter`, `Index < 0`) of the function being decompiled. Every `this`/`base` reference the decompiler emits - explicit `this.x`, `base.M()`, and the target of an unqualified `x` - is annotated with that variable.

## Analysis

### Where `ThisResolveResult` was created

| Site | Has an `ILVariable`? |
|---|---|
| `ExpressionBuilder.TranslateTarget`, `base` branch | yes - the target instruction is `ldloc this` (or `box T(ldobj T(ldloc this))` for structs) |
| `ExpressionBuilder.TranslateTarget`, explicit `this` branch (added in 13c6cc674 for #3984) | yes - `ConvertVariable` already annotated the `ThisReferenceExpression` with an `ILVariableResolveResult` |
| `CSharpResolver.ResolveThisReference()` / `ResolveBaseReference()` | **no** - the resolver only knows a `CSharpTypeResolveContext`, not an `ILFunction` |

The resolver-created one mattered in exactly one place: `LookInCurrentType` used `ResolveThisReference()` as the lookup target for simple names in the current type, and `ExpressionBuilder.ConvertField` annotated the resulting `MemberResolveResult` on an *unqualified* field access. That is why `TransformFieldAndConstructorInitializers.ReferencesInstanceMember` saw a `ThisResolveResult` target for `A` but (before #3984) not for `this.A`.

### Options considered

1. **Plumb the `this` variable into `CSharpResolver`** (`WithCurrentThisVariable`). Rejected: threads an IL concept through the resolver's immutable-copy constructor and every `With*` method, and still needs a fallback for resolvers created without an `ILFunction` (`TypeSystemAstBuilder`, `IntroduceUsingDeclarations`, `IntroduceExtensionMethods`, static contexts).
2. **Make the variable nullable on `ILVariableResolveResult`.** Rejected: breaks the non-null contract every consumer relies on.
3. **Stop synthesizing `this` in the resolver; annotate from the translated target instead.** Chosen - see below.

### Why the lookup does not need a `ThisResolveResult`

`MemberLookup` uses `is ThisResolveResult` for two things: (a) granting protected access, which `IsProtectedAccessAllowed(type)` already grants for the current type; (b) rewriting the target of a *static* member to a `TypeResolveResult`, which is a no-op when the target already is one. The other consumers of `ResolveSimpleName` in the decompiler (`CallBuilder` overload checks) only use the member lists.

One subtlety surfaced by the Pretty suite (114 failures on the first attempt): the lookup target for the current type must stay **self-parameterized** (`C<T>` rather than the bare definition), otherwise the members come out unspecialized and `SpecializedMember.Equals(..., TypeErasure)` never matches the specialized members that IL references inside the type resolve to - which made every unqualified access in a generic type look ambiguous and get a `this.` qualifier.

## Changes

- **`Semantics/ThisResolveResult.cs`** - `: ILVariableResolveResult`; ctor `(ILVariable thisVariable, IType type, bool causesNonVirtualInvocation = false)`. The `Type` is the one the reference is spelled with (`base` -> base type; struct `this` -> the struct, while the variable itself is by-ref).
- **`IL/Instructions/PatternMatching.cs`** - new `MatchLdThis(out ILVariable? variable)`; the parameterless overload delegates to it.
- **`CSharp/ExpressionBuilder.cs`**
  - `TranslateTarget`: `ShouldUseBaseReference`/`MatchLdThis` return the matched `this` variable for the `base` branch; the explicit-`this` branch takes it from the `ILVariableResolveResult` `ConvertVariable` produced.
  - `ConvertField`: an unqualified field access is annotated with the translated target's resolve result (`this`/`base`/type) instead of the resolver's synthesized one. This keeps `ReferencesInstanceMember` seeing a `ThisResolveResult` for the unqualified spelling (the #3984 fixture `StructInitializerDependsOnField` covers this).
- **`CSharp/Resolver/CSharpResolver.cs`**
  - `LookInCurrentType` looks names up against `TypeResolveResult(self-parameterized current type)`.
  - `ResolveThisReference()` / `ResolveBaseReference()` removed. They are public, but had no callers left in the repo, and nothing can construct a `ThisResolveResult` without an `ILVariable` any more. Flagging this as the one public-API removal in case stubs are preferred.
- **`ICSharpCode.Decompiler.Tests/Semantics/ThisResolveResultTests.cs`** (new) - explicit `this`, unqualified field target, `base` (base type + `CausesNonVirtualInvocation`), struct by-ref `this`. All four fail against the pre-change sources (verified by stashing) and pass now.

## Behavior notes

- Output is unchanged (Pretty suite green).
- Annotation shape: an unqualified **static** field access now carries `MemberResolveResult(TypeResolveResult(field.DeclaringType), field)` (same as the qualified spelling produces) instead of `TypeResolveResult(currentType)`. No in-repo consumer distinguishes these.
- No `ILSpy`/`ILSpyX` code references `ThisResolveResult` or the removed resolver methods.

## Test plan

- [x] `PrettyTestRunner` - 1980 passed, 5 skipped
- [x] all other in-process decompiler tests (excluding Correctness/Roundtrip) - 1362 passed, 9 skipped
- [x] new `ThisResolveResultTests` - red before, 4/4 green after
- [x] `ILSpy.csproj` builds
- [ ] Correctness / Roundtrip suites not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
