### PR TITLE
Overlap the sequential waits inside the decompiler test infrastructure

### DIFF
--- a/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
+++ b/ICSharpCode.Decompiler.Tests/CorrectnessTestRunner.cs
@@ -436,10 +436,30 @@ namespace ICSharpCode.Decompiler.Tests
 			string testOutputFileName = TestsAssemblyOutput.GetFilePath(TestCasePath, testName, Tester.GetSuffix(options) + ".exe");
 			Helpers.CompilerResults outputFile = null, decompiledOutputFile = null;
 
+			// The mcs mutation below never touches these flags, so they can be captured here
+			// and used for the original run started before the mutation happens.
+			bool useTestRunner = (options & CompilerOptions.UseTestRunner) != 0;
+			bool force32Bit = (options & CompilerOptions.Force32Bit) != 0;
+
 			try
 			{
 				outputFile = await Tester.CompileCSharp(Path.Combine(TestCasePath, testFileName), options,
 					outputFileName: testOutputFileName).ConfigureAwait(false);
+				if ((options & CompilerOptions.UseMcsMask) != 0)
+				{
+					// Add an .exe.config so that we consistently use the .NET 4.x runtime.
+					// Written before the original executable starts below, because the runtime
+					// reads it at process start.
+					File.WriteAllText(outputFile.PathToAssembly + ".config", @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+	<startup>
+		<supportedRuntime version=""v4.0"" sku="".NETFramework,Version=v4.0,Profile=Client"" />
+	</startup>
+</configuration>");
+				}
+				// The original executable is complete at this point; its run overlaps the
+				// decompile and recompile of the same assembly, which only read it.
+				var originalRun = Tester.StartRun(outputFile.PathToAssembly, useTestRunner, force32Bit);
 				string decompiledCodeFile = await Tester.DecompileCSharp(outputFile.PathToAssembly, Tester.GetSettings(options)).ConfigureAwait(false);
 				if ((options & CompilerOptions.UseMcsMask) != 0)
 				{
@@ -448,18 +468,11 @@ namespace ICSharpCode.Decompiler.Tests
 					// for example when there's unreachable code due to other compiler bugs in the first mcs run.
 					options &= ~CompilerOptions.UseMcsMask;
 					options |= CompilerOptions.UseRoslynLatest;
-					// Also, add an .exe.config so that we consistently use the .NET 4.x runtime.
-					File.WriteAllText(outputFile.PathToAssembly + ".config", @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-	<startup>
-		<supportedRuntime version=""v4.0"" sku="".NETFramework,Version=v4.0,Profile=Client"" />
-	</startup>
-</configuration>");
 					options |= CompilerOptions.TargetNet40;
 				}
 				decompiledOutputFile = await Tester.CompileCSharp(decompiledCodeFile, options).ConfigureAwait(false);
 
-				await Tester.RunAndCompareOutput(testFileName, outputFile.PathToAssembly, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
+				await Tester.RunAndCompareOutput(testFileName, originalRun, decompiledOutputFile.PathToAssembly, decompiledCodeFile, useTestRunner, force32Bit);
 				Tester.RepeatOnIOError(() => File.Delete(decompiledCodeFile));
 			}
 			finally
@@ -484,10 +497,13 @@ namespace ICSharpCode.Decompiler.Tests
 			{
 				outputFile = await Tester.CompileVB(Path.Combine(TestCasePath, testFileName), options,
 					outputFileName: testOutputFileName).ConfigureAwait(false);
+				// The original executable is complete at this point; its run overlaps the
+				// decompile and recompile of the same assembly, which only read it.
+				var originalRun = Tester.StartRun(outputFile.PathToAssembly, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
 				string decompiledCodeFile = await Tester.DecompileCSharp(outputFile.PathToAssembly, Tester.GetSettings(options)).ConfigureAwait(false);
 				decompiledOutputFile = await Tester.CompileCSharp(decompiledCodeFile, options).ConfigureAwait(false);
 
-				await Tester.RunAndCompareOutput(testFileName, outputFile.PathToAssembly, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
+				await Tester.RunAndCompareOutput(testFileName, originalRun, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
 				Tester.RepeatOnIOError(() => File.Delete(decompiledCodeFile));
 			}
 			finally
@@ -519,10 +535,13 @@ namespace ICSharpCode.Decompiler.Tests
 					options |= CompilerOptions.UseRoslynLatest;
 				}
 				outputFile = await Tester.AssembleIL(Path.Combine(TestCasePath, testFileName), asmOptions).ConfigureAwait(false);
+				// The original executable is complete at this point; its run overlaps the
+				// decompile and recompile of the same assembly, which only read it.
+				var originalRun = Tester.StartRun(outputFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0);
 				string decompiledCodeFile = await Tester.DecompileCSharp(outputFile, Tester.GetSettings(options)).ConfigureAwait(false);
 				decompiledOutputFile = await Tester.CompileCSharp(decompiledCodeFile, options).ConfigureAwait(false);
 
-				await Tester.RunAndCompareOutput(testFileName, outputFile, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0).ConfigureAwait(false);
+				await Tester.RunAndCompareOutput(testFileName, originalRun, decompiledOutputFile.PathToAssembly, decompiledCodeFile, (options & CompilerOptions.UseTestRunner) != 0, (options & CompilerOptions.Force32Bit) != 0).ConfigureAwait(false);
 				Tester.RepeatOnIOError(() => File.Delete(decompiledCodeFile));
 			}
 			finally

--- a/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/RoslynToolset.cs
@@ -127,6 +127,8 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 	class RoslynToolset : AbstractToolset
 	{
+		// Registrations run concurrently while Tester.Initialize awaits all Fetch calls;
+		// lookups only happen after Initialize completes, so the read paths stay lock-free.
 		readonly Dictionary<string, string> installedCompilers = new Dictionary<string, string> {
 			{ "legacy", Environment.ExpandEnvironmentVariables(@"%WINDIR%\Microsoft.NET\Framework\v4.0.30319") }
 		};
@@ -144,7 +146,10 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 				await FetchPackage(packageName, version, sourcePath, Path.Combine(baseDir, version)).ConfigureAwait(false);
 			}
 
-			installedCompilers.Add(SanitizeVersion(version), path);
+			lock (installedCompilers)
+			{
+				installedCompilers.Add(SanitizeVersion(version), path);
+			}
 		}
 
 		// In the .NET ("netcore") build of the compiler toolset the executables live in a
@@ -218,6 +223,8 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 	class RefAssembliesToolset : AbstractToolset
 	{
+		// Registrations run concurrently while Tester.Initialize awaits all Fetch calls;
+		// lookups only happen after Initialize completes, so the read paths stay lock-free.
 		readonly Dictionary<string, string> installedFrameworks = new Dictionary<string, string> {
 			{ "legacy", Path.Combine(Roundtrip.RoundtripAssembly.TestDir, "dotnet", "legacy") },
 			{ "2.2.0", Path.Combine(Roundtrip.RoundtripAssembly.TestDir, "dotnet", "netcore-2.2") },
@@ -236,7 +243,10 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 				await FetchPackage(packageName, version, sourcePath, Path.Combine(baseDir, version)).ConfigureAwait(false);
 			}
 
-			installedFrameworks.Add(RoslynToolset.SanitizeVersion(version), path);
+			lock (installedFrameworks)
+			{
+				installedFrameworks.Add(RoslynToolset.SanitizeVersion(version), path);
+			}
 		}
 
 		internal string GetPath(string targetFramework)

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -1224,10 +1224,23 @@ namespace System.Runtime.CompilerServices
 			}
 		}
 
-		public static async Task<string> FindMSBuild()
+		// Lazy<Task<T>> memoizes the vswhere lookup: the answer is invariant for the process,
+		// and the parallel roundtrip tests would otherwise each spawn their own vswhere.exe.
+		// A failed lookup stays cached, which is fine because a missing MSBuild is
+		// environmental, not transient.
+		static readonly Lazy<Task<string>> msbuildPath = new(FindMSBuildUncached, LazyThreadSafetyMode.ExecutionAndPublication);
+
+		public static Task<string> FindMSBuild()
 		{
+			// The platform check stays outside the cache so that the IgnoreException is
+			// raised per test instead of being memoized as a faulted task.
 			if (!OperatingSystem.IsWindows())
 				Assert.Ignore("FindMSBuild uses vswhere.exe to locate Visual Studio's MSBuild; not available on this platform.");
+			return msbuildPath.Value;
+		}
+
+		static async Task<string> FindMSBuildUncached()
+		{
 			string path = vswhereToolset.GetVsWhere();
 
 			var result = await Cli.Wrap(path)

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -143,30 +143,44 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 
 		internal static async Task Initialize()
 		{
-			await roslynToolset.Fetch("1.3.2", "Microsoft.Net.Compilers", "tools").ConfigureAwait(false);
-			if (OperatingSystem.IsWindows())
-			{
-				await roslynToolset.Fetch("2.10.0", "Microsoft.Net.Compilers", "tools").ConfigureAwait(false);
-			}
-			else
-			{
+			// All fetches download/extract into disjoint directories and the TestRunner builds
+			// do not depend on any fetched toolset, so everything runs concurrently and is
+			// awaited in one place. Individual toolset registrations are synchronized inside
+			// the toolsets (see RoslynToolset.cs).
+			var tasks = new List<Task> {
+				roslynToolset.Fetch("1.3.2", "Microsoft.Net.Compilers", "tools"),
 				// Microsoft.Net.Compilers only ships .NET Framework executables. The sibling
 				// Microsoft.NETCore.Compilers package contains the dotnet-hosted build of the
 				// same compiler version (tools/bincore/csc.dll), usable on any platform.
-				await roslynToolset.Fetch("2.10.0", "Microsoft.NETCore.Compilers", "tools/bincore").ConfigureAwait(false);
+				OperatingSystem.IsWindows()
+					? roslynToolset.Fetch("2.10.0", "Microsoft.Net.Compilers", "tools")
+					: roslynToolset.Fetch("2.10.0", "Microsoft.NETCore.Compilers", "tools/bincore"),
+				// On non-Windows hosts the net472 compiler binaries cannot be executed; use the
+				// .NET build of each toolset instead. Its tasks folder is named "netcoreapp3.1"
+				// up to Roslyn 3.x and "netcore" from Roslyn 4.x on.
+				roslynToolset.Fetch("3.11.0", sourcePath: OperatingSystem.IsWindows() ? "tasks/net472" : "tasks/netcoreapp3.1"),
+				roslynToolset.Fetch("4.14.0", sourcePath: OperatingSystem.IsWindows() ? "tasks/net472" : "tasks/netcore"),
+				roslynToolset.Fetch(roslynLatestVersion, sourcePath: OperatingSystem.IsWindows() ? "tasks/net472" : "tasks/netcore"),
+				vswhereToolset.Fetch(),
+				RefAssembliesToolset.Fetch("5.0.0", sourcePath: "ref/net5.0"),
+				RefAssembliesToolset.Fetch("9.0.0", sourcePath: "ref/net9.0"),
+				RefAssembliesToolset.Fetch(CurrentNetCoreRefAsmVersion, sourcePath: $"ref/net{CurrentNetCoreVersion}"),
+				BuildTestRunners(),
+			};
+			Task all = Task.WhenAll(tasks);
+			try
+			{
+				await all.ConfigureAwait(false);
 			}
-			// On non-Windows hosts the net472 compiler binaries cannot be executed; use the
-			// .NET build of each toolset instead. Its tasks folder is named "netcoreapp3.1"
-			// up to Roslyn 3.x and "netcore" from Roslyn 4.x on.
-			await roslynToolset.Fetch("3.11.0", sourcePath: OperatingSystem.IsWindows() ? "tasks/net472" : "tasks/netcoreapp3.1").ConfigureAwait(false);
-			await roslynToolset.Fetch("4.14.0", sourcePath: OperatingSystem.IsWindows() ? "tasks/net472" : "tasks/netcore").ConfigureAwait(false);
-			await roslynToolset.Fetch(roslynLatestVersion, sourcePath: OperatingSystem.IsWindows() ? "tasks/net472" : "tasks/netcore").ConfigureAwait(false);
+			catch when (all.Exception is { InnerExceptions.Count: > 1 })
+			{
+				// Surface every failed download/build, not just the first.
+				throw all.Exception;
+			}
+		}
 
-			await vswhereToolset.Fetch().ConfigureAwait(false);
-			await RefAssembliesToolset.Fetch("5.0.0", sourcePath: "ref/net5.0").ConfigureAwait(false);
-			await RefAssembliesToolset.Fetch("9.0.0", sourcePath: "ref/net9.0").ConfigureAwait(false);
-			await RefAssembliesToolset.Fetch(CurrentNetCoreRefAsmVersion, sourcePath: $"ref/net{CurrentNetCoreVersion}").ConfigureAwait(false);
-
+		static async Task BuildTestRunners()
+		{
 #if DEBUG
 			const string testRunnerConfig = "Debug";
 #else
@@ -174,6 +188,9 @@ namespace ICSharpCode.Decompiler.Tests.Helpers
 #endif
 			if (OperatingSystem.IsWindows())
 			{
+				// The two RID builds share the same project file and intermediate directory
+				// (obj/project.assets.json is written by each build's implicit restore), so
+				// they must not run concurrently with each other.
 				await BuildTestRunner("win-x86", testRunnerConfig).ConfigureAwait(false);
 				await BuildTestRunner("win-x64", testRunnerConfig).ConfigureAwait(false);
 			}

--- a/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
+++ b/ICSharpCode.Decompiler.Tests/Helpers/Tester.cs
@@ -1107,21 +1107,34 @@ namespace System.Runtime.CompilerServices
 			return formattingPolicy;
 		}
 
-		public static async Task RunAndCompareOutput(string testFileName, string outputFile, string decompiledOutputFile, string decompiledCodeFile = null, bool useTestRunner = false, bool force32Bit = false)
+		/// <summary>
+		/// Starts executing the given assembly and returns the in-flight task, so that the run
+		/// can overlap other work (e.g. decompiling and recompiling the same assembly). The
+		/// task's fault is pre-observed: a caller that abandons the run because an earlier
+		/// pipeline stage failed first does not trigger UnobservedTaskException.
+		/// </summary>
+		public static Task<(int ExitCode, string Output, string Error)> StartRun(string assemblyFileName, bool useTestRunner = false, bool force32Bit = false)
 		{
-			string output1, output2, error1, error2;
-			int result1, result2;
+			var task = useTestRunner ? RunWithTestRunner(assemblyFileName, force32Bit) : Run(assemblyFileName);
+			task.ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+				TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+			return task;
+		}
 
-			if (useTestRunner)
-			{
-				(result1, output1, error1) = await RunWithTestRunner(outputFile, force32Bit).ConfigureAwait(false);
-				(result2, output2, error2) = await RunWithTestRunner(decompiledOutputFile, force32Bit).ConfigureAwait(false);
-			}
-			else
-			{
-				(result1, output1, error1) = await Run(outputFile).ConfigureAwait(false);
-				(result2, output2, error2) = await Run(decompiledOutputFile).ConfigureAwait(false);
-			}
+		public static Task RunAndCompareOutput(string testFileName, string outputFile, string decompiledOutputFile, string decompiledCodeFile = null, bool useTestRunner = false, bool force32Bit = false)
+		{
+			return RunAndCompareOutput(testFileName, StartRun(outputFile, useTestRunner, force32Bit), decompiledOutputFile, decompiledCodeFile, useTestRunner, force32Bit);
+		}
+
+		public static async Task RunAndCompareOutput(string testFileName, Task<(int ExitCode, string Output, string Error)> originalRun, string decompiledOutputFile, string decompiledCodeFile = null, bool useTestRunner = false, bool force32Bit = false)
+		{
+			var decompiledRun = StartRun(decompiledOutputFile, useTestRunner, force32Bit);
+			// Plain WhenAll, no error aggregation: it observes both faults and rethrows the
+			// first one, which keeps NUnit's Ignore semantics intact when both runs raise
+			// IgnoreException (e.g. Force32Bit on a non-Windows host).
+			await Task.WhenAll(originalRun, decompiledRun).ConfigureAwait(false);
+			var (result1, output1, error1) = originalRun.Result;
+			var (result2, output2, error2) = decompiledRun.Result;
 
 			Assert.That(result1, Is.EqualTo(0), "Exit code != 0; did the test case crash?" + Environment.NewLine + error1);
 			Assert.That(result2, Is.EqualTo(0), "Exit code != 0; did the decompiled code crash?" + Environment.NewLine + error2);

--- a/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
+++ b/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
@@ -135,23 +135,23 @@ namespace ICSharpCode.Decompiler.Roundtrip
 
 		async Task RunWithTest(string dir, string fileToRoundtrip, string fileToTest, LanguageVersion languageVersion = defaultLanguageVersion, string keyFile = null, bool useOldProjectFormat = false)
 		{
-			await RunInternal(dir, fileToRoundtrip, outputDir => RunTest(outputDir, fileToTest).GetAwaiter().GetResult(), languageVersion, snkFilePath: keyFile, useOldProjectFormat: useOldProjectFormat);
+			await RunInternal(dir, fileToRoundtrip, outputDir => RunTest(outputDir, fileToTest), languageVersion, snkFilePath: keyFile, useOldProjectFormat: useOldProjectFormat);
 		}
 
 		async Task RunWithOutput(string dir, string fileToRoundtrip, LanguageVersion languageVersion = defaultLanguageVersion)
 		{
 			string inputDir = Path.Combine(TestDir, dir);
 			await RunInternal(dir, fileToRoundtrip,
-				outputDir => Tester.RunAndCompareOutput(fileToRoundtrip, Path.Combine(inputDir, fileToRoundtrip), Path.Combine(outputDir, fileToRoundtrip)).GetAwaiter().GetResult(),
+				outputDir => Tester.RunAndCompareOutput(fileToRoundtrip, Path.Combine(inputDir, fileToRoundtrip), Path.Combine(outputDir, fileToRoundtrip)),
 				languageVersion);
 		}
 
 		async Task RunOnly(string dir, string fileToRoundtrip, LanguageVersion languageVersion = defaultLanguageVersion)
 		{
-			await RunInternal(dir, fileToRoundtrip, outputDir => { }, languageVersion);
+			await RunInternal(dir, fileToRoundtrip, _ => Task.CompletedTask, languageVersion);
 		}
 
-		async Task RunInternal(string dir, string fileToRoundtrip, Action<string> testAction, LanguageVersion languageVersion, string snkFilePath = null, bool useOldProjectFormat = false)
+		async Task RunInternal(string dir, string fileToRoundtrip, Func<string, Task> testAction, LanguageVersion languageVersion, string snkFilePath = null, bool useOldProjectFormat = false)
 		{
 			if (!Directory.Exists(TestDir))
 			{
@@ -220,7 +220,7 @@ namespace ICSharpCode.Decompiler.Roundtrip
 			Assert.That(projectFile, Is.Not.Null, $"Could not find {fileToRoundtrip}");
 
 			await Compile(projectFile, outputDir);
-			testAction(outputDir);
+			await testAction(outputDir).ConfigureAwait(false);
 		}
 
 		static void ClearDirectory(string dir)

--- a/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
+++ b/ICSharpCode.Decompiler.Tests/RoundtripAssembly.cs
@@ -140,9 +140,15 @@ namespace ICSharpCode.Decompiler.Roundtrip
 
 		async Task RunWithOutput(string dir, string fileToRoundtrip, LanguageVersion languageVersion = defaultLanguageVersion)
 		{
+			// Guard before starting the run, so a missing ILSpy-tests checkout still Ignores
+			// instead of faulting the eagerly started process launch.
+			EnsureTestDirAvailable();
 			string inputDir = Path.Combine(TestDir, dir);
+			// The pristine executable only reads from inputDir, which RunInternal never
+			// writes; its run overlaps the whole-project decompile and MSBuild rebuild.
+			var originalRun = Tester.StartRun(Path.Combine(inputDir, fileToRoundtrip));
 			await RunInternal(dir, fileToRoundtrip,
-				outputDir => Tester.RunAndCompareOutput(fileToRoundtrip, Path.Combine(inputDir, fileToRoundtrip), Path.Combine(outputDir, fileToRoundtrip)),
+				outputDir => Tester.RunAndCompareOutput(fileToRoundtrip, originalRun, Path.Combine(outputDir, fileToRoundtrip)),
 				languageVersion);
 		}
 
@@ -151,13 +157,18 @@ namespace ICSharpCode.Decompiler.Roundtrip
 			await RunInternal(dir, fileToRoundtrip, _ => Task.CompletedTask, languageVersion);
 		}
 
-		async Task RunInternal(string dir, string fileToRoundtrip, Func<string, Task> testAction, LanguageVersion languageVersion, string snkFilePath = null, bool useOldProjectFormat = false)
+		static void EnsureTestDirAvailable()
 		{
 			if (!Directory.Exists(TestDir))
 			{
 				Assert.Ignore($"Assembly-roundtrip test ignored: test directory '{TestDir}' needs to be checked out separately." + Environment.NewLine +
 							  $"git clone https://github.com/icsharpcode/ILSpy-tests \"{TestDir}\"");
 			}
+		}
+
+		async Task RunInternal(string dir, string fileToRoundtrip, Func<string, Task> testAction, LanguageVersion languageVersion, string snkFilePath = null, bool useOldProjectFormat = false)
+		{
+			EnsureTestDirAvailable();
 			string inputDir = Path.Combine(TestDir, dir);
 			string decompiledDir = inputDir + "-decompiled";
 			string outputDir = inputDir + "-output";


### PR DESCRIPTION
The "Round 2: sequential awaits inside the test infra" commits of #3940, split out on their own. They do not depend on #3940's NUnit worker-count / fixture-parallelism change (which is not being pursued): `RoundtripAssembly` and the matrix runners are already `Parallelizable(ParallelScope.All)` on master, and the overlaps below are per-test or per-process, independent of how many workers NUnit runs. All seven apply to master without conflicts and are cherry-picked verbatim; only `ICSharpCode.Decompiler.Tests` is touched (`Helpers/Tester.cs`, `Helpers/RoslynToolset.cs`, `CorrectnessTestRunner.cs`, `RoundtripAssembly.cs`).

| commit | what | why |
|---|---|---|
| Synchronize toolset registration dictionaries | `lock` around the two `Dictionary.Add` in `RoslynToolset`/`RefAssembliesToolset.Fetch`; lookups stay lock-free (they only happen after `Initialize` completed) | prerequisite of the next one |
| Overlap toolset downloads and TestRunner builds in `Tester.Initialize` | the nine NuGet fetches and the TestRunner builds start eagerly and are awaited in one `Task.WhenAll` (every failure surfaced, not just the first); only the two Windows RID TestRunner builds stay sequential with each other (shared `obj/`, implicit restores would race on `project.assets.json`) | `Initialize` gates every test in the suite; on a cold machine / CI it serialized all downloads and builds |
| Cache the vswhere-based MSBuild lookup | `Lazy<Task<string>>` (`ExecutionAndPublication`); the non-Windows `Assert.Ignore` stays outside the cache so it is raised per test, not memoized as a faulted task | the parallel roundtrip fixture spawned one `vswhere.exe` per test for a process-invariant answer |
| Run original and decompiled executables concurrently | `Tester.StartRun` returns the in-flight run (fault pre-observed, so an abandoned run after an upstream failure cannot raise `UnobservedTaskException`); `RunAndCompareOutput` gets an overload taking that task and awaits both with a plain `WhenAll` (keeps NUnit Ignore semantics); exit codes are still asserted in the original order, so failure output is unchanged | the two runs are independent processes with separately buffered output |
| Start the original executable before decompiling in correctness tests | `RunCS`/`RunVB`/`RunIL` start the original exe right after the first compile; for mcs configs the `.exe.config` write moves ahead of the run start (the runtime reads it at launch) while the compiler-option mutation stays after the decompile, which must see the original options | the decompile/recompile stages only read the original binary |
| Make the roundtrip `testAction` asynchronous | `Func<string, Task>` instead of `GetAwaiter().GetResult()` on NUnit worker threads | cleanup; enables the next one |
| Overlap the pristine-executable run with the roundtrip pipeline | `RunWithOutput` starts the reference exe from the `ILSpy-tests` checkout before the whole-project decompile + MSBuild rebuild (nothing in that pipeline writes to the input dir); the submodule-missing guard is hoisted into `EnsureTestDirAvailable()` and runs before the early start, so those tests still report Ignored | the pristine run used to wait for the multi-minute decompile it does not depend on |

## Verification

Local, 24-thread Windows 11 box, Debug, `ILSpy-tests` checked out (roundtrips and the mcs matrix run: 140 mcs cases passed, which exercises the `.exe.config`-before-run reordering), workstation GC (this branch is off master; #4033 is separate):

| run | result | wall | sum of per-test durations (TRX) |
|---|---|---|---|
| master, warm (same day, same box) | 4254 / 0 / 20 | 553 s | 11,532 s |
| this branch, **cold** (`bin/.../{roslyn,vswhere,netfx}` deleted, exercises the concurrent `Initialize`) | 4254 / 0 / 20 | 554 s | 10,819 s |
| this branch, warm | 4254 / 0 / 20 | 512 s | 10,663 s |

The 20 skips are the usual environment-gated ones. The wall-time difference is within a few percent and is not the point; the per-test overlap shows up as ~7% less summed test time for the same work. The local "cold" `Initialize` is served from `ILSpy-tests/nuget` and the already-built TestRunner, so it is only a correctness check of the concurrent path here (4 s); CI is where the downloads actually happen.

### CI

Run https://github.com/icsharpcode/ILSpy/actions/runs/32240841471: all four jobs green (Windows Debug/Release, Linux, macOS).

| decompiler test host | master (run 32177067040) | this branch |
|---|---|---|
| Windows Debug | 1393 s | 1373 s |
| Windows Release | 664 s | 766 s |
| Linux (own step) | 6m19 | 6m25 |

No measurable CI wall-time effect either way: the Windows numbers sit inside the run-to-run spread of that shared 4-core runner (master's own Release test step has ranged 11m10-15m26 across recent runs), and on Linux the suite is CPU-bound with most of its matrix skipped. The value of these commits is structural (no blocking waits on worker threads, no per-test `vswhere.exe`, setup downloads and builds overlapped, original/decompiled runs concurrent), not a headline number.

Not taken from #3940: the NUnit `LevelOfParallelism`/`Parallelizable(Fixtures)`/`Order` commit and the Defender doc (dropped), the block-invariant change (reverted there), server GC (#4033), the fixture-host hardening (#4032), the concurrent .NET Framework scan and the diagnostics sampler (reverted there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
