### PR TITLE
Fix #4054: Accept drops from sources that do not permit the Move effect

### DIFF
--- a/ILSpy/TreeNodes/AssemblyListTreeNode.cs
+++ b/ILSpy/TreeNodes/AssemblyListTreeNode.cs
@@ -92,7 +92,11 @@ namespace ICSharpCode.ILSpy.TreeNodes
 		{
 			if (e.Data.GetDataPresent(AssemblyTreeNode.DataFormat) || e.Data.GetDataPresent(FileDropFormat))
 			{
-				e.Effects = ICSharpCode.ILSpyX.TreeView.PlatformAbstractions.XPlatDragDropEffects.Move;
+				// Offer every effect and let the drag source pick: some external sources (e.g. FileLocator
+				// Pro) only permit Copy, and answering just Move makes OLE reject the drop with a no-drop cursor.
+				e.Effects = ICSharpCode.ILSpyX.TreeView.PlatformAbstractions.XPlatDragDropEffects.Move
+					| ICSharpCode.ILSpyX.TreeView.PlatformAbstractions.XPlatDragDropEffects.Copy
+					| ICSharpCode.ILSpyX.TreeView.PlatformAbstractions.XPlatDragDropEffects.Link;
 				return true;
 			}
 			e.Effects = ICSharpCode.ILSpyX.TreeView.PlatformAbstractions.XPlatDragDropEffects.None;


### PR DESCRIPTION
Fixes #4054.

## Symptom

Dragging a managed DLL from the search results of a third-party program such as FileLocator Pro onto the assembly list shows the no-drop cursor and the file is never opened. Dragging the same file from Windows Explorer works. ILSpy 10 (WPF) accepted both.

## What was ruled out

The natural suspect was the data object. WPF's `DataObject.GetDataPresent(DataFormats.FileDrop)` asks the source via `IDataObject::QueryGetData`, while Avalonia's Win32 backend (`OleDataObjectToDataTransferWrapper.ProvideFormats`) builds its format list solely from `IDataObject::EnumFormatEtc`, so a source that serves `CF_HDROP` without enumerating it would be invisible to Avalonia. That is not the case here: a trace in `SharpTreeView.OnDragOver` showed FileLocator Pro enumerates `CF_HDROP` (`DataFormat.File`) plus `Shell IDList Array`, `TryGetFiles()` returns the item, and `TryGetLocalPath()` resolves the full path. `AssemblyListTreeNode.CanDrop` therefore returned `true`.

## Actual cause

The effect negotiation. `AssemblyListTreeNode.CanDrop` answered DragOver with `XPlatDragDropEffects.Move` only. Avalonia passes that back to OLE as `*pdwEffect`, and OLE intersects it with the effects the drag source allowed in `DoDragDrop`. FileLocator Pro's source only permits `DROPEFFECT_COPY` (it offers files to read, not to move), so `Move & Copy == None` and Windows shows the no-drop cursor. Explorer permits Move/Copy/Link, which is why Explorer drops kept working and masked the bug. VS Code accepts these drags because it answers Copy.

The WPF `AssemblyListTreeNode.CanDrop` in ILSpy 10 answered `Move | Copy | Link` and let the source pick whichever it permits; the Avalonia port narrowed that to `Move`.

## Fix

Offer `Move | Copy | Link` again in `AssemblyListTreeNode.CanDrop`. The effect only influences the cursor and the negotiation; `Drop` opens the files and moves them into position regardless of which effect was chosen, so the internal reorder drag is unaffected.

Verified manually with FileLocator Pro and Explorer; `AssemblyTreeFileDropTests` pass.
