### PR TITLE
Tie the .NET Framework fixture host to the test host's lifetime

### DIFF
--- a/ILSpy.Tests.Windows/Processes/NetFrameworkProcessesTests.cs
+++ b/ILSpy.Tests.Windows/Processes/NetFrameworkProcessesTests.cs
@@ -55,8 +55,10 @@ public class NetFrameworkProcessesTests
 		File.Exists(WindowsPowerShellPath).Should().BeTrue(
 			"Windows PowerShell 5.1 is the .NET Framework process this fixture inspects");
 
+		// The host lives exactly as long as the test host process: no wall clock for a slow
+		// machine to outrun mid-fixture, and no orphan if the teardown never runs.
 		host = Process.Start(new ProcessStartInfo(WindowsPowerShellPath,
-			"-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 300\"") {
+			$"-NoProfile -NonInteractive -Command \"Wait-Process -Id {Environment.ProcessId}\"") {
 			UseShellExecute = false,
 			CreateNoWindow = true,
 		});


### PR DESCRIPTION
Hardening only, no behaviour change in green runs.

`NetFrameworkProcessesTests` starts a Windows PowerShell 5.1 process as the .NET Framework process it inspects. That host used to sleep for a fixed 300 s, which is a wall clock for a slow or starved machine to outrun: on a loaded CI runner the fixture's process walks got slow enough that the host exited mid-fixture and the remaining tests failed for the wrong reason (seen on #3940's Windows jobs). It also left an orphaned `powershell.exe` whenever the teardown never ran.

`Wait-Process -Id <test host PID>` ties the host to the test host's lifetime instead: no wall clock to outrun, and the host disappears with the test host even without teardown.

Split out of #3940, where it was noted as optional hardening; the process-walk slowness itself is a separate topic (#4012, and the server-GC follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
