### PR TITLE
Wait for the click target instead of counting frames

### DIFF
--- a/ILSpy.Tests/ContextMenus/DecompileInNewViewTests.cs
+++ b/ILSpy.Tests/ContextMenus/DecompileInNewViewTests.cs
@@ -257,6 +257,15 @@ public class DecompileInNewViewTests
 			var row = Row(node);
 			var clickX = System.Math.Min(row.Bounds.Width, grid.Bounds.Width) / 2;
 			var pt = row.TranslatePoint(new Point(clickX, row.Bounds.Height / 2), window);
+			// A popup's light-dismiss overlay keeps answering hit tests for as long as the frame
+			// that still shows it, and it swallows a press without raising ContextRequested - so
+			// nothing becomes the context target. Hit testing the point is the same question the
+			// context-request handler asks, so waiting for it to reach the row is exactly the
+			// precondition for this click, however many frames the overlay takes to disappear.
+			await Waiters.WaitForAsync(
+				() => window.InputHitTest(pt!.Value) is Visual hit
+					&& ReferenceEquals(hit.FindAncestorOfType<ICSharpCode.ILSpy.Controls.TreeView.SharpTreeViewItem>(includeSelf: true), row),
+				description: "the row to answer hit tests at the point about to be right-clicked");
 			HeadlessWindowExtensions.MouseDown(window, pt!.Value, MouseButton.Right);
 			HeadlessWindowExtensions.MouseUp(window, pt.Value, MouseButton.Right);
 			// The highlight is scoped to the popup - set while the menu is being requested, dropped
@@ -269,13 +278,6 @@ public class DecompileInNewViewTests
 		{
 			window.KeyPress(Key.Escape, RawInputModifiers.None, PhysicalKey.Escape, keySymbol: null);
 			await Waiters.WaitForAsync(() => !menu.IsOpen, description: "the context menu to close");
-			// IsOpen flips the moment the popup is torn down, but the frame that still shows its
-			// light-dismiss overlay is what answers hit tests until the scene is rendered again.
-			// Right-clicking into that frame delivers press and release to the vanishing overlay
-			// instead of the row: no ContextRequested is raised at all, so nothing becomes the
-			// context target and the next assertion sees a row with no classes on it.
-			for (int i = 0; i < 4; i++)
-				Waiters.PumpUI();
 		}
 
 		await RightClick(nodeB);


### PR DESCRIPTION
### Problem

`Right_Clicking_A_Second_Row_Moves_The_Context_Highlight_To_It` timed out on the Windows CI agent (60s, waiting for the second context menu to open) in an unrelated PR's run. Linux and macOS passed; master is green at the same commit.

A closed popup's light-dismiss overlay keeps answering hit tests until the scene is rendered again. A press that lands on it raises no `ContextRequested` at all, so nothing becomes the context target and the menu never opens. The test knew about this and pumped a fixed four frames after dismissing the first menu — a guess at how long the overlay survives, which holds on a fast machine and not on a loaded agent.

### Solution

* Wait for the condition instead of counting frames: hit testing the click point is the same question `OnContextRequested` asks to pick the target row (`AssemblyListPane.axaml.cs`), so waiting for it to reach the row is the actual precondition for the click, however many frames the overlay takes to disappear. The same idiom is already used in `HeadlessMmbPointerTests`.
* `Dismiss()` loses its fixed pump loop.
* **Most in need of attention:** the failure could not be reproduced locally — removing the four frames entirely still passes here — so this fixes the mechanism the test documents and the stack trace points at, rather than a reproduction. If the real cause is different, a timeout now names which of the two conditions was not met instead of only "menu didn't open".

Verified: full `ILSpy.Tests` 1243 total, 0 failed, 3 skipped; the target test 3/3 green in isolation.

* [x] At least one test covering the code changed

<sub>Written by Claude Code (`claude-opus-5`) on behalf of @siegfriedpammer; test runs reproduced locally.</sub>