### PR TITLE
Update NuGet packages; adapt to Dock.Serializer.SystemTextJson 12.1.0.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <NetPackageVersion>10.0.11</NetPackageVersion>
     <TomsToolboxVersion>2.24.0</TomsToolboxVersion>
     <AvaloniaVersion>12.1.1</AvaloniaVersion>
-    <DockVersion>12.1.0.1</DockVersion>
+    <DockVersion>12.1.0.6</DockVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Avalonia (ILSpy port) -->
@@ -23,17 +23,17 @@
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.13" />
     <PackageVersion Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageVersion Include="AvaloniaEdit.TextMate" Version="12.0.0" />
-    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
+    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.7" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
     <PackageVersion Include="Dock.Avalonia" Version="$(DockVersion)" />
     <PackageVersion Include="Dock.Avalonia.Themes.Simple" Version="$(DockVersion)" />
     <PackageVersion Include="Dock.Controls.Recycling" Version="$(DockVersion)" />
     <PackageVersion Include="Dock.Model.Mvvm" Version="$(DockVersion)" />
     <PackageVersion Include="Dock.Serializer.SystemTextJson" Version="$(DockVersion)" />
-    <PackageVersion Include="ProDataGrid" Version="12.1.0.1" />
+    <PackageVersion Include="ProDataGrid" Version="12.1.0.4" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
-    <PackageVersion Include="CliWrap" Version="3.10.4" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />
+    <PackageVersion Include="CliWrap" Version="3.10.5" />
     <PackageVersion Include="DiffLib" Version="2025.0.0" />
     <PackageVersion Include="ILCompiler.Reflection.ReadyToRun.Experimental" Version="10.0.0-rtm.25531.102" />
     <PackageVersion Include="Iced" Version="1.21.0" />
@@ -66,7 +66,7 @@
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageVersion Include="NuGet.Frameworks" Version="7.9.0" />
     <PackageVersion Include="NuGet.Protocol" Version="7.9.0" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />

--- a/ICSharpCode.Decompiler.Tests/packages.lock.json
+++ b/ICSharpCode.Decompiler.Tests/packages.lock.json
@@ -4,15 +4,15 @@
     "net11.0": {
       "AwesomeAssertions": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "CliWrap": {
         "type": "Direct",
-        "requested": "[3.10.4, )",
-        "resolved": "3.10.4",
-        "contentHash": "Vv0HjTkbCOsicbY4uX978MJOoWabFV/GE0zS2ww2mKNLcqLVPY8xaFRIRWa8dRhjkAYhe9h9uhRnw5FCT8Qa4A=="
+        "requested": "[3.10.5, )",
+        "resolved": "3.10.5",
+        "contentHash": "L5SghZThsAVhV8ucwwW5FLMzKj1Ps57JB8DM2bEjpBNTyGi1EDjDO7Mi39Yx1FoXM2fZ1l9j39xqlPsZI1QCJQ=="
       },
       "coverlet.MTP": {
         "type": "Direct",
@@ -159,13 +159,13 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "System.Collections.Immutable": {
@@ -320,10 +320,10 @@
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {

--- a/ICSharpCode.Decompiler/Properties/DecompilerVersionInfo.template.cs
+++ b/ICSharpCode.Decompiler/Properties/DecompilerVersionInfo.template.cs
@@ -1,7 +1,7 @@
 public static class DecompilerVersionInfo
 {
 	public const string Major = "11";
-	public const string Minor = "0";
+	public const string Minor = "1";
 	public const string Build = "0";
 	public const string Revision = "$INSERTREVISION$";
 	public const string VersionName = null;

--- a/ICSharpCode.ILSpyCmd.Tests/packages.lock.json
+++ b/ICSharpCode.ILSpyCmd.Tests/packages.lock.json
@@ -32,13 +32,13 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "TomsToolbox.Composition.Analyzer": {
@@ -309,10 +309,10 @@
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {

--- a/ILSpy.BamlDecompiler.Tests.Windows/packages.lock.json
+++ b/ILSpy.BamlDecompiler.Tests.Windows/packages.lock.json
@@ -4,9 +4,9 @@
     "net11.0-windows7.0": {
       "AwesomeAssertions": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "coverlet.MTP": {
         "type": "Direct",
@@ -50,13 +50,13 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "TomsToolbox.Composition.Analyzer": {
@@ -184,10 +184,10 @@
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -1097,8 +1097,8 @@
       "icsharpcode.decompiler.tests": {
         "type": "Project",
         "dependencies": {
-          "AwesomeAssertions": "[9.5.0, )",
-          "CliWrap": "[3.10.4, )",
+          "AwesomeAssertions": "[9.6.0, )",
+          "CliWrap": "[3.10.5, )",
           "DiffLib": "[2025.0.0, )",
           "ICSharpCode.Decompiler": "[8.0.0-noversion, )",
           "ICSharpCode.ILSpyX": "[8.0.0-noversion, )",
@@ -1115,7 +1115,7 @@
           "Microsoft.Testing.Extensions.VSTestBridge": "[2.3.3, )",
           "Mono.Cecil": "[0.11.6, )",
           "NUnit": "[4.6.1, )",
-          "NUnit3TestAdapter": "[6.2.0, )",
+          "NUnit3TestAdapter": "[6.3.0, )",
           "NuGet.Protocol": "[7.9.0, )",
           "System.Collections.Immutable": "[10.0.11, )",
           "System.Memory": "[4.6.3, )",
@@ -1137,9 +1137,9 @@
       },
       "CliWrap": {
         "type": "CentralTransitive",
-        "requested": "[3.10.4, )",
-        "resolved": "3.10.4",
-        "contentHash": "Vv0HjTkbCOsicbY4uX978MJOoWabFV/GE0zS2ww2mKNLcqLVPY8xaFRIRWa8dRhjkAYhe9h9uhRnw5FCT8Qa4A=="
+        "requested": "[3.10.5, )",
+        "resolved": "3.10.5",
+        "contentHash": "L5SghZThsAVhV8ucwwW5FLMzKj1Ps57JB8DM2bEjpBNTyGi1EDjDO7Mi39Yx1FoXM2fZ1l9j39xqlPsZI1QCJQ=="
       },
       "DiffLib": {
         "type": "CentralTransitive",

--- a/ILSpy.BamlDecompiler.Tests/packages.lock.json
+++ b/ILSpy.BamlDecompiler.Tests/packages.lock.json
@@ -4,9 +4,9 @@
     "net11.0": {
       "AwesomeAssertions": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "coverlet.MTP": {
         "type": "Direct",
@@ -50,13 +50,13 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "TomsToolbox.Composition.Analyzer": {
@@ -158,10 +158,10 @@
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {

--- a/ILSpy.ReadyToRun/packages.lock.json
+++ b/ILSpy.ReadyToRun/packages.lock.json
@@ -139,48 +139,48 @@
       },
       "Dock.Controls.DeferredContentControl": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "B1GViYiaPxOfY1tTmJqtefupQsixwtNrfoK7R8YErsr2kCOJ8xWT7l7XfKNnsQN5JIozHCwe3iHpZzZI57LkYQ==",
+        "resolved": "12.1.0.6",
+        "contentHash": "4wwHEYUg4TfUfJxCOjiV8BJINZfFVlSbmPmi9S+hCOR17ouqg65j1hD6oqj43R+bt4V8NVpsp64HKkadVo+lug==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.ProportionalStackPanel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "2uSxLdH0IcGjB5ix+yi0/I44mQjWSbfi5sNoyavO8KsL2/T6PBTPH/3pUH1N16V3crIig6btlwueu2Dcu5WzxA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "poJrxZZlCZ7D+nv/eVgB7MyS36VWpDWOl07wmlBGPE2FVsimE8DiUTOlh0GwtOMkB785BN7/sMdp3JyHHMVq4w==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.Recycling.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "OiAVhQsKF3Bs0X4R31uBL+PmvxnyuO7NyneuXyLEm1DygCM4YC0WkpjPZT7ODUbges4qkIm2+p54OJfoUyMWww=="
+        "resolved": "12.1.0.6",
+        "contentHash": "aUSZtGzyhR8LQFBnZkwvzy8MCt2KGcntR6ei0Gn1e4b38NRAxkbyI9GasGOPsv0H1CJJRSmDCuqjQ1bGjdYNqg=="
       },
       "Dock.MarkupExtension": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "/qThcNWEXHYd7Y4gPxSUWiQjFrDH+V2vpuEDUGOcOtiSeUeXlRScDmmHqDCQTFhqiu1JKI86820ZLXBTS0Uvow==",
+        "resolved": "12.1.0.6",
+        "contentHash": "MQ0VCKT37hrCH8Fan8/eXttKtrYA0DKN0z1Du2+529p3mbBk2iTNz9s4PHXWFBfBj3JG+yMsXcxU9mje9butAg==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "NWysuK6Rp/QkOcbEPuzNH428bGyzyukUDuucgZA9qWRrtfpyf3Jnnd+QLnhFWBViqVwU5GSXyYCOFRW5VELJSA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "eyptYTadJbhdGnT/9qkbTquFZpPBiRcr6yJvzMv5tLQB56JgbUlVAR1816ILuSeyN8wGPPW3im8g3gdGCp0lIA==",
         "dependencies": {
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Settings": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "n+eoHszNCVdjffMwInLZQVd0s08pMu24Nrt560Q/6twLId54cuyTH+vLpVyfAu8djf6LQ+ogpFTESlrwdt4ixw==",
+        "resolved": "12.1.0.6",
+        "contentHash": "n3fBTNxeCt+t0v62OdhiE9CTBeqR/5y6MBfJ/ma9rSw2PXHLf1NFzodq38mX4HKm1sF8JaX4Y8YZw8IqaxUDBw==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Model": "12.1.0.6"
         }
       },
       "ExCSS": {
@@ -365,15 +365,15 @@
       },
       "ProDataGrid.FormulaEngine": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "mOtxLps58R4GDC6D1OnD0Z7xHtljZqZlMqInszEbhJBo/fGdsDxc1kcTSrof8HnPp9fX8eBFLhtytP4MfFVF5w=="
+        "resolved": "12.1.0.4",
+        "contentHash": "EGokmPuRKbsqndoqHR5Hbc2Zok2jWYiRGxb2W2ELtFaVWyQZUhhx1ZsMVTsJG2OvJZp/eM3B0enqTXA63kQUdA=="
       },
       "ProDataGrid.FormulaEngine.Excel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "AY/XxAX8OTEiej73GWLr9GoWIMAgaHnjNj0tVbKBHFUsT3T4vnPiMmFTFp9Mc0M028LmWWBXjVoxMtDZ4WuHOg==",
+        "resolved": "12.1.0.4",
+        "contentHash": "akwuyW1lQ6s605t+EgIkDxYU4OsKR6ZypT3TM3O+JnR3hKgN9LxkrWa+6QtjC6sc6ff6NLvKMIH8KqXOpfQTLw==",
         "dependencies": {
-          "ProDataGrid.FormulaEngine": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -1289,64 +1289,73 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Xaml.Behaviors.Animations": {
+        "type": "Transitive",
+        "resolved": "12.0.7",
+        "contentHash": "4bZF2H+0Fno6iYXwIrpbQisi8JlFfBpPIezWytljHP87C0PA21bnugtmP7cfgPAI6JZn0A6Ae9+JK3POKN1+Pg==",
+        "dependencies": {
+          "Avalonia": "12.0.5"
+        }
+      },
       "Xaml.Behaviors.Interactions": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "A9iq4aRu0XCUZ5bnhPqRKF1lRfSfvmrJRf+F+P+FxuFuSenpy6Ouq4fcalBWGMYxBsRfp4/FC+zvI0UyFSEfCg==",
+        "resolved": "12.0.7",
+        "contentHash": "o1PwBW7NUWLkktvuSmM52z2OBH1w1yo2dc+NetP8PLWC0/QsTVql/dE56B8IjPJzmpGb3Y9XSitTKh7R+EL2cA==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Custom": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "rLYqZglj0NeHbHBOFpHomPvYeeL9bdwdh8n9hNG8xjm6yUqL+P8lcEwTnrhT++ReRjdPJgvfTJAwi4lIoMmQmQ==",
+        "resolved": "12.0.7",
+        "contentHash": "RCmhJa8ps+ML1e5rXr91k6ETS4xAjmkHOM5XN2q6rI/Tbx74SEiAKzC4rzKZ+SX1/BLOlE47nMpMNuxrkkzk+A==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.DragAndDrop": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "u5SJG0ZCtSFlcX/74jawbUcTOeKyv6QwSb0xj3pKjG4qfpfvmI3kwvQXv3ImwhrLR+0xhUn7lvyY+/SfdtMG/Q==",
+        "resolved": "12.0.7",
+        "contentHash": "l0PsZ3U2Nwsap9srbuPTdkHk10ipjeNBI9eZELW6jNgO8+thV7BsW6mk/Z5D5Hh3Fq6YDrj3KKyJ6CD3ECtHDg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Draggable": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "+TOUCKFCaPdfNBlNQRDSvfx00Q+KLKMlTLpeBMRWHx7K3yXqRXGz7PD1WpDmRQfLrFWn6muJpSzt4BIcBYACRA==",
+        "resolved": "12.0.7",
+        "contentHash": "cm9h+vFKCTgpxCsi7Bp4KHEXVbQ4QH8WrrqE/81kN5U7roWVW+JVnGZ+k67HP2LOhyt+eIEQokLVMcipv9cFpw==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Events": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "gLPWRmjH9swFQMrEN1og8gyhj8RWeCdM8q9OZ7pCUhk7SjRp3/7WURdyyrH9eTLtheXB9sT69FGrXD2gnHOOxg==",
+        "resolved": "12.0.7",
+        "contentHash": "0JwzoIOX21dj9geo+st+RSxl/7bU4Wb35P1YjKD4IeUw6mIf8EMQkB7PKGPy+hibeOnmSDTbLoNoCY0EdvTNgg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Responsive": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "PKvMu5UuHMmLkQYES96qeYbFVIYiEFyftAXzuEiM2fHTe7ur5HfrzFkyAfH0O5oQObmsog4A/GAU59SXmnT/5Q==",
+        "resolved": "12.0.7",
+        "contentHash": "9h9hncn2OcxYMbDUQSNzJs7SY6YVb6dDp2W3W64ns9Xqza3FpCZITGFeJKBZQEhqeS/vvUKbtpRIC6MrQSh3Yg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactivity": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "aoXlptjbRIDorjv4yzdClkBUZX1awi9/3iaORMsDkBceDzY03N5ZMMNRAKfp+MWz/z3YsKzy0GxZMkCUAlYxqQ==",
+        "resolved": "12.0.7",
+        "contentHash": "PzWwozUtizvnNYuCJhlbl+EwuRpva0+qYWYlGkyNKMjyrTxujBWBBr1g6o1PtauVTLPCkX5+lGNK6JHImYDJAQ==",
         "dependencies": {
           "Avalonia": "12.0.5"
         }
@@ -1385,11 +1394,11 @@
           "AvaloniaEdit.TextMate": "[12.0.0, )",
           "AvaloniaUI.DiagnosticsSupport": "[2.2.3, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Dock.Avalonia": "[12.1.0.1, )",
-          "Dock.Avalonia.Themes.Simple": "[12.1.0.1, )",
-          "Dock.Controls.Recycling": "[12.1.0.1, )",
-          "Dock.Model.Mvvm": "[12.1.0.1, )",
-          "Dock.Serializer.SystemTextJson": "[12.1.0.1, )",
+          "Dock.Avalonia": "[12.1.0.6, )",
+          "Dock.Avalonia.Themes.Simple": "[12.1.0.6, )",
+          "Dock.Controls.Recycling": "[12.1.0.6, )",
+          "Dock.Model.Mvvm": "[12.1.0.6, )",
+          "Dock.Serializer.SystemTextJson": "[12.1.0.6, )",
           "ICSharpCode.BamlDecompiler": "[10.0.0-noversion, )",
           "ICSharpCode.Decompiler": "[8.0.0-noversion, )",
           "ICSharpCode.ILSpyX": "[8.0.0-noversion, )",
@@ -1400,13 +1409,13 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.11, )",
           "NuGet.Frameworks": "[7.9.0, )",
           "NuGet.Protocol": "[7.9.0, )",
-          "ProDataGrid": "[12.1.0.1, )",
+          "ProDataGrid": "[12.1.0.4, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.13, )",
           "System.Composition.AttributedModel": "[10.0.11, )",
           "System.Composition.Hosting": "[10.0.11, )",
           "System.Composition.TypedParts": "[10.0.11, )",
           "System.Formats.Nrbf": "[10.0.11, )",
-          "Xaml.Behaviors.Avalonia": "[12.0.5, )"
+          "Xaml.Behaviors.Avalonia": "[12.0.7, )"
         }
       },
       "Avalonia.AvaloniaEdit": {
@@ -1465,56 +1474,56 @@
       },
       "Dock.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "l+bJtDfyG6HrHJA6+pzY1NWynwu2udD2XiJ6vXoBkCGAvWe5yAPPZ8rSODxqbwgkqGoS3UDRbgRbWV4Z++75jQ==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "Y5kTyQtxKHXoUEQfSn9nxsUk+9shIavU/C6ub3Dxs/Sxz4VSlGuTdfRI4mGLO4MJwWetb96xKxhrtCzufg2NrQ==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.DeferredContentControl": "12.1.0.1",
-          "Dock.Controls.ProportionalStackPanel": "12.1.0.1",
-          "Dock.Controls.Recycling": "12.1.0.1",
-          "Dock.MarkupExtension": "12.1.0.1",
-          "Dock.Model": "12.1.0.1",
-          "Dock.Settings": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.DeferredContentControl": "12.1.0.6",
+          "Dock.Controls.ProportionalStackPanel": "12.1.0.6",
+          "Dock.Controls.Recycling": "12.1.0.6",
+          "Dock.MarkupExtension": "12.1.0.6",
+          "Dock.Model": "12.1.0.6",
+          "Dock.Settings": "12.1.0.6"
         }
       },
       "Dock.Avalonia.Themes.Simple": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "8RaFfoXWlV13YTPzrcS2JHy2CqaCQGMvfsmUUMnTjBslWv9sp0obthKCTeWZp+jb2lOIFdhQS69jW9JhlwtILA==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "m4/P8+wMAmeHqmEsthYPl/n22vAdBpOAoMugyEcyHeAfGIlbX7e16plwDJ70FobP8V7wQzDhmlpTZUed+Y+nBA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Avalonia": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Avalonia": "12.1.0.6"
         }
       },
       "Dock.Controls.Recycling": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "qHZgt6VaX4UcE7rjpV/szeH93NqDMOG4umuzb0gX7JauO54QkTMgiA42nuu5iaS3gqr7QvK4tWkyB0lObD91Tg==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "I6xRruBunK7UOZuCfk8hPh5F0dGhAOTtFk8UDCtYX3223ETdiDqcJk9cvrMdWmPQl3FfdqeZjgkywPeSWFh9UA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Model.Mvvm": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "A4u4LkPLqD5NsHozMy3wnJDu4RD0g6HKLhYzpZ3gEAxKPSimzf+s/JZ4XF9kqIWhz+g9WWLAq62d1AAEWQuLdw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "JEKzUjFeqXjFfKXTWBqb2DTtHmigcogVXYaKihUGc316NhJa8Qth+GLL+Pgl0AqqQr+zbVx8vmZearStH3vCfQ==",
         "dependencies": {
           "CommunityToolkit.Mvvm": "8.4.0",
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "Dock.Serializer.SystemTextJson": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "I2eh9RQfXL272wbB3HSWLUTCVx9YJwPBH0Yeo5wj+8fwXOEWz2jUihuDGUkLQexFddEyn6RjMzuFdU32OmdcSw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "4ld6TwWPK0+OZeHo8VylUyx76D2trMxi1hFHfZnH1eHhWZPCHRxuv6C/OvtFZ3lUY+UlcTAUZdoVgzVGmMR4hg==",
         "dependencies": {
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "K4os.Compression.LZ4": {
@@ -1586,13 +1595,13 @@
       },
       "ProDataGrid": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "Nf6qqKi8TLUtICafUGbTeuaAvNiKya8g7EkVkRT01kUKOS5ev0btm9XaA1qN9RJYwyBl6cEu+unfZg+621bRew==",
+        "requested": "[12.1.0.4, )",
+        "resolved": "12.1.0.4",
+        "contentHash": "/7Qbh08HBDE4DEuK1NBgHWcZBJIYYgG7GDnxhCsZ4XJRG/APdJQyMELCt/PAuV0/o2SuwC898r1BmsFzbU5dxw==",
         "dependencies": {
           "Avalonia": "12.1.0",
-          "ProDataGrid.FormulaEngine": "12.1.0.1",
-          "ProDataGrid.FormulaEngine.Excel": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4",
+          "ProDataGrid.FormulaEngine.Excel": "12.1.0.4"
         }
       },
       "Svg.Controls.Skia.Avalonia": {
@@ -1700,18 +1709,19 @@
       },
       "Xaml.Behaviors.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.5, )",
-        "resolved": "12.0.5",
-        "contentHash": "YiZmPTLPQFRePGSFg8MCGb+1KMjLNAgqA6IDxreOr8x4VlBZNr8FSde1VrwEEbKRhj6ErNCZW34dHT39EskKCg==",
+        "requested": "[12.0.7, )",
+        "resolved": "12.0.7",
+        "contentHash": "vSBI0io5gFhhH6J5b0oCvQfoBYUR86S86cIticuyWvEnm9miAkRcAHZs7QS1vcWeVFVnlVqDy90zOK/l4USr6Q==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactions": "12.0.5",
-          "Xaml.Behaviors.Interactions.Custom": "12.0.5",
-          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.5",
-          "Xaml.Behaviors.Interactions.Draggable": "12.0.5",
-          "Xaml.Behaviors.Interactions.Events": "12.0.5",
-          "Xaml.Behaviors.Interactions.Responsive": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactions": "12.0.7",
+          "Xaml.Behaviors.Interactions.Custom": "12.0.7",
+          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.7",
+          "Xaml.Behaviors.Interactions.Draggable": "12.0.7",
+          "Xaml.Behaviors.Interactions.Events": "12.0.7",
+          "Xaml.Behaviors.Interactions.Responsive": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       }
     },

--- a/ILSpy.Tests.Windows/packages.lock.json
+++ b/ILSpy.Tests.Windows/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "AwesomeAssertions": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "coverlet.MTP": {
         "type": "Direct",
@@ -117,13 +117,13 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "System.Resources.Extensions": {
@@ -254,48 +254,48 @@
       },
       "Dock.Controls.DeferredContentControl": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "B1GViYiaPxOfY1tTmJqtefupQsixwtNrfoK7R8YErsr2kCOJ8xWT7l7XfKNnsQN5JIozHCwe3iHpZzZI57LkYQ==",
+        "resolved": "12.1.0.6",
+        "contentHash": "4wwHEYUg4TfUfJxCOjiV8BJINZfFVlSbmPmi9S+hCOR17ouqg65j1hD6oqj43R+bt4V8NVpsp64HKkadVo+lug==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.ProportionalStackPanel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "2uSxLdH0IcGjB5ix+yi0/I44mQjWSbfi5sNoyavO8KsL2/T6PBTPH/3pUH1N16V3crIig6btlwueu2Dcu5WzxA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "poJrxZZlCZ7D+nv/eVgB7MyS36VWpDWOl07wmlBGPE2FVsimE8DiUTOlh0GwtOMkB785BN7/sMdp3JyHHMVq4w==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.Recycling.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "OiAVhQsKF3Bs0X4R31uBL+PmvxnyuO7NyneuXyLEm1DygCM4YC0WkpjPZT7ODUbges4qkIm2+p54OJfoUyMWww=="
+        "resolved": "12.1.0.6",
+        "contentHash": "aUSZtGzyhR8LQFBnZkwvzy8MCt2KGcntR6ei0Gn1e4b38NRAxkbyI9GasGOPsv0H1CJJRSmDCuqjQ1bGjdYNqg=="
       },
       "Dock.MarkupExtension": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "/qThcNWEXHYd7Y4gPxSUWiQjFrDH+V2vpuEDUGOcOtiSeUeXlRScDmmHqDCQTFhqiu1JKI86820ZLXBTS0Uvow==",
+        "resolved": "12.1.0.6",
+        "contentHash": "MQ0VCKT37hrCH8Fan8/eXttKtrYA0DKN0z1Du2+529p3mbBk2iTNz9s4PHXWFBfBj3JG+yMsXcxU9mje9butAg==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "NWysuK6Rp/QkOcbEPuzNH428bGyzyukUDuucgZA9qWRrtfpyf3Jnnd+QLnhFWBViqVwU5GSXyYCOFRW5VELJSA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "eyptYTadJbhdGnT/9qkbTquFZpPBiRcr6yJvzMv5tLQB56JgbUlVAR1816ILuSeyN8wGPPW3im8g3gdGCp0lIA==",
         "dependencies": {
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Settings": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "n+eoHszNCVdjffMwInLZQVd0s08pMu24Nrt560Q/6twLId54cuyTH+vLpVyfAu8djf6LQ+ogpFTESlrwdt4ixw==",
+        "resolved": "12.1.0.6",
+        "contentHash": "n3fBTNxeCt+t0v62OdhiE9CTBeqR/5y6MBfJ/ma9rSw2PXHLf1NFzodq38mX4HKm1sF8JaX4Y8YZw8IqaxUDBw==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Model": "12.1.0.6"
         }
       },
       "ExCSS": {
@@ -464,10 +464,10 @@
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -587,15 +587,15 @@
       },
       "ProDataGrid.FormulaEngine": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "mOtxLps58R4GDC6D1OnD0Z7xHtljZqZlMqInszEbhJBo/fGdsDxc1kcTSrof8HnPp9fX8eBFLhtytP4MfFVF5w=="
+        "resolved": "12.1.0.4",
+        "contentHash": "EGokmPuRKbsqndoqHR5Hbc2Zok2jWYiRGxb2W2ELtFaVWyQZUhhx1ZsMVTsJG2OvJZp/eM3B0enqTXA63kQUdA=="
       },
       "ProDataGrid.FormulaEngine.Excel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "AY/XxAX8OTEiej73GWLr9GoWIMAgaHnjNj0tVbKBHFUsT3T4vnPiMmFTFp9Mc0M028LmWWBXjVoxMtDZ4WuHOg==",
+        "resolved": "12.1.0.4",
+        "contentHash": "akwuyW1lQ6s605t+EgIkDxYU4OsKR6ZypT3TM3O+JnR3hKgN9LxkrWa+6QtjC6sc6ff6NLvKMIH8KqXOpfQTLw==",
         "dependencies": {
-          "ProDataGrid.FormulaEngine": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -1509,64 +1509,73 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Xaml.Behaviors.Animations": {
+        "type": "Transitive",
+        "resolved": "12.0.7",
+        "contentHash": "4bZF2H+0Fno6iYXwIrpbQisi8JlFfBpPIezWytljHP87C0PA21bnugtmP7cfgPAI6JZn0A6Ae9+JK3POKN1+Pg==",
+        "dependencies": {
+          "Avalonia": "12.0.5"
+        }
+      },
       "Xaml.Behaviors.Interactions": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "A9iq4aRu0XCUZ5bnhPqRKF1lRfSfvmrJRf+F+P+FxuFuSenpy6Ouq4fcalBWGMYxBsRfp4/FC+zvI0UyFSEfCg==",
+        "resolved": "12.0.7",
+        "contentHash": "o1PwBW7NUWLkktvuSmM52z2OBH1w1yo2dc+NetP8PLWC0/QsTVql/dE56B8IjPJzmpGb3Y9XSitTKh7R+EL2cA==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Custom": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "rLYqZglj0NeHbHBOFpHomPvYeeL9bdwdh8n9hNG8xjm6yUqL+P8lcEwTnrhT++ReRjdPJgvfTJAwi4lIoMmQmQ==",
+        "resolved": "12.0.7",
+        "contentHash": "RCmhJa8ps+ML1e5rXr91k6ETS4xAjmkHOM5XN2q6rI/Tbx74SEiAKzC4rzKZ+SX1/BLOlE47nMpMNuxrkkzk+A==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.DragAndDrop": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "u5SJG0ZCtSFlcX/74jawbUcTOeKyv6QwSb0xj3pKjG4qfpfvmI3kwvQXv3ImwhrLR+0xhUn7lvyY+/SfdtMG/Q==",
+        "resolved": "12.0.7",
+        "contentHash": "l0PsZ3U2Nwsap9srbuPTdkHk10ipjeNBI9eZELW6jNgO8+thV7BsW6mk/Z5D5Hh3Fq6YDrj3KKyJ6CD3ECtHDg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Draggable": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "+TOUCKFCaPdfNBlNQRDSvfx00Q+KLKMlTLpeBMRWHx7K3yXqRXGz7PD1WpDmRQfLrFWn6muJpSzt4BIcBYACRA==",
+        "resolved": "12.0.7",
+        "contentHash": "cm9h+vFKCTgpxCsi7Bp4KHEXVbQ4QH8WrrqE/81kN5U7roWVW+JVnGZ+k67HP2LOhyt+eIEQokLVMcipv9cFpw==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Events": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "gLPWRmjH9swFQMrEN1og8gyhj8RWeCdM8q9OZ7pCUhk7SjRp3/7WURdyyrH9eTLtheXB9sT69FGrXD2gnHOOxg==",
+        "resolved": "12.0.7",
+        "contentHash": "0JwzoIOX21dj9geo+st+RSxl/7bU4Wb35P1YjKD4IeUw6mIf8EMQkB7PKGPy+hibeOnmSDTbLoNoCY0EdvTNgg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Responsive": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "PKvMu5UuHMmLkQYES96qeYbFVIYiEFyftAXzuEiM2fHTe7ur5HfrzFkyAfH0O5oQObmsog4A/GAU59SXmnT/5Q==",
+        "resolved": "12.0.7",
+        "contentHash": "9h9hncn2OcxYMbDUQSNzJs7SY6YVb6dDp2W3W64ns9Xqza3FpCZITGFeJKBZQEhqeS/vvUKbtpRIC6MrQSh3Yg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactivity": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "aoXlptjbRIDorjv4yzdClkBUZX1awi9/3iaORMsDkBceDzY03N5ZMMNRAKfp+MWz/z3YsKzy0GxZMkCUAlYxqQ==",
+        "resolved": "12.0.7",
+        "contentHash": "PzWwozUtizvnNYuCJhlbl+EwuRpva0+qYWYlGkyNKMjyrTxujBWBBr1g6o1PtauVTLPCkX5+lGNK6JHImYDJAQ==",
         "dependencies": {
           "Avalonia": "12.0.5"
         }
@@ -1605,11 +1614,11 @@
           "AvaloniaEdit.TextMate": "[12.0.0, )",
           "AvaloniaUI.DiagnosticsSupport": "[2.2.3, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Dock.Avalonia": "[12.1.0.1, )",
-          "Dock.Avalonia.Themes.Simple": "[12.1.0.1, )",
-          "Dock.Controls.Recycling": "[12.1.0.1, )",
-          "Dock.Model.Mvvm": "[12.1.0.1, )",
-          "Dock.Serializer.SystemTextJson": "[12.1.0.1, )",
+          "Dock.Avalonia": "[12.1.0.6, )",
+          "Dock.Avalonia.Themes.Simple": "[12.1.0.6, )",
+          "Dock.Controls.Recycling": "[12.1.0.6, )",
+          "Dock.Model.Mvvm": "[12.1.0.6, )",
+          "Dock.Serializer.SystemTextJson": "[12.1.0.6, )",
           "ICSharpCode.BamlDecompiler": "[10.0.0-noversion, )",
           "ICSharpCode.Decompiler": "[8.0.0-noversion, )",
           "ICSharpCode.ILSpyX": "[8.0.0-noversion, )",
@@ -1620,13 +1629,13 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.11, )",
           "NuGet.Frameworks": "[7.9.0, )",
           "NuGet.Protocol": "[7.9.0, )",
-          "ProDataGrid": "[12.1.0.1, )",
+          "ProDataGrid": "[12.1.0.4, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.13, )",
           "System.Composition.AttributedModel": "[10.0.11, )",
           "System.Composition.Hosting": "[10.0.11, )",
           "System.Composition.TypedParts": "[10.0.11, )",
           "System.Formats.Nrbf": "[10.0.11, )",
-          "Xaml.Behaviors.Avalonia": "[12.0.5, )"
+          "Xaml.Behaviors.Avalonia": "[12.0.7, )"
         }
       },
       "ilspy.tests": {
@@ -1635,13 +1644,13 @@
           "Avalonia": "[12.1.1, )",
           "Avalonia.Headless.NUnit": "[12.1.1, )",
           "Avalonia.Themes.Simple": "[12.1.1, )",
-          "AwesomeAssertions": "[9.5.0, )",
+          "AwesomeAssertions": "[9.6.0, )",
           "ILSpy": "[1.0.0, )",
           "Microsoft.Testing.Extensions.TrxReport": "[2.3.3, )",
           "Microsoft.Testing.Extensions.VSTestBridge": "[2.3.3, )",
           "NSubstitute": "[6.2.0, )",
           "NUnit": "[4.6.1, )",
-          "NUnit3TestAdapter": "[6.2.0, )",
+          "NUnit3TestAdapter": "[6.3.0, )",
           "coverlet.MTP": "[10.0.1, )"
         }
       },
@@ -1698,56 +1707,56 @@
       },
       "Dock.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "l+bJtDfyG6HrHJA6+pzY1NWynwu2udD2XiJ6vXoBkCGAvWe5yAPPZ8rSODxqbwgkqGoS3UDRbgRbWV4Z++75jQ==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "Y5kTyQtxKHXoUEQfSn9nxsUk+9shIavU/C6ub3Dxs/Sxz4VSlGuTdfRI4mGLO4MJwWetb96xKxhrtCzufg2NrQ==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.DeferredContentControl": "12.1.0.1",
-          "Dock.Controls.ProportionalStackPanel": "12.1.0.1",
-          "Dock.Controls.Recycling": "12.1.0.1",
-          "Dock.MarkupExtension": "12.1.0.1",
-          "Dock.Model": "12.1.0.1",
-          "Dock.Settings": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.DeferredContentControl": "12.1.0.6",
+          "Dock.Controls.ProportionalStackPanel": "12.1.0.6",
+          "Dock.Controls.Recycling": "12.1.0.6",
+          "Dock.MarkupExtension": "12.1.0.6",
+          "Dock.Model": "12.1.0.6",
+          "Dock.Settings": "12.1.0.6"
         }
       },
       "Dock.Avalonia.Themes.Simple": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "8RaFfoXWlV13YTPzrcS2JHy2CqaCQGMvfsmUUMnTjBslWv9sp0obthKCTeWZp+jb2lOIFdhQS69jW9JhlwtILA==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "m4/P8+wMAmeHqmEsthYPl/n22vAdBpOAoMugyEcyHeAfGIlbX7e16plwDJ70FobP8V7wQzDhmlpTZUed+Y+nBA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Avalonia": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Avalonia": "12.1.0.6"
         }
       },
       "Dock.Controls.Recycling": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "qHZgt6VaX4UcE7rjpV/szeH93NqDMOG4umuzb0gX7JauO54QkTMgiA42nuu5iaS3gqr7QvK4tWkyB0lObD91Tg==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "I6xRruBunK7UOZuCfk8hPh5F0dGhAOTtFk8UDCtYX3223ETdiDqcJk9cvrMdWmPQl3FfdqeZjgkywPeSWFh9UA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Model.Mvvm": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "A4u4LkPLqD5NsHozMy3wnJDu4RD0g6HKLhYzpZ3gEAxKPSimzf+s/JZ4XF9kqIWhz+g9WWLAq62d1AAEWQuLdw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "JEKzUjFeqXjFfKXTWBqb2DTtHmigcogVXYaKihUGc316NhJa8Qth+GLL+Pgl0AqqQr+zbVx8vmZearStH3vCfQ==",
         "dependencies": {
           "CommunityToolkit.Mvvm": "8.4.0",
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "Dock.Serializer.SystemTextJson": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "I2eh9RQfXL272wbB3HSWLUTCVx9YJwPBH0Yeo5wj+8fwXOEWz2jUihuDGUkLQexFddEyn6RjMzuFdU32OmdcSw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "4ld6TwWPK0+OZeHo8VylUyx76D2trMxi1hFHfZnH1eHhWZPCHRxuv6C/OvtFZ3lUY+UlcTAUZdoVgzVGmMR4hg==",
         "dependencies": {
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "K4os.Compression.LZ4": {
@@ -1813,13 +1822,13 @@
       },
       "ProDataGrid": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "Nf6qqKi8TLUtICafUGbTeuaAvNiKya8g7EkVkRT01kUKOS5ev0btm9XaA1qN9RJYwyBl6cEu+unfZg+621bRew==",
+        "requested": "[12.1.0.4, )",
+        "resolved": "12.1.0.4",
+        "contentHash": "/7Qbh08HBDE4DEuK1NBgHWcZBJIYYgG7GDnxhCsZ4XJRG/APdJQyMELCt/PAuV0/o2SuwC898r1BmsFzbU5dxw==",
         "dependencies": {
           "Avalonia": "12.1.0",
-          "ProDataGrid.FormulaEngine": "12.1.0.1",
-          "ProDataGrid.FormulaEngine.Excel": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4",
+          "ProDataGrid.FormulaEngine.Excel": "12.1.0.4"
         }
       },
       "Svg.Controls.Skia.Avalonia": {
@@ -1939,18 +1948,19 @@
       },
       "Xaml.Behaviors.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.5, )",
-        "resolved": "12.0.5",
-        "contentHash": "YiZmPTLPQFRePGSFg8MCGb+1KMjLNAgqA6IDxreOr8x4VlBZNr8FSde1VrwEEbKRhj6ErNCZW34dHT39EskKCg==",
+        "requested": "[12.0.7, )",
+        "resolved": "12.0.7",
+        "contentHash": "vSBI0io5gFhhH6J5b0oCvQfoBYUR86S86cIticuyWvEnm9miAkRcAHZs7QS1vcWeVFVnlVqDy90zOK/l4USr6Q==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactions": "12.0.5",
-          "Xaml.Behaviors.Interactions.Custom": "12.0.5",
-          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.5",
-          "Xaml.Behaviors.Interactions.Draggable": "12.0.5",
-          "Xaml.Behaviors.Interactions.Events": "12.0.5",
-          "Xaml.Behaviors.Interactions.Responsive": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactions": "12.0.7",
+          "Xaml.Behaviors.Interactions.Custom": "12.0.7",
+          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.7",
+          "Xaml.Behaviors.Interactions.Draggable": "12.0.7",
+          "Xaml.Behaviors.Interactions.Events": "12.0.7",
+          "Xaml.Behaviors.Interactions.Responsive": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       }
     }

--- a/ILSpy.Tests/packages.lock.json
+++ b/ILSpy.Tests/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "AwesomeAssertions": {
         "type": "Direct",
-        "requested": "[9.5.0, )",
-        "resolved": "9.5.0",
-        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "8kdtgI+tZIgP46ncnk650/dU4JSrn+n2Dkic8FvjIFn72P6Nv1Afyr5F8F3PsokHg1GBSBVo1/Z+eZOrU5esSA=="
       },
       "coverlet.MTP": {
         "type": "Direct",
@@ -89,13 +89,13 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "8PMJB8za2u8S0ey/nEtvh9BHjLhv5yzUEMCmA0+VIPLKSeOAZ3TEHWDyAp0+iPQb3jnBH1o8k0PoU2FgzXLRnQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "8ZD+0dIfDHsL4w4Gl/LPxWH0O4ky3hFXqTZjY+ry0ThI3cMVErr9Tjxal5O5wJxGXh50a9qkDEAWVca8KQYCEw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyModel": "8.0.2",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.1.0",
-          "Microsoft.Testing.Platform.MSBuild": "2.1.0"
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.3",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.3"
         }
       },
       "TomsToolbox.Composition.Analyzer": {
@@ -217,48 +217,48 @@
       },
       "Dock.Controls.DeferredContentControl": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "B1GViYiaPxOfY1tTmJqtefupQsixwtNrfoK7R8YErsr2kCOJ8xWT7l7XfKNnsQN5JIozHCwe3iHpZzZI57LkYQ==",
+        "resolved": "12.1.0.6",
+        "contentHash": "4wwHEYUg4TfUfJxCOjiV8BJINZfFVlSbmPmi9S+hCOR17ouqg65j1hD6oqj43R+bt4V8NVpsp64HKkadVo+lug==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.ProportionalStackPanel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "2uSxLdH0IcGjB5ix+yi0/I44mQjWSbfi5sNoyavO8KsL2/T6PBTPH/3pUH1N16V3crIig6btlwueu2Dcu5WzxA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "poJrxZZlCZ7D+nv/eVgB7MyS36VWpDWOl07wmlBGPE2FVsimE8DiUTOlh0GwtOMkB785BN7/sMdp3JyHHMVq4w==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.Recycling.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "OiAVhQsKF3Bs0X4R31uBL+PmvxnyuO7NyneuXyLEm1DygCM4YC0WkpjPZT7ODUbges4qkIm2+p54OJfoUyMWww=="
+        "resolved": "12.1.0.6",
+        "contentHash": "aUSZtGzyhR8LQFBnZkwvzy8MCt2KGcntR6ei0Gn1e4b38NRAxkbyI9GasGOPsv0H1CJJRSmDCuqjQ1bGjdYNqg=="
       },
       "Dock.MarkupExtension": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "/qThcNWEXHYd7Y4gPxSUWiQjFrDH+V2vpuEDUGOcOtiSeUeXlRScDmmHqDCQTFhqiu1JKI86820ZLXBTS0Uvow==",
+        "resolved": "12.1.0.6",
+        "contentHash": "MQ0VCKT37hrCH8Fan8/eXttKtrYA0DKN0z1Du2+529p3mbBk2iTNz9s4PHXWFBfBj3JG+yMsXcxU9mje9butAg==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "NWysuK6Rp/QkOcbEPuzNH428bGyzyukUDuucgZA9qWRrtfpyf3Jnnd+QLnhFWBViqVwU5GSXyYCOFRW5VELJSA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "eyptYTadJbhdGnT/9qkbTquFZpPBiRcr6yJvzMv5tLQB56JgbUlVAR1816ILuSeyN8wGPPW3im8g3gdGCp0lIA==",
         "dependencies": {
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Settings": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "n+eoHszNCVdjffMwInLZQVd0s08pMu24Nrt560Q/6twLId54cuyTH+vLpVyfAu8djf6LQ+ogpFTESlrwdt4ixw==",
+        "resolved": "12.1.0.6",
+        "contentHash": "n3fBTNxeCt+t0v62OdhiE9CTBeqR/5y6MBfJ/ma9rSw2PXHLf1NFzodq38mX4HKm1sF8JaX4Y8YZw8IqaxUDBw==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Model": "12.1.0.6"
         }
       },
       "ExCSS": {
@@ -427,10 +427,10 @@
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.1.0",
-        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "resolved": "2.3.3",
+        "contentHash": "iVAvNbZ5JPDZSrTcIrCDoCsAkzjDxwDEt2mDuMd8ng1P6e2P2NCd0g0BsoBVG+nJLSmK//V+yeEvjCa3E2fxHw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.1.0"
+          "Microsoft.Testing.Platform": "2.3.3"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -550,15 +550,15 @@
       },
       "ProDataGrid.FormulaEngine": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "mOtxLps58R4GDC6D1OnD0Z7xHtljZqZlMqInszEbhJBo/fGdsDxc1kcTSrof8HnPp9fX8eBFLhtytP4MfFVF5w=="
+        "resolved": "12.1.0.4",
+        "contentHash": "EGokmPuRKbsqndoqHR5Hbc2Zok2jWYiRGxb2W2ELtFaVWyQZUhhx1ZsMVTsJG2OvJZp/eM3B0enqTXA63kQUdA=="
       },
       "ProDataGrid.FormulaEngine.Excel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "AY/XxAX8OTEiej73GWLr9GoWIMAgaHnjNj0tVbKBHFUsT3T4vnPiMmFTFp9Mc0M028LmWWBXjVoxMtDZ4WuHOg==",
+        "resolved": "12.1.0.4",
+        "contentHash": "akwuyW1lQ6s605t+EgIkDxYU4OsKR6ZypT3TM3O+JnR3hKgN9LxkrWa+6QtjC6sc6ff6NLvKMIH8KqXOpfQTLw==",
         "dependencies": {
-          "ProDataGrid.FormulaEngine": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -1472,64 +1472,73 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Xaml.Behaviors.Animations": {
+        "type": "Transitive",
+        "resolved": "12.0.7",
+        "contentHash": "4bZF2H+0Fno6iYXwIrpbQisi8JlFfBpPIezWytljHP87C0PA21bnugtmP7cfgPAI6JZn0A6Ae9+JK3POKN1+Pg==",
+        "dependencies": {
+          "Avalonia": "12.0.5"
+        }
+      },
       "Xaml.Behaviors.Interactions": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "A9iq4aRu0XCUZ5bnhPqRKF1lRfSfvmrJRf+F+P+FxuFuSenpy6Ouq4fcalBWGMYxBsRfp4/FC+zvI0UyFSEfCg==",
+        "resolved": "12.0.7",
+        "contentHash": "o1PwBW7NUWLkktvuSmM52z2OBH1w1yo2dc+NetP8PLWC0/QsTVql/dE56B8IjPJzmpGb3Y9XSitTKh7R+EL2cA==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Custom": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "rLYqZglj0NeHbHBOFpHomPvYeeL9bdwdh8n9hNG8xjm6yUqL+P8lcEwTnrhT++ReRjdPJgvfTJAwi4lIoMmQmQ==",
+        "resolved": "12.0.7",
+        "contentHash": "RCmhJa8ps+ML1e5rXr91k6ETS4xAjmkHOM5XN2q6rI/Tbx74SEiAKzC4rzKZ+SX1/BLOlE47nMpMNuxrkkzk+A==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.DragAndDrop": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "u5SJG0ZCtSFlcX/74jawbUcTOeKyv6QwSb0xj3pKjG4qfpfvmI3kwvQXv3ImwhrLR+0xhUn7lvyY+/SfdtMG/Q==",
+        "resolved": "12.0.7",
+        "contentHash": "l0PsZ3U2Nwsap9srbuPTdkHk10ipjeNBI9eZELW6jNgO8+thV7BsW6mk/Z5D5Hh3Fq6YDrj3KKyJ6CD3ECtHDg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Draggable": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "+TOUCKFCaPdfNBlNQRDSvfx00Q+KLKMlTLpeBMRWHx7K3yXqRXGz7PD1WpDmRQfLrFWn6muJpSzt4BIcBYACRA==",
+        "resolved": "12.0.7",
+        "contentHash": "cm9h+vFKCTgpxCsi7Bp4KHEXVbQ4QH8WrrqE/81kN5U7roWVW+JVnGZ+k67HP2LOhyt+eIEQokLVMcipv9cFpw==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Events": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "gLPWRmjH9swFQMrEN1og8gyhj8RWeCdM8q9OZ7pCUhk7SjRp3/7WURdyyrH9eTLtheXB9sT69FGrXD2gnHOOxg==",
+        "resolved": "12.0.7",
+        "contentHash": "0JwzoIOX21dj9geo+st+RSxl/7bU4Wb35P1YjKD4IeUw6mIf8EMQkB7PKGPy+hibeOnmSDTbLoNoCY0EdvTNgg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Responsive": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "PKvMu5UuHMmLkQYES96qeYbFVIYiEFyftAXzuEiM2fHTe7ur5HfrzFkyAfH0O5oQObmsog4A/GAU59SXmnT/5Q==",
+        "resolved": "12.0.7",
+        "contentHash": "9h9hncn2OcxYMbDUQSNzJs7SY6YVb6dDp2W3W64ns9Xqza3FpCZITGFeJKBZQEhqeS/vvUKbtpRIC6MrQSh3Yg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactivity": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "aoXlptjbRIDorjv4yzdClkBUZX1awi9/3iaORMsDkBceDzY03N5ZMMNRAKfp+MWz/z3YsKzy0GxZMkCUAlYxqQ==",
+        "resolved": "12.0.7",
+        "contentHash": "PzWwozUtizvnNYuCJhlbl+EwuRpva0+qYWYlGkyNKMjyrTxujBWBBr1g6o1PtauVTLPCkX5+lGNK6JHImYDJAQ==",
         "dependencies": {
           "Avalonia": "12.0.5"
         }
@@ -1568,11 +1577,11 @@
           "AvaloniaEdit.TextMate": "[12.0.0, )",
           "AvaloniaUI.DiagnosticsSupport": "[2.2.3, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Dock.Avalonia": "[12.1.0.1, )",
-          "Dock.Avalonia.Themes.Simple": "[12.1.0.1, )",
-          "Dock.Controls.Recycling": "[12.1.0.1, )",
-          "Dock.Model.Mvvm": "[12.1.0.1, )",
-          "Dock.Serializer.SystemTextJson": "[12.1.0.1, )",
+          "Dock.Avalonia": "[12.1.0.6, )",
+          "Dock.Avalonia.Themes.Simple": "[12.1.0.6, )",
+          "Dock.Controls.Recycling": "[12.1.0.6, )",
+          "Dock.Model.Mvvm": "[12.1.0.6, )",
+          "Dock.Serializer.SystemTextJson": "[12.1.0.6, )",
           "ICSharpCode.BamlDecompiler": "[10.0.0-noversion, )",
           "ICSharpCode.Decompiler": "[8.0.0-noversion, )",
           "ICSharpCode.ILSpyX": "[8.0.0-noversion, )",
@@ -1583,13 +1592,13 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.11, )",
           "NuGet.Frameworks": "[7.9.0, )",
           "NuGet.Protocol": "[7.9.0, )",
-          "ProDataGrid": "[12.1.0.1, )",
+          "ProDataGrid": "[12.1.0.4, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.13, )",
           "System.Composition.AttributedModel": "[10.0.11, )",
           "System.Composition.Hosting": "[10.0.11, )",
           "System.Composition.TypedParts": "[10.0.11, )",
           "System.Formats.Nrbf": "[10.0.11, )",
-          "Xaml.Behaviors.Avalonia": "[12.0.5, )"
+          "Xaml.Behaviors.Avalonia": "[12.0.7, )"
         }
       },
       "Avalonia.AvaloniaEdit": {
@@ -1645,56 +1654,56 @@
       },
       "Dock.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "l+bJtDfyG6HrHJA6+pzY1NWynwu2udD2XiJ6vXoBkCGAvWe5yAPPZ8rSODxqbwgkqGoS3UDRbgRbWV4Z++75jQ==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "Y5kTyQtxKHXoUEQfSn9nxsUk+9shIavU/C6ub3Dxs/Sxz4VSlGuTdfRI4mGLO4MJwWetb96xKxhrtCzufg2NrQ==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.DeferredContentControl": "12.1.0.1",
-          "Dock.Controls.ProportionalStackPanel": "12.1.0.1",
-          "Dock.Controls.Recycling": "12.1.0.1",
-          "Dock.MarkupExtension": "12.1.0.1",
-          "Dock.Model": "12.1.0.1",
-          "Dock.Settings": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.DeferredContentControl": "12.1.0.6",
+          "Dock.Controls.ProportionalStackPanel": "12.1.0.6",
+          "Dock.Controls.Recycling": "12.1.0.6",
+          "Dock.MarkupExtension": "12.1.0.6",
+          "Dock.Model": "12.1.0.6",
+          "Dock.Settings": "12.1.0.6"
         }
       },
       "Dock.Avalonia.Themes.Simple": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "8RaFfoXWlV13YTPzrcS2JHy2CqaCQGMvfsmUUMnTjBslWv9sp0obthKCTeWZp+jb2lOIFdhQS69jW9JhlwtILA==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "m4/P8+wMAmeHqmEsthYPl/n22vAdBpOAoMugyEcyHeAfGIlbX7e16plwDJ70FobP8V7wQzDhmlpTZUed+Y+nBA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Avalonia": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Avalonia": "12.1.0.6"
         }
       },
       "Dock.Controls.Recycling": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "qHZgt6VaX4UcE7rjpV/szeH93NqDMOG4umuzb0gX7JauO54QkTMgiA42nuu5iaS3gqr7QvK4tWkyB0lObD91Tg==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "I6xRruBunK7UOZuCfk8hPh5F0dGhAOTtFk8UDCtYX3223ETdiDqcJk9cvrMdWmPQl3FfdqeZjgkywPeSWFh9UA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Model.Mvvm": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "A4u4LkPLqD5NsHozMy3wnJDu4RD0g6HKLhYzpZ3gEAxKPSimzf+s/JZ4XF9kqIWhz+g9WWLAq62d1AAEWQuLdw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "JEKzUjFeqXjFfKXTWBqb2DTtHmigcogVXYaKihUGc316NhJa8Qth+GLL+Pgl0AqqQr+zbVx8vmZearStH3vCfQ==",
         "dependencies": {
           "CommunityToolkit.Mvvm": "8.4.0",
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "Dock.Serializer.SystemTextJson": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "I2eh9RQfXL272wbB3HSWLUTCVx9YJwPBH0Yeo5wj+8fwXOEWz2jUihuDGUkLQexFddEyn6RjMzuFdU32OmdcSw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "4ld6TwWPK0+OZeHo8VylUyx76D2trMxi1hFHfZnH1eHhWZPCHRxuv6C/OvtFZ3lUY+UlcTAUZdoVgzVGmMR4hg==",
         "dependencies": {
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "K4os.Compression.LZ4": {
@@ -1788,13 +1797,13 @@
       },
       "ProDataGrid": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "Nf6qqKi8TLUtICafUGbTeuaAvNiKya8g7EkVkRT01kUKOS5ev0btm9XaA1qN9RJYwyBl6cEu+unfZg+621bRew==",
+        "requested": "[12.1.0.4, )",
+        "resolved": "12.1.0.4",
+        "contentHash": "/7Qbh08HBDE4DEuK1NBgHWcZBJIYYgG7GDnxhCsZ4XJRG/APdJQyMELCt/PAuV0/o2SuwC898r1BmsFzbU5dxw==",
         "dependencies": {
           "Avalonia": "12.1.0",
-          "ProDataGrid.FormulaEngine": "12.1.0.1",
-          "ProDataGrid.FormulaEngine.Excel": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4",
+          "ProDataGrid.FormulaEngine.Excel": "12.1.0.4"
         }
       },
       "Svg.Controls.Skia.Avalonia": {
@@ -1914,18 +1923,19 @@
       },
       "Xaml.Behaviors.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.5, )",
-        "resolved": "12.0.5",
-        "contentHash": "YiZmPTLPQFRePGSFg8MCGb+1KMjLNAgqA6IDxreOr8x4VlBZNr8FSde1VrwEEbKRhj6ErNCZW34dHT39EskKCg==",
+        "requested": "[12.0.7, )",
+        "resolved": "12.0.7",
+        "contentHash": "vSBI0io5gFhhH6J5b0oCvQfoBYUR86S86cIticuyWvEnm9miAkRcAHZs7QS1vcWeVFVnlVqDy90zOK/l4USr6Q==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactions": "12.0.5",
-          "Xaml.Behaviors.Interactions.Custom": "12.0.5",
-          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.5",
-          "Xaml.Behaviors.Interactions.Draggable": "12.0.5",
-          "Xaml.Behaviors.Interactions.Events": "12.0.5",
-          "Xaml.Behaviors.Interactions.Responsive": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactions": "12.0.7",
+          "Xaml.Behaviors.Interactions.Custom": "12.0.7",
+          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.7",
+          "Xaml.Behaviors.Interactions.Draggable": "12.0.7",
+          "Xaml.Behaviors.Interactions.Events": "12.0.7",
+          "Xaml.Behaviors.Interactions.Responsive": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       }
     }

--- a/ILSpy/Docking/ILSpyDockJson.cs
+++ b/ILSpy/Docking/ILSpyDockJson.cs
@@ -29,7 +29,6 @@ using System.Windows.Input;
 
 using Dock.Model.Controls;
 using Dock.Model.Core;
-using Dock.Serializer.SystemTextJson;
 
 using ICSharpCode.ILSpy.ViewModels;
 
@@ -72,24 +71,36 @@ namespace ICSharpCode.ILSpy.Docking
 			resolver.Modifiers.Add(RemoveIgnoredMembers);
 			resolver.Modifiers.Add(KeepWritablePropertiesOnly);
 			resolver.Modifiers.Add(StripCycleProneProperties);
+			resolver.Modifiers.Add(UseObservableCollectionsForLists);
 			return new JsonSerializerOptions {
 				WriteIndented = true,
 				DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
 				NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
 				TypeInfoResolver = resolver,
-				// Dock's converter handles IList<T> → ObservableCollection<T> at deserialise
-				// time, matching Newtonsoft's ListContractResolver substitution.
-				Converters = { new JsonConverterFactoryList(typeof(ObservableCollection<>)) },
 				MaxDepth = 256,
 				// ReferenceHandler.Preserve is intentionally NOT set. Newtonsoft tolerates
 				// $id/$ref/$type in any order; STJ requires $type first when polymorphism
-				// is in play, and Dock's JsonConverterList<T>.Write makes per-element
-				// JsonSerializer.Serialize calls which reset Preserve's $id counter — so
-				// multiple unrelated objects would share $id="1". Both incompatibilities
-				// vanish once back-reference properties (Owner / Window / Layout) are
-				// stripped, leaving a DAG that doesn't need $id/$ref. StripCycleProneProperties
-				// below does the stripping.
+				// is in play. That incompatibility vanishes once back-reference properties
+				// (Owner / Window / Layout) are stripped, leaving a DAG that doesn't need
+				// $id/$ref. StripCycleProneProperties below does the stripping.
 			};
+		}
+
+		static void UseObservableCollectionsForLists(JsonTypeInfo typeInfo)
+		{
+			// IList<T> members on the dock model (VisibleDockables, Windows, ...) must
+			// deserialise into ObservableCollection<T> so the UI observes later changes,
+			// matching Newtonsoft's ListContractResolver substitution. Dock.Serializer's
+			// own STJ serializer does this with an internal type-info modifier that swaps
+			// the CreateObject factory; this is the same technique, since a converter would
+			// bypass STJ's built-in enumerable path (and polymorphism handling) for elements.
+			if (typeInfo.Kind != JsonTypeInfoKind.Enumerable)
+				return;
+			var type = typeInfo.Type;
+			if (!type.IsGenericType || type.GetGenericTypeDefinition() != typeof(IList<>))
+				return;
+			var listType = typeof(ObservableCollection<>).MakeGenericType(type.GetGenericArguments()[0]);
+			typeInfo.CreateObject = () => Activator.CreateInstance(listType)!;
 		}
 
 		static void AddPolymorphism(JsonTypeInfo typeInfo)

--- a/ILSpy/packages.lock.json
+++ b/ILSpy/packages.lock.json
@@ -75,56 +75,56 @@
       },
       "Dock.Avalonia": {
         "type": "Direct",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "l+bJtDfyG6HrHJA6+pzY1NWynwu2udD2XiJ6vXoBkCGAvWe5yAPPZ8rSODxqbwgkqGoS3UDRbgRbWV4Z++75jQ==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "Y5kTyQtxKHXoUEQfSn9nxsUk+9shIavU/C6ub3Dxs/Sxz4VSlGuTdfRI4mGLO4MJwWetb96xKxhrtCzufg2NrQ==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.DeferredContentControl": "12.1.0.1",
-          "Dock.Controls.ProportionalStackPanel": "12.1.0.1",
-          "Dock.Controls.Recycling": "12.1.0.1",
-          "Dock.MarkupExtension": "12.1.0.1",
-          "Dock.Model": "12.1.0.1",
-          "Dock.Settings": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.DeferredContentControl": "12.1.0.6",
+          "Dock.Controls.ProportionalStackPanel": "12.1.0.6",
+          "Dock.Controls.Recycling": "12.1.0.6",
+          "Dock.MarkupExtension": "12.1.0.6",
+          "Dock.Model": "12.1.0.6",
+          "Dock.Settings": "12.1.0.6"
         }
       },
       "Dock.Avalonia.Themes.Simple": {
         "type": "Direct",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "8RaFfoXWlV13YTPzrcS2JHy2CqaCQGMvfsmUUMnTjBslWv9sp0obthKCTeWZp+jb2lOIFdhQS69jW9JhlwtILA==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "m4/P8+wMAmeHqmEsthYPl/n22vAdBpOAoMugyEcyHeAfGIlbX7e16plwDJ70FobP8V7wQzDhmlpTZUed+Y+nBA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Avalonia": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Avalonia": "12.1.0.6"
         }
       },
       "Dock.Controls.Recycling": {
         "type": "Direct",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "qHZgt6VaX4UcE7rjpV/szeH93NqDMOG4umuzb0gX7JauO54QkTMgiA42nuu5iaS3gqr7QvK4tWkyB0lObD91Tg==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "I6xRruBunK7UOZuCfk8hPh5F0dGhAOTtFk8UDCtYX3223ETdiDqcJk9cvrMdWmPQl3FfdqeZjgkywPeSWFh9UA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Model.Mvvm": {
         "type": "Direct",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "A4u4LkPLqD5NsHozMy3wnJDu4RD0g6HKLhYzpZ3gEAxKPSimzf+s/JZ4XF9kqIWhz+g9WWLAq62d1AAEWQuLdw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "JEKzUjFeqXjFfKXTWBqb2DTtHmigcogVXYaKihUGc316NhJa8Qth+GLL+Pgl0AqqQr+zbVx8vmZearStH3vCfQ==",
         "dependencies": {
           "CommunityToolkit.Mvvm": "8.4.0",
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "Dock.Serializer.SystemTextJson": {
         "type": "Direct",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "I2eh9RQfXL272wbB3HSWLUTCVx9YJwPBH0Yeo5wj+8fwXOEWz2jUihuDGUkLQexFddEyn6RjMzuFdU32OmdcSw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "4ld6TwWPK0+OZeHo8VylUyx76D2trMxi1hFHfZnH1eHhWZPCHRxuv6C/OvtFZ3lUY+UlcTAUZdoVgzVGmMR4hg==",
         "dependencies": {
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "McMaster.Extensions.CommandLineUtils": {
@@ -184,13 +184,13 @@
       },
       "ProDataGrid": {
         "type": "Direct",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "Nf6qqKi8TLUtICafUGbTeuaAvNiKya8g7EkVkRT01kUKOS5ev0btm9XaA1qN9RJYwyBl6cEu+unfZg+621bRew==",
+        "requested": "[12.1.0.4, )",
+        "resolved": "12.1.0.4",
+        "contentHash": "/7Qbh08HBDE4DEuK1NBgHWcZBJIYYgG7GDnxhCsZ4XJRG/APdJQyMELCt/PAuV0/o2SuwC898r1BmsFzbU5dxw==",
         "dependencies": {
           "Avalonia": "12.1.0",
-          "ProDataGrid.FormulaEngine": "12.1.0.1",
-          "ProDataGrid.FormulaEngine.Excel": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4",
+          "ProDataGrid.FormulaEngine.Excel": "12.1.0.4"
         }
       },
       "Svg.Controls.Skia.Avalonia": {
@@ -243,18 +243,19 @@
       },
       "Xaml.Behaviors.Avalonia": {
         "type": "Direct",
-        "requested": "[12.0.5, )",
-        "resolved": "12.0.5",
-        "contentHash": "YiZmPTLPQFRePGSFg8MCGb+1KMjLNAgqA6IDxreOr8x4VlBZNr8FSde1VrwEEbKRhj6ErNCZW34dHT39EskKCg==",
+        "requested": "[12.0.7, )",
+        "resolved": "12.0.7",
+        "contentHash": "vSBI0io5gFhhH6J5b0oCvQfoBYUR86S86cIticuyWvEnm9miAkRcAHZs7QS1vcWeVFVnlVqDy90zOK/l4USr6Q==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactions": "12.0.5",
-          "Xaml.Behaviors.Interactions.Custom": "12.0.5",
-          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.5",
-          "Xaml.Behaviors.Interactions.Draggable": "12.0.5",
-          "Xaml.Behaviors.Interactions.Events": "12.0.5",
-          "Xaml.Behaviors.Interactions.Responsive": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactions": "12.0.7",
+          "Xaml.Behaviors.Interactions.Custom": "12.0.7",
+          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.7",
+          "Xaml.Behaviors.Interactions.Draggable": "12.0.7",
+          "Xaml.Behaviors.Interactions.Events": "12.0.7",
+          "Xaml.Behaviors.Interactions.Responsive": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Avalonia.Angle.Windows.Natives": {
@@ -344,48 +345,48 @@
       },
       "Dock.Controls.DeferredContentControl": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "B1GViYiaPxOfY1tTmJqtefupQsixwtNrfoK7R8YErsr2kCOJ8xWT7l7XfKNnsQN5JIozHCwe3iHpZzZI57LkYQ==",
+        "resolved": "12.1.0.6",
+        "contentHash": "4wwHEYUg4TfUfJxCOjiV8BJINZfFVlSbmPmi9S+hCOR17ouqg65j1hD6oqj43R+bt4V8NVpsp64HKkadVo+lug==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.ProportionalStackPanel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "2uSxLdH0IcGjB5ix+yi0/I44mQjWSbfi5sNoyavO8KsL2/T6PBTPH/3pUH1N16V3crIig6btlwueu2Dcu5WzxA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "poJrxZZlCZ7D+nv/eVgB7MyS36VWpDWOl07wmlBGPE2FVsimE8DiUTOlh0GwtOMkB785BN7/sMdp3JyHHMVq4w==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.Recycling.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "OiAVhQsKF3Bs0X4R31uBL+PmvxnyuO7NyneuXyLEm1DygCM4YC0WkpjPZT7ODUbges4qkIm2+p54OJfoUyMWww=="
+        "resolved": "12.1.0.6",
+        "contentHash": "aUSZtGzyhR8LQFBnZkwvzy8MCt2KGcntR6ei0Gn1e4b38NRAxkbyI9GasGOPsv0H1CJJRSmDCuqjQ1bGjdYNqg=="
       },
       "Dock.MarkupExtension": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "/qThcNWEXHYd7Y4gPxSUWiQjFrDH+V2vpuEDUGOcOtiSeUeXlRScDmmHqDCQTFhqiu1JKI86820ZLXBTS0Uvow==",
+        "resolved": "12.1.0.6",
+        "contentHash": "MQ0VCKT37hrCH8Fan8/eXttKtrYA0DKN0z1Du2+529p3mbBk2iTNz9s4PHXWFBfBj3JG+yMsXcxU9mje9butAg==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "NWysuK6Rp/QkOcbEPuzNH428bGyzyukUDuucgZA9qWRrtfpyf3Jnnd+QLnhFWBViqVwU5GSXyYCOFRW5VELJSA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "eyptYTadJbhdGnT/9qkbTquFZpPBiRcr6yJvzMv5tLQB56JgbUlVAR1816ILuSeyN8wGPPW3im8g3gdGCp0lIA==",
         "dependencies": {
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Settings": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "n+eoHszNCVdjffMwInLZQVd0s08pMu24Nrt560Q/6twLId54cuyTH+vLpVyfAu8djf6LQ+ogpFTESlrwdt4ixw==",
+        "resolved": "12.1.0.6",
+        "contentHash": "n3fBTNxeCt+t0v62OdhiE9CTBeqR/5y6MBfJ/ma9rSw2PXHLf1NFzodq38mX4HKm1sF8JaX4Y8YZw8IqaxUDBw==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Model": "12.1.0.6"
         }
       },
       "ExCSS": {
@@ -570,15 +571,15 @@
       },
       "ProDataGrid.FormulaEngine": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "mOtxLps58R4GDC6D1OnD0Z7xHtljZqZlMqInszEbhJBo/fGdsDxc1kcTSrof8HnPp9fX8eBFLhtytP4MfFVF5w=="
+        "resolved": "12.1.0.4",
+        "contentHash": "EGokmPuRKbsqndoqHR5Hbc2Zok2jWYiRGxb2W2ELtFaVWyQZUhhx1ZsMVTsJG2OvJZp/eM3B0enqTXA63kQUdA=="
       },
       "ProDataGrid.FormulaEngine.Excel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "AY/XxAX8OTEiej73GWLr9GoWIMAgaHnjNj0tVbKBHFUsT3T4vnPiMmFTFp9Mc0M028LmWWBXjVoxMtDZ4WuHOg==",
+        "resolved": "12.1.0.4",
+        "contentHash": "akwuyW1lQ6s605t+EgIkDxYU4OsKR6ZypT3TM3O+JnR3hKgN9LxkrWa+6QtjC6sc6ff6NLvKMIH8KqXOpfQTLw==",
         "dependencies": {
-          "ProDataGrid.FormulaEngine": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -1494,64 +1495,73 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Xaml.Behaviors.Animations": {
+        "type": "Transitive",
+        "resolved": "12.0.7",
+        "contentHash": "4bZF2H+0Fno6iYXwIrpbQisi8JlFfBpPIezWytljHP87C0PA21bnugtmP7cfgPAI6JZn0A6Ae9+JK3POKN1+Pg==",
+        "dependencies": {
+          "Avalonia": "12.0.5"
+        }
+      },
       "Xaml.Behaviors.Interactions": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "A9iq4aRu0XCUZ5bnhPqRKF1lRfSfvmrJRf+F+P+FxuFuSenpy6Ouq4fcalBWGMYxBsRfp4/FC+zvI0UyFSEfCg==",
+        "resolved": "12.0.7",
+        "contentHash": "o1PwBW7NUWLkktvuSmM52z2OBH1w1yo2dc+NetP8PLWC0/QsTVql/dE56B8IjPJzmpGb3Y9XSitTKh7R+EL2cA==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Custom": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "rLYqZglj0NeHbHBOFpHomPvYeeL9bdwdh8n9hNG8xjm6yUqL+P8lcEwTnrhT++ReRjdPJgvfTJAwi4lIoMmQmQ==",
+        "resolved": "12.0.7",
+        "contentHash": "RCmhJa8ps+ML1e5rXr91k6ETS4xAjmkHOM5XN2q6rI/Tbx74SEiAKzC4rzKZ+SX1/BLOlE47nMpMNuxrkkzk+A==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.DragAndDrop": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "u5SJG0ZCtSFlcX/74jawbUcTOeKyv6QwSb0xj3pKjG4qfpfvmI3kwvQXv3ImwhrLR+0xhUn7lvyY+/SfdtMG/Q==",
+        "resolved": "12.0.7",
+        "contentHash": "l0PsZ3U2Nwsap9srbuPTdkHk10ipjeNBI9eZELW6jNgO8+thV7BsW6mk/Z5D5Hh3Fq6YDrj3KKyJ6CD3ECtHDg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Draggable": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "+TOUCKFCaPdfNBlNQRDSvfx00Q+KLKMlTLpeBMRWHx7K3yXqRXGz7PD1WpDmRQfLrFWn6muJpSzt4BIcBYACRA==",
+        "resolved": "12.0.7",
+        "contentHash": "cm9h+vFKCTgpxCsi7Bp4KHEXVbQ4QH8WrrqE/81kN5U7roWVW+JVnGZ+k67HP2LOhyt+eIEQokLVMcipv9cFpw==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Events": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "gLPWRmjH9swFQMrEN1og8gyhj8RWeCdM8q9OZ7pCUhk7SjRp3/7WURdyyrH9eTLtheXB9sT69FGrXD2gnHOOxg==",
+        "resolved": "12.0.7",
+        "contentHash": "0JwzoIOX21dj9geo+st+RSxl/7bU4Wb35P1YjKD4IeUw6mIf8EMQkB7PKGPy+hibeOnmSDTbLoNoCY0EdvTNgg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Responsive": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "PKvMu5UuHMmLkQYES96qeYbFVIYiEFyftAXzuEiM2fHTe7ur5HfrzFkyAfH0O5oQObmsog4A/GAU59SXmnT/5Q==",
+        "resolved": "12.0.7",
+        "contentHash": "9h9hncn2OcxYMbDUQSNzJs7SY6YVb6dDp2W3W64ns9Xqza3FpCZITGFeJKBZQEhqeS/vvUKbtpRIC6MrQSh3Yg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactivity": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "aoXlptjbRIDorjv4yzdClkBUZX1awi9/3iaORMsDkBceDzY03N5ZMMNRAKfp+MWz/z3YsKzy0GxZMkCUAlYxqQ==",
+        "resolved": "12.0.7",
+        "contentHash": "PzWwozUtizvnNYuCJhlbl+EwuRpva0+qYWYlGkyNKMjyrTxujBWBBr1g6o1PtauVTLPCkX5+lGNK6JHImYDJAQ==",
         "dependencies": {
           "Avalonia": "12.0.5"
         }

--- a/TestPlugin/packages.lock.json
+++ b/TestPlugin/packages.lock.json
@@ -121,48 +121,48 @@
       },
       "Dock.Controls.DeferredContentControl": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "B1GViYiaPxOfY1tTmJqtefupQsixwtNrfoK7R8YErsr2kCOJ8xWT7l7XfKNnsQN5JIozHCwe3iHpZzZI57LkYQ==",
+        "resolved": "12.1.0.6",
+        "contentHash": "4wwHEYUg4TfUfJxCOjiV8BJINZfFVlSbmPmi9S+hCOR17ouqg65j1hD6oqj43R+bt4V8NVpsp64HKkadVo+lug==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.ProportionalStackPanel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "2uSxLdH0IcGjB5ix+yi0/I44mQjWSbfi5sNoyavO8KsL2/T6PBTPH/3pUH1N16V3crIig6btlwueu2Dcu5WzxA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "poJrxZZlCZ7D+nv/eVgB7MyS36VWpDWOl07wmlBGPE2FVsimE8DiUTOlh0GwtOMkB785BN7/sMdp3JyHHMVq4w==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Controls.Recycling.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "OiAVhQsKF3Bs0X4R31uBL+PmvxnyuO7NyneuXyLEm1DygCM4YC0WkpjPZT7ODUbges4qkIm2+p54OJfoUyMWww=="
+        "resolved": "12.1.0.6",
+        "contentHash": "aUSZtGzyhR8LQFBnZkwvzy8MCt2KGcntR6ei0Gn1e4b38NRAxkbyI9GasGOPsv0H1CJJRSmDCuqjQ1bGjdYNqg=="
       },
       "Dock.MarkupExtension": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "/qThcNWEXHYd7Y4gPxSUWiQjFrDH+V2vpuEDUGOcOtiSeUeXlRScDmmHqDCQTFhqiu1JKI86820ZLXBTS0Uvow==",
+        "resolved": "12.1.0.6",
+        "contentHash": "MQ0VCKT37hrCH8Fan8/eXttKtrYA0DKN0z1Du2+529p3mbBk2iTNz9s4PHXWFBfBj3JG+yMsXcxU9mje9butAg==",
         "dependencies": {
-          "Avalonia": "12.1.0"
+          "Avalonia": "12.1.1"
         }
       },
       "Dock.Model": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "NWysuK6Rp/QkOcbEPuzNH428bGyzyukUDuucgZA9qWRrtfpyf3Jnnd+QLnhFWBViqVwU5GSXyYCOFRW5VELJSA==",
+        "resolved": "12.1.0.6",
+        "contentHash": "eyptYTadJbhdGnT/9qkbTquFZpPBiRcr6yJvzMv5tLQB56JgbUlVAR1816ILuSeyN8wGPPW3im8g3gdGCp0lIA==",
         "dependencies": {
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Settings": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "n+eoHszNCVdjffMwInLZQVd0s08pMu24Nrt560Q/6twLId54cuyTH+vLpVyfAu8djf6LQ+ogpFTESlrwdt4ixw==",
+        "resolved": "12.1.0.6",
+        "contentHash": "n3fBTNxeCt+t0v62OdhiE9CTBeqR/5y6MBfJ/ma9rSw2PXHLf1NFzodq38mX4HKm1sF8JaX4Y8YZw8IqaxUDBw==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Model": "12.1.0.6"
         }
       },
       "ExCSS": {
@@ -347,15 +347,15 @@
       },
       "ProDataGrid.FormulaEngine": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "mOtxLps58R4GDC6D1OnD0Z7xHtljZqZlMqInszEbhJBo/fGdsDxc1kcTSrof8HnPp9fX8eBFLhtytP4MfFVF5w=="
+        "resolved": "12.1.0.4",
+        "contentHash": "EGokmPuRKbsqndoqHR5Hbc2Zok2jWYiRGxb2W2ELtFaVWyQZUhhx1ZsMVTsJG2OvJZp/eM3B0enqTXA63kQUdA=="
       },
       "ProDataGrid.FormulaEngine.Excel": {
         "type": "Transitive",
-        "resolved": "12.1.0.1",
-        "contentHash": "AY/XxAX8OTEiej73GWLr9GoWIMAgaHnjNj0tVbKBHFUsT3T4vnPiMmFTFp9Mc0M028LmWWBXjVoxMtDZ4WuHOg==",
+        "resolved": "12.1.0.4",
+        "contentHash": "akwuyW1lQ6s605t+EgIkDxYU4OsKR6ZypT3TM3O+JnR3hKgN9LxkrWa+6QtjC6sc6ff6NLvKMIH8KqXOpfQTLw==",
         "dependencies": {
-          "ProDataGrid.FormulaEngine": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -1271,64 +1271,73 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Xaml.Behaviors.Animations": {
+        "type": "Transitive",
+        "resolved": "12.0.7",
+        "contentHash": "4bZF2H+0Fno6iYXwIrpbQisi8JlFfBpPIezWytljHP87C0PA21bnugtmP7cfgPAI6JZn0A6Ae9+JK3POKN1+Pg==",
+        "dependencies": {
+          "Avalonia": "12.0.5"
+        }
+      },
       "Xaml.Behaviors.Interactions": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "A9iq4aRu0XCUZ5bnhPqRKF1lRfSfvmrJRf+F+P+FxuFuSenpy6Ouq4fcalBWGMYxBsRfp4/FC+zvI0UyFSEfCg==",
+        "resolved": "12.0.7",
+        "contentHash": "o1PwBW7NUWLkktvuSmM52z2OBH1w1yo2dc+NetP8PLWC0/QsTVql/dE56B8IjPJzmpGb3Y9XSitTKh7R+EL2cA==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Custom": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "rLYqZglj0NeHbHBOFpHomPvYeeL9bdwdh8n9hNG8xjm6yUqL+P8lcEwTnrhT++ReRjdPJgvfTJAwi4lIoMmQmQ==",
+        "resolved": "12.0.7",
+        "contentHash": "RCmhJa8ps+ML1e5rXr91k6ETS4xAjmkHOM5XN2q6rI/Tbx74SEiAKzC4rzKZ+SX1/BLOlE47nMpMNuxrkkzk+A==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.DragAndDrop": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "u5SJG0ZCtSFlcX/74jawbUcTOeKyv6QwSb0xj3pKjG4qfpfvmI3kwvQXv3ImwhrLR+0xhUn7lvyY+/SfdtMG/Q==",
+        "resolved": "12.0.7",
+        "contentHash": "l0PsZ3U2Nwsap9srbuPTdkHk10ipjeNBI9eZELW6jNgO8+thV7BsW6mk/Z5D5Hh3Fq6YDrj3KKyJ6CD3ECtHDg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Draggable": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "+TOUCKFCaPdfNBlNQRDSvfx00Q+KLKMlTLpeBMRWHx7K3yXqRXGz7PD1WpDmRQfLrFWn6muJpSzt4BIcBYACRA==",
+        "resolved": "12.0.7",
+        "contentHash": "cm9h+vFKCTgpxCsi7Bp4KHEXVbQ4QH8WrrqE/81kN5U7roWVW+JVnGZ+k67HP2LOhyt+eIEQokLVMcipv9cFpw==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Events": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "gLPWRmjH9swFQMrEN1og8gyhj8RWeCdM8q9OZ7pCUhk7SjRp3/7WURdyyrH9eTLtheXB9sT69FGrXD2gnHOOxg==",
+        "resolved": "12.0.7",
+        "contentHash": "0JwzoIOX21dj9geo+st+RSxl/7bU4Wb35P1YjKD4IeUw6mIf8EMQkB7PKGPy+hibeOnmSDTbLoNoCY0EdvTNgg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactions.Responsive": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "PKvMu5UuHMmLkQYES96qeYbFVIYiEFyftAXzuEiM2fHTe7ur5HfrzFkyAfH0O5oQObmsog4A/GAU59SXmnT/5Q==",
+        "resolved": "12.0.7",
+        "contentHash": "9h9hncn2OcxYMbDUQSNzJs7SY6YVb6dDp2W3W64ns9Xqza3FpCZITGFeJKBZQEhqeS/vvUKbtpRIC6MrQSh3Yg==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       },
       "Xaml.Behaviors.Interactivity": {
         "type": "Transitive",
-        "resolved": "12.0.5",
-        "contentHash": "aoXlptjbRIDorjv4yzdClkBUZX1awi9/3iaORMsDkBceDzY03N5ZMMNRAKfp+MWz/z3YsKzy0GxZMkCUAlYxqQ==",
+        "resolved": "12.0.7",
+        "contentHash": "PzWwozUtizvnNYuCJhlbl+EwuRpva0+qYWYlGkyNKMjyrTxujBWBBr1g6o1PtauVTLPCkX5+lGNK6JHImYDJAQ==",
         "dependencies": {
           "Avalonia": "12.0.5"
         }
@@ -1367,11 +1376,11 @@
           "AvaloniaEdit.TextMate": "[12.0.0, )",
           "AvaloniaUI.DiagnosticsSupport": "[2.2.3, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Dock.Avalonia": "[12.1.0.1, )",
-          "Dock.Avalonia.Themes.Simple": "[12.1.0.1, )",
-          "Dock.Controls.Recycling": "[12.1.0.1, )",
-          "Dock.Model.Mvvm": "[12.1.0.1, )",
-          "Dock.Serializer.SystemTextJson": "[12.1.0.1, )",
+          "Dock.Avalonia": "[12.1.0.6, )",
+          "Dock.Avalonia.Themes.Simple": "[12.1.0.6, )",
+          "Dock.Controls.Recycling": "[12.1.0.6, )",
+          "Dock.Model.Mvvm": "[12.1.0.6, )",
+          "Dock.Serializer.SystemTextJson": "[12.1.0.6, )",
           "ICSharpCode.BamlDecompiler": "[10.0.0-noversion, )",
           "ICSharpCode.Decompiler": "[8.0.0-noversion, )",
           "ICSharpCode.ILSpyX": "[8.0.0-noversion, )",
@@ -1382,13 +1391,13 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.11, )",
           "NuGet.Frameworks": "[7.9.0, )",
           "NuGet.Protocol": "[7.9.0, )",
-          "ProDataGrid": "[12.1.0.1, )",
+          "ProDataGrid": "[12.1.0.4, )",
           "Svg.Controls.Skia.Avalonia": "[12.0.0.13, )",
           "System.Composition.AttributedModel": "[10.0.11, )",
           "System.Composition.Hosting": "[10.0.11, )",
           "System.Composition.TypedParts": "[10.0.11, )",
           "System.Formats.Nrbf": "[10.0.11, )",
-          "Xaml.Behaviors.Avalonia": "[12.0.5, )"
+          "Xaml.Behaviors.Avalonia": "[12.0.7, )"
         }
       },
       "Avalonia.Desktop": {
@@ -1438,56 +1447,56 @@
       },
       "Dock.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "l+bJtDfyG6HrHJA6+pzY1NWynwu2udD2XiJ6vXoBkCGAvWe5yAPPZ8rSODxqbwgkqGoS3UDRbgRbWV4Z++75jQ==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "Y5kTyQtxKHXoUEQfSn9nxsUk+9shIavU/C6ub3Dxs/Sxz4VSlGuTdfRI4mGLO4MJwWetb96xKxhrtCzufg2NrQ==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.DeferredContentControl": "12.1.0.1",
-          "Dock.Controls.ProportionalStackPanel": "12.1.0.1",
-          "Dock.Controls.Recycling": "12.1.0.1",
-          "Dock.MarkupExtension": "12.1.0.1",
-          "Dock.Model": "12.1.0.1",
-          "Dock.Settings": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.DeferredContentControl": "12.1.0.6",
+          "Dock.Controls.ProportionalStackPanel": "12.1.0.6",
+          "Dock.Controls.Recycling": "12.1.0.6",
+          "Dock.MarkupExtension": "12.1.0.6",
+          "Dock.Model": "12.1.0.6",
+          "Dock.Settings": "12.1.0.6"
         }
       },
       "Dock.Avalonia.Themes.Simple": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "8RaFfoXWlV13YTPzrcS2JHy2CqaCQGMvfsmUUMnTjBslWv9sp0obthKCTeWZp+jb2lOIFdhQS69jW9JhlwtILA==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "m4/P8+wMAmeHqmEsthYPl/n22vAdBpOAoMugyEcyHeAfGIlbX7e16plwDJ70FobP8V7wQzDhmlpTZUed+Y+nBA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Avalonia": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Avalonia": "12.1.0.6"
         }
       },
       "Dock.Controls.Recycling": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "qHZgt6VaX4UcE7rjpV/szeH93NqDMOG4umuzb0gX7JauO54QkTMgiA42nuu5iaS3gqr7QvK4tWkyB0lObD91Tg==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "I6xRruBunK7UOZuCfk8hPh5F0dGhAOTtFk8UDCtYX3223ETdiDqcJk9cvrMdWmPQl3FfdqeZjgkywPeSWFh9UA==",
         "dependencies": {
-          "Avalonia": "12.1.0",
-          "Dock.Controls.Recycling.Model": "12.1.0.1"
+          "Avalonia": "12.1.1",
+          "Dock.Controls.Recycling.Model": "12.1.0.6"
         }
       },
       "Dock.Model.Mvvm": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "A4u4LkPLqD5NsHozMy3wnJDu4RD0g6HKLhYzpZ3gEAxKPSimzf+s/JZ4XF9kqIWhz+g9WWLAq62d1AAEWQuLdw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "JEKzUjFeqXjFfKXTWBqb2DTtHmigcogVXYaKihUGc316NhJa8Qth+GLL+Pgl0AqqQr+zbVx8vmZearStH3vCfQ==",
         "dependencies": {
           "CommunityToolkit.Mvvm": "8.4.0",
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "Dock.Serializer.SystemTextJson": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "I2eh9RQfXL272wbB3HSWLUTCVx9YJwPBH0Yeo5wj+8fwXOEWz2jUihuDGUkLQexFddEyn6RjMzuFdU32OmdcSw==",
+        "requested": "[12.1.0.6, )",
+        "resolved": "12.1.0.6",
+        "contentHash": "4ld6TwWPK0+OZeHo8VylUyx76D2trMxi1hFHfZnH1eHhWZPCHRxuv6C/OvtFZ3lUY+UlcTAUZdoVgzVGmMR4hg==",
         "dependencies": {
-          "Dock.Model": "12.1.0.1"
+          "Dock.Model": "12.1.0.6"
         }
       },
       "K4os.Compression.LZ4": {
@@ -1559,13 +1568,13 @@
       },
       "ProDataGrid": {
         "type": "CentralTransitive",
-        "requested": "[12.1.0.1, )",
-        "resolved": "12.1.0.1",
-        "contentHash": "Nf6qqKi8TLUtICafUGbTeuaAvNiKya8g7EkVkRT01kUKOS5ev0btm9XaA1qN9RJYwyBl6cEu+unfZg+621bRew==",
+        "requested": "[12.1.0.4, )",
+        "resolved": "12.1.0.4",
+        "contentHash": "/7Qbh08HBDE4DEuK1NBgHWcZBJIYYgG7GDnxhCsZ4XJRG/APdJQyMELCt/PAuV0/o2SuwC898r1BmsFzbU5dxw==",
         "dependencies": {
           "Avalonia": "12.1.0",
-          "ProDataGrid.FormulaEngine": "12.1.0.1",
-          "ProDataGrid.FormulaEngine.Excel": "12.1.0.1"
+          "ProDataGrid.FormulaEngine": "12.1.0.4",
+          "ProDataGrid.FormulaEngine.Excel": "12.1.0.4"
         }
       },
       "Svg.Controls.Skia.Avalonia": {
@@ -1685,18 +1694,19 @@
       },
       "Xaml.Behaviors.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.5, )",
-        "resolved": "12.0.5",
-        "contentHash": "YiZmPTLPQFRePGSFg8MCGb+1KMjLNAgqA6IDxreOr8x4VlBZNr8FSde1VrwEEbKRhj6ErNCZW34dHT39EskKCg==",
+        "requested": "[12.0.7, )",
+        "resolved": "12.0.7",
+        "contentHash": "vSBI0io5gFhhH6J5b0oCvQfoBYUR86S86cIticuyWvEnm9miAkRcAHZs7QS1vcWeVFVnlVqDy90zOK/l4USr6Q==",
         "dependencies": {
           "Avalonia": "12.0.5",
-          "Xaml.Behaviors.Interactions": "12.0.5",
-          "Xaml.Behaviors.Interactions.Custom": "12.0.5",
-          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.5",
-          "Xaml.Behaviors.Interactions.Draggable": "12.0.5",
-          "Xaml.Behaviors.Interactions.Events": "12.0.5",
-          "Xaml.Behaviors.Interactions.Responsive": "12.0.5",
-          "Xaml.Behaviors.Interactivity": "12.0.5"
+          "Xaml.Behaviors.Animations": "12.0.7",
+          "Xaml.Behaviors.Interactions": "12.0.7",
+          "Xaml.Behaviors.Interactions.Custom": "12.0.7",
+          "Xaml.Behaviors.Interactions.DragAndDrop": "12.0.7",
+          "Xaml.Behaviors.Interactions.Draggable": "12.0.7",
+          "Xaml.Behaviors.Interactions.Events": "12.0.7",
+          "Xaml.Behaviors.Interactions.Responsive": "12.0.7",
+          "Xaml.Behaviors.Interactivity": "12.0.7"
         }
       }
     }


### PR DESCRIPTION
## Package updates

| Package | From | To |
|---|---|---|
| Dock.* (`DockVersion`) | 12.1.0.1 | 12.1.0.6 |
| ProDataGrid | 12.1.0.1 | 12.1.0.4 |
| Xaml.Behaviors.Avalonia | 12.0.5 | 12.0.7 |
| AwesomeAssertions | 9.5.0 | 9.6.0 |
| CliWrap | 3.10.4 | 3.10.5 |
| NUnit3TestAdapter | 6.2.0 | 6.3.0 |

Also bumps `DecompilerVersionInfo` minor to 11.1. Lock files regenerated via `updatedeps.ps1`.

## Build break: `Dock.Serializer.SystemTextJson` 12.1.0.6

The Dock bump broke `ILSpy/Docking/ILSpyDockJson.cs`:

```
error CS0246: The type or namespace name 'JsonConverterFactoryList' could not be found
```

### What changed upstream

Decompiling 12.1.0.1 vs 12.1.0.6 of `Dock.Serializer.SystemTextJson.dll` with this repo's `ilspycmd`:

- **Removed (public):** `JsonConverterFactoryList`, `JsonConverterList<T>` -- the `JsonConverterFactory` ILSpy registered in `Options.Converters` to deserialize `IList<T>` model properties (`VisibleDockables`, `Windows`, ...) into `ObservableCollection<T>`.
- **Added (internal):** `DockListTypeInfoModifier.Apply(JsonTypeInfo, Type listType)`. Dock's own `DockSerializerOptionsFactory` now does `typeInfoResolver.WithAddedModifier(ti => DockListTypeInfoModifier.Apply(ti, listType))`. For any `JsonTypeInfoKind.Enumerable` whose type is `IList<T>`, it sets `typeInfo.CreateObject = () => new ObservableCollection<T>()` (with AOT-safe fast paths for `IList<IDockable>`/`IList<IDockWindow>`).

So the `IList<T> -> ObservableCollection<T>` substitution moved from a converter to a type-info modifier, and the public surface went away. Since the replacement is `internal`, ILSpy cannot reference it.

### What this PR does

`ILSpyDockJson` already builds its `JsonSerializerOptions` from a `DefaultJsonTypeInfoResolver` with a chain of modifiers (`AddPolymorphism`, `RemoveIgnoredMembers`, `KeepWritablePropertiesOnly`, `StripCycleProneProperties`). This PR:

- drops the `Converters = { new JsonConverterFactoryList(typeof(ObservableCollection<>)) }` registration and the `using Dock.Serializer.SystemTextJson;`,
- adds a fifth modifier `UseObservableCollectionsForLists` that does exactly what Dock's internal modifier does: for `IList<T>` enumerable type infos, set `CreateObject` to construct an `ObservableCollection<T>`.

### Why this is at least as good as before

The old `JsonConverterList<T>.Write` issued per-element `JsonSerializer.Serialize` calls, which bypassed STJ's built-in enumerable path (and was one of the two documented reasons `ReferenceHandler.Preserve` could not be used -- it reset the `$id` counter per element). The modifier approach only swaps the collection factory; serialization and polymorphic element handling stay on STJ's normal path. The comment in `BuildOptions()` was updated to drop the now-obsolete converter caveat.

### Verification

- `dotnet build ILSpy.sln` succeeds.
- `ILSpy.Tests`: 1236 passed, 0 failed, 4 skipped (includes `SessionSettingsTests`, which round-trips the dock layout through `ILSpyDockJson`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
