### PR TITLE
Drop isReferenceType when erasing unknown types

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3729.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/ILPretty/Issue3729.cs
@@ -46,7 +46,7 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.ILPretty
 		public void TestArrayElemCtor()
 		{
 			//IL_000f: Unknown result type (might be due to invalid IL or missing references)
-			MyStruct[] array = (MyStruct[])(object)new MyStruct[1] {
+			MyStruct[] array = new MyStruct[1] {
 				new MyStruct(7)
 			};
 		}

--- a/ICSharpCode.Decompiler/TypeSystem/Implementation/UnknownType.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/Implementation/UnknownType.cs
@@ -117,6 +117,22 @@ namespace ICSharpCode.Decompiler.TypeSystem.Implementation
 				return new NullabilityAnnotatedType(this, nullability);
 		}
 
+		/// <summary>
+		/// Returns this type without the knowledge whether it is a reference type.
+		/// </summary>
+		/// <remarks>
+		/// Whether an unresolvable type is a reference type is not a property of the type, but of
+		/// the metadata that mentioned it: a signature spelling it `valuetype T` yields false, a
+		/// bare TypeRef yields null. Two such spellings of the same missing type must still compare
+		/// equal after type erasure, so NormalizeTypeVisitor drops the flag before comparing.
+		/// </remarks>
+		internal UnknownType WithoutReferenceTypeKnowledge()
+		{
+			if (isReferenceType == null)
+				return this;
+			return new UnknownType(fullTypeName);
+		}
+
 		public override int GetHashCode()
 		{
 			return (namespaceKnown ? 812571 : 12651) ^ fullTypeName.GetHashCode();

--- a/ICSharpCode.Decompiler/TypeSystem/NormalizeTypeVisitor.cs
+++ b/ICSharpCode.Decompiler/TypeSystem/NormalizeTypeVisitor.cs
@@ -97,6 +97,13 @@ namespace ICSharpCode.Decompiler.TypeSystem
 			}
 		}
 
+		public override IType VisitOtherType(IType type)
+		{
+			if (type is UnknownType unknownType)
+				return unknownType.WithoutReferenceTypeKnowledge();
+			return base.VisitOtherType(type);
+		}
+
 		public override IType VisitTypeDefinition(ITypeDefinition type)
 		{
 			switch (type.KnownTypeCode)


### PR DESCRIPTION
### Problem

Whether an unresolvable type is a reference type is not a property of the type, but of the metadata that mentioned it: a signature spelling `valuetype T` yields `isReferenceType == false`, a bare `TypeRef` (MemberRef parent, `constrained.` prefix) yields `null`.

`UnknownType.Equals` compares that flag, so the two spellings of one and the same missing type compare unequal. `NormalizeTypeVisitor.TypeErasure.EquivalentTypes` then reports false and the decompiler emits a cast between a type and itself, e.g. in `ILPretty/Issue3729`:

```csharp
MyStruct[] array = (MyStruct[])(object)new MyStruct[1] { new MyStruct(7) };
```

### Fix

`NormalizeTypeVisitor` erases the flag before comparing. That keeps the relaxation inside the comparisons that ask for erasure, next to the nullability, modopt and tuple erasure it already performs — all use-site spellings of the same kind.

### Why not drop the term from `UnknownType.Equals`

That was the other candidate; it was built and measured, and it is worse. `Equals` is global, and among other things it keys `CSharpConversions.implicitConversionCache` (`ConcurrentDictionary<(IType, IType), Conversion>`). `UnknownType.GetHashCode` already ignores `isReferenceType`, so both spellings already share a hash bucket and only `Equals` keeps them apart; merging them lets whichever conversion is computed first answer for both.

Measured over 15 nuget assemblies decompiled with their dependencies absent:

| variant | `(object)` casts |
| --- | --- |
| master | 21934 |
| `Equals` change | 21824 (−163 in Azure.AI.OpenAI, **+398** in Themes.Fluent/Simple) |
| this PR | 21798, never worse on any assembly |

Under the `Equals` variant two sibling types in one method are treated differently — `PushParent(val5)` next to `PushParent((object)val21)`, both unresolved reference types.

### Test

`ILPretty/Issue3729`'s expectation carried the cast above and is updated to the correct output; it is the regression guard for this change.

`ICSharpCode.Decompiler.Tests`: 3539 total, 3494 passed, 45 skipped, 0 failed.

* [x] At least one test covering the code changed

<sub>Written by Claude Code (`claude-opus-5`) on behalf of @siegfriedpammer; measurements and test runs reproduced locally.</sub>