### PR TITLE
Cap LightJson parser nesting depth to prevent stack overflow

### DIFF
--- a/ICSharpCode.Decompiler.Tests/LightJsonParserTests.cs
+++ b/ICSharpCode.Decompiler.Tests/LightJsonParserTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Christoph Wille
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Text;
+
+using LightJson.Serialization;
+
+using NUnit.Framework;
+
+namespace ICSharpCode.Decompiler.Tests
+{
+	[TestFixture]
+	public class LightJsonParserTests
+	{
+		[Test]
+		public void DeeplyNestedArrays_ThrowCatchableException_InsteadOfOverflowingTheStack()
+		{
+			// A crafted .deps.json (see DotNetCorePathFinder) nested far beyond any real
+			// dependency graph must fail with a catchable parse exception, not an
+			// uncatchable StackOverflowException that terminates the process.
+			const int depth = 500;
+			var json = new string('[', depth) + new string(']', depth);
+
+			Assert.Throws<JsonParseException>(() => JsonReader.Parse(json));
+		}
+
+		[Test]
+		public void DeeplyNestedObjects_ThrowCatchableException_InsteadOfOverflowingTheStack()
+		{
+			const int depth = 500;
+			var builder = new StringBuilder();
+			for (int i = 0; i < depth; i++)
+				builder.Append("{\"a\":");
+			builder.Append("1");
+			builder.Append('}', depth);
+
+			Assert.Throws<JsonParseException>(() => JsonReader.Parse(builder.ToString()));
+		}
+
+		[Test]
+		public void ModeratelyNestedJson_ParsesSuccessfully()
+		{
+			// Depth well within the limit must still round-trip; the guard must not
+			// reject legitimately structured documents.
+			const int depth = 32;
+			var json = new string('[', depth) + "42" + new string(']', depth);
+
+			var value = JsonReader.Parse(json);
+
+			var current = value;
+			for (int i = 0; i < depth; i++)
+				current = current[0];
+			Assert.That((int)current, Is.EqualTo(42));
+		}
+	}
+}

--- a/ICSharpCode.Decompiler/Metadata/LightJson/Serialization/JsonParseException.cs
+++ b/ICSharpCode.Decompiler/Metadata/LightJson/Serialization/JsonParseException.cs
@@ -68,6 +68,11 @@ namespace LightJson.Serialization
 			/// Indicates that the parser encountered and invalid or unexpected character.
 			/// </summary>
 			InvalidOrUnexpectedCharacter,
+
+			/// <summary>
+			/// Indicates that the input nested arrays/objects deeper than the parser allows.
+			/// </summary>
+			MaximumNestingDepthExceeded,
 		}
 
 		/// <summary>
@@ -94,6 +99,9 @@ namespace LightJson.Serialization
 
 				case ErrorType.DuplicateObjectKeys:
 					return "The parser encountered a JsonObject with duplicate keys.";
+
+				case ErrorType.MaximumNestingDepthExceeded:
+					return "The parser exceeded the maximum allowed nesting depth.";
 
 				default:
 					return "An error occurred while parsing the JSON message.";

--- a/ICSharpCode.Decompiler/Metadata/LightJson/Serialization/JsonReader.cs
+++ b/ICSharpCode.Decompiler/Metadata/LightJson/Serialization/JsonReader.cs
@@ -17,6 +17,15 @@ namespace LightJson.Serialization
 	{
 		private TextScanner scanner;
 
+		/// <summary>
+		/// The deepest array/object nesting the parser will descend into before failing.
+		/// Guards against uncontrolled recursion (CWE-674): without it, deeply nested input
+		/// such as a crafted .deps.json overflows the stack with an uncatchable
+		/// StackOverflowException. 64 matches the ecosystem default (System.Text.Json) and is
+		/// far beyond any real dependency manifest.
+		/// </summary>
+		private const int MaxNestingDepth = 64;
+
 		private JsonReader(TextReader reader)
 		{
 			this.scanner = new TextScanner(reader);
@@ -60,8 +69,15 @@ namespace LightJson.Serialization
 			return this.ReadString();
 		}
 
-		private JsonValue ReadJsonValue()
+		private JsonValue ReadJsonValue(int depth)
 		{
+			if (depth > MaxNestingDepth)
+			{
+				throw new JsonParseException(
+					ErrorType.MaximumNestingDepthExceeded,
+					this.scanner.Position);
+			}
+
 			this.scanner.SkipWhitespace();
 
 			var next = this.scanner.Peek();
@@ -74,10 +90,10 @@ namespace LightJson.Serialization
 			switch (next)
 			{
 				case '{':
-					return this.ReadObject();
+					return this.ReadObject(depth);
 
 				case '[':
-					return this.ReadArray();
+					return this.ReadArray(depth);
 
 				case '"':
 					return this.ReadString();
@@ -320,12 +336,12 @@ namespace LightJson.Serialization
 			return (char)value;
 		}
 
-		private JsonObject ReadObject()
+		private JsonObject ReadObject(int depth)
 		{
-			return this.ReadObject(new JsonObject());
+			return this.ReadObject(new JsonObject(), depth);
 		}
 
-		private JsonObject ReadObject(JsonObject jsonObject)
+		private JsonObject ReadObject(JsonObject jsonObject, int depth)
 		{
 			this.scanner.Assert('{');
 
@@ -357,7 +373,7 @@ namespace LightJson.Serialization
 
 					this.scanner.SkipWhitespace();
 
-					var value = this.ReadJsonValue();
+					var value = this.ReadJsonValue(depth + 1);
 
 					jsonObject.Add(key, value);
 
@@ -395,12 +411,12 @@ namespace LightJson.Serialization
 			return jsonObject;
 		}
 
-		private JsonArray ReadArray()
+		private JsonArray ReadArray(int depth)
 		{
-			return this.ReadArray(new JsonArray());
+			return this.ReadArray(new JsonArray(), depth);
 		}
 
-		private JsonArray ReadArray(JsonArray jsonArray)
+		private JsonArray ReadArray(JsonArray jsonArray, int depth)
 		{
 			this.scanner.Assert('[');
 
@@ -416,7 +432,7 @@ namespace LightJson.Serialization
 				{
 					this.scanner.SkipWhitespace();
 
-					var value = this.ReadJsonValue();
+					var value = this.ReadJsonValue(depth + 1);
 
 					jsonArray.Add(value);
 
@@ -457,7 +473,7 @@ namespace LightJson.Serialization
 		private JsonValue Parse()
 		{
 			this.scanner.SkipWhitespace();
-			return this.ReadJsonValue();
+			return this.ReadJsonValue(0);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Caps the nesting depth of the bundled LightJson parser so that pathologically nested JSON fails with a catchable exception instead of crashing the process with an uncatchable `StackOverflowException`.

## The vulnerability (CWE-674, uncontrolled recursion)

`ICSharpCode.Decompiler/Metadata/LightJson/Serialization/JsonReader.cs` parses values through three mutually recursive methods with **no depth limit**:

`ReadJsonValue` -> `ReadObject` / `ReadArray` -> `ReadJsonValue` -> ...

Each level of `[` / `{` nesting adds stack frames. Input nested tens of thousands of levels deep (`[[[[ ... ]]]]`) exhausts the stack and raises a `StackOverflowException`, which on .NET **cannot be caught** and terminates the whole process.

### Reachability

`DotNetCorePathFinder` parses the `*.deps.json` that ships next to an opened assembly:

```csharp
// ICSharpCode.Decompiler/Metadata/DotNetCorePathFinder.cs:190
var dependencies = JsonReader.Parse(File.ReadAllText(depsJsonFileName));
```

So a crafted `.deps.json` placed beside a target assembly turns ordinary dependency resolution into a clean process kill. It is a secondary surface (the attacker must drop a file next to the assembly rather than embed bytes in the assembly itself), but the outcome - an uncatchable crash during a routine load - is severe enough to fix.

## The fix

Thread an integer `depth` counter through `ReadJsonValue` / `ReadObject` / `ReadArray`, incrementing on each descent into a nested container, and throw a catchable `JsonParseException` (new `ErrorType.MaximumNestingDepthExceeded`) once nesting passes a fixed cap.

The cap is **64**, matching the `System.Text.Json` default `MaxDepth` and sitting far beyond any real dependency manifest (real `.deps.json` files nest only a handful of levels). This is the smallest change that closes the hole without adding a dependency or altering the parser's accepted grammar for legitimate input.

## Why patch in place rather than swap to a maintained fork

The actively maintained fork `CypherPotato/LightJson` was evaluated as an alternative and rejected for this purpose:

- **It does not fix this bug.** Its `ReadJsonValue`/`ReadObject`/`ReadArray` are still mutually recursive with no depth guard on the DOM parse path. Its `DynamicObjectMaxDepth = 64` limit lives only in the reflection object-mapper layer (`JsonDeserializer`/`JsonSerializer`), not in the raw `Parse` path we use. The same crafted input still overflows the stack.
- **It is not a drop-in.** The API diverged substantially: no static `JsonReader.Parse(string)`; parsing goes through `JsonValue`/an instance `Parse`, and value access moved from `As*` properties to `GetString()`/`GetNumber()`.
- **It changes default semantics.** Our copy always strips `//` and `/* */` comments and always rejects duplicate object keys; the fork gates both behind opt-in options that are off by default, so a straight swap would silently start accepting duplicate keys and rejecting commented manifests.

Adopting the fork would therefore cost an API migration and a behavior audit while still leaving this exact bug unpatched. A ~5-line depth guard on the vendored copy is the lower-risk fix.

## Tests

`ICSharpCode.Decompiler.Tests/LightJsonParserTests.cs` (new):

- Deeply nested arrays -> `JsonParseException` (not a crash).
- Deeply nested objects -> `JsonParseException` (not a crash).
- Moderately nested JSON (within the cap) still round-trips, so the guard does not reject legitimately structured documents.

Verified red before the change (the deep-nesting cases parsed without throwing) and green after.

---
Generated with [Claude Code](https://claude.com/claude-code)
