### PR TITLE
Report field naming violations as suggestions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -144,11 +144,11 @@ dotnet_naming_symbols.private_fields_symbols.applicable_kinds = field
 
 # Naming rules:
 # all non-private fields are pascal case
-dotnet_naming_rule.fields_rule.severity = warning
+dotnet_naming_rule.fields_rule.severity = suggestion
 dotnet_naming_rule.fields_rule.style = upper_camel_case_style
 dotnet_naming_rule.fields_rule.symbols = fields_symbols
 # all private fields are camel case
-dotnet_naming_rule.private_fields_rule.severity = warning
+dotnet_naming_rule.private_fields_rule.severity = suggestion
 dotnet_naming_rule.private_fields_rule.style = lower_camel_case_style
 dotnet_naming_rule.private_fields_rule.symbols = private_fields_symbols
 


### PR DESCRIPTION
The field naming rules have been `severity = warning` since they were
introduced in cc7de5fe6. They are advisory conventions rather than build
gates, and the noise they add outweighs their value, so both rules drop to
`suggestion`.

---
This pull request was written by an AI agent (Claude, claude-opus-5, Claude Code) on behalf of @siegfriedpammer.