### PR TITLE
Infer the C# type of ldlen

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DynamicTests.cs
@@ -23,13 +23,6 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			}
 		}
 
-		private class CtorTarget
-		{
-			public CtorTarget(dynamic d, int i)
-			{
-			}
-		}
-
 		private struct MyValueType
 		{
 			private readonly dynamic _getOnlyProperty;
@@ -384,57 +377,12 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 		{
 		}
 
-		private static dynamic M5(dynamic d, int i)
-		{
-			return null;
-		}
-
-		private static void M6<T>(dynamic d, int i)
-		{
-		}
-
 #if CS60
-		// #3704: the call target of a dynamic member access on a static type is typeof(DynamicTests).
-		// The array is loaded into a temporary that survives as its own statement, which strands the
-		// typeof between the two, so it cannot reach the call site by ordinary inlining.
-		private static void StaticTargetBehindSurvivingTemporary(dynamic d)
+		// #3704: the call target of a dynamic member access on a static type is
+		// typeof(DynamicTests), which has to reach the call site.
+		private static void StaticTargetOnDynamicCall(dynamic d)
 		{
-#if EXPECTED_OUTPUT
-			byte[] data = GetData();
-			DynamicTests.M4(d, (data != null) ? data.Length : 0);
-#else
 			DynamicTests.M4(d, GetData()?.Length ?? 0);
-#endif
-		}
-
-		private static dynamic StaticTargetResultUsed(dynamic d)
-		{
-#if EXPECTED_OUTPUT
-			byte[] data = GetData();
-			return DynamicTests.M5(d, (data != null) ? data.Length : 0);
-#else
-			return DynamicTests.M5(d, GetData()?.Length ?? 0);
-#endif
-		}
-
-		private static void StaticTargetWithTypeArguments(dynamic d)
-		{
-#if EXPECTED_OUTPUT
-			byte[] data = GetData();
-			DynamicTests.M6<int>(d, (data != null) ? data.Length : 0);
-#else
-			DynamicTests.M6<int>(d, GetData()?.Length ?? 0);
-#endif
-		}
-
-		private static void StaticCtorBehindSurvivingTemporary(dynamic d)
-		{
-#if EXPECTED_OUTPUT
-			byte[] data = GetData();
-			new CtorTarget(d, (data != null) ? data.Length : 0);
-#else
-			new CtorTarget(d, GetData()?.Length ?? 0);
-#endif
 		}
 #endif
 

--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullPropagation.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/NullPropagation.cs
@@ -320,6 +320,17 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(setsOfNumbers?[1]?[1].ToString() == null);
 		}
 
+		private static byte[] GetBytes()
+		{
+			return null;
+		}
+
+		private static void ArrayLengthWithFallback()
+		{
+			Console.WriteLine(GetBytes()?.Length ?? 0);
+			Console.WriteLine(GetBytes()?.LongLength ?? 0);
+		}
+
 		private static dynamic DynamicNullProp(dynamic a)
 		{
 			return a?.b.c(1)?.d[10];

--- a/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
+++ b/ICSharpCode.Decompiler/CSharp/ExpressionBuilder.cs
@@ -4584,10 +4584,10 @@ namespace ICSharpCode.Decompiler.CSharp
 		protected internal override TranslatedExpression VisitDynamicInvokeMemberInstruction(DynamicInvokeMemberInstruction inst, TranslationContext context)
 		{
 			Expression targetExpr;
-			var target = inst.StaticTargetType is IType staticTargetType
-				? new TypeReferenceExpression(ConvertType(staticTargetType))
+			var target = inst.StaticTargetType != null
+				? new TypeReferenceExpression(ConvertType(inst.StaticTargetType))
 					.WithoutILInstruction()
-					.WithRR(new TypeResolveResult(staticTargetType))
+					.WithRR(new TypeResolveResult(inst.StaticTargetType))
 				: TranslateDynamicTarget(inst.Arguments[0], inst.ArgumentInfo[0]);
 			if (inst.BinderFlags.HasFlag(CSharpBinderFlags.InvokeSimpleName) && target.Expression is ThisReferenceExpression)
 			{

--- a/ICSharpCode.Decompiler/IL/ILTypeExtensions.cs
+++ b/ICSharpCode.Decompiler/IL/ILTypeExtensions.cs
@@ -287,6 +287,12 @@ namespace ICSharpCode.Decompiler.IL
 						default:
 							return SpecialType.UnknownType;
 					}
+				case LdLen ldLen:
+					if (compilation == null)
+						return SpecialType.UnknownType;
+					// Mirrors ExpressionBuilder.VisitLdLen, which picks Array.Length or
+					// Array.LongLength based on the result type alone.
+					return compilation.FindType(ldLen.ResultType == StackType.I4 ? KnownTypeCode.Int32 : KnownTypeCode.Int64);
 				case DefaultValue defaultValue:
 					return defaultValue.Type;
 				case ILFunction func when func.DelegateType != null:


### PR DESCRIPTION
`NullPropagationTransform` only rewrites `x != null ? x.Chain : fallback` into `x?.Chain ?? fallback` when the chain's inferred type is a non-nullable value type. `InferType` had no case for `ldlen`, so array length came back as `SpecialType.UnknownType`, `NullableType.IsNonNullableValueType` returned false, and the rewrite was skipped:

```csharp
// GetData()?.Length ?? 0
byte[] data = GetData();
Use((data != null) ? data.Length : 0);
```

The access chain itself was fine - the same chain without the `??` fallback takes the `MatchDefaultValue(Nullable<int>)` branch, never consults `InferType`, and produced `GetData()?.Length` correctly. Only the coalescing branch was blocked.

The inferred type mirrors `ExpressionBuilder.VisitLdLen`, which picks `Array.Length` or `Array.LongLength` from `ResultType` alone - note the split is `== StackType.I4`, not `!= StackType.I8`, because `ILReader` emits `LdLen(StackType.I, ...)` and only `ExpressionTransforms.VisitConv` folds it down to `ldlen.i4`.

Two other `InferType` consumers see a real type where they previously saw `Unknown`, both toward more accuracy: `AllStoresUseConsistentType` in `ExpressionBuilder`, and `CheckImplicitTruncation` in `TransformAssignment`, which otherwise falls through to "assume that the value might be changed by truncation".

Found while investigating #3704, where the surviving ternary also keeps the tested array in a stack slot and strands the `typeof` of a dynamic call's static target. That issue is fixed separately in #4072; this change is independent of it.

## Why the `DynamicTests` cases shrink to one

#4072 added four members whose premise was that temporary: the array survived as its own statement, so the `typeof` could not reach the call site by ordinary inlining. Inferring the type of `ldlen` removes the temporary, so the target now reaches the call site by inlining and #4072's `StaticTargetType` path is no longer taken there. Measured by reverting #4072's source changes and running `DynamicTests`:

| fixture | result with #4072 reverted |
|---|---|
| the four members as this PR would leave them | 24 / 24 pass |
| the four members as they are on master | 18 / 24 fail |
| `DynamicAwait` (untouched by this PR) | 10 / 10 fail |

They no longer detect the regression they were written for, and with the temporary gone all four take the same route through `VisitDynamicInvokeMemberInstruction`. One is kept as `StaticTargetOnDynamicCall`; the old name asserted a shape the source no longer produces. `DynamicAwait` keeps the #3704 regression covered, so nothing is lost by dropping the other three along with the callees that existed only for them.

Full `ICSharpCode.Decompiler.Tests` run: 3542 passed, 0 failed, 45 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

