### PR TITLE
Fix five Avalonia UI regressions: mouse navigation, derived types, Enter, Delete, Analyze in the Analyzer pane

### DIFF
--- a/ILSpy.Tests/Analyzers/AnalyzeContextMenuTests.cs
+++ b/ILSpy.Tests/Analyzers/AnalyzeContextMenuTests.cs
@@ -29,6 +29,7 @@ using ICSharpCode.ILSpyX.TreeView;
 
 using ICSharpCode.ILSpy;
 using ICSharpCode.ILSpy.Analyzers;
+using ICSharpCode.ILSpy.Analyzers.TreeNodes;
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.TreeNodes;
@@ -236,6 +237,62 @@ public class AnalyzeContextMenuTests
 			((object?)searchHeader.Icon).Should().NotBeNull(
 				$"'{searchHeader.AnalyzerHeader}' analyzer-search row needs an icon — was the regression");
 		}
+	}
+
+	[AvaloniaTest]
+	public async Task Analyze_Promotes_An_Analyzer_Result_Row_To_A_Top_Level_Entry()
+	{
+		// Right-click on a result row inside the analyzer pane (a "Used By" hit, say) must
+		// offer Analyze and, on Execute, add that row's entity as a new top-level entry.
+		var (_, vm) = await TestHarness.BootAsync();
+		var entry = AppComposition.Current.GetExport<ContextMenuEntryRegistry>()
+			.GetEntry(nameof(Resources.Analyze));
+		var analyzerVm = AppComposition.Current.GetExport<AnalyzerTreeViewModel>();
+
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		typeNode.IsExpanded = true;
+		var method = typeNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Empty").MethodDefinition;
+
+		entry.Execute(new TextViewContext { SelectedTreeNodes = new SharpTreeNode[] { typeNode } });
+		var rootRow = analyzerVm.Root.Children.OfType<AnalyzerEntityTreeNode>().Last();
+		rootRow.EnsureLazyChildren();
+		// A result row lives underneath an analyzer-search header, never directly under the root.
+		var resultRow = new AnalyzedMethodTreeNode(method, typeNode.Member);
+		rootRow.Children.OfType<AnalyzerSearchTreeNode>().First().Children.Add(resultRow);
+
+		var context = new TextViewContext { SelectedTreeNodes = new SharpTreeNode[] { resultRow } };
+		entry.IsVisible(context).Should().BeTrue("an analyzer result row wraps an entity, so Analyze must be offered");
+		entry.IsEnabled(context).Should().BeTrue();
+
+		var before = analyzerVm.Root.Children.Count;
+		entry.Execute(context);
+		TestCapture.Step("result-row-analyzed");
+
+		analyzerVm.Root.Children.Count.Should().Be(before + 1, "the result row's entity must become a top-level entry");
+		var promoted = analyzerVm.Root.Children.OfType<AnalyzerEntityTreeNode>().Last();
+		promoted.Member.Should().BeSameAs(method);
+		((object)analyzerVm.SelectedItems.Single()).Should().BeSameAs(promoted);
+	}
+
+	[AvaloniaTest]
+	public async Task Analyze_Is_Hidden_For_A_Top_Level_Analyzer_Row()
+	{
+		// A top-level analyzer row is already analysed; re-analysing it would be a no-op, so the
+		// entry stays hidden there (Remove is the entry offered for those rows).
+		var (_, vm) = await TestHarness.BootAsync();
+		var entry = AppComposition.Current.GetExport<ContextMenuEntryRegistry>()
+			.GetEntry(nameof(Resources.Analyze));
+		var analyzerVm = AppComposition.Current.GetExport<AnalyzerTreeViewModel>();
+
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		entry.Execute(new TextViewContext { SelectedTreeNodes = new SharpTreeNode[] { typeNode } });
+		var rootRow = analyzerVm.Root.Children.OfType<AnalyzerEntityTreeNode>().Last();
+
+		entry.IsVisible(new TextViewContext { SelectedTreeNodes = new SharpTreeNode[] { rootRow } })
+			.Should().BeFalse("a top-level analyzer row is already analysed");
 	}
 
 	static AnalyzerTreeViewModel? FindAnalyzerPane(ICSharpCode.ILSpy.Docking.DockWorkspace dockWorkspace)

--- a/ILSpy.Tests/Analyzers/AnalyzeContextMenuTests.cs
+++ b/ILSpy.Tests/Analyzers/AnalyzeContextMenuTests.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Threading.Tasks;
 
 using Avalonia.Headless.NUnit;
@@ -25,6 +26,7 @@ using AwesomeAssertions;
 
 using ICSharpCode.Decompiler.TypeSystem;
 using ICSharpCode.ILSpy.Properties;
+using ICSharpCode.ILSpyX;
 using ICSharpCode.ILSpyX.TreeView;
 
 using ICSharpCode.ILSpy;
@@ -293,6 +295,37 @@ public class AnalyzeContextMenuTests
 
 		entry.IsVisible(new TextViewContext { SelectedTreeNodes = new SharpTreeNode[] { rootRow } })
 			.Should().BeFalse("a top-level analyzer row is already analysed");
+	}
+
+	[AvaloniaTest]
+	public async Task Analyze_Reuses_The_Row_When_The_Same_Entity_Comes_From_Another_Type_System()
+	{
+		// Analyzer result rows carry entities from the type system each analyzer run builds, so
+		// the same member reaches the pane as different IEntity/IModule instances depending on
+		// whether it was analysed from the assembly tree or from a result row. Both must land on
+		// the same top-level row.
+		var (_, vm) = await TestHarness.BootAsync();
+		var analyzerVm = AppComposition.Current.GetExport<AnalyzerTreeViewModel>();
+
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		typeNode.IsExpanded = true;
+		var method = typeNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Empty").MethodDefinition;
+		var first = analyzerVm.Analyze(method);
+		var count = analyzerVm.Root.Children.Count;
+
+		var file = method.ParentModule!.MetadataFile!;
+		var otherTypeSystem = new DecompilerTypeSystem(file, file.GetAssemblyResolver());
+		var other = otherTypeSystem.MainModule.GetDefinition((MethodDefinitionHandle)method.MetadataToken);
+		other.ParentModule.Should().NotBeSameAs(method.ParentModule, "the test must exercise the cross-type-system case");
+
+		var second = analyzerVm.Analyze(other);
+		TestCapture.Step("same-entity-other-type-system");
+
+		((object)second).Should().BeSameAs(first, "the existing row must be reused");
+		analyzerVm.Root.Children.Count.Should().Be(count);
+		((object)analyzerVm.SelectedItems.Single()).Should().BeSameAs(first);
 	}
 
 	static AnalyzerTreeViewModel? FindAnalyzerPane(ICSharpCode.ILSpy.Docking.DockWorkspace dockWorkspace)

--- a/ILSpy.Tests/Analyzers/AnalyzerTreeKeyboardTests.cs
+++ b/ILSpy.Tests/Analyzers/AnalyzerTreeKeyboardTests.cs
@@ -71,6 +71,39 @@ public class AnalyzerTreeKeyboardTests
 	}
 
 	[AvaloniaTest]
+	public async Task Enter_Activates_The_Selected_Analyzer_Node()
+	{
+		// Enter on a single selected analyzer row activates it -- for an entity node that means
+		// navigating to the member's home in the assembly tree, like 10.x did. The key must reach
+		// SharpTreeView.OnKeyDown: the container is a ListBoxItem, and Avalonia's default key
+		// selection triggers treat Enter/Space as selection input and mark the event handled
+		// before it bubbles, so SharpTreeView suppresses that trigger for the activation case.
+		var (window, vm) = await TestHarness.BootAsync(3);
+		var dockWorkspace = AppComposition.Current.GetExport<DockWorkspace>();
+		var analyzerVm = AppComposition.Current.GetExport<AnalyzerTreeViewModel>();
+
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		var entity = (ITypeDefinition)typeNode.Member!;
+		var analyzed = analyzerVm.Analyze(entity);
+
+		dockWorkspace.ShowToolPane(AnalyzerTreeViewModel.PaneContentId);
+		var view = await window.WaitForComponent<ICSharpCode.ILSpy.Analyzers.AnalyzerTreeView>();
+		var tree = await view.WaitForComponent<ICSharpCode.ILSpy.Controls.TreeView.SharpTreeView>();
+		tree.SelectedItem = analyzed;
+		Dispatcher.UIThread.RunJobs();
+		tree.FocusNode(analyzed);
+		Dispatcher.UIThread.RunJobs();
+
+		((object?)vm.AssemblyTreeModel.SelectedItem).Should().NotBeSameAs(typeNode,
+			"precondition: the assembly tree must not already sit on the target node");
+
+		window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, null);
+		await Waiters.WaitForAsync(() => ReferenceEquals(vm.AssemblyTreeModel.SelectedItem, typeNode),
+			description: "Enter must activate the analyzer node and select the type in the assembly tree");
+	}
+
+	[AvaloniaTest]
 	public async Task Ctrl_R_Analyzes_The_Selected_Member()
 	{
 		// Ctrl+R on the assembly tree analyzes the selected member(s) -- the keyboard equivalent of the

--- a/ILSpy.Tests/Analyzers/AnalyzerTreeKeyboardTests.cs
+++ b/ILSpy.Tests/Analyzers/AnalyzerTreeKeyboardTests.cs
@@ -104,6 +104,44 @@ public class AnalyzerTreeKeyboardTests
 	}
 
 	[AvaloniaTest]
+	public async Task Delete_Removes_The_Selected_Top_Level_Analyzer_Node()
+	{
+		// Delete on a selected top-level analyzer row removes it from the pane (the keyboard
+		// equivalent of the "Remove" context-menu entry). Rows below the top level are not
+		// deletable, so Delete on one of them leaves the pane untouched.
+		var (window, vm) = await TestHarness.BootAsync(3);
+		var dockWorkspace = AppComposition.Current.GetExport<DockWorkspace>();
+		var analyzerVm = AppComposition.Current.GetExport<AnalyzerTreeViewModel>();
+
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		var analyzed = analyzerVm.Analyze((ITypeDefinition)typeNode.Member!);
+		analyzed.IsExpanded = true;
+		var child = analyzed.Children.First();
+
+		dockWorkspace.ShowToolPane(AnalyzerTreeViewModel.PaneContentId);
+		var view = await window.WaitForComponent<ICSharpCode.ILSpy.Analyzers.AnalyzerTreeView>();
+		var tree = await view.WaitForComponent<ICSharpCode.ILSpy.Controls.TreeView.SharpTreeView>();
+
+		tree.SelectedItem = child;
+		Dispatcher.UIThread.RunJobs();
+		tree.FocusNode(child);
+		Dispatcher.UIThread.RunJobs();
+		window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.Delete, null);
+		Dispatcher.UIThread.RunJobs();
+		analyzed.Children.Should().Contain(child, "Delete must not remove a nested analyzer row");
+		analyzerVm.Root.Children.Should().Contain(analyzed, "Delete on a nested row must not remove its top-level node");
+
+		tree.SelectedItem = analyzed;
+		Dispatcher.UIThread.RunJobs();
+		tree.FocusNode(analyzed);
+		Dispatcher.UIThread.RunJobs();
+		window.KeyPress(Key.Delete, RawInputModifiers.None, PhysicalKey.Delete, null);
+		await Waiters.WaitForAsync(() => !analyzerVm.Root.Children.Contains(analyzed),
+			description: "Delete must remove the selected top-level analyzer node from the pane");
+	}
+
+	[AvaloniaTest]
 	public async Task Ctrl_R_Analyzes_The_Selected_Member()
 	{
 		// Ctrl+R on the assembly tree analyzes the selected member(s) -- the keyboard equivalent of the

--- a/ILSpy.Tests/AssemblyList/AssemblyTreeTests.cs
+++ b/ILSpy.Tests/AssemblyList/AssemblyTreeTests.cs
@@ -1540,6 +1540,35 @@ public class AssemblyTreeTests
 	}
 
 	[AvaloniaTest]
+	public async Task Derived_Type_Entries_Stay_Visible_When_The_DerivedTypes_Node_Is_Expanded()
+	{
+		// The filter cascade runs for children added under a visible parent. A derived-type
+		// entry must report FilterResult.Match there: the Recurse handling force-loads the
+		// entry's own (lazy) children and hides the entry when all of them are hidden -- a
+		// leaf derived type has none, so every entry under "Derived Types" ended up hidden.
+
+		var (_, vm) = await TestHarness.BootAsync(3);
+
+		var coreLibName = typeof(object).Assembly.GetName().Name!;
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			coreLibName, "System", "System.Exception");
+		// Expand the full ancestor chain so the type node is IsVisible -- the cascade only
+		// fires for children of visible parents, which is the state the real tree is in.
+		foreach (var ancestor in typeNode.Ancestors())
+			ancestor.IsExpanded = true;
+		typeNode.IsExpanded = true;
+
+		var derived = typeNode.Children.OfType<DerivedTypesTreeNode>().Single();
+		derived.IsExpanded = true;
+
+		var entries = derived.Children.OfType<DerivedTypesEntryNode>().ToList();
+		entries.Should().NotBeEmpty(
+			"the loaded assembly list contains several Exception subclasses");
+		entries.Should().OnlyContain(e => e.IsVisible,
+			"public derived-type entries must show under the expanded Derived Types node");
+	}
+
+	[AvaloniaTest]
 	public async Task Sealed_Class_Has_No_DerivedTypes_Node()
 	{
 		// Sealed types can't be derived from, so the DerivedTypes sub-tree must not appear.

--- a/ILSpy.Tests/Navigation/BrowseBackForwardCommandTests.cs
+++ b/ILSpy.Tests/Navigation/BrowseBackForwardCommandTests.cs
@@ -19,9 +19,12 @@
 using System.Linq;
 using System.Threading.Tasks;
 
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
 using AwesomeAssertions;
@@ -29,8 +32,10 @@ using AwesomeAssertions;
 using ICSharpCode.ILSpy.Properties;
 
 using ICSharpCode.ILSpy.AppEnv;
+using ICSharpCode.ILSpy.AssemblyTree;
 using ICSharpCode.ILSpy.Commands;
 using ICSharpCode.ILSpy.Docking;
+using ICSharpCode.ILSpy.TextView;
 using ICSharpCode.ILSpy.TreeNodes;
 using ICSharpCode.ILSpy.ViewModels;
 using ICSharpCode.ILSpy.Views;
@@ -119,6 +124,118 @@ public class BrowseBackForwardCommandTests
 		await Waiters.WaitForAsync(() => ReferenceEquals(vm.AssemblyTreeModel.SelectedItem, firstMethod));
 		vm.DockWorkspace.NavigateForwardCommand.CanExecute(null).Should().BeTrue(
 			"after one back-step the forward stack should be non-empty");
+	}
+
+	[AvaloniaTest]
+	public async Task Mouse_Back_And_Forward_Buttons_Navigate_The_History()
+	{
+		// The extra mouse buttons (XButton1 = back, XButton2 = forward) drive the same history
+		// as Alt+Left / Alt+Right, matching browsers and the WPF version (where WPF itself
+		// translated the buttons into BrowseBack/BrowseForward commands). Avalonia has no such
+		// translation, so MainWindow routes the pointer events to the navigation commands.
+
+		// Arrange — build a two-entry history exactly like the menu-driven test above.
+		var (window, vm) = await TestHarness.BootAsync(3);
+		var (firstMethod, secondMethod) = await BuildTwoEntryHistoryAsync(vm);
+
+		// Act — click mouse-back anywhere in the window.
+		var point = new Point(100, 100);
+		window.MouseDown(point, MouseButton.XButton1);
+		window.MouseUp(point, MouseButton.XButton1);
+
+		// Assert — selection rewinds, then mouse-forward replays the step.
+		await Waiters.WaitForAsync(() => ReferenceEquals(vm.AssemblyTreeModel.SelectedItem, firstMethod),
+			description: "XButton1 must navigate back one history entry");
+		await Waiters.WaitForAsync(() => vm.DockWorkspace.NavigateForwardCommand.CanExecute(null),
+			description: "after one back-step the forward stack should be non-empty");
+
+		window.MouseDown(point, MouseButton.XButton2);
+		window.MouseUp(point, MouseButton.XButton2);
+
+		await Waiters.WaitForAsync(() => ReferenceEquals(vm.AssemblyTreeModel.SelectedItem, secondMethod),
+			description: "XButton2 must navigate forward one history entry");
+	}
+
+	[AvaloniaTest]
+	public async Task Mouse_Back_Button_Press_Does_Not_Reach_The_Control_Under_The_Pointer()
+	{
+		// The X buttons are navigation gestures, not clicks (WPF never delivered them to the
+		// control under the pointer). The press must not activate the pane under the pointer,
+		// move keyboard focus, or toggle a folding marker; only the release navigates, and the
+		// active pane stays where it was across the navigation.
+
+		// Arrange — two-entry history, assembly pane active, pointer over the editor.
+		var (window, vm) = await TestHarness.BootAsync(3);
+		var (firstMethod, _) = await BuildTwoEntryHistoryAsync(vm);
+		var view = await window.WaitForComponent<DecompilerTextView>();
+
+		vm.DockWorkspace.ShowToolPane(AssemblyTreeModel.PaneContentId);
+		var activePane = vm.DockWorkspace.Layout.FocusedDockable;
+		activePane.Should().NotBeNull("showing the assembly pane must make it the focused dockable");
+		var focusedElement = window.FocusManager?.GetFocusedElement();
+
+		int pressedInEditor = 0;
+		view.AddHandler(InputElement.PointerPressedEvent, (_, _) => pressedInEditor++,
+			RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
+		var point = view.TranslatePoint(new Point(view.Bounds.Width / 2, view.Bounds.Height / 2), window);
+		point.Should().NotBeNull("the editor centre must map into the test window");
+
+		// Act / Assert — the press is swallowed at the window ...
+		window.MouseDown(point!.Value, MouseButton.XButton1);
+		pressedInEditor.Should().Be(0, "an X-button press must not reach the control under the pointer");
+		vm.DockWorkspace.Layout.FocusedDockable.Should().BeSameAs(activePane,
+			"pressing a mouse navigation button must not activate the pane under the pointer");
+		ReferenceEquals(window.FocusManager?.GetFocusedElement(), focusedElement).Should().BeTrue(
+			"pressing a mouse navigation button must not move keyboard focus");
+
+		// ... and the release navigates without moving the active pane to the editor.
+		window.MouseUp(point.Value, MouseButton.XButton1);
+		await Waiters.WaitForAsync(() => ReferenceEquals(vm.AssemblyTreeModel.SelectedItem, firstMethod),
+			description: "XButton1 must navigate back one history entry");
+		vm.DockWorkspace.Layout.FocusedDockable.Should().BeSameAs(activePane,
+			"navigating back must not move the active pane to the editor");
+	}
+
+	[AvaloniaTest]
+	public async Task Browse_Back_Keeps_The_Active_Pane()
+	{
+		// Back/Forward re-select a tree node and restore the tab's view state; the tab being
+		// navigated is already the active document, so the navigation must not move the active
+		// pane to it (WPF kept the current view focused). Exercises the command directly, which
+		// is what the Alt+Left key binding and the View menu invoke.
+		var (_, vm) = await TestHarness.BootAsync(3);
+		var (firstMethod, _) = await BuildTwoEntryHistoryAsync(vm);
+		vm.DockWorkspace.ShowToolPane(AssemblyTreeModel.PaneContentId);
+		var activePane = vm.DockWorkspace.Layout.FocusedDockable;
+		activePane.Should().NotBeNull("showing the assembly pane must make it the focused dockable");
+
+		vm.DockWorkspace.NavigateBackCommand.Execute(null);
+
+		await Waiters.WaitForAsync(() => ReferenceEquals(vm.AssemblyTreeModel.SelectedItem, firstMethod),
+			description: "BrowseBack must navigate back one history entry");
+		await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		vm.DockWorkspace.Layout.FocusedDockable.Should().BeSameAs(activePane,
+			"navigating back must not move the active pane to the editor");
+	}
+
+	// Selects two methods of System.Linq.Enumerable with a pause in between so the history records
+	// them as two separate entries; returns them in selection order.
+	static async Task<(MethodTreeNode First, MethodTreeNode Second)> BuildTwoEntryHistoryAsync(MainWindowViewModel vm)
+	{
+		var typeNode = vm.AssemblyTreeModel.FindNode<TypeTreeNode>(
+			"System.Linq", "System.Linq", "System.Linq.Enumerable");
+		typeNode.IsExpanded = true;
+		var firstMethod = typeNode.Children.OfType<MethodTreeNode>()
+			.Single(m => m.MethodDefinition.Name == "AsEnumerable");
+		var secondMethod = typeNode.Children.OfType<MethodTreeNode>()
+			.First(m => m.MethodDefinition.Name == "Empty");
+
+		vm.AssemblyTreeModel.SelectNode(firstMethod);
+		await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		await Task.Delay(600);
+		vm.AssemblyTreeModel.SelectNode(secondMethod);
+		await vm.DockWorkspace.WaitForDecompiledTextAsync();
+		return (firstMethod, secondMethod);
 	}
 
 	[AvaloniaTest]

--- a/ILSpy/Analyzers/AnalyzeContextMenuEntry.cs
+++ b/ILSpy/Analyzers/AnalyzeContextMenuEntry.cs
@@ -29,9 +29,11 @@ namespace ICSharpCode.ILSpy.Analyzers
 {
 	/// <summary>
 	/// Right-click → "Analyze" — pushes every selected member (type, method, field, property,
-	/// event) into the analyzer pane. The pane's <see cref="AnalyzerTreeViewModel.Analyze"/>
-	/// dedupes entries by <see cref="IEntity.MetadataToken"/> + parent module so re-running
-	/// the menu on the same entity just refocuses the existing row.
+	/// event) into the analyzer pane, from the assembly tree, from a code reference, or from a
+	/// result row inside the analyzer pane itself (promoting it to a top-level entry). The
+	/// pane's <see cref="AnalyzerTreeViewModel.Analyze"/> dedupes entries by
+	/// <see cref="IEntity.MetadataToken"/> + parent module so re-running the menu on the same
+	/// entity just refocuses the existing row.
 	/// </summary>
 	[ExportContextMenuEntry(
 		Header = nameof(Resources.Analyze),
@@ -54,7 +56,12 @@ namespace ICSharpCode.ILSpy.Analyzers
 		public bool IsVisible(TextViewContext context)
 		{
 			if (context.SelectedTreeNodes is { Length: > 0 } nodes)
-				return nodes.All(n => n is IMemberTreeNode);
+			{
+				// Top-level analyzer rows are already analysed (Remove is the entry for those);
+				// result rows underneath promote their entity to a new top-level row.
+				return nodes.All(n => n is IMemberTreeNode
+					&& n is not AnalyzerEntityTreeNode { Parent.IsRoot: true });
+			}
 			// Right-clicking a resolved symbol in the decompiled code: the reference carries the entity.
 			return context.Reference?.Reference is IEntity;
 		}

--- a/ILSpy/Analyzers/AnalyzerEntityTreeNode.cs
+++ b/ILSpy/Analyzers/AnalyzerEntityTreeNode.cs
@@ -30,6 +30,7 @@ using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.AssemblyTree;
 using ICSharpCode.ILSpy.Controls.TreeView;
 using ICSharpCode.ILSpy.Themes;
+using ICSharpCode.ILSpy.TreeNodes;
 using ICSharpCode.ILSpy.Util;
 
 namespace ICSharpCode.ILSpy.Analyzers
@@ -39,9 +40,10 @@ namespace ICSharpCode.ILSpy.Analyzers
 	/// per-entity root row plus every analyser result row underneath an
 	/// <see cref="AnalyzerSearchTreeNode"/>). Concrete subclasses supply the entity, its
 	/// icon, and its text; this base owns the navigation hook and the assembly-change
-	/// pruning logic.
+	/// pruning logic. Implementing <see cref="IMemberTreeNode"/> is what lets the member-based
+	/// context-menu entries (Analyze, Copy name, ...) act on analyzer rows like on assembly-tree rows.
 	/// </summary>
-	public abstract class AnalyzerEntityTreeNode : AnalyzerTreeNode, IRichTextNode
+	public abstract class AnalyzerEntityTreeNode : AnalyzerTreeNode, IRichTextNode, IMemberTreeNode
 	{
 		// Flags reproducing the plain signature the pane used before highlighting: the member's
 		// declaring type, fully-qualified names, and the usual return-type/parameter detail.

--- a/ILSpy/Analyzers/AnalyzerTreeViewModel.cs
+++ b/ILSpy/Analyzers/AnalyzerTreeViewModel.cs
@@ -86,10 +86,12 @@ namespace ICSharpCode.ILSpy.Analyzers
 
 		static bool IsSameEntity(IEntity? a, IEntity b)
 		{
-			if (a == null)
-				return false;
-			return a.MetadataToken == b.MetadataToken
-				&& ReferenceEquals(a.ParentModule, b.ParentModule);
+			// Entities reaching the pane come from different type systems (the assembly tree's,
+			// and the fresh one each analyzer run builds), so the IModule instances differ even
+			// for the same member; the loaded MetadataFile is the stable identity.
+			return a?.ParentModule?.MetadataFile is { } file
+				&& a.MetadataToken == b.MetadataToken
+				&& ReferenceEquals(file, b.ParentModule?.MetadataFile);
 		}
 
 		void SyncSelection(SharpTreeNode node)

--- a/ILSpy/AssemblyTree/AssemblyListPane.axaml.cs
+++ b/ILSpy/AssemblyTree/AssemblyListPane.axaml.cs
@@ -232,26 +232,12 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 
 		#endregion
 
-		#region Keyboard (assembly-specific: Delete, Ctrl+R)
+		#region Keyboard (assembly-specific: Ctrl+R; Delete is handled by SharpTreeView)
 
 		void OnTreeKeyDown(object? sender, KeyEventArgs e)
 		{
 			if (DataContext is not AssemblyTreeModel model)
 				return;
-			if (e.Key == Key.Delete && e.KeyModifiers == KeyModifiers.None && model.AssemblyList is { } list)
-			{
-				var selectedAssemblyNodes = model.SelectedItems.OfType<AssemblyTreeNode>().ToList();
-				if (selectedAssemblyNodes.Count == 0)
-					return;
-				int reselectIndex = FlattenedIndexOf(selectedAssemblyNodes[0]);
-				foreach (var node in selectedAssemblyNodes)
-					list.Unload(node.LoadedAssembly);
-				e.Handled = true;
-				global::Avalonia.Threading.Dispatcher.UIThread.Post(
-					() => ReselectAfterDelete(reselectIndex),
-					global::Avalonia.Threading.DispatcherPriority.Background);
-				return;
-			}
 			if (e.Key == Key.R && e.KeyModifiers == KeyModifiers.Control)
 			{
 				var members = model.SelectedItems.OfType<IMemberTreeNode>()
@@ -267,23 +253,6 @@ namespace ICSharpCode.ILSpy.AssemblyTree
 					analyzerVm.Analyze(member!);
 				e.Handled = true;
 			}
-		}
-
-		System.Collections.IList? Flattened => Tree.ItemsSource as System.Collections.IList;
-
-		int FlattenedIndexOf(SharpTreeNode node) => Flattened?.IndexOf(node) ?? -1;
-
-		void ReselectAfterDelete(int index)
-		{
-			if (DataContext is not AssemblyTreeModel model)
-				return;
-			var flattened = Flattened;
-			if (flattened == null || flattened.Count == 0 || index < 0)
-			{
-				model.SelectNode(null);
-				return;
-			}
-			model.SelectNode(flattened[Math.Clamp(index, 0, flattened.Count - 1)] as SharpTreeNode);
 		}
 
 		#endregion

--- a/ILSpy/Controls/TreeView/SharpTreeView.cs
+++ b/ILSpy/Controls/TreeView/SharpTreeView.cs
@@ -328,6 +328,11 @@ namespace ICSharpCode.ILSpy.Controls.TreeView
 				e.Handled = true;
 				return;
 			}
+			if (e.Key == Key.Delete && e.KeyModifiers == KeyModifiers.None && DeleteSelection())
+			{
+				e.Handled = true;
+				return;
+			}
 			var node = (e.Source as Visual)?.FindAncestorOfType<SharpTreeViewItem>(includeSelf: true)?.Node
 				?? SelectedItem as SharpTreeNode;
 			if (node != null && e.KeyModifiers == KeyModifiers.None)
@@ -380,6 +385,28 @@ namespace ICSharpCode.ILSpy.Controls.TreeView
 			}
 			if (!e.Handled)
 				base.OnKeyDown(e);
+		}
+
+		/// <summary>
+		/// Deletes the top-level selection (see <see cref="GetTopLevelSelection"/>) when every node in it
+		/// supports deletion, then selects the row that takes the first deleted node's place so a
+		/// repeated Delete keeps working. Returns false without touching anything otherwise, e.g. for
+		/// a selection that mixes deletable and non-deletable rows.
+		/// </summary>
+		bool DeleteSelection()
+		{
+			if (flattener is null)
+				return false;
+			var nodes = GetTopLevelSelection().ToArray();
+			if (nodes.Length == 0 || !nodes.All(n => n.CanDelete()))
+				return false;
+			int index = nodes.Min(flattener.IndexOf);
+			foreach (var node in nodes)
+				node.Delete();
+			// The deleted rows leave the selection with the source; pick the nearest survivor.
+			if (SelectedItems!.Count == 0 && flattener.Count > 0)
+				SelectAndFocus((SharpTreeNode)flattener[Math.Clamp(index, 0, flattener.Count - 1)]!);
+			return true;
 		}
 
 		static void ExpandRecursively(SharpTreeNode node)
@@ -447,7 +474,7 @@ namespace ICSharpCode.ILSpy.Controls.TreeView
 			searchBuffer = string.Empty;
 		}
 
-		/// <summary>Selected items with no selected ancestor (used by Delete).</summary>
+		/// <summary>Selected items with no selected ancestor.</summary>
 		public IEnumerable<SharpTreeNode> GetTopLevelSelection()
 		{
 			var selection = SelectedItems!.OfType<SharpTreeNode>().ToHashSet();

--- a/ILSpy/Controls/TreeView/SharpTreeView.cs
+++ b/ILSpy/Controls/TreeView/SharpTreeView.cs
@@ -295,6 +295,27 @@ namespace ICSharpCode.ILSpy.Controls.TreeView
 			scrollViewer.Offset = new Vector(scrollViewer.Offset.X, newOffsetY);
 		}
 
+		/// <summary>
+		/// Avalonia's default key selection triggers treat plain Enter/Space as selection input:
+		/// the ListBoxItem container marks the KeyDown handled before it bubbles here, so the
+		/// activation handling in <see cref="OnKeyDown"/> would never see those keys. Suppress the
+		/// selection trigger exactly for the case OnKeyDown activates instead -- a single selected
+		/// row that is the row the key landed on. Multi-row selections keep the default behaviour
+		/// (Enter/Space collapses the selection to the focused row).
+		/// </summary>
+		protected override bool ShouldTriggerSelection(Visual selectable, KeyEventArgs eventArgs)
+		{
+			if (eventArgs.KeyModifiers == KeyModifiers.None
+				&& eventArgs.Key is Key.Enter or Key.Space
+				&& selectable is SharpTreeViewItem { Node: { } node }
+				&& SelectedItems?.Count == 1
+				&& ReferenceEquals(SelectedItem, node))
+			{
+				return false;
+			}
+			return base.ShouldTriggerSelection(selectable, eventArgs);
+		}
+
 		protected override void OnKeyDown(KeyEventArgs e)
 		{
 			// Ctrl+A select-all must work on the first press even before a current item is

--- a/ILSpy/Docking/DockWorkspace.cs
+++ b/ILSpy/Docking/DockWorkspace.cs
@@ -596,7 +596,11 @@ namespace ICSharpCode.ILSpy.Docking
 			suppressHistoryRecording = true;
 			try
 			{
-				if (factory.Documents?.VisibleDockables is { } docs && docs.Contains(target.Tab))
+				// Only activate a tab that is not already active: Dock's ActiveDockable setter re-runs
+				// InitActiveDockable -> SetFocusedDockable even for an unchanged value, which would
+				// move the active pane to the document on every navigation.
+				if (factory.Documents is { VisibleDockables: { } docs } documents
+					&& docs.Contains(target.Tab) && !ReferenceEquals(documents.ActiveDockable, target.Tab))
 					factory.SetActiveDockable(target.Tab);
 				if (target is TreeNodeEntry treeNode)
 				{

--- a/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
+++ b/ILSpy/TreeNodes/DerivedTypesEntryNode.cs
@@ -69,16 +69,18 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		};
 
 		/// <summary>
-		/// Drops non-public entries under PublicOnly visibility, otherwise recurses so the user
-		/// can drill into derived chains. The active search term is deliberately not consulted:
-		/// <see cref="LanguageSettings.SearchTermMatches"/> is a no-op so the assembly tree stays
-		/// independent of the search pane.
+		/// Drops non-public entries under PublicOnly visibility, otherwise reports a match. It must
+		/// not report Recurse: the filter cascade's Recurse handling force-loads this node's lazy
+		/// children and hides the node when all of them are hidden, so a leaf derived type (no
+		/// further subclasses, hence no children) would vanish from the tree. The active search term
+		/// is deliberately not consulted: <see cref="LanguageSettings.SearchTermMatches"/> is a
+		/// no-op so the assembly tree stays independent of the search pane.
 		/// </summary>
 		public override FilterResult Filter(LanguageSettings settings)
 		{
 			if (settings.ShowApiLevel == ApiVisibility.PublicOnly && !IsPublicAPI)
 				return FilterResult.Hidden;
-			return FilterResult.Recurse;
+			return FilterResult.Match;
 		}
 
 		public override void ActivateItem(IPlatformRoutedEventArgs e)

--- a/ILSpy/Views/MainWindow.axaml
+++ b/ILSpy/Views/MainWindow.axaml
@@ -20,8 +20,8 @@
 	</Design.DataContext>
 
 	<Window.KeyBindings>
-		<!-- Browser-style navigation. XButton1/2 (mouse Back/Forward) aren't first-class in
-		     Avalonia 12 yet, so we wire keyboard only for now. -->
+		<!-- Browser-style keyboard navigation. The mouse back/forward buttons drive the same
+		     commands from code-behind (KeyBindings cannot express pointer buttons). -->
 		<KeyBinding Gesture="Alt+Left" Command="{Binding DockWorkspace.NavigateBackCommand}" />
 		<KeyBinding Gesture="Alt+Right" Command="{Binding DockWorkspace.NavigateForwardCommand}" />
 		<!-- Search pane shortcuts. Ctrl+Shift+F is the WPF default; Ctrl+E mirrors the

--- a/ILSpy/Views/MainWindow.axaml.cs
+++ b/ILSpy/Views/MainWindow.axaml.cs
@@ -21,6 +21,8 @@ using System.Composition;
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 
 using ICSharpCode.ILSpy.AppEnv;
 using ICSharpCode.ILSpy.ViewModels;
@@ -60,6 +62,16 @@ namespace ICSharpCode.ILSpy.Views
 			// gesture that triggered the DBus call. No-op unless that category is enabled.
 			InputDiagnostics.Attach(this);
 			ICSharpCode.ILSpy.MainMenu.Attach(this);
+			// Mouse back/forward buttons navigate the history, like Alt+Left / Alt+Right. There is
+			// no KeyBinding equivalent for pointer buttons, so listen window-wide. The press is
+			// swallowed while tunnelling (the window is the first stop) so the control under the
+			// pointer never sees it as a click: Dock would activate the pane, AvaloniaEdit would
+			// focus the editor or toggle a folding marker. The release then navigates;
+			// handledEventsToo because inner controls handle pointer events for their own gestures
+			// without ever using the X buttons.
+			AddHandler(PointerPressedEvent, OnBrowserNavigationPointerPressed, RoutingStrategies.Tunnel);
+			AddHandler(PointerReleasedEvent, OnBrowserNavigationPointerReleased,
+				RoutingStrategies.Bubble, handledEventsToo: true);
 			ApplySessionSettings(settingsService.SessionSettings);
 			Opened += async (_, _) => {
 				AppLog.Mark("MainWindow.Opened fired");
@@ -75,6 +87,31 @@ namespace ICSharpCode.ILSpy.Views
 					Avalonia.Threading.DispatcherPriority.Background);
 			};
 			AppLog.Mark("MainWindow ctor exited");
+		}
+
+		void OnBrowserNavigationPointerPressed(object? sender, PointerPressedEventArgs e)
+		{
+			if (e.GetCurrentPoint(this).Properties.PointerUpdateKind
+				is PointerUpdateKind.XButton1Pressed or PointerUpdateKind.XButton2Pressed)
+			{
+				e.Handled = true;
+			}
+		}
+
+		void OnBrowserNavigationPointerReleased(object? sender, PointerReleasedEventArgs e)
+		{
+			if (DataContext is not MainWindowViewModel viewModel)
+				return;
+			var command = e.InitialPressMouseButton switch {
+				MouseButton.XButton1 => viewModel.DockWorkspace.NavigateBackCommand,
+				MouseButton.XButton2 => viewModel.DockWorkspace.NavigateForwardCommand,
+				_ => null
+			};
+			if (command?.CanExecute(null) == true)
+			{
+				command.Execute(null);
+				e.Handled = true;
+			}
 		}
 
 		static void SurfaceCompositionErrors()


### PR DESCRIPTION
Five UI regressions from the Avalonia migration (the fourth and fifth, Delete and Analyze in the Analyzer pane, were reported in the #4030 thread), one commit each, each with a headless regression test that was shown red before the fix.

Fixes #4027
Fixes #4028
Fixes #4030

### Mouse4 / Mouse5 no longer navigate back / forward (#4027)

WPF translated the extra mouse buttons into `BrowseBack`/`BrowseForward` commands by itself, so they never reached the control under the pointer as a click; Avalonia has no such translation and `KeyBinding` cannot express pointer buttons, so only Alt+Left / Alt+Right survived the migration. `MainWindow` now swallows the `XButton1`/`XButton2` press while it tunnels (otherwise Dock activates the pane under the pointer and AvaloniaEdit focuses the editor or toggles a folding marker) and routes the release to the existing `DockWorkspace.NavigateBackCommand`/`NavigateForwardCommand`. Navigating also no longer moves the active pane to the editor: the history target is usually the already-active tab, and Dock's `ActiveDockable` setter re-runs `SetFocusedDockable` even for an unchanged value, so `ApplyNavigationTarget` only activates a tab that is not active yet (WPF's `ActiveTabPage` setter was a no-op for the same value).

### Derived types not shown in tree (#4028)

`DerivedTypesEntryNode.Filter` reported `FilterResult.Recurse`, but the filter cascade's Recurse handling force-loads the node's lazy children and hides the node when all of them are hidden. A leaf derived type has no children, so every entry under "Derived Types" ended up hidden, and the hiding propagated up the whole chain. Reporting `Match` (what the WPF tree effectively did, since the tree ignores the search term) restores the entries and also keeps derived chains lazy instead of eagerly scanning the assembly list for every level.

### Enter does nothing on a selected tree row (#4030)

Avalonia 12's default key selection triggers treat plain Enter/Space on a `ListBoxItem` as selection input and mark the `KeyDown` handled before it bubbles, so the activation handling in `SharpTreeView.OnKeyDown` (navigate to the member from an analyzer row, toggle a checkable row) never saw those keys. `SharpTreeView` now overrides `ShouldTriggerSelection` — the Avalonia 12 extension point for exactly this — to suppress the selection trigger precisely for the case `OnKeyDown` activates instead: a single selected row that is the row the key landed on. Multi-row selections keep the default collapse-to-focused-row behaviour.

### Delete does nothing on a selected analyzer row (#4030, follow-up report)

The WPF `SharpTreeView` bound `ApplicationCommands.Delete` at class level, so Delete removed the top-level selection of any tree whose nodes opt in through `CanDelete`/`Delete` -- which is how a top-level analyzer entry was removed from the Analyzer pane. The Avalonia tree never received that binding; only the assembly list pane carried a hand-rolled Delete handler for assemblies. The gesture now lives in `SharpTreeView.OnKeyDown` again (delete the top-level selection when every node in it is deletable, then reselect the nearest survivor), which restores it for the analyzer pane and lets the pane-specific handler go.

### Analyze missing from the Analyzer pane's context menu (#4030 thread, second follow-up report)

The WPF `AnalyzerEntityTreeNode` implemented `IMemberTreeNode`, which is what the "Analyze" entry (and "Copy name") keys off, so right-clicking a result row in the Analyzer pane offered Analyze and promoted that row's entity to a new top-level entry. The Avalonia port dropped the interface from the node, so no analyzer row ever showed the entry. The interface is back on the node; as in WPF, top-level analyzer rows keep Analyze hidden (re-analysing them is a no-op, Remove is the entry for those rows).

A follow-up from the same thread: analysing one member from a result row and then from the assembly tree produced two top-level rows, because the pane deduped by `IModule` instance while analyzer results live in the type system each analyzer run builds. The dedupe now keys off the loaded `MetadataFile`, which is the identity that survives across type systems.

### Verification

Full `ILSpy.Tests` suite green locally, including the new regression tests (`Mouse_Back_And_Forward_Buttons_Navigate_The_History`, `Mouse_Back_Button_Press_Does_Not_Reach_The_Control_Under_The_Pointer`, `Browse_Back_Keeps_The_Active_Pane`, `Derived_Type_Entries_Stay_Visible_When_The_DerivedTypes_Node_Is_Expanded`, `Enter_Activates_The_Selected_Analyzer_Node`, `Delete_Removes_The_Selected_Top_Level_Analyzer_Node`, `Analyze_Promotes_An_Analyzer_Result_Row_To_A_Top_Level_Entry`, `Analyze_Is_Hidden_For_A_Top_Level_Analyzer_Row`, `Analyze_Reuses_The_Row_When_The_Same_Entity_Comes_From_Another_Type_System`).

_Written by an AI agent (Claude) on Christoph's behalf._
