### PR TITLE
Add mouse back and forward navigation

### DIFF
--- a/ILSpy/Views/MainWindow.axaml
+++ b/ILSpy/Views/MainWindow.axaml
@@ -20,8 +20,7 @@
 	</Design.DataContext>
 
 	<Window.KeyBindings>
-		<!-- Browser-style navigation. XButton1/2 (mouse Back/Forward) aren't first-class in
-		     Avalonia 12 yet, so we wire keyboard only for now. -->
+		<!-- Browser-style keyboard navigation. -->
 		<KeyBinding Gesture="Alt+Left" Command="{Binding DockWorkspace.NavigateBackCommand}" />
 		<KeyBinding Gesture="Alt+Right" Command="{Binding DockWorkspace.NavigateForwardCommand}" />
 		<!-- Search pane shortcuts. Ctrl+Shift+F is the WPF default; Ctrl+E mirrors the

--- a/ILSpy/Views/MainWindow.axaml.cs
+++ b/ILSpy/Views/MainWindow.axaml.cs
@@ -21,6 +21,8 @@ using System.Composition;
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.ViewModels;
@@ -32,6 +34,14 @@ namespace ICSharpCode.ILSpy.Views
 	public partial class MainWindow : Window
 	{
 		readonly SettingsService? settingsService;
+
+		static MainWindow()
+		{
+			PointerReleasedEvent.AddClassHandler<MainWindow>(
+				OnBrowserNavigationPointerReleased,
+				RoutingStrategies.Bubble,
+				handledEventsToo: true);
+		}
 
 		public MainWindow()
 		{
@@ -75,6 +85,24 @@ namespace ICSharpCode.ILSpy.Views
 					Avalonia.Threading.DispatcherPriority.Background);
 			};
 			AppLog.Mark("MainWindow ctor exited");
+		}
+
+		static void OnBrowserNavigationPointerReleased(MainWindow window, PointerReleasedEventArgs e)
+		{
+			if (window.DataContext is not MainWindowViewModel viewModel)
+				return;
+
+			var command = e.InitialPressMouseButton switch {
+				MouseButton.XButton1 => viewModel.DockWorkspace.NavigateBackCommand,
+				MouseButton.XButton2 => viewModel.DockWorkspace.NavigateForwardCommand,
+				_ => null
+			};
+
+			if (command?.CanExecute(null) == true)
+			{
+				command.Execute(null);
+				e.Handled = true;
+			}
 		}
 
 		static void SurfaceCompositionErrors()


### PR DESCRIPTION
Fixes #4027

### Problem
Mouse4 and Mouse5 worked as back and forward navigation in the WPF version of ILSpy, but this behavior was not carried over to the Avalonia UI.

The Avalonia implementation currently wires the existing navigation commands to Alt+Left and Alt+Right only. XButton1 and XButton2 are available through Avalonia's pointer input API, but there is no equivalent `KeyBinding` declaration for these mouse buttons.

### Solution
* Handle XButton1 and XButton2 through `MainWindow` and route them to the existing back and forward navigation commands.