### PR TITLE
Fix package search and navigation follow-ups from #4023

### DIFF
--- a/ICSharpCode.ILSpyX/AssemblyListSnapshot.cs
+++ b/ICSharpCode.ILSpyX/AssemblyListSnapshot.cs
@@ -207,7 +207,7 @@ namespace ICSharpCode.ILSpyX
 				}
 				else if (result.Package != null)
 				{
-					foreach (var descendant in EnumerateDescendants(result.Package.RootFolder))
+					foreach (var descendant in EnumerateDescendants(result.Package.RootFolder, cancellationToken))
 					{
 						yield return descendant;
 					}
@@ -218,11 +218,11 @@ namespace ICSharpCode.ILSpyX
 				}
 			}
 
-			static IEnumerable<LoadedAssembly> EnumerateDescendants(PackageFolder folder)
+			static IEnumerable<LoadedAssembly> EnumerateDescendants(PackageFolder folder, CancellationToken cancellationToken)
 			{
 				foreach (var subFolder in folder.Folders)
 				{
-					foreach (var descendant in EnumerateDescendants(subFolder))
+					foreach (var descendant in EnumerateDescendants(subFolder, cancellationToken))
 					{
 						yield return descendant;
 					}
@@ -230,12 +230,15 @@ namespace ICSharpCode.ILSpyX
 
 				foreach (var entry in folder.Entries)
 				{
+					// Checked per entry, not per package: resolving one starts extracting it from
+					// the archive, so a walk the consumer has given up on must stop expanding.
+					cancellationToken.ThrowIfCancellationRequested();
 					if (!entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && !entry.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
 						continue;
 					LoadedAssembly? asm;
 					try
 					{
-						asm = folder.ResolveFileName(entry.Name);
+						asm = folder.ResolveEntry(entry);
 					}
 					catch
 					{

--- a/ICSharpCode.ILSpyX/LoadedPackage.cs
+++ b/ICSharpCode.ILSpyX/LoadedPackage.cs
@@ -349,34 +349,57 @@ namespace ICSharpCode.ILSpyX
 			return Task.FromResult<MetadataFile?>(null);
 		}
 
-		readonly Dictionary<string, LoadedAssembly?> assemblies = new Dictionary<string, LoadedAssembly?>(StringComparer.OrdinalIgnoreCase);
+		// Keyed by entry name, ordinal: an assembly-reference lookup is case-insensitive, but two
+		// entries whose names differ only in case are two distinct files (archive entry names are
+		// case-sensitive) and must not share one LoadedAssembly.
+		readonly Dictionary<string, LoadedAssembly> assemblies = new Dictionary<string, LoadedAssembly>(StringComparer.Ordinal);
 
 		public LoadedAssembly? ResolveFileName(string name)
 		{
+			var entry = Entries.FirstOrDefault(e => string.Equals(name, e.Name, StringComparison.Ordinal))
+				?? Entries.FirstOrDefault(e => string.Equals(name, e.Name, StringComparison.OrdinalIgnoreCase));
+			return entry == null ? null : ResolveEntry(entry);
+		}
+
+		/// <summary>
+		/// The <see cref="LoadedAssembly"/> for one of this folder's entries, created on first use.
+		/// Creating it starts reading the entry out of the package, so call this only for entries
+		/// that are about to be inspected.
+		/// </summary>
+		public LoadedAssembly? ResolveEntry(PackageEntry entry)
+		{
+			ArgumentNullException.ThrowIfNull(entry);
 			if (package.LoadedAssembly == null)
 				return null;
 			lock (assemblies)
 			{
-				if (assemblies.TryGetValue(name, out var asm))
+				if (assemblies.TryGetValue(entry.Name, out var asm))
 					return asm;
-				var entry = Entries.FirstOrDefault(e => string.Equals(name, e.Name, StringComparison.OrdinalIgnoreCase));
-				if (entry != null)
-				{
-					asm = new LoadedAssembly(
-						package.LoadedAssembly, entry.Name,
-						fileLoaders: package.LoadedAssembly.AssemblyList.LoaderRegistry,
-						assemblyResolver: this,
-						stream: Task.Run(entry.TryOpenStream),
-						applyWinRTProjections: package.LoadedAssembly.AssemblyList.ApplyWinRTProjections,
-						useDebugSymbols: package.LoadedAssembly.AssemblyList.UseDebugSymbols
-					);
-				}
-				else
-				{
-					asm = null;
-				}
-				assemblies.Add(name, asm);
+				// FullName is the package-relative path ("lib/net10.0/Foo.dll"), which is what makes
+				// the copies of one assembly in a multi-target package tellable apart wherever the
+				// file name is surfaced. ShortName/Text stay the bare file name either way.
+				asm = new LoadedAssembly(
+					package.LoadedAssembly, entry.FullName,
+					fileLoaders: package.LoadedAssembly.AssemblyList.LoaderRegistry,
+					assemblyResolver: this,
+					stream: Task.Run(entry.TryOpenStream),
+					applyWinRTProjections: package.LoadedAssembly.AssemblyList.ApplyWinRTProjections,
+					useDebugSymbols: package.LoadedAssembly.AssemblyList.UseDebugSymbols
+				);
+				assemblies.Add(entry.Name, asm);
 				return asm;
+			}
+		}
+
+		/// <summary>
+		/// Whether this folder has already resolved <paramref name="assembly"/> from one of its
+		/// entries. Consults the resolution cache only -- nothing is loaded or extracted.
+		/// </summary>
+		public bool HasResolved(LoadedAssembly assembly)
+		{
+			lock (assemblies)
+			{
+				return assemblies.ContainsValue(assembly);
 			}
 		}
 	}

--- a/ILSpy.Tests/AssemblyTree/AssemblyTreeModelTests.cs
+++ b/ILSpy.Tests/AssemblyTree/AssemblyTreeModelTests.cs
@@ -17,9 +17,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Avalonia.Headless.NUnit;
@@ -69,6 +71,76 @@ public class AssemblyTreeModelTests
 			"Initialize mirrors AssemblyListManager.AssemblyLists into the toolbar combo's source.");
 		model.ActiveListName.Should().Be(AssemblyListManager.DefaultListName,
 			"Initialize selects the (Default) list so the tree has something to render at startup.");
+	}
+
+	static readonly string TempRoot = Path.Combine(Path.GetTempPath(), "ILSpy.Tests.Packages", Guid.NewGuid().ToString("N"));
+
+	// Two assemblies in sibling folder chains, so a walk that reaches only one of them fails.
+	static string CreatePackage()
+	{
+		var dir = Directory.CreateDirectory(Path.Combine(TempRoot, Guid.NewGuid().ToString("N"))).FullName;
+		var zipPath = Path.Combine(dir, "package.zip");
+		using var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+		zip.CreateEntryFromFile(FixtureAssembly.Emit("Nested"), "lib/net10.0/Nested.dll");
+		zip.CreateEntryFromFile(FixtureAssembly.Emit("Sibling"), "runtimes/win-x64/Sibling.dll");
+		return zipPath;
+	}
+
+	[OneTimeTearDown]
+	public void DeleteTempPackages()
+	{
+		if (Directory.Exists(TempRoot))
+			Directory.Delete(TempRoot, recursive: true);
+	}
+
+	[AvaloniaTest]
+	public async Task EnumerateAllAssemblies_expands_a_package_into_its_entries()
+	{
+		// The search corpus is this walk, so an assembly it does not yield is an assembly no
+		// search can ever match.
+		var (_, vm) = await TestHarness.BootAsync();
+		await vm.OpenAssemblyAsync(CreatePackage());
+
+		var nested = new List<LoadedAssembly>();
+		await foreach (var asm in vm.AssemblyTreeModel.AssemblyList!.EnumerateAllAssemblies())
+		{
+			if (asm.ParentBundle != null)
+				nested.Add(asm);
+		}
+
+		nested.Select(a => a.FileName).Should().BeEquivalentTo(
+			new[] { "lib/net10.0/Nested.dll", "runtimes/win-x64/Sibling.dll" },
+			"every .dll in the package is searchable, and the package-relative path is what "
+			+ "distinguishes copies of one assembly built for several targets.");
+	}
+
+	[AvaloniaTest]
+	public async Task EnumerateAllAssemblies_stops_expanding_a_package_once_cancelled()
+	{
+		// Both search panes restart on every keystroke, so an abandoned walk that keeps
+		// extracting package entries competes with the run the user is waiting for.
+		var (_, vm) = await TestHarness.BootAsync();
+		await vm.OpenAssemblyAsync(CreatePackage());
+
+		using var cts = new CancellationTokenSource();
+		var walk = vm.AssemblyTreeModel.AssemblyList!.EnumerateAllAssemblies(cts.Token).GetAsyncEnumerator();
+		try
+		{
+			while (await walk.MoveNextAsync() && walk.Current.ParentBundle == null)
+			{
+				// Skip past the list's own assemblies to the package's first entry.
+			}
+			walk.Current.ParentBundle.Should().NotBeNull("the package's entries come last on the list.");
+			cts.Cancel();
+
+			var next = async () => await walk.MoveNextAsync();
+			await next.Should().ThrowAsync<OperationCanceledException>(
+				"the second entry must not be extracted after the walk was cancelled.");
+		}
+		finally
+		{
+			await walk.DisposeAsync();
+		}
 	}
 
 	[AvaloniaTest]

--- a/ILSpy.Tests/AssemblyTree/AssemblyTreeModelTests.cs
+++ b/ILSpy.Tests/AssemblyTree/AssemblyTreeModelTests.cs
@@ -149,24 +149,43 @@ public class AssemblyTreeModelTests
 		// Search enumerates the contents of packages whether or not the user ever opened them in
 		// the tree, so activating such a result has to reach a node that does not exist yet.
 		var (_, vm) = await TestHarness.BootAsync();
-
-		var tempDir = Path.Combine(Path.GetTempPath(), "ILSpy.Tests", Guid.NewGuid().ToString("N"));
-		Directory.CreateDirectory(tempDir);
-		var zipPath = Path.Combine(tempDir, "package.zip");
-		using (var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create))
-			zip.CreateEntryFromFile(FixtureAssembly.Emit("Nested"), "lib/net10.0/Nested.dll");
-
-		await vm.OpenAssemblyAsync(zipPath);
+		await vm.OpenAssemblyAsync(CreatePackage());
 
 		var nested = (await vm.AssemblyTreeModel.AssemblyList!.GetAllAssemblies())
-			.Single(a => a.ParentBundle != null);
+			.Single(a => a.FileName == "lib/net10.0/Nested.dll");
 		var type = nested.GetTypeSystemOrNull()!.MainModule.TypeDefinitions
 			.Single(t => t.Name == FixtureAssembly.TypeName);
 
 		var node = vm.AssemblyTreeModel.FindTreeNode(type);
 
-		// Cast through object so the generic Should() resolves, not the SharpTreeNode shadow.
-		((object?)node).Should().BeOfType<TypeTreeNode>(
-			"the lookup must descend into the package's folders, expanding them on the way");
+		// Assert the owning module, not just the node type: the fixture's type handle is
+		// 0x02000002, which resolves in nearly every assembly on the list, so a lookup that fell
+		// back to the first top-level node would still hand back some TypeTreeNode.
+		((object?)node).Should().BeOfType<TypeTreeNode>()
+			.Which.Module.Should().BeSameAs(nested.GetMetadataFileOrNull(),
+				"the lookup must descend into the package's folders, expanding them on the way.");
+	}
+
+	[AvaloniaTest]
+	public async Task FindTreeNode_leaves_package_folders_off_the_path_unexpanded()
+	{
+		// Expanding a package folder resolves and extracts every .dll it holds, so a lookup that
+		// swept the package depth-first would pay for entries the user never asked about.
+		var (_, vm) = await TestHarness.BootAsync();
+		var package = await vm.OpenAssemblyAsync(CreatePackage());
+
+		var nested = (await vm.AssemblyTreeModel.AssemblyList!.GetAllAssemblies())
+			.Single(a => a.FileName == "lib/net10.0/Nested.dll");
+		var type = nested.GetTypeSystemOrNull()!.MainModule.TypeDefinitions
+			.Single(t => t.Name == FixtureAssembly.TypeName);
+
+		((object?)vm.AssemblyTreeModel.FindTreeNode(type)).Should().NotBeNull();
+
+		var packageNode = vm.AssemblyTreeModel.FindAssemblyNode(package);
+		((object?)packageNode).Should().NotBeNull();
+		var sibling = packageNode!.Children.OfType<PackageFolderTreeNode>()
+			.Single(f => f.Text as string == "runtimes/win-x64");
+		sibling.Children.Should().BeEmpty(
+			"only the folders on the path down to the target get expanded.");
 	}
 }

--- a/ILSpy/AssemblyTree/TreeNodeLocator.cs
+++ b/ILSpy/AssemblyTree/TreeNodeLocator.cs
@@ -97,7 +97,7 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 					return FindMemberNode(root, member);
 
 				case LoadedAssembly lasm:
-					return root.FindAssemblyNode(lasm);
+					return FindAssemblyNode(root, lasm);
 
 				case MetadataFile metadataFile:
 					return FindAssemblyNode(root, metadataFile);
@@ -122,13 +122,15 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 		/// down, so this resolves even when the user has never opened the package in the tree.
 		/// </summary>
 		public static AssemblyTreeNode? FindAssemblyNode(AssemblyListTreeNode root, MetadataFile? module)
+			=> FindAssemblyNode(root, module?.GetLoadedAssemblyOrNull());
+
+		/// <inheritdoc cref="FindAssemblyNode(AssemblyListTreeNode, MetadataFile?)"/>
+		public static AssemblyTreeNode? FindAssemblyNode(AssemblyListTreeNode root, LoadedAssembly? assembly)
 		{
-			// A package child records the bundle it came from, so walking up that chain leads
-			// straight to the one top-level node worth descending into. Searching the tree for a
-			// matching module instead would have to visit every namespace and type node already
-			// built, and would still miss nested assemblies that are not loaded yet.
+			// A package child records the bundle it came from, so walking up that chain names every
+			// package to descend into, outermost first, ending at the one top-level node.
 			var nesting = new Stack<LoadedAssembly>();
-			for (var current = module?.GetLoadedAssemblyOrNull(); current != null; current = current.ParentBundle)
+			for (var current = assembly; current != null; current = current.ParentBundle)
 				nesting.Push(current);
 			if (nesting.Count == 0)
 				return null;
@@ -139,22 +141,49 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			return node;
 		}
 
-		// Depth-first search for one assembly within a package node's folder structure. Only
-		// package folders are descended into, so the walk stays inside the package.
-		static AssemblyTreeNode? FindNestedAssemblyNode(SharpTreeNode packageNode, LoadedAssembly assembly)
+		// Finds one assembly inside a package node, expanding only the folders on the path down to
+		// it. Expanding a package folder resolves and extracts every .dll/.exe it holds, so the
+		// path is taken from the package's in-memory folder graph first -- that costs no tree node
+		// and reads no package entry.
+		static AssemblyTreeNode? FindNestedAssemblyNode(AssemblyTreeNode packageNode, LoadedAssembly assembly)
 		{
-			packageNode.EnsureLazyChildren();
-			foreach (var child in packageNode.Children)
+			var rootFolder = packageNode.LoadedAssembly.GetLoadResultAsync().GetAwaiter().GetResult().Package?.RootFolder;
+			if (rootFolder == null)
+				return null;
+			var path = new HashSet<PackageFolder>();
+			if (!rootFolder.HasResolved(assembly) && !CollectFolderPath(rootFolder, assembly, path))
+				return null;
+
+			SharpTreeNode node = packageNode;
+			while (true)
 			{
-				switch (child)
+				node.EnsureLazyChildren();
+				if (node.Children.OfType<AssemblyTreeNode>().FirstOrDefault(n => n.LoadedAssembly == assembly) is { } nested)
+					return nested;
+				// A folder node stands for the deepest link of a collapsed single-child chain
+				// (a/b/c shows as one node), so match its folder against the whole path rather
+				// than against one expected next segment.
+				if (node.Children.OfType<PackageFolderTreeNode>().FirstOrDefault(f => path.Contains(f.Folder)) is not { } next)
+					return null;
+				node = next;
+			}
+		}
+
+		// Fills <paramref name="path"/> with the folders between <paramref name="folder"/> (exclusive)
+		// and the one that already resolved <paramref name="assembly"/>. Every package-nested
+		// LoadedAssembly is produced by exactly one PackageFolder.ResolveEntry call, so the owning
+		// folder's resolution cache is what identifies it.
+		static bool CollectFolderPath(PackageFolder folder, LoadedAssembly assembly, HashSet<PackageFolder> path)
+		{
+			foreach (var subFolder in folder.Folders)
+			{
+				if (subFolder.HasResolved(assembly) || CollectFolderPath(subFolder, assembly, path))
 				{
-					case AssemblyTreeNode nested when nested.LoadedAssembly == assembly:
-						return nested;
-					case PackageFolderTreeNode folder when FindNestedAssemblyNode(folder, assembly) is { } found:
-						return found;
+					path.Add(subFolder);
+					return true;
 				}
 			}
-			return null;
+			return false;
 		}
 
 		// Resolves a resource (optionally a named sub-entry) to its tree node. Mirrors the previous
@@ -185,19 +214,16 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 			return resourceNode.Children.OfType<ILSpyTreeNode>().FirstOrDefault(x => name.Equals(x.Text)) ?? resourceNode;
 		}
 
-		// Resolves a namespace to its tree node within its contributing assembly. Mirrors the previous
-		// version's AssemblyListTreeNode.FindNamespaceNode.
+		// Resolves a namespace to its tree node within its contributing assembly.
 		static NamespaceTreeNode? FindNamespaceNode(AssemblyListTreeNode root, INamespace ns)
 		{
 			var module = ns.ContributingModules.FirstOrDefault();
 			if (module?.MetadataFile == null)
 				return null;
-			var assembly = FindAssemblyNode(root, module.MetadataFile);
-			if (assembly == null)
-				return null;
-			assembly.EnsureLazyChildren();
-			return assembly.Children.OfType<NamespaceTreeNode>()
-				.FirstOrDefault(n => ns.FullName.Length == 0 || ns.FullName.Equals(n.Text));
+			// The assembly node indexes every namespace it built by full, unescaped name. Matching
+			// against the node labels instead would fail in nested-namespace mode, where the node
+			// for "A.B.C" is a descendant and its label is only the last segment.
+			return FindAssemblyNode(root, module.MetadataFile)?.FindNamespaceNode(ns.FullName);
 		}
 
 		public static TypeTreeNode? FindTypeNode(AssemblyListTreeNode root, ITypeDefinition type)

--- a/ILSpy/Controls/Omnibar/Omnibar.axaml.cs
+++ b/ILSpy/Controls/Omnibar/Omnibar.axaml.cs
@@ -21,6 +21,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
@@ -67,6 +68,14 @@ namespace ICSharpCode.ILSpy.Controls.Omnibar
 				SearchInput.Focus();
 				SearchInput.SelectAll();
 			});
+		}
+
+		protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+		{
+			// The hosting tab is gone (closed, or its content swapped out). Nothing will read the
+			// results, so end the run rather than let it walk the rest of the assembly list.
+			viewModel.CancelSearch();
+			base.OnDetachedFromVisualTree(e);
 		}
 
 		void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/ILSpy/Controls/Omnibar/OmnibarViewModel.cs
+++ b/ILSpy/Controls/Omnibar/OmnibarViewModel.cs
@@ -191,13 +191,23 @@ namespace ICSharpCode.ILSpy.Controls.Omnibar
 
 		RunningSearch? currentSearch;
 
-		void RestartSearch()
+		/// <summary>
+		/// Ends the search in flight, if any. A run holds the assembly list and keeps expanding
+		/// packages until it finishes, so a bar that is going away has to stop its run instead of
+		/// leaving it to drain into a sink nobody can see.
+		/// </summary>
+		public void CancelSearch()
 		{
 			currentSearch?.Cancel();
 			currentSearch = null;
+			IsSearching = false;
+		}
+
+		void RestartSearch()
+		{
+			CancelSearch();
 			searchSink.Clear();
 			Suggestions.Clear();
-			IsSearching = false;
 
 			var term = SearchText ?? string.Empty;
 			if (string.IsNullOrWhiteSpace(term))

--- a/ILSpy/Metadata/MetadataNavigator.cs
+++ b/ILSpy/Metadata/MetadataNavigator.cs
@@ -71,10 +71,6 @@ namespace ICSharpCode.ILSpy.Metadata
 			if (!TryReadRow(row, "Token", out var file, out var handle) || handle.IsNil)
 				return null;
 
-			var owningAssembly = assemblyTreeModel.AssemblyList?.GetAssemblies()
-				.FirstOrDefault(a => ReferenceEquals(a.GetMetadataFileOrNull(), file));
-			if (owningAssembly is null)
-				return null;
 			if (file?.GetTypeSystemWithCurrentOptionsOrNull()?.MainModule is not MetadataModule metadataModule)
 				return null;
 			IEntity? entity;
@@ -93,10 +89,9 @@ namespace ICSharpCode.ILSpy.Metadata
 		/// </summary>
 		public MetadataTableTreeNode? FindTableNode(MetadataTokenReference reference)
 		{
-			var targetAssembly = assemblyTreeModel.Root?.Children
-				.OfType<AssemblyTreeNode>()
-				.FirstOrDefault(a => ReferenceEquals(a.LoadedAssembly.GetMetadataFileOrNull(), reference.MetadataFile));
-			if (targetAssembly == null)
+			// FindTreeNode, not a scan of the root's children: the module may sit inside a package
+			// or bundle, whose assembly nodes are grandchildren of a folder node.
+			if (assemblyTreeModel.FindTreeNode(reference.MetadataFile) is not AssemblyTreeNode targetAssembly)
 				return null;
 			targetAssembly.EnsureLazyChildren();
 			var metaNode = targetAssembly.Children.OfType<MetadataTreeNode>().FirstOrDefault();

--- a/ILSpy/Metadata/MetadataProtocolHandler.cs
+++ b/ILSpy/Metadata/MetadataProtocolHandler.cs
@@ -52,13 +52,10 @@ namespace ICSharpCode.ILSpy.Metadata
 			newTabPage = true;
 			if (protocol != "metadata")
 				return null;
-			// AssemblyTreeModel.FindTreeNode only resolves EntityReference/ITypeDefinition/IMember,
-			// not MetadataFile — walk the assembly-tree root manually here. Same lookup pattern
-			// FindTypeNode uses internally.
-			var assemblyNode = (assemblyTreeModel.Root as AssemblyListTreeNode)?.Children
-				.OfType<AssemblyTreeNode>()
-				.FirstOrDefault(a => a.LoadedAssembly.GetMetadataFileOrNull() == module);
-			if (assemblyNode == null)
+			// FindTreeNode resolves a MetadataFile to its assembly node, including one nested in a
+			// package or bundle, where the node is a grandchild of a folder node rather than a
+			// child of the root.
+			if (assemblyTreeModel.FindTreeNode(module) is not AssemblyTreeNode assemblyNode)
 				return null;
 			assemblyNode.EnsureLazyChildren();
 			var metadataNode = assemblyNode.Children.OfType<MetadataTreeNode>().FirstOrDefault();

--- a/ILSpy/Search/RunningSearch.cs
+++ b/ILSpy/Search/RunningSearch.cs
@@ -131,15 +131,9 @@ namespace ICSharpCode.ILSpy.Search
 				var strategy = GetStrategy(request);
 				if (strategy == null)
 					return;
-				// Streaming enumeration: expanding bundles/packages into their contained
-				// assemblies triggers the lazy load of every entry on the list, so awaiting
-				// the whole set up front would mean no results at all until the last
-				// assembly is off disk. Enumerating starts the walk here on the worker
-				// thread, not at construction time on the UI thread.
-				//
-				// Serial walk: per-assembly metadata walk is allocation-dominated, and 4
-				// parallel producers fighting for the ConcurrentQueue + the resulting UI
-				// batching jitter end up slower than serial in practice.
+				// The per-assembly metadata walk is allocation-dominated, and 4 parallel
+				// producers fighting for the ConcurrentQueue + the resulting UI batching
+				// jitter end up slower than walking the assemblies one at a time.
 				await foreach (var assembly in assemblyList.EnumerateAllAssemblies(ct).ConfigureAwait(false))
 				{
 					if (ct.IsCancellationRequested)

--- a/ILSpy/TreeNodes/PackageFolderTreeNode.cs
+++ b/ILSpy/TreeNodes/PackageFolderTreeNode.cs
@@ -88,7 +88,7 @@ namespace ICSharpCode.ILSpy.TreeNodes
 				if (entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
 					|| entry.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
 				{
-					var asm = root.ResolveFileName(entry.Name);
+					var asm = root.ResolveEntry(entry);
 					if (asm != null)
 					{
 						yield return new AssemblyTreeNode(asm, entry);


### PR DESCRIPTION
Follow-ups to #4023, from a review of that PR after it merged. Two commits, one per half of the original change; no behaviour from #4023 is reverted.

### Searching a package (`3dfb59ac8`)

- **Entries resolved by name collapsed case-only twins.** `PackageFolder`'s cache is keyed case-insensitively, which is correct for an assembly reference but not for an archive entry: `lib/net10.0/a.dll` and `lib/net10.0/A.dll` are two files and shared one `LoadedAssembly`, so one was searched twice and the other never. The cache is now keyed by the entry itself; `ResolveFileName` keeps case-insensitive *name* lookup for reference resolution.
- **A multi-target package produced indistinguishable results.** `lib/net472/X.dll`, `lib/net8.0/X.dll` and `lib/netstandard2.0/X.dll` are three assemblies, and every search hit in them showed `X.dll` as its location. A nested assembly's file name is now the package-relative path. `ShortName` and the tree label are unchanged (`GetFileNameWithoutExtension` handles the path).
- **Cancellation did not reach the expensive part.** The token was checked only between top-level list entries, never while expanding a package, so a walk the user had already replaced by typing another character kept extracting entries alongside the run they were waiting for. It is now checked per entry, before the extraction each resolve starts.
- **The omnibar never cancelled its run.** Its view model is per document tab and nothing ended the search when the tab went away, so an abandoned run kept its render-priority timer ticking and kept the assembly list alive. It now cancels on detach.

### Reaching a package-nested node (`482c0bd81`)

- **The fix landed in 2 of 5 places.** `FindTreeNode`'s `MetadataFile` arm learned to descend into packages; its `LoadedAssembly` arm, `MetadataNavigator.FindTableNode`, and `MetadataProtocolHandler` kept their own scan of the root's direct children, so a token reference, a `metadata://` link and a `LoadedAssembly` reference still resolved to nothing inside a package. All now route through the one lookup.
- **`MetadataNavigator.ResolveRowToTreeNode` returned early for the case it was meant to serve.** Its `GetAssemblies()` guard is top-level-only and its result was never used, so double-clicking a metadata row under a package did nothing.
- **`FindNamespaceNode`'s namespace half compared a full name against a node label.** Those are only ever equal in flat mode; with nested namespace nodes the label is the last segment, so `"System.Collections.Generic" == "System"` failed, and the empty-name test matched the first child rather than the global-namespace node. The assembly node already indexes its namespaces by full name.
- **The descent swept the package depth-first.** Expanding a package folder resolves and extracts every `.dll` it holds, so reaching one assembly built the folders ordered ahead of it too. The path now comes from the package's in-memory folder graph, which costs no tree node and reads no entry.

### Tests

Four new tests in `AssemblyTreeModelTests`, over a two-assembly zip: the walk yields both entries with their paths, a cancelled walk stops before the next entry, navigation lands on a node whose module is the nested assembly (the fixture's type handle is `0x02000002` and resolves in nearly every assembly, so asserting the node type alone cannot fail), and the sibling folder is left unexpanded.

`ILSpy.Tests` 1210 passed / 0 failed, `ICSharpCode.ILSpyCmd.Tests` 22 passed / 0 failed, clean rebuild of `ILSpy.Desktop.slnf` and `ILSpy.XPlat.slnf` with no warnings.

---
_Opened by an AI agent (Claude) on Siegfried's behalf._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
