### PR TITLE
Restore keyboard activation for selected tree items

### DIFF
--- a/ILSpy/Controls/TreeView/SharpTreeView.cs
+++ b/ILSpy/Controls/TreeView/SharpTreeView.cs
@@ -295,6 +295,23 @@ namespace ICSharpCode.ILSpy.Controls.TreeView
 			scrollViewer.Offset = new Vector(scrollViewer.Offset.X, newOffsetY);
 		}
 
+		protected override bool ShouldTriggerSelection(Visual selectable, KeyEventArgs eventArgs)
+		{
+			// Avalonia treats Enter and Space as selection input. For a single selected
+			// tree item, let SharpTreeView handle those keys instead.
+			// https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#customizing-selection-behavior
+			if (eventArgs.KeyModifiers == KeyModifiers.None
+				&& eventArgs.Key is Key.Enter or Key.Space
+				&& selectable is SharpTreeViewItem { Node: { } node }
+				&& SelectedItems?.Count == 1
+				&& ReferenceEquals(SelectedItem, node))
+			{
+				return false;
+			}
+
+			return base.ShouldTriggerSelection(selectable, eventArgs);
+		}
+
 		protected override void OnKeyDown(KeyEventArgs e)
 		{
 			// Ctrl+A select-all must work on the first press even before a current item is


### PR DESCRIPTION
Fixes #4030

### Problem
In ILSpy 10.x, Enter and Space activated the selected item in `SharpTreeView`.
After the Avalonia migration, `ListBoxItem` handles these keys as selection input before they reach `SharpTreeView`, so the existing activation logic is not invoked.

### Solution
* Override `ShouldTriggerSelection` so Enter and Space can be handled by `SharpTreeView` instead of being intercepted by `ListBoxItem` selection handling.