### PR TITLE
Detect local functions renamed by obfuscators

### DIFF
--- a/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/AssignVariableNames.cs
@@ -505,13 +505,21 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 		private static void AssignNameToLocalFunction(ILFunction function, VariableScope parentContext)
 		{
-			if (!LocalFunctionDecompiler.ParseLocalFunctionName(function.Name, out _, out var newName) || !IsValidName(newName))
-				newName = null;
 			string nameWithoutNumber;
 			int number;
-			if (!string.IsNullOrEmpty(newName))
+			string newName;
+			if (LocalFunctionDecompiler.ParseLocalFunctionName(function.Name, out _, out newName) && IsValidName(newName))
 			{
 				nameWithoutNumber = SplitName(newName, out number);
+			}
+			else if (IsValidName(function.Name))
+			{
+				// An obfuscated assembly carries an arbitrary name instead of
+				// "<caller>g__name|x_y". Take it verbatim: it has no synthetic suffix to
+				// split off, so its trailing digits belong to the name itself
+				// ("smethod_1", not "smethod_" numbered 1).
+				nameWithoutNumber = function.Name;
+				number = 1;
 			}
 			else
 			{

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -781,34 +781,44 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			var method = metadata.GetMethodDefinition(methodHandle);
 			var declaringType = method.GetDeclaringType();
 
-			if ((method.Attributes & MethodAttributes.Assembly) == 0 || !(method.IsCompilerGenerated(metadata) || declaringType.IsCompilerGenerated(metadata)))
+			if ((method.Attributes & MethodAttributes.Assembly) == 0)
 				return false;
 
-			if (!ParseLocalFunctionName(metadata.GetString(method.Name), out _, out _))
-				return false;
+			if ((method.IsCompilerGenerated(metadata) || declaringType.IsCompilerGenerated(metadata))
+				&& ParseLocalFunctionName(metadata.GetString(method.Name), out _, out _))
+			{
+				return true;
+			}
 
-			return true;
+			// Obfuscators strip the CompilerGeneratedAttribute and rewrite the
+			// "<caller>g__name|x_y" name, but they cannot remove the by-ref display-struct
+			// parameter: a compiler-generated struct closure is only ever passed by reference
+			// to the local functions that capture it.
+			return HasDisplayStructParameter(module, methodHandle);
+		}
+
+		/// <summary>
+		/// True if any parameter is a by-ref compiler-generated closure struct of this module.
+		/// </summary>
+		static bool HasDisplayStructParameter(MetadataFile module, MethodDefinitionHandle methodHandle)
+		{
+			var metadata = module.Metadata;
+			var method = metadata.GetMethodDefinition(methodHandle);
+			FindRefStructParameters visitor = new FindRefStructParameters();
+			method.DecodeSignature(visitor, default);
+			foreach (var h in visitor.RefStructTypes)
+			{
+				var td = metadata.GetTypeDefinition(h);
+				if (td.IsCompilerGenerated(metadata) && td.IsValueType(metadata) && td.HasGeneratedName(metadata))
+					return true;
+			}
+			return false;
 		}
 
 		public static bool LocalFunctionNeedsAccessibilityChange(MetadataFile module, MethodDefinitionHandle methodHandle)
 		{
-			if (!IsLocalFunctionMethod(module, methodHandle))
-				return false;
-
-			var metadata = module.Metadata;
-			var method = metadata.GetMethodDefinition(methodHandle);
-
-			FindRefStructParameters visitor = new FindRefStructParameters();
-			method.DecodeSignature(visitor, default);
-
-			foreach (var h in visitor.RefStructTypes)
-			{
-				var td = metadata.GetTypeDefinition(h);
-				if (td.IsCompilerGenerated(metadata) && td.IsValueType(metadata))
-					return true;
-			}
-
-			return false;
+			return IsLocalFunctionMethod(module, methodHandle)
+				&& HasDisplayStructParameter(module, methodHandle);
 		}
 
 		public static bool IsLocalFunctionDisplayClass(MetadataFile module, TypeDefinitionHandle typeHandle, ILTransformContext context = null)

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -873,7 +873,10 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 
 			public TypeDefinitionHandle GetArrayType(TypeDefinitionHandle elementType, ArrayShape shape) => default;
 			public TypeDefinitionHandle GetFunctionPointerType(MethodSignature<TypeDefinitionHandle> signature) => default;
-			public TypeDefinitionHandle GetGenericInstantiation(TypeDefinitionHandle genericType, ImmutableArray<TypeDefinitionHandle> typeArguments) => default;
+			// A closure struct of a generic method or generic declaring type arrives as an instantiation;
+			// its definition handle is what identifies the struct. Cross-module generic types still drop out,
+			// because GetTypeFromReference already returned nil for them.
+			public TypeDefinitionHandle GetGenericInstantiation(TypeDefinitionHandle genericType, ImmutableArray<TypeDefinitionHandle> typeArguments) => genericType;
 			public TypeDefinitionHandle GetGenericMethodParameter(Unit genericContext, int index) => default;
 			public TypeDefinitionHandle GetGenericTypeParameter(Unit genericContext, int index) => default;
 			public TypeDefinitionHandle GetModifiedType(TypeDefinitionHandle modifier, TypeDefinitionHandle unmodifiedType, bool isRequired) => default;


### PR DESCRIPTION
Closes half of #3202. The other half - the `Class148.GetItem` async pattern in the same report -
already decompiles cleanly on master and needs nothing.

## What the report shows

`Class148.DefaultCheckCopyed` keeps its closure struct in the output:

```csharp
<>c__DisplayClass29_0 <>c__DisplayClass29_0_ = default;
<>c__DisplayClass29_0_.iid = 0L;
...
smethod_1(null, ref <>c__DisplayClass29_0_);
```

## Why

The 2024 analysis on the issue blamed `TransformDisplayClassUsage` for requiring the display
struct's first field store to be the first instruction of its init block. That is no longer what
blocks this file: a clean Roslyn build of the same shape - struct closure, field stores preceded
by unrelated statements, captured by a local function, inside an async method - decompiles
correctly on master today.

The obfuscator destroyed both markers `LocalFunctionDecompiler.IsLocalFunctionMethod` relies on:

```
.method assembly hidebysig static
    void smethod_1 (string string_0, valuetype Class148/'<>c__DisplayClass29_0'& ...)
```

No `[CompilerGenerated]`, and the name is `smethod_1` rather than
`<DefaultCheckCopyed>g__...|29_0`. The method therefore stays an ordinary static method, the
display struct escapes by reference into a plain call, and
`TransformDisplayClassUsage.ValidateDisplayClassUses` correctly refuses to scalar-replace it.
Everything downstream behaves as designed; only the detection gate is wrong.

## The fix

When the attribute-and-name test fails, fall back to a signature test: an assembly-visible method
that takes a by-ref, compiler-generated, generated-named nested value type **of the same module**
can only be a local function. Roslyn emits struct closures exclusively for local functions, and no
hand-written C# can name a `<>c__DisplayClass` type.

It reuses the existing `FindRefStructParameters` visitor, which already drops cross-module handles
- so BCL signatures like `AwaitUnsafeOnCompleted(ref TAwaiter, ref TStateMachine)` cannot match.
`LocalFunctionNeedsAccessibilityChange` had its own copy of that loop and now shares the helper.

The second commit stops `AssignVariableNames` renaming the recovered function to `f`: an
obfuscated name has no synthetic `|x_y` suffix to split off, so its trailing digits belong to the
name and it is taken verbatim.

## Verification

- `DefaultCheckCopyed` decompiles to plain `long iid` / `IEnumerable<string> hist` locals plus
  `void smethod_1(string)` as a local function.
- `ICSharpCode.Decompiler.Tests`: 3490 total, 0 failed, 45 skipped.
- Whole-assembly decompile of `ICSharpCode.Decompiler.dll` (161,864 lines): **byte-identical**
  before and after, and identical again at `--languageversion CSharp6`, which is the only setting
  that exercises `LocalFunctionNeedsAccessibilityChange`.
- No measurable cost: three timed runs of that decompile, medians 69.1 s before and after.

_Written by an AI agent (Claude) on Siegfried's behalf._
