### PR TITLE
Avoid using query expressions if there's indications that lambda parameter types cannot be omitted.

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/QueryExpressions.cs
@@ -274,5 +274,18 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				   where t != null
 				   select t;
 		}
+
+#if CS70
+		public IEnumerable<string> Issue3352()
+		{
+			// We don't have backward type inference, so LINQ syntax cannot be used with named tuple types.
+			return new (string, int)[4] {
+				("A", 10),
+				("B", 20),
+				("C", 30),
+				("D", 40)
+			}.Where(((string Name, int Age) t) => t.Age >= 18).Select(((string Name, int Age) t) => t.Name);
+		}
+#endif
 	}
 }

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/CSharpOutputVisitor.cs
@@ -620,7 +620,11 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			StartNode(arrayCreateExpression);
 			WriteKeyword(ArrayCreateExpression.NewKeyword);
-			arrayCreateExpression.Type?.AcceptVisitor(this);
+			if (arrayCreateExpression.Type != null)
+			{
+				Space();
+				arrayCreateExpression.Type.AcceptVisitor(this);
+			}
 			if (arrayCreateExpression.Arguments.Count > 0)
 			{
 				WriteCommaSeparatedListInBrackets(arrayCreateExpression.Arguments);
@@ -1110,6 +1114,7 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 		{
 			StartNode(objectCreateExpression);
 			WriteKeyword(ObjectCreateExpression.NewKeyword);
+			Space();
 			objectCreateExpression.Type.AcceptVisitor(this);
 			bool useParenthesis = objectCreateExpression.Arguments.Any() || objectCreateExpression.Initializer is null;
 			if (useParenthesis)

--- a/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/IntroduceQueryExpressions.cs
@@ -426,6 +426,12 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 		{
 			if (expr is LambdaExpression lambda && lambda.Parameters.Count == 1 && lambda.Body is Expression)
 			{
+				if (lambda.GetResolveResult() is DecompiledLambdaResolveResult { AttemptedConversionWithTypeMismatch: true })
+				{
+					parameter = null;
+					body = null;
+					return false;
+				}
 				ParameterDeclaration p = lambda.Parameters.Single();
 				if (ValidateParameter(p))
 				{

--- a/ICSharpCode.Decompiler/Semantics/LambdaResolveResult.cs
+++ b/ICSharpCode.Decompiler/Semantics/LambdaResolveResult.cs
@@ -107,6 +107,15 @@ namespace ICSharpCode.Decompiler.Semantics
 		/// </summary>
 		public IType InferredReturnType;
 
+		/// <summary>
+		/// Set to true if overload resolution might be able to call
+		/// the wrong method if this lambda's parameter types are removed.
+		/// Also set on minor type mismatches (e.g. tuple element names)
+		/// that don't affect overload resolution, but could render the
+		/// lambda body invalid if the lambda's parameter types were removed.
+		/// </summary>
+		public bool AttemptedConversionWithTypeMismatch = false;
+
 		public DecompiledLambdaResolveResult(IL.ILFunction function,
 			IType delegateType,
 			IType inferredReturnType,
@@ -137,7 +146,13 @@ namespace ICSharpCode.Decompiler.Semantics
 		{
 			// We don't know how to compute which type would be inferred if
 			// given other parameter types.
-			// Let's hope this is good enough:
+			// But: initially, our lambdas always have explicit parameter types
+			// (except anonymous types...),
+			// so it's correct to say that the parameter types of the delegate we're
+			// converting to don't matter -- we always have the inferred return type
+			// from our body.
+			// Later, we may drop explicit parameter types, but only if this
+			// doesn't change our actual parameter types.
 			return InferredReturnType;
 		}
 
@@ -150,11 +165,18 @@ namespace ICSharpCode.Decompiler.Semantics
 					return Conversion.None;
 				for (int i = 0; i < parameterTypes.Length; ++i)
 				{
+					if (parameterTypes[i].Equals(this.Parameters[i].Type))
+					{
+						continue;
+					}
+					this.AttemptedConversionWithTypeMismatch = true;
 					if (!conversions.IdentityConversion(parameterTypes[i], this.Parameters[i].Type))
 					{
 						if (IsImplicitlyTyped)
 						{
 							// it's possible that different parameter types also lead to a valid conversion
+							// Note that this case is currently only reachable when ExpressionBuilder
+							// omits lambda parameters due to anonymous methods.
 							return LambdaConversion.Instance;
 						}
 						else


### PR DESCRIPTION
I think this isn't reliable enough yet to actually omit parameter types for lambdas (it only protects against switching to the wrong overload/causing ambiguities; not against type inference failures); so for now it's only used in the query expression transform.

Fixes #3352.