### PR TITLE
Run decompdiff against git refs, and build a corpus from nuget's most-downloaded packages

### DIFF
--- a/TestTools/README.md
+++ b/TestTools/README.md
@@ -72,10 +72,11 @@ download itself is `nugetfuzz --download-only`, so package selection, TFM matchi
 dependency walk behave exactly as they do in a sweep - only the decompiling is skipped.
 
 The corpus is written as a list of directories rather than one root, because a package already
-restored on this machine is used from the machine-wide NuGet cache instead of being copied:
+restored on this machine is used from the machine-wide NuGet cache instead of being copied. Pass the
+list with `@`, which both tools understand and which needs no help from the shell:
 
 ```pwsh
-dotnet run decompdiff.cs -- --old master --new my-branch -o report $(cat crawl/top-200.corpus.txt)
+dotnet run decompdiff.cs -- --old master --new my-branch -o report @crawl/top-200.corpus.txt
 ```
 
 ## decompdiff
@@ -91,6 +92,9 @@ dotnet run decompdiff.cs -- --old master --new fix/my-branch -o report ~/.cache/
 dotnet run decompdiff.cs -- --old ../../ILSpy-master --new . -o report ~/.cache/nugetfuzz
 dotnet run decompdiff.cs -- --old v9.1.dll --new v11.dll --refs <dir> corpus.dll
 ```
+
+A corpus argument is a dll, a directory scanned recursively for dlls, or `@file` listing either one
+per line (`#` comments allowed).
 
 An `--old`/`--new` argument is a path to `ICSharpCode.Decompiler.dll`, an ILSpy checkout, or a
 commit-ish. A checkout is restored and built in Release on demand. **Watch the timestamp in the

--- a/TestTools/README.md
+++ b/TestTools/README.md
@@ -1,12 +1,13 @@
 # TestTools
 
-Two standalone tools that run the decompiler over real-world assemblies, to find defects the
+Standalone tools that run the decompiler over real-world assemblies, to find defects the
 in-repo test suite cannot: it decompiles fixtures we wrote, these decompile what the world ships.
 
 | tool | question it answers |
 |---|---|
 | `nugetfuzz.cs` | Does the decompiler *crash* on real code? (asserts, exceptions, IL warnings) |
 | `decompdiff.cs` | Did a change make the *output* better or worse? (readability across two builds) |
+| `nuget-top.ps1` | Where do I get a corpus? (downloads the most-downloaded packages) |
 
 Both are [file-based apps](https://learn.microsoft.com/dotnet/core/whats-new/dotnet-10/sdk#file-based-apps):
 single `.cs` files run directly by the SDK, no project, no solution entry. They are not built by
@@ -54,6 +55,28 @@ Findings from every package land in `crawl/findings.jsonl`; render the aggregate
 including while the sweep is still running, with `--report`. Logs of failed runs are kept in
 `logs/`, successful ones are deleted. The package cache (`~/.cache/nugetfuzz`) is capped at 20 GB
 by default (`-CacheCapMB`) and pruned least-recently-used, because `decompdiff` uses it as a corpus.
+
+## nuget-top
+
+Downloads the most-downloaded packages on nuget.org, with their dependency closures, and writes the
+list of lib directories they resolved to - a ready-made corpus for either tool:
+
+```pwsh
+./nuget-top.ps1 -Count 200
+./nuget-top.ps1 -Count 50 -Skip 200      # extend an existing corpus further down the ranking
+./nuget-top.ps1 -Count 200 -ListOnly     # just the ids, download nothing
+```
+
+The ids come from an empty query against the search service, which orders by download count. The
+download itself is `nugetfuzz --download-only`, so package selection, TFM matching and the
+dependency walk behave exactly as they do in a sweep - only the decompiling is skipped.
+
+The corpus is written as a list of directories rather than one root, because a package already
+restored on this machine is used from the machine-wide NuGet cache instead of being copied:
+
+```pwsh
+dotnet run decompdiff.cs -- --old master --new my-branch -o report $(cat crawl/top-200.corpus.txt)
+```
 
 ## decompdiff
 

--- a/TestTools/README.md
+++ b/TestTools/README.md
@@ -64,13 +64,27 @@ round-trip tests check; this checks readability. Exit code 1 means the new side 
 side did not.
 
 ```pwsh
+dotnet run decompdiff.cs -- --old master --new fix/my-branch -o report ~/.cache/nugetfuzz
 dotnet run decompdiff.cs -- --old ../../ILSpy-master --new . -o report ~/.cache/nugetfuzz
 dotnet run decompdiff.cs -- --old v9.1.dll --new v11.dll --refs <dir> corpus.dll
 ```
 
-An `--old`/`--new` argument is either a path to `ICSharpCode.Decompiler.dll` or an ILSpy checkout,
-which is restored and built in Release on demand. **Watch the timestamp in the header line**: an
-existing Release build is reused as-is; pass `--build` to force a rebuild.
+An `--old`/`--new` argument is a path to `ICSharpCode.Decompiler.dll`, an ILSpy checkout, or a
+commit-ish. A checkout is restored and built in Release on demand. **Watch the timestamp in the
+header line**: an existing Release build is reused as-is; pass `--build` to force a rebuild.
+
+A commit-ish (branch, tag, sha, `FETCH_HEAD`) is resolved against the repository the tool is run
+from and checked out into a worktree under `~/.cache/decompdiff/<repo>/<commit>`, so diffing two
+commits needs no checkouts prepared by hand. Paths win over refs, so a branch that shares its name
+with a directory has to be spelled as a path. The worktrees are kept: a rerun reuses the Release
+build already in one, which is what dominates the runtime. They live outside the repository and
+`git worktree remove` (or deleting the cache directory) is enough to clean them up. To diff a pull
+request, fetch it first:
+
+```pwsh
+git fetch origin pull/4071/head
+dotnet run decompdiff.cs -- --old origin/master --new FETCH_HEAD -o report ~/.cache/nugetfuzz
+```
 
 The report directory gets `summary.md`, a self-contained `index.html` with inline diffs, and the
 changed types dumped under `old/` and `new/` for `git diff --no-index report/old report/new`.

--- a/TestTools/decompdiff.cs
+++ b/TestTools/decompdiff.cs
@@ -25,7 +25,7 @@
 // round-trip tests, which verify correctness but not output quality.
 //
 // usage: dotnet run decompdiff.cs -- --old <commit-ish|ILSpy-checkout|Decompiler.dll> --new <...>
-//                                    [-o <report-dir>] [--build] [--refs <dir>]... <dll|dir>...
+//                                    [-o <report-dir>] [--build] [--refs <dir>]... <dll|dir|@list>...
 //
 // - checkout args are built on demand (Release; restore keeps packages.lock.json
 //   whole via -p:RestoreEnablePackagePruning=false); pass --build to force rebuild.
@@ -33,7 +33,8 @@
 //   the tool is run from and checked out into a worktree under
 //   ~/.cache/decompdiff/<repo>/<commit>, kept and reused so a rerun keeps the
 //   Release build it already contains.
-// - corpus dirs are scanned recursively for *.dll (e.g. ~/.cache/nugetfuzz).
+// - corpus dirs are scanned recursively for *.dll (e.g. ~/.cache/nugetfuzz); @list reads
+//   the entries from a file, one per line, as nugetfuzz does with its package list.
 // - changed/errored types are written to <report-dir>/{old,new}/...; inspect with
 //   `git diff --no-index <report-dir>/old <report-dir>/new`, or open the generated
 //   <report-dir>/index.html, which carries the same data with inline diffs.
@@ -97,13 +98,24 @@ for (int i = 0; i < args.Length; i++)
 			refDirs.Add(args[++i]);
 			break;
 		default:
-			corpus.Add(args[i]);
+			// @file lists corpus entries one per line, the same spelling nugetfuzz uses. Shells
+			// differ on how (or whether) a file expands into arguments, so the tool reads it.
+			if (args[i].StartsWith('@'))
+			{
+				corpus.AddRange(File.ReadAllLines(args[i][1..])
+					.Select(l => l.Trim())
+					.Where(l => l.Length > 0 && !l.StartsWith('#')));
+			}
+			else
+			{
+				corpus.Add(args[i]);
+			}
 			break;
 	}
 }
 if (oldSpec == null || newSpec == null || corpus.Count == 0)
 {
-	Console.Error.WriteLine("usage: decompdiff --old <commit-ish|ILSpy-checkout|Decompiler.dll> --new <...> [-o report-dir] [--build] [--refs <dir>]... <dll|dir>...");
+	Console.Error.WriteLine("usage: decompdiff --old <commit-ish|ILSpy-checkout|Decompiler.dll> --new <...> [-o report-dir] [--build] [--refs <dir>]... <dll|dir|@list>...");
 	return 1;
 }
 reportDir ??= "decompdiff-report";

--- a/TestTools/decompdiff.cs
+++ b/TestTools/decompdiff.cs
@@ -24,11 +24,15 @@
 // changes across real-world code. The textual complement to the Windows
 // round-trip tests, which verify correctness but not output quality.
 //
-// usage: dotnet run decompdiff.cs -- --old <ILSpy-checkout|Decompiler.dll> --new <ILSpy-checkout|Decompiler.dll>
+// usage: dotnet run decompdiff.cs -- --old <commit-ish|ILSpy-checkout|Decompiler.dll> --new <...>
 //                                    [-o <report-dir>] [--build] [--refs <dir>]... <dll|dir>...
 //
 // - checkout args are built on demand (Release; restore keeps packages.lock.json
 //   whole via -p:RestoreEnablePackagePruning=false); pass --build to force rebuild.
+// - a commit-ish (branch, tag, sha, FETCH_HEAD) is resolved against the repository
+//   the tool is run from and checked out into a worktree under
+//   ~/.cache/decompdiff/<repo>/<commit>, kept and reused so a rerun keeps the
+//   Release build it already contains.
 // - corpus dirs are scanned recursively for *.dll (e.g. ~/.cache/nugetfuzz).
 // - changed/errored types are written to <report-dir>/{old,new}/...; inspect with
 //   `git diff --no-index <report-dir>/old <report-dir>/new`, or open the generated
@@ -99,7 +103,7 @@ for (int i = 0; i < args.Length; i++)
 }
 if (oldSpec == null || newSpec == null || corpus.Count == 0)
 {
-	Console.Error.WriteLine("usage: decompdiff --old <ILSpy-checkout|Decompiler.dll> --new <...> [-o report-dir] [--build] [--refs <dir>]... <dll|dir>...");
+	Console.Error.WriteLine("usage: decompdiff --old <commit-ish|ILSpy-checkout|Decompiler.dll> --new <...> [-o report-dir] [--build] [--refs <dir>]... <dll|dir>...");
 	return 1;
 }
 reportDir ??= "decompdiff-report";
@@ -114,8 +118,19 @@ if (Directory.Exists(reportDir))
 }
 Directory.CreateDirectory(reportDir);
 
-var oldSide = Side.Create("old", oldSpec, forceBuild);
-var newSide = Side.Create("new", newSpec, forceBuild);
+Side oldSide, newSide;
+try
+{
+	oldSide = Side.Create("old", oldSpec, forceBuild);
+	newSide = Side.Create("new", newSpec, forceBuild);
+}
+catch (ArgumentException ex)
+{
+	// A mistyped branch name is the easiest way to get here, and its message says more
+	// than the stack trace does.
+	Console.Error.WriteLine(ex.Message);
+	return 1;
+}
 Console.WriteLine($"old: {oldSide.Description}");
 Console.WriteLine($"new: {newSide.Description}");
 
@@ -856,9 +871,19 @@ class Side
 			// The dll timestamp exposes stale pre-existing builds; --build forces a fresh one.
 			description = $"{checkout} ({GitDescribe(checkout)}, dll of {File.GetLastWriteTime(dllPath):yyyy-MM-dd HH:mm})";
 		}
+		else if (TryResolveCommit(spec, out var commit, out var repoRoot))
+		{
+			// A git ref, so a PR or a tag can be diffed without preparing checkouts by hand.
+			// The worktree is keyed by commit and kept: reusing it reuses the Release build
+			// already sitting in its bin/, which is what dominates the runtime of a rerun.
+			var checkout = EnsureWorktree(repoRoot, commit);
+			dllPath = BuildCheckout(checkout, forceBuild);
+			description = $"{spec} ({commit[..9]}, dll of {File.GetLastWriteTime(dllPath):yyyy-MM-dd HH:mm})";
+		}
 		else
 		{
-			throw new ArgumentException($"--{name} {spec}: no such file or directory");
+			throw new ArgumentException(
+				$"--{name} {spec}: not a file, a directory, or a commit-ish in the repository at {Environment.CurrentDirectory}");
 		}
 		var alc = new DecompilerLoadContext(name, dllPath);
 		return new Side(alc.LoadFromAssemblyPath(dllPath), description);
@@ -897,24 +922,66 @@ class Side
 			throw new InvalidOperationException($"{exe} {arguments} failed:\n{output}");
 	}
 
-	static string GitDescribe(string checkout)
+	// Resolves a commit-ish against the repository the tool is run from. Files and directories
+	// win over refs, so a branch sharing a name with a directory still needs the path spelled out.
+	static bool TryResolveCommit(string spec, out string commit, out string repoRoot)
+	{
+		commit = "";
+		repoRoot = "";
+		var root = Git(Environment.CurrentDirectory, "rev-parse", "--show-toplevel");
+		if (root == null)
+			return false;
+		var resolved = Git(root, "rev-parse", "--verify", "--quiet", spec + "^{commit}");
+		if (string.IsNullOrEmpty(resolved))
+			return false;
+		commit = resolved;
+		repoRoot = root;
+		return true;
+	}
+
+	// Worktrees live outside the repository, so they never show up in its status or get
+	// swept up by a clean; `git worktree list` still shows them, and they are safe to delete.
+	static string EnsureWorktree(string repoRoot, string commit)
+	{
+		var dir = Path.Combine(
+			Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+			".cache", "decompdiff", Path.GetFileName(repoRoot), commit);
+		if (Directory.Exists(dir))
+			return dir;
+		Directory.CreateDirectory(Path.GetDirectoryName(dir)!);
+		Console.WriteLine($"  $ git worktree add --detach {dir} {commit[..9]}");
+		if (Git(repoRoot, "worktree", "add", "--detach", dir, commit) == null)
+			throw new InvalidOperationException($"git worktree add failed for {commit}");
+		return dir;
+	}
+
+	// Runs git and returns its trimmed stdout, or null if it could not be run or failed.
+	static string? Git(string workingDirectory, params string[] arguments)
 	{
 		try
 		{
-			var psi = new ProcessStartInfo("git", "describe --always --dirty --exclude *") {
-				WorkingDirectory = checkout,
+			var psi = new ProcessStartInfo("git") {
+				WorkingDirectory = workingDirectory,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
 			};
+			foreach (var argument in arguments)
+				psi.ArgumentList.Add(argument);
 			using var p = Process.Start(psi)!;
 			var output = p.StandardOutput.ReadToEnd().Trim();
 			p.WaitForExit();
-			return p.ExitCode == 0 && output.Length > 0 ? output : "unknown";
+			return p.ExitCode == 0 ? output : null;
 		}
 		catch
 		{
-			return "unknown";
+			return null;
 		}
+	}
+
+	static string GitDescribe(string checkout)
+	{
+		var output = Git(checkout, "describe", "--always", "--dirty", "--exclude", "*");
+		return string.IsNullOrEmpty(output) ? "unknown" : output;
 	}
 
 	// Decompiles every top-level type; null when the assembly itself cannot be

--- a/TestTools/nuget-top.ps1
+++ b/TestTools/nuget-top.ps1
@@ -70,4 +70,4 @@ $dirs = $log | ForEach-Object { if ($_ -match '^\s*cached:\s*(.+)$') { $Matches[
 Set-Content -Path $corpusFile -Value $dirs
 Write-Host ""
 Write-Host "$($dirs.Count) lib directories -> $corpusFile"
-Write-Host "decompdiff --old <ref> --new <ref> -o report `$(cat $corpusFile)"
+Write-Host "dotnet run decompdiff.cs -- --old <ref> --new <ref> -o report `@$corpusFile"

--- a/TestTools/nuget-top.ps1
+++ b/TestTools/nuget-top.ps1
@@ -1,0 +1,73 @@
+#!/usr/bin/env pwsh
+# Downloads the N most-downloaded packages on nuget.org into the cache that decompdiff
+# uses as its corpus (~/.cache/nugetfuzz), together with their dependency closures.
+#
+# The download, TFM selection and dependency walk all live in nugetfuzz.cs already, so
+# this only picks the ids and hands them over: an empty query against the search service
+# returns packages ordered by download count.
+#
+# usage: ./nuget-top.ps1 [-Count n] [-ListOnly] [-Out path] [-Skip n]
+# ponytail: no per-id retry; a package that fails to download is reported and skipped
+
+[CmdletBinding()]
+param(
+	[int]$Count = 100,
+	[int]$Skip = 0,          # start further down the ranking, to extend an existing corpus
+	[switch]$ListOnly,       # write the id list, download nothing
+	[string]$Out
+)
+
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+# Required by the local OpenSSL configuration to validate the SHA-1 signed packages.
+if (-not $env:OPENSSL_ENABLE_SHA1_SIGNATURES) {
+	$env:OPENSSL_ENABLE_SHA1_SIGNATURES = '1'
+}
+
+$state = Join-Path $PSScriptRoot 'crawl'
+New-Item -ItemType Directory -Force -Path $state | Out-Null
+if (-not $Out) {
+	$Out = Join-Path $state "top-$Count.txt"
+}
+
+# The search service caps how far a caller may page; ask for the ids in blocks and stop
+# as soon as it stops handing any back, so a too-large -Count truncates instead of failing.
+$endpoint = 'https://azuresearch-usnc.nuget.org/query'
+$ids = [System.Collections.Generic.List[string]]::new()
+$page = 100
+while ($ids.Count -lt $Count) {
+	$take = [Math]::Min($page, $Count - $ids.Count)
+	$uri = "${endpoint}?q=&skip=$($Skip + $ids.Count)&take=$take&prerelease=false&semVerLevel=2.0.0"
+	$response = Invoke-RestMethod -Uri $uri
+	if (-not $response.data -or $response.data.Count -eq 0) {
+		Write-Warning "search returned nothing at skip=$($Skip + $ids.Count); stopping at $($ids.Count) ids"
+		break
+	}
+	foreach ($entry in $response.data) {
+		$ids.Add($entry.id)
+	}
+}
+
+# Ranking order is worth keeping in the file: it says what a truncated corpus dropped.
+Set-Content -Path $Out -Value $ids
+Write-Host "$($ids.Count) package ids -> $Out"
+
+if ($ListOnly) {
+	return
+}
+
+# A package already restored on this machine is used from the machine-wide NuGet cache
+# rather than copied, so the downloaded set is not one directory that can be handed to
+# decompdiff. nugetfuzz names the lib directory it settled on for each package, and that
+# list IS the corpus - one entry per package, at the target framework it chose.
+$corpusFile = [IO.Path]::ChangeExtension($Out, '.corpus.txt')
+dotnet run nugetfuzz.cs -- --download-only "@$Out" | Tee-Object -Variable log
+if ($LASTEXITCODE -ne 0) {
+	throw "nugetfuzz exited with $LASTEXITCODE"
+}
+$dirs = $log | ForEach-Object { if ($_ -match '^\s*cached:\s*(.+)$') { $Matches[1].Trim() } }
+Set-Content -Path $corpusFile -Value $dirs
+Write-Host ""
+Write-Host "$($dirs.Count) lib directories -> $corpusFile"
+Write-Host "decompdiff --old <ref> --new <ref> -o report `$(cat $corpusFile)"

--- a/TestTools/nugetfuzz.cs
+++ b/TestTools/nugetfuzz.cs
@@ -25,7 +25,7 @@
 // Microsoft.NETFramework.ReferenceAssemblies packages), then decompiles every
 // assembly type-by-type and reports Debug.Assert failures / exceptions.
 //
-// usage: dotnet run nugetfuzz.cs -- <PackageId[@Version]>... | @packagelist.txt
+// usage: dotnet run nugetfuzz.cs -- [--download-only] <PackageId[@Version]>... | @packagelist.txt
 
 using System.Diagnostics;
 using System.IO.Compression;
@@ -108,14 +108,18 @@ if (args is ["--report", var ledgerPath, ..])
 	return 0;
 }
 
+// Populates the cache without decompiling: the sweep is the slow part, and a corpus
+// only needs the assemblies on disk.
+var downloadOnly = args.Contains("--download-only");
 var packages = args
+	.Where(a => a != "--download-only")
 	.SelectMany(a => a.StartsWith('@') ? File.ReadAllLines(a[1..]) : new[] { a })
 	.Select(l => l.Trim())
 	.Where(l => l.Length > 0 && !l.StartsWith('#'))
 	.ToList();
 if (packages.Count == 0)
 {
-	Console.Error.WriteLine("usage: nugetfuzz <PackageId[@Version]>... | @packagelist.txt");
+	Console.Error.WriteLine("usage: nugetfuzz [--download-only] <PackageId[@Version]>... | @packagelist.txt");
 	Console.Error.WriteLine("       nugetfuzz --report <ledger.jsonl> [out.html]");
 	return 1;
 }
@@ -147,7 +151,11 @@ foreach (var entry in failures.Values.OrderByDescending(f => f.Count))
 // shared ledger; `--report <ledger>` renders the aggregate. Without a ledger the run
 // reports only itself.
 var ledger = Environment.GetEnvironmentVariable("NUGETFUZZ_LEDGER");
-if (ledger != null)
+if (downloadOnly)
+{
+	// Nothing was decompiled, so there are no findings to report on.
+}
+else if (ledger != null)
 {
 	AppendToLedger(ledger, failures.Values, assemblyCount, typeCount, refsResolved, refsTotal);
 	Console.WriteLine($"ledger: {Path.GetFullPath(ledger)}");
@@ -190,6 +198,13 @@ async Task ProcessPackage(string spec)
 
 	var searchDirs = await CollectDependencies(dir, matchTarget, id);
 	searchDirs.Insert(0, libDir);
+	if (downloadOnly)
+	{
+		// The package and its dependency closure are in the cache now, which is all a
+		// corpus needs; decompiling every type is what the sweep is for.
+		Console.WriteLine($"  cached: {libDir}");
+		return;
+	}
 	// The installed runtime dir is a last-resort fallback only: Microsoft.NETCore.App
 	// ships stub facades (e.g. WindowsBase.dll without System.Windows.Point) that must
 	// not shadow the real assemblies from ref packs or dependency packages.


### PR DESCRIPTION
### Problem

Two things stood between wanting a decompdiff run and having one, and both were manual work that is easy to get wrong.

**Preparing the sides.** Comparing two commits meant creating a worktree for each by hand first. That is most of the effort of running the tool, and a checkout carrying a stale Release build is reused silently — the dll timestamp in the header line was the only thing that said so.

**Getting a corpus.** Neither tool had a way to obtain one. `nugetfuzz-all.ps1` walks the catalog in publish order, which suits a crash sweep but makes a poor readability corpus, so the alternative was picking package ids by hand.

### Solution

**`--old` / `--new` also take a commit-ish** — branch, tag, sha, `FETCH_HEAD` — resolved against the repository the tool is run from and checked out into a worktree under `~/.cache/decompdiff/<repo>/<commit>`:

```pwsh
dotnet run decompdiff.cs -- --old master --new fix/my-branch -o report @corpus.txt

git fetch origin pull/4071/head
dotnet run decompdiff.cs -- --old origin/master --new FETCH_HEAD -o report @corpus.txt
```

* Paths keep priority over refs, so an existing directory never changes meaning.
* The worktrees are kept, keyed by commit: the Release build inside one is what a rerun would otherwise repeat. A second run of the same pair went from ~10 minutes to 2.4s here.
* A mistyped ref previously fell through to an unhandled `ArgumentException`; bad specs now print the message and exit 1.

**`nuget-top.ps1`** downloads the most-downloaded packages with their dependency closures and writes the corpus list:

```pwsh
./nuget-top.ps1 -Count 200
```

The ids come from an empty search query, which orders by download count. The downloading is `nugetfuzz --download-only` (new flag), so version resolution, TFM matching and the dependency walk behave exactly as in a sweep and only the decompiling is skipped.

It writes a list of lib directories rather than one root on purpose: a package already restored on the machine is used from the machine-wide NuGet cache instead of being copied into ours, and a corpus pointed at a single directory would silently omit those.

**Corpus entries can come from an `@file`**, the spelling `nugetfuzz` already uses for its package list — one entry per line, `#` comments allowed, dlls or directories. Passing the list as `$(cat ...)` is a bourne shell construct that does not work on Windows, so the shell is left out of it:

```pwsh
dotnet run decompdiff.cs -- --old master --new my-branch -o report @crawl/top-200.corpus.txt
```

* [ ] At least one test covering the code changed

`TestTools` is in no solution and not built by CI, so there is no test project to extend. Verified by running: sha pair, branch-name pair, `FETCH_HEAD` against a PR, the worktree-reuse path, the bad-ref path, and the whole loop end to end — `nuget-top.ps1 -Count 8` into a decompdiff run that reported 8 assemblies with per-package changed-type counts.

<sub>Written by Claude Code (`claude-opus-5`) on behalf of @siegfriedpammer; runs reproduced locally.</sub>
