### PR TITLE
docs: fix typo implemenation -> implementation

### DIFF
--- a/ICSharpCode.ILSpyX/PackageReadme.md
+++ b/ICSharpCode.ILSpyX/PackageReadme.md
@@ -1,3 +1,3 @@
 ## About
 
-ICSharpCode.ILSpyX is the core cross-platform implemenation of [ILSpy](https://github.com/icsharpcode/ILSpy/) that can be reused to build alternate frontends more easily.
+ICSharpCode.ILSpyX is the core cross-platform implementation of [ILSpy](https://github.com/icsharpcode/ILSpy/) that can be reused to build alternate frontends more easily.


### PR DESCRIPTION
One-word typo fix in `ICSharpCode.ILSpyX/PackageReadme.md:3`: "ICSharpCode.ILSpyX is the ..." → `implementation`.
