### PR TITLE
Insert casts in switch expression to ensure a best common type exists

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/SwitchExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/SwitchExpressions.cs
@@ -37,10 +37,34 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Null
 		}
 
+		public abstract class Animal
+		{
+			public abstract string Name { get; }
+
+			public Animal ToValidated()
+			{
+				return this;
+			}
+		}
+
+		public class Dog : Animal
+		{
+			public override string Name => "Dog";
+		}
+
+		public class Fish : Animal
+		{
+			public override string Name => "Fish";
+		}
+
 		public static bool? SwitchOverNullableEnum(State? state)
 		{
+			// Note: we output a cast for the first element because
+			// {false,true,null} has no "best common type".
+			// (however C# doesn't require this cast due to target
+			//  typing, but the decompiler doesn't make use of that yet)
 			return state switch {
-				State.False => false,
+				State.False => (bool?)false,
 				State.True => true,
 				State.Null => null,
 				_ => throw new InvalidOperationException(),
@@ -209,6 +233,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 				StringComparison.OrdinalIgnoreCase => StringComparison.InvariantCulture,
 			};
 #endif
+		}
+
+		public static Animal Issue3683(int animalType)
+		{
+			return (animalType switch {
+				0 => (Animal)new Dog(),
+				1 => new Fish(),
+				_ => throw new ArgumentException("Invalid animal type"),
+			}).ToValidated();
 		}
 
 		public static int SwitchOnStringImplicitDefault(string s)

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/SwitchExpressions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/SwitchExpressions.cs
@@ -244,6 +244,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}).ToValidated();
 		}
 
+		public static void ThrowDifferentExceptions(int i)
+		{
+			throw i switch {
+				0 => (Exception)new ArgumentException("Invalid argument"),
+				1 => new InvalidOperationException("Invalid operation"),
+				_ => new NotSupportedException(),
+			};
+		}
+
 		public static int SwitchOnStringImplicitDefault(string s)
 		{
 			return s switch {

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4342,6 +4342,8 @@ namespace ICSharpCode.Decompiler.CSharp
 				resultType = compilation.FindType(inst.ResultType);
 			}
 
+			var expressionsForTypeInference = new List<TranslatedExpression>();
+
 			foreach (var section in inst.Sections)
 			{
 				if (section == defaultSection)
@@ -4370,12 +4372,51 @@ namespace ICSharpCode.Decompiler.CSharp
 				switchExpr.SwitchSections.Add(defaultSES);
 			}
 
-			return switchExpr.WithILInstruction(inst).WithRR(new ResolveResult(resultType));
+			var ti = new TypeInference(compilation, resolver.conversions);
+			IType commonType = ti.GetBestCommonType(
+				expressionsForTypeInference.SelectArray(e => e.ResolveResult),
+				out bool success);
+			if (success && commonType.GetStackType() == inst.ResultType)
+			{
+				return switchExpr.WithILInstruction(inst).WithRR(new ResolveResult(commonType));
+			}
+			else
+			{
+				// Try to help out the C# compiler by casting the first element to the expected type:
+				expressionsForTypeInference[0].Expression.ReplaceWith(
+					node => expressionsForTypeInference[0] = expressionsForTypeInference[0].ConvertTo(resultType, this)
+				);
+				commonType = ti.GetBestCommonType(
+					expressionsForTypeInference.SelectArray(e => e.ResolveResult),
+					out success);
+				if (success && commonType.GetStackType() == inst.ResultType)
+				{
+					return switchExpr.WithILInstruction(inst).WithRR(new ResolveResult(commonType));
+				}
+				else
+				{
+					// Cast all expressions
+					for (int i = 1; i < expressionsForTypeInference.Count; i++)
+					{
+						expressionsForTypeInference[i].Expression.ReplaceWith(
+							node => expressionsForTypeInference[i].ConvertTo(resultType, this)
+						);
+					}
+					return switchExpr.WithILInstruction(inst).WithRR(new ResolveResult(resultType));
+				}
+			}
 
 			Expression TranslateSectionBody(IL.SwitchSection section)
 			{
 				var body = Translate(section.Body, resultType);
-				return body.ConvertTo(resultType, this, allowImplicitConversion: true);
+				// Initially we allow implicit conversions for the body,
+				body = body.ConvertTo(resultType, this, allowImplicitConversion: true);
+				// but we may add explicit casts later if needed to satisfy the C# compiler.
+				if (body.Expression is not ThrowExpression)
+				{
+					expressionsForTypeInference.Add(body);
+				}
+				return body;
 			}
 		}
 

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -1272,7 +1272,8 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		protected internal override TranslatedExpression VisitThrow(Throw inst, TranslationContext context)
 		{
-			return new ThrowExpression(Translate(inst.Argument))
+			var ex = Translate(inst.Argument, typeHint: compilation.FindType(KnownTypeCode.Exception));
+			return new ThrowExpression(ex)
 				.WithILInstruction(inst)
 				.WithRR(new ThrowResolveResult());
 		}

--- a/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/StatementBuilder.cs
@@ -434,7 +434,8 @@ namespace ICSharpCode.Decompiler.CSharp
 
 		protected internal override TranslatedStatement VisitThrow(Throw inst)
 		{
-			return new ThrowStatement(exprBuilder.Translate(inst.Argument)).WithILInstruction(inst);
+			var ex = exprBuilder.Translate(inst.Argument, typeHint: typeSystem.FindType(KnownTypeCode.Exception));
+			return new ThrowStatement(ex).WithILInstruction(inst);
 		}
 
 		protected internal override TranslatedStatement VisitRethrow(Rethrow inst)


### PR DESCRIPTION
Fixes #3683.