### PR TITLE
Parenthesize a ref-conditional assignment target

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/RefLocalsAndReturns.cs
@@ -343,6 +343,13 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			RefReassignment(ref reference.GetHashCode() == 4 ? ref reference : ref s);
 		}
 
+		public static void ConditionalRefAssignment(bool c, ref int a, ref int b)
+		{
+			(c ? ref a : ref b) = 3;
+			(c ? ref a : ref b) += 10;
+			(c ? ref b : ref a)++;
+		}
+
 		public static void Main(string[] args)
 		{
 			DoubleNumber(ref args.Length == 1 ? ref numbers[0] : ref DefaultInt);

--- a/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
+++ b/ICSharpCode.Decompiler/CSharp/OutputVisitor/InsertParenthesesVisitor.cs
@@ -475,8 +475,10 @@ namespace ICSharpCode.Decompiler.CSharp.OutputVisitor
 			{
 				Parenthesize(assignmentExpression);
 			}
-			// assignment is right-associative
-			ParenthesizeIfRequired(assignmentExpression.Left, PrecedenceLevel.Assignment + 1);
+			// assignment is right-associative. A ref-conditional target (cond ? ref a : ref b)
+			// has conditional precedence and would otherwise re-parse as cond ? ref a : (ref b = value),
+			// so the target needs precedence above ?: to keep its parentheses.
+			ParenthesizeIfRequired(assignmentExpression.Left, PrecedenceLevel.Conditional + 1);
 			HandleAssignmentRHS(assignmentExpression.Right);
 			base.VisitAssignmentExpression(assignmentExpression);
 		}


### PR DESCRIPTION
Assigning through a ref-conditional was emitted without parentheses:

```csharp
// before: does not compile (CS8156 / CS0201)
c ? ref a : ref b = 3;

// after
(c ? ref a : ref b) = 3;
```

Without them the statement re-parses as `c ? ref a : (ref b = 3)`, which is neither a valid expression statement nor a legal assignment to a ref-returning conditional branch.

`VisitAssignmentExpression` in `InsertParenthesesVisitor` parenthesized the target only above **assignment** precedence, on the grounds that assignment is right-associative. A conditional binds tighter than assignment, so a ref-conditional target cleared that bar and lost its parentheses. The target now has to have precedence above the conditional operator.

Ordinary lvalues are unaffected: locals, fields, array accesses and indexers are primary expressions, well above `?:`. The postfix `++` form already came out right, because `UnaryOperatorExpression` parenthesizes its operand at unary precedence.

`TestCases/Pretty/RefLocalsAndReturns.cs` covers plain assignment, compound assignment and the postfix increment:

```csharp
public static void ConditionalRefAssignment(bool c, ref int a, ref int b)
{
	(c ? ref a : ref b) = 3;
	(c ? ref a : ref b) += 10;
	(c ? ref b : ref a)++;
}
```

Full `ICSharpCode.Decompiler.Tests` run: 3546 passed, 0 failed, 45 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
