### PR TITLE
Fix #3714: declare a local function in its innermost capture scope

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -877,5 +877,30 @@ namespace LocalFunctions
 			static extern int EnumWindows(long hWnd, long lParam);
 		}
 #endif
+
+		public int Issue3714_LocalFunctionInsideLambda()
+		{
+			int outer = 1;
+#if !OPT
+			Action action = () => {
+#else
+			((Action)(() => {
+#endif
+				int inner = 2;
+				Local(3);
+				Console.WriteLine(inner);
+				void Local(int d)
+				{
+					inner += d;
+					outer += d;
+				}
+#if !OPT
+			};
+			action();
+#else
+			}))();
+#endif
+			return outer;
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -732,8 +732,21 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 			if (function.DeclarationScope == null)
 				function.DeclarationScope = closureVar.CaptureScope;
-			else if (!IsInNestedLocalFunction(function.DeclarationScope, closureVar.CaptureScope.Ancestors.OfType<ILFunction>().First()))
+			else if (closureVar.CaptureScope.IsDescendantOf(function.DeclarationScope))
+			{
+				// The closures captured by one local function are nested in one another: a
+				// local function declared inside a lambda still reaches the enclosing method's
+				// closure, but not the other way round. Where one capture scope contains the
+				// other, the declaration belongs in the inner one; taking the common ancestor
+				// would move the function out of the lambda owning the deeper closure and
+				// leave the variables captured there out of scope.
+				function.DeclarationScope = closureVar.CaptureScope;
+			}
+			else if (!function.DeclarationScope.IsDescendantOf(closureVar.CaptureScope)
+				&& !IsInNestedLocalFunction(function.DeclarationScope, closureVar.CaptureScope.Ancestors.OfType<ILFunction>().First()))
+			{
 				function.DeclarationScope = FindCommonAncestorInstruction<BlockContainer>(function.DeclarationScope, closureVar.CaptureScope);
+			}
 			return true;
 
 			ILInstruction GetClosureInitializer(ILVariable variable)


### PR DESCRIPTION
Fixes #3714.

A local function nested in a lambda can capture closures at two depths: csc emits it as an instance method on the enclosing method's display class that takes the lambda's display class as a parameter. Combining those two capture scopes with `FindCommonAncestorInstruction` picked the enclosing method, moving the function out of the lambda that owns the deeper closure; the variables captured there were then unreachable and the display-class parameter survived into the output as an undeclared identifier:

```csharp
return outer;
void Local(int d)
{
    P_1.inner += d;   // P_1: undeclared, uncompilable
    outer += d;
}
```

Nested capture scopes now resolve to the innermost instead, which a local function can always see - it reaches the outer closure through the display class it is declared on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
