### PR TITLE
Fix #3008: local function forwarding a display class loses its scope

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/LocalFunctions.cs
@@ -902,5 +902,29 @@ namespace LocalFunctions
 #endif
 			return outer;
 		}
+
+		public void Issue3008_DisplayClassForwardedThroughLocalFunction(int start)
+		{
+			Run();
+			void Run()
+			{
+				int captured = start;
+				A();
+				Console.WriteLine(captured);
+				void A()
+				{
+					captured++;
+					if (captured < 10)
+					{
+						B();
+					}
+				}
+				void B()
+				{
+					captured += 2;
+					A();
+				}
+			}
+		}
 	}
 }

--- a/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
+++ b/ICSharpCode.Decompiler/IL/Transforms/LocalFunctionDecompiler.cs
@@ -141,22 +141,27 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 					foreach (var useSite in info.UseSites)
 					{
 						DetermineCaptureAndDeclarationScope(info, useSite);
+					}
 
-						if (context.Function.Method.IsConstructor)
+					if (context.Function.Method.IsConstructor)
+					{
+						// Local functions reached from a field initializer usually capture nothing, so
+						// the closure analysis leaves no scope behind; the innermost block containing
+						// all use-sites is a better place for them than the whole constructor body.
+						// Use-sites spread over separate function bodies have no common block
+						// container at all; there the scope from the closure analysis stands.
+						BlockContainer useSiteScope = null;
+						foreach (var useSite in info.UseSites)
 						{
-							if (localFunction.DeclarationScope == null)
-							{
-								localFunction.DeclarationScope = BlockContainer.FindClosestContainer(useSite);
-							}
-							else
-							{
-								localFunction.DeclarationScope = FindCommonAncestorInstruction<BlockContainer>(useSite, localFunction.DeclarationScope);
-								if (localFunction.DeclarationScope == null)
-								{
-									localFunction.DeclarationScope = (BlockContainer)context.Function.Body;
-								}
-							}
+							useSiteScope = useSiteScope == null
+								? BlockContainer.FindClosestContainer(useSite)
+								: FindCommonAncestorInstruction<BlockContainer>(useSite, useSiteScope);
+							if (useSiteScope == null)
+								break;
 						}
+						localFunction.DeclarationScope = useSiteScope
+							?? localFunction.DeclarationScope
+							?? (BlockContainer)context.Function.Body;
 					}
 
 					if (localFunction.DeclarationScope == null)
@@ -341,9 +346,18 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 				return null;
 			if (!(TransformDisplayClassUsage.IsPotentialClosure(context, field.Type.GetDefinition()) || context.Function.Method.DeclaringType.Equals(field.Type)))
 				return null;
-			foreach (var v in context.Function.Descendants.OfType<ILFunction>().SelectMany(f => f.Variables))
+			return FindClosureVariableOfType(field.Type);
+		}
+
+		/// <summary>
+		/// Finds the variable holding the display class instance of the given type, anywhere in the
+		/// function tree currently being decompiled.
+		/// </summary>
+		private ILVariable FindClosureVariableOfType(IType type)
+		{
+			foreach (var v in context.Function.Descendants.OfType<ILFunction>().Prepend(context.Function).SelectMany(f => f.Variables))
 			{
-				if (!(TransformDisplayClassUsage.IsClosure(context, v, out var varType, out _) && varType.Equals(field.Type)))
+				if (!(TransformDisplayClassUsage.IsClosure(context, v, out var varType, out _) && varType.Equals(type)))
 					continue;
 				return v;
 			}
@@ -713,6 +727,13 @@ namespace ICSharpCode.Decompiler.IL.Transforms
 			}
 			if (closureVar.Kind == VariableKind.NamedArgument)
 				return false;
+			if (parameterIndex >= 0 && closureVar.Kind == VariableKind.Parameter)
+			{
+				// The use-site sits inside another local function that received the display class as
+				// a parameter and forwards it. A parameter has no initializer, so the scope the
+				// display class was created in has to be recovered from the variable holding it.
+				closureVar = FindClosureVariableOfType(closureVar.Type.UnwrapByRef()) ?? closureVar;
+			}
 			var initializer = GetClosureInitializer(closureVar);
 			if (initializer == null)
 				return false;


### PR DESCRIPTION
> _Written by Claude (agent), posted on behalf of @siegfriedpammer._

Fixes #3008.

Decompiling `Microsoft.CodeAnalysis.CSharp.Binder.CreateConversion` asserted at `Debug.Assert(localFunction != null)` in `CallBuilder`, and the Release build emitted uncompilable code - calls written as raw metadata names, `<CreateConversion>g__reportUseSiteDiagnostics|253_1(...)`.

`DetermineCaptureAndDeclarationScope` derives a local function's declaration scope from the display-class variable at its use sites. Roslyn passes display classes into local functions as `ref` parameters, and `GetClosureInitializer` returns null for a parameter, so a local function used only from inside *another* local function never resolved a scope. It fell through to the blanket root-body fallback and was hoisted out of the function whose closure its callees read, leaving those callees out of scope. A closure parameter now resolves to the variable that actually holds the display class, so all three end up siblings in the same local function, matching the source layout.

The constructor branch had a second, smaller instance of the same problem: use sites in separate function bodies share no `BlockContainer`, so `FindCommonAncestorInstruction` returned null and a valid closure-derived scope was discarded. The use-site scope is now computed separately and the closure-derived one kept when there is none.

Two points for review:

- The constructor-path change makes the use-site scope win outright instead of folding it into the closure scope. The suite is green either way; it is the one judgement call in the diff.
- An alternative fix - declaring at the innermost function containing all use sites - also resolved this case but tripped `TryValidateSkipCount`'s assert on `Generic<T1>.MixedLocalFunction`, which assumes generic local functions are declared at the root. Worth knowing if anyone revisits this area.

Pretty fixture `Issue3008_DisplayClassForwardedThroughLocalFunction` covers the shape. A whole-assembly Debug decompile of the reporter's assembly no longer asserts.
