### PR TITLE
Search inside packages without stalling, and navigate to what it finds

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,20 +5,33 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "ILSpy",
+            "name": ".NET Core Debugger (launch)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${command:dotrush.activeTargetPath}",
+            // ILSpy is single-instance: without this a launch forwards its arguments to an
+            // already-running ILSpy and exits before Avalonia starts, so no breakpoint is hit.
+            "args": ["--newinstance"],
+            "preLaunchTask": "dotrush: Build"
+        },
+        {
+            // Fallback for setups without the dotrush extension: builds and launches ILSpy
+            // directly, no ${command:dotrush.*} resolution involved.
+            "name": "ILSpy (no dotrush)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/ILSpy/bin/Debug/net10.0/ILSpy.exe",
+            "program": "${workspaceFolder}/ILSpy/bin/Debug/net10.0/ILSpy.dll",
             "args": ["--newinstance"],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",
             "stopAtEntry": false
         },
         {
-            "name": ".NET Core Attach",
+            "name": ".NET Core Debugger (attach)",
             "type": "coreclr",
-            "request": "attach"
+            "request": "attach",
+            "processId": "${command:dotrush.pickProcess}"
         }
     ]
 }

--- a/ICSharpCode.ILSpyX/AssemblyList.cs
+++ b/ICSharpCode.ILSpyX/AssemblyList.cs
@@ -161,6 +161,15 @@ namespace ICSharpCode.ILSpyX
 			return GetSnapshot().GetAllAssembliesAsync();
 		}
 
+		/// <summary>
+		/// Streaming variant of <see cref="GetAllAssemblies"/>, for consumers that can act on each
+		/// assembly as it loads instead of waiting for the whole list.
+		/// </summary>
+		public IAsyncEnumerable<LoadedAssembly> EnumerateAllAssemblies(CancellationToken cancellationToken = default)
+		{
+			return GetSnapshot().EnumerateAllAssembliesAsync(cancellationToken);
+		}
+
 		public int Count {
 			get {
 				lock (lockObj)

--- a/ICSharpCode.ILSpyX/AssemblyListSnapshot.cs
+++ b/ICSharpCode.ILSpyX/AssemblyListSnapshot.cs
@@ -22,6 +22,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using ICSharpCode.Decompiler.Metadata;
@@ -171,48 +173,80 @@ namespace ICSharpCode.ILSpyX
 		public async Task<IList<LoadedAssembly>> GetAllAssembliesAsync()
 		{
 			var results = new List<LoadedAssembly>(assemblies.Length);
+			await foreach (var asm in EnumerateAllAssembliesAsync().ConfigureAwait(false))
+			{
+				results.Add(asm);
+			}
+			return results;
+		}
 
+		/// <summary>
+		/// Streaming variant of <see cref="GetAllAssembliesAsync"/>: yields each assembly as soon
+		/// as it is known. Awaiting the load result is what triggers the lazy load, so a consumer
+		/// that materializes the whole sequence first waits for every assembly on the list to be
+		/// read off disk before it can do any work.
+		/// </summary>
+		public async IAsyncEnumerable<LoadedAssembly> EnumerateAllAssembliesAsync(
+			[EnumeratorCancellation] CancellationToken cancellationToken = default)
+		{
 			foreach (var asm in assemblies)
 			{
-				LoadResult result;
+				cancellationToken.ThrowIfCancellationRequested();
+				LoadResult? result = null;
 				try
 				{
 					result = await asm.GetLoadResultAsync().ConfigureAwait(false);
 				}
 				catch
 				{
-					results.Add(asm);
-					continue;
+					// Load failure: still yield the assembly so the consumer can surface it.
 				}
-				if (result.Package != null)
+				if (result == null)
 				{
-					AddDescendants(result.Package.RootFolder);
+					yield return asm;
+				}
+				else if (result.Package != null)
+				{
+					foreach (var descendant in EnumerateDescendants(result.Package.RootFolder))
+					{
+						yield return descendant;
+					}
 				}
 				else if (result.MetadataFile != null)
 				{
-					results.Add(asm);
+					yield return asm;
 				}
 			}
 
-			void AddDescendants(PackageFolder folder)
+			static IEnumerable<LoadedAssembly> EnumerateDescendants(PackageFolder folder)
 			{
 				foreach (var subFolder in folder.Folders)
 				{
-					AddDescendants(subFolder);
+					foreach (var descendant in EnumerateDescendants(subFolder))
+					{
+						yield return descendant;
+					}
 				}
 
 				foreach (var entry in folder.Entries)
 				{
 					if (!entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && !entry.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
 						continue;
-					var asm = folder.ResolveFileName(entry.Name);
+					LoadedAssembly? asm;
+					try
+					{
+						asm = folder.ResolveFileName(entry.Name);
+					}
+					catch
+					{
+						// One unreadable entry must not abandon the rest of the package.
+						continue;
+					}
 					if (asm == null)
 						continue;
-					results.Add(asm);
+					yield return asm;
 				}
 			}
-
-			return results;
 		}
 	}
 }

--- a/ICSharpCode.ILSpyX/LoadedAssemblyExtensions.cs
+++ b/ICSharpCode.ILSpyX/LoadedAssemblyExtensions.cs
@@ -70,6 +70,20 @@ namespace ICSharpCode.ILSpyX
 			return GetLoadedAssembly(file).GetTypeSystemOrNull(DecompilerTypeSystem.GetOptions(settings));
 		}
 
+		/// <summary>
+		/// Like <see cref="GetLoadedAssembly"/>, but returns null for a file that was built outside
+		/// the <see cref="LoadedAssembly"/> machinery instead of throwing.
+		/// </summary>
+		public static LoadedAssembly? GetLoadedAssemblyOrNull(this MetadataFile file)
+		{
+			if (file == null)
+				throw new ArgumentNullException(nameof(file));
+			lock (LoadedAssembly.loadedAssemblies)
+			{
+				return LoadedAssembly.loadedAssemblies.TryGetValue(file, out var loadedAssembly) ? loadedAssembly : null;
+			}
+		}
+
 		public static LoadedAssembly GetLoadedAssembly(this MetadataFile file)
 		{
 			if (file == null)

--- a/ILSpy.Tests/AssemblyTree/AssemblyTreeModelTests.cs
+++ b/ILSpy.Tests/AssemblyTree/AssemblyTreeModelTests.cs
@@ -16,6 +16,12 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+
 using Avalonia.Headless.NUnit;
 
 using AwesomeAssertions;
@@ -24,6 +30,7 @@ using ICSharpCode.ILSpyX;
 
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.AssemblyTree;
+using ICSharpCode.ILSpy.TreeNodes;
 
 using NUnit.Framework;
 
@@ -62,5 +69,32 @@ public class AssemblyTreeModelTests
 			"Initialize mirrors AssemblyListManager.AssemblyLists into the toolbar combo's source.");
 		model.ActiveListName.Should().Be(AssemblyListManager.DefaultListName,
 			"Initialize selects the (Default) list so the tree has something to render at startup.");
+	}
+
+	[AvaloniaTest]
+	public async Task FindTreeNode_resolves_a_type_inside_an_unexpanded_package()
+	{
+		// Search enumerates the contents of packages whether or not the user ever opened them in
+		// the tree, so activating such a result has to reach a node that does not exist yet.
+		var (_, vm) = await TestHarness.BootAsync();
+
+		var tempDir = Path.Combine(Path.GetTempPath(), "ILSpy.Tests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+		var zipPath = Path.Combine(tempDir, "package.zip");
+		using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
+			zip.CreateEntryFromFile(FixtureAssembly.Emit("Nested"), "lib/net10.0/Nested.dll");
+
+		await vm.OpenAssemblyAsync(zipPath);
+
+		var nested = (await vm.AssemblyTreeModel.AssemblyList!.GetAllAssemblies())
+			.Single(a => a.ParentBundle != null);
+		var type = nested.GetTypeSystemOrNull()!.MainModule.TypeDefinitions
+			.Single(t => t.Name == FixtureAssembly.TypeName);
+
+		var node = vm.AssemblyTreeModel.FindTreeNode(type);
+
+		// Cast through object so the generic Should() resolves, not the SharpTreeNode shadow.
+		((object?)node).Should().BeOfType<TypeTreeNode>(
+			"the lookup must descend into the package's folders, expanding them on the way");
 	}
 }

--- a/ILSpy.Tests/TreeNodes/TypeSystemSharingTests.cs
+++ b/ILSpy.Tests/TreeNodes/TypeSystemSharingTests.cs
@@ -24,6 +24,7 @@ using Avalonia.Headless.NUnit;
 using AwesomeAssertions;
 
 using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.AssemblyTree;
 using ICSharpCode.ILSpy.Languages;
 using ICSharpCode.ILSpy.Search;
 using ICSharpCode.ILSpy.TreeNodes;
@@ -75,7 +76,8 @@ public class TypeSystemSharingTests
 		var language = AppComposition.Current.GetExport<LanguageService>().CurrentLanguage;
 
 		var search = new RunningSearch(
-			new[] { fixture }, FixtureAssembly.TypeName, SearchMode.TypeAndMember, language,
+			AppComposition.Current.GetExport<AssemblyTreeModel>().AssemblyList!,
+			FixtureAssembly.TypeName, SearchMode.TypeAndMember, language,
 			ApiVisibility.PublicAndInternal, new AvaloniaSearchResultFactory(language),
 			new ObservableCollection<SearchResult>(), SearchResult.ComparerByName);
 		var request = search.BuildRequest();

--- a/ILSpy/AssemblyTree/TreeNodeLocator.cs
+++ b/ILSpy/AssemblyTree/TreeNodeLocator.cs
@@ -100,8 +100,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 					return root.FindAssemblyNode(lasm);
 
 				case MetadataFile metadataFile:
-					return root.Children.OfType<AssemblyTreeNode>()
-						.FirstOrDefault(a => a.LoadedAssembly.GetMetadataFileOrNull() == metadataFile);
+					return FindAssemblyNode(root, metadataFile);
 
 				case Resource resource:
 					return FindResourceNode(root, resource, null);
@@ -115,6 +114,47 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 				default:
 					return null;
 			}
+		}
+
+		/// <summary>
+		/// Finds the node for the assembly <paramref name="module"/> was loaded from, including
+		/// assemblies nested inside a package or bundle. Package folders are expanded on the way
+		/// down, so this resolves even when the user has never opened the package in the tree.
+		/// </summary>
+		public static AssemblyTreeNode? FindAssemblyNode(AssemblyListTreeNode root, MetadataFile? module)
+		{
+			// A package child records the bundle it came from, so walking up that chain leads
+			// straight to the one top-level node worth descending into. Searching the tree for a
+			// matching module instead would have to visit every namespace and type node already
+			// built, and would still miss nested assemblies that are not loaded yet.
+			var nesting = new Stack<LoadedAssembly>();
+			for (var current = module?.GetLoadedAssemblyOrNull(); current != null; current = current.ParentBundle)
+				nesting.Push(current);
+			if (nesting.Count == 0)
+				return null;
+
+			var node = root.FindAssemblyNode(nesting.Pop());
+			while (node != null && nesting.Count > 0)
+				node = FindNestedAssemblyNode(node, nesting.Pop());
+			return node;
+		}
+
+		// Depth-first search for one assembly within a package node's folder structure. Only
+		// package folders are descended into, so the walk stays inside the package.
+		static AssemblyTreeNode? FindNestedAssemblyNode(SharpTreeNode packageNode, LoadedAssembly assembly)
+		{
+			packageNode.EnsureLazyChildren();
+			foreach (var child in packageNode.Children)
+			{
+				switch (child)
+				{
+					case AssemblyTreeNode nested when nested.LoadedAssembly == assembly:
+						return nested;
+					case PackageFolderTreeNode folder when FindNestedAssemblyNode(folder, assembly) is { } found:
+						return found;
+				}
+			}
+			return null;
 		}
 
 		// Resolves a resource (optionally a named sub-entry) to its tree node. Mirrors the previous
@@ -152,8 +192,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			var module = ns.ContributingModules.FirstOrDefault();
 			if (module?.MetadataFile == null)
 				return null;
-			var assembly = root.Children.OfType<AssemblyTreeNode>()
-				.FirstOrDefault(a => a.LoadedAssembly.GetMetadataFileOrNull() == module.MetadataFile);
+			var assembly = FindAssemblyNode(root, module.MetadataFile);
 			if (assembly == null)
 				return null;
 			assembly.EnsureLazyChildren();
@@ -166,8 +205,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			var module = type.ParentModule?.MetadataFile;
 			if (module == null)
 				return null;
-			var assembly = root.Children.OfType<AssemblyTreeNode>()
-				.FirstOrDefault(a => a.LoadedAssembly.GetMetadataFileOrNull() == module);
+			var assembly = FindAssemblyNode(root, module);
 			if (assembly == null)
 				return null;
 

--- a/ILSpy/Controls/Omnibar/OmnibarViewModel.cs
+++ b/ILSpy/Controls/Omnibar/OmnibarViewModel.cs
@@ -213,7 +213,7 @@ namespace ICSharpCode.ILSpy.Controls.Omnibar
 				?? ApiVisibility.PublicOnly;
 
 			var run = new RunningSearch(
-				assemblyList.GetAssemblies(),
+				assemblyList,
 				term,
 				SearchMode.TypeAndMember,
 				language,

--- a/ILSpy/Search/RunningSearch.cs
+++ b/ILSpy/Search/RunningSearch.cs
@@ -53,7 +53,7 @@ namespace ICSharpCode.ILSpy.Search
 		// when the queue is jammed with thousands of late-arriving hits.
 		const int RefreshTimeBudgetMs = 10;
 
-		readonly IReadOnlyList<LoadedAssembly> assemblies;
+		readonly AssemblyList assemblyList;
 		readonly SearchMode mode;
 		readonly string searchTerm;
 		readonly Language language;
@@ -70,7 +70,7 @@ namespace ICSharpCode.ILSpy.Search
 		bool completedRaised;
 
 		public RunningSearch(
-			IReadOnlyList<LoadedAssembly> assemblies,
+			AssemblyList assemblyList,
 			string searchTerm,
 			SearchMode mode,
 			Language language,
@@ -79,7 +79,7 @@ namespace ICSharpCode.ILSpy.Search
 			ObservableCollection<SearchResult> sink,
 			IComparer<SearchResult> sortComparer)
 		{
-			this.assemblies = assemblies;
+			this.assemblyList = assemblyList;
 			this.searchTerm = searchTerm;
 			this.mode = mode;
 			this.language = language;
@@ -123,7 +123,7 @@ namespace ICSharpCode.ILSpy.Search
 			RaiseCompletedIfFirst();
 		}
 
-		void RunSearch(CancellationToken ct)
+		async Task RunSearch(CancellationToken ct)
 		{
 			try
 			{
@@ -131,20 +131,23 @@ namespace ICSharpCode.ILSpy.Search
 				var strategy = GetStrategy(request);
 				if (strategy == null)
 					return;
+				// Streaming enumeration: expanding bundles/packages into their contained
+				// assemblies triggers the lazy load of every entry on the list, so awaiting
+				// the whole set up front would mean no results at all until the last
+				// assembly is off disk. Enumerating starts the walk here on the worker
+				// thread, not at construction time on the UI thread.
+				//
 				// Serial walk: per-assembly metadata walk is allocation-dominated, and 4
 				// parallel producers fighting for the ConcurrentQueue + the resulting UI
 				// batching jitter end up slower than serial in practice.
-				foreach (var assembly in assemblies)
+				await foreach (var assembly in assemblyList.EnumerateAllAssemblies(ct).ConfigureAwait(false))
 				{
 					if (ct.IsCancellationRequested)
 						break;
 					MetadataFile? module;
 					try
 					{
-						// Block here — we're already on a worker thread (Task.Run) and
-						// this matches the WPF call shape. ConfigureAwait in an async
-						// state machine would just add overhead for the same effect.
-						module = assembly.GetMetadataFileAsync().GetAwaiter().GetResult();
+						module = await assembly.GetMetadataFileAsync().ConfigureAwait(false);
 					}
 					catch (OperationCanceledException)
 					{

--- a/ILSpy/Search/SearchPaneModel.cs
+++ b/ILSpy/Search/SearchPaneModel.cs
@@ -251,7 +251,7 @@ namespace ICSharpCode.ILSpy.Search
 				? SearchResult.ComparerByFitness
 				: SearchResult.ComparerByName;
 			var run = new RunningSearch(
-				assemblyList.GetAssemblies(),
+				assemblyList,
 				term,
 				SelectedSearchMode.Mode,
 				language,


### PR DESCRIPTION
Searching inside bundles and packages needs them expanded into their contained
assemblies, and that expansion awaits each assembly's load result - which is
what triggers the lazy load in the first place. Building the full list up front
means a search on a freshly restored list produces nothing at all until the last
assembly is off disk, and the blocking wait for it ignored the cancellation
token the pane fires on every keystroke. The walk is a stream now: the snapshot
is still taken eagerly, before the first element is yielded, so the set cannot
change under a running search, and a failing assembly or unreadable package
entry skips itself instead of abandoning the rest.

Navigating to what the search finds had the matching problem. Resolving a type
to its tree node scanned every descendant of the root - every namespace node of
every assembly, all built eagerly - to find one assembly node. A package child
records the bundle it came from, so that chain now leads straight to the single
top-level node worth descending into. The two sibling lookups (a bare
`MetadataFile` reference, and a namespace) only ever considered the root's
direct children and so never resolved anything inside a package; they share the
same helper now. The descent expands package folders, which is required because
search surfaces package contents whether or not the tree was ever opened there.

Covered by `FindTreeNode_resolves_a_type_inside_an_unexpanded_package`. Full
`ILSpy.Tests` run: 1204 passed, 0 failed, 3 skipped.

The VS Code launch configuration change is unrelated housekeeping that rode
along on the branch.

Prepared with assistance from Claude Code.
