### PR TITLE
Allow reordered record primary constructor assignments

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Records.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/Records.cs
@@ -66,6 +66,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			public double C = 1.0;
 			public string D = A + B;
 		}
+#if EXPECTED_OUTPUT
+		public record PrimaryCtorWithReorderedPropertyInitializers(int First, int Second);
+#else
+		public record PrimaryCtorWithReorderedPropertyInitializers(int First, int Second)
+		{
+			public int Second { get; init; } = Second;
+			public int First { get; init; } = First;
+		}
+#endif
 		public record PrimaryCtorWithInParameter(in int A, in string B);
 		public record PrimaryCtorWithProperty(int A, string B)
 		{

--- a/ICSharpCode.Decompiler/CSharp/RecordDecompiler.cs
+++ b/ICSharpCode.Decompiler/CSharp/RecordDecompiler.cs
@@ -293,8 +293,6 @@ namespace ICSharpCode.Decompiler.CSharp
 				if (body.Instructions.Count < addonInst)
 					return false;
 
-				int parameterIndex = 0;
-
 				for (int i = 0; i < body.Instructions.Count - addonInst; i++)
 				{
 					if (!body.Instructions[i].MatchStFld(out var target, out var field, out var valueInst))
@@ -306,16 +304,14 @@ namespace ICSharpCode.Decompiler.CSharp
 						continue;
 					if (valueInst.MatchLdLoc(out var v))
 					{
-						if (!ValidateParameter(v, parameterIndex))
+						if (!ValidateParameter(v))
 							return false;
-						parameterIndex = v.Index!.Value;
 					}
 					else if (valueInst.MatchLdObj(out valueInst, out _) && valueInst.MatchLdLoc(out v))
 					{
-						if (!ValidateParameter(v, parameterIndex))
+						if (!ValidateParameter(v))
 							return false;
-						parameterIndex = v.Index!.Value;
-						if (method.Parameters[parameterIndex].ReferenceKind is ReferenceKind.None)
+						if (method.Parameters[v.Index!.Value].ReferenceKind is ReferenceKind.None)
 						{
 							return false;
 						}
@@ -324,7 +320,7 @@ namespace ICSharpCode.Decompiler.CSharp
 					{
 						continue;
 					}
-					IParameter parameter = unspecializedMethod.Parameters[parameterIndex];
+					IParameter parameter = unspecializedMethod.Parameters[v.Index!.Value];
 					if (primaryCtorParameterToAutoProperty.ContainsKey(parameter))
 					{
 						continue;
@@ -343,17 +339,12 @@ namespace ICSharpCode.Decompiler.CSharp
 				var returnInst = body.Instructions.LastOrDefault();
 				return returnInst != null && returnInst.MatchReturn(out var retVal) && retVal.MatchNop();
 
-				bool ValidateParameter(ILVariable v, int expectedMinimumIndex)
+				bool ValidateParameter(ILVariable v)
 				{
 					if (v.Kind != VariableKind.Parameter)
 						return false;
 					Debug.Assert(v.Index.HasValue);
-					if (v.Index < 0 || v.Index >= unspecializedMethod.Parameters.Count)
-						return false;
-					var parameter = unspecializedMethod.Parameters[v.Index.Value];
-					if (primaryCtorParameterToAutoProperty.ContainsKey(parameter))
-						return true;
-					return v.Index >= expectedMinimumIndex;
+					return v.Index >= 0 && v.Index < unspecializedMethod.Parameters.Count;
 				}
 			}
 


### PR DESCRIPTION
Related to #4049.

### Problem

`RecordDecompiler.IsPrimaryConstructor` implicitly required assignments to positional auto-properties to follow primary-constructor parameter order.

That is not guaranteed: explicit positional properties can be declared in a different order, so their backing-field assignments follow member initialization order instead. In that case ILSpy failed to recognize the primary constructor and emitted an explicit constructor, synthesized `Deconstruct`, and an invalid `base._002Ector()` call.

### Solution

Validate each assignment against the parameter actually loaded by that assignment, without carrying a monotonic parameter index between assignments.

This PR intentionally contains only the record primary-constructor fix and its regression test. It does not include collection expressions, project export/resolution changes, record synthesized-member changes, or unrelated backing-field fixes from #4049.

### Test

The test was added first and failed in all six `PrettyTestRunner.Records` Roslyn 3-or-newer configurations. Before the implementation, the new record was emitted with an explicit constructor and `base._002Ector()`.

After the implementation:

- `PrettyTestRunner.Records`: 6 passed, 0 failed.
- Full `Release|Any CPU` solution build: 16 succeeded, 0 failed.
- `BuildTools/format.ps1`: clean.

* [x] At least one test covering the code changed
