### PR TITLE
Fix #2362: resolve Xamarin compressed references in ilspycmd

### DIFF
--- a/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
+++ b/ICSharpCode.Decompiler/Metadata/UniversalAssemblyResolver.cs
@@ -238,8 +238,7 @@ namespace ICSharpCode.Decompiler.Metadata
 
 			try
 			{
-				FileStream stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-				return new PEFile(fileName, stream, streamOptions, metadataOptions);
+				return LoadModuleFromFile(fileName);
 			}
 			catch (BadImageFormatException ex)
 			{
@@ -252,6 +251,19 @@ namespace ICSharpCode.Decompiler.Metadata
 					throw makeException(ex);
 			}
 			return null;
+		}
+
+		/// <summary>
+		/// Loads the module stored at <paramref name="fileName"/>, once the file for a reference
+		/// has been found. Override to accept file formats other than a plain PE image. Throws
+		/// <see cref="BadImageFormatException"/> or <see cref="IOException"/> for a file that is
+		/// not a loadable module; the caller turns that into null or a
+		/// <see cref="ResolutionException"/> according to the throwOnError setting.
+		/// </summary>
+		protected virtual MetadataFile LoadModuleFromFile(string fileName)
+		{
+			FileStream stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+			return new PEFile(fileName, stream, streamOptions, metadataOptions);
 		}
 
 		public Task<MetadataFile?> ResolveAsync(IAssemblyReference name)

--- a/ICSharpCode.ILSpyCmd.Tests/XamarinCompressedInputTests.cs
+++ b/ICSharpCode.ILSpyCmd.Tests/XamarinCompressedInputTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Christoph Wille
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+using ICSharpCode.Decompiler.Metadata;
+
+using K4os.Compression.LZ4;
+
+using NUnit.Framework;
+
+using static ICSharpCode.ILSpyCmd.Tests.CliTestRunner;
+
+namespace ICSharpCode.ILSpyCmd.Tests
+{
+	/// <summary>
+	/// A Xamarin.Android app ships every assembly LZ4-compressed behind a 12-byte "XALZ" header.
+	/// These tests lay out a directory the way such an app does - the input assembly and the
+	/// assembly it references, both compressed - because decompiling one file of an app only
+	/// gives good output when its references next to it load too.
+	/// </summary>
+	[TestFixture]
+	public class ILSpyCmdXamarinCompressedInputTests
+	{
+		// Magic used for the Xamarin compressed module header ('XALZ', little-endian).
+		const uint CompressedDataMagic = 0x5A4C4158;
+
+		string tempDirectory;
+		string compressedInputPath;
+
+		[OneTimeSetUp]
+		public void CreateCompressedAssemblies()
+		{
+			tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			Directory.CreateDirectory(tempDirectory);
+
+			string inputAssembly = typeof(ILSpyCmdXamarinCompressedInputTests).Assembly.Location;
+			string referencedAssembly = typeof(TargetFrameworkIdentifier).Assembly.Location;
+			compressedInputPath = WriteCompressed(inputAssembly);
+			WriteCompressed(referencedAssembly);
+		}
+
+		[OneTimeTearDown]
+		public void DeleteCompressedAssemblies()
+		{
+			if (tempDirectory != null && Directory.Exists(tempDirectory))
+				Directory.Delete(tempDirectory, recursive: true);
+		}
+
+		/// <summary>
+		/// Writes the XALZ form of <paramref name="assemblyPath"/> into the temp directory under
+		/// the same file name, so references resolve by name next to the input, and returns it.
+		/// </summary>
+		string WriteCompressed(string assemblyPath)
+		{
+			byte[] original = File.ReadAllBytes(assemblyPath);
+			byte[] compressed = new byte[LZ4Codec.MaximumOutputSize(original.Length)];
+			int compressedLength = LZ4Codec.Encode(original, 0, original.Length, compressed, 0, compressed.Length);
+
+			string path = Path.Combine(tempDirectory, Path.GetFileName(assemblyPath));
+			using var stream = File.Create(path);
+			using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+			writer.Write(CompressedDataMagic);
+			writer.Write((uint)0); // descriptor table index, unused by the loader
+			writer.Write((uint)original.Length);
+			writer.Write(compressed, 0, compressedLength);
+			return path;
+		}
+
+		[Test]
+		public async Task CompressedInputIsDecompiled()
+		{
+			var result = await RunAsync(compressedInputPath, "--disable-updatecheck",
+				"-m", "M:ICSharpCode.ILSpyCmd.Tests.MemberOptionSample.Add(System.Int32,System.Int32)");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain("int Add(int a, int b)"));
+		}
+
+		/// <summary>
+		/// An enum from an unresolved reference is an unknown type, so a comparison against one of
+		/// its members prints as a cast of the raw value. The member name appearing proves the
+		/// compressed reference was loaded.
+		/// </summary>
+		[Test]
+		public async Task CompressedReferenceIsResolved()
+		{
+			var result = await RunAsync(compressedInputPath, "--disable-updatecheck",
+				"-m", "M:ICSharpCode.ILSpyCmd.Tests.XamarinReferenceSample.IsCore(ICSharpCode.Decompiler.Metadata.TargetFrameworkIdentifier)");
+
+			Assert.That(result.ExitCode, Is.EqualTo(0), result.Error);
+			Assert.That(result.Output, Does.Contain("id == TargetFrameworkIdentifier.NETCoreApp"));
+		}
+	}
+
+	public static class XamarinReferenceSample
+	{
+		public static bool IsCore(TargetFrameworkIdentifier id)
+		{
+			return id == TargetFrameworkIdentifier.NETCoreApp;
+		}
+	}
+}

--- a/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
+++ b/ICSharpCode.ILSpyCmd/IlspyCmdProgram.cs
@@ -557,16 +557,26 @@ Examples:
 			return InputFileLoader.Load(assemblyFileName, BundleEntryName, applyWinRTProjections);
 		}
 
+		/// <summary>
+		/// Resolves the references of <paramref name="module"/> from next to the input file, the
+		/// -r directories, and the usual framework locations.
+		/// </summary>
+		UniversalAssemblyResolver CreateResolver(string assemblyFileName, PEFile module)
+		{
+			var resolver = new FileLoaderAssemblyResolver(assemblyFileName, module.Metadata.DetectTargetFrameworkId());
+			foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
+			{
+				resolver.AddSearchDirectory(path);
+			}
+			return resolver;
+		}
+
 		CSharpDecompiler GetDecompiler(string assemblyFileName) => GetDecompiler(assemblyFileName, out _);
 
 		CSharpDecompiler GetDecompiler(string assemblyFileName, out DecompilerSettings settings)
 		{
 			var module = LoadInputModule(assemblyFileName);
-			var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Metadata.DetectTargetFrameworkId());
-			foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
-			{
-				resolver.AddSearchDirectory(path);
-			}
+			var resolver = CreateResolver(assemblyFileName, module);
 			settings = GetSettings(module);
 			if (!settings.ApplyWindowsRuntimeProjections)
 			{
@@ -617,9 +627,7 @@ Examples:
 			bool isBaml = resourceName.EndsWith(".baml", StringComparison.OrdinalIgnoreCase);
 			if (isBaml && value is byte[] bamlBytes)
 			{
-				var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Metadata.DetectTargetFrameworkId());
-				foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
-					resolver.AddSearchDirectory(path);
+				var resolver = CreateResolver(assemblyFileName, module);
 				var bamlSettings = new BamlDecompilerSettings {
 					ThrowOnAssemblyResolveErrors = GetSettings(module).ThrowOnAssemblyResolveErrors
 				};
@@ -788,11 +796,7 @@ Examples:
 		ProjectId DecompileAsProject(string assemblyFileName, string projectFileName)
 		{
 			var module = LoadInputModule(assemblyFileName);
-			var resolver = new UniversalAssemblyResolver(assemblyFileName, false, module.Metadata.DetectTargetFrameworkId());
-			foreach (var path in (ReferencePaths ?? Array.Empty<string>()))
-			{
-				resolver.AddSearchDirectory(path);
-			}
+			var resolver = CreateResolver(assemblyFileName, module);
 			var settings = GetSettings(module);
 			var debugInfo = TryLoadPDB(module);
 			WholeProjectDecompiler decompiler;

--- a/ICSharpCode.ILSpyCmd/InputFileLoader.cs
+++ b/ICSharpCode.ILSpyCmd/InputFileLoader.cs
@@ -79,7 +79,7 @@ namespace ICSharpCode.ILSpyCmd
 			return new PEFile(fileName, metadataOptions: MetadataOptions(context));
 		}
 
-		static LoadResult LoadFile(string fileName, FileLoadContext context)
+		internal static LoadResult LoadFile(string fileName, FileLoadContext context)
 		{
 			using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
 			foreach (var loader in loaders.RegisteredLoaders)
@@ -220,6 +220,27 @@ namespace ICSharpCode.ILSpyCmd
 			return context.ApplyWinRTProjections
 				? MetadataReaderOptions.ApplyWindowsRuntimeProjections
 				: MetadataReaderOptions.None;
+		}
+	}
+
+	/// <summary>
+	/// Resolves references the way the input file is loaded: a referenced file goes through the
+	/// file loaders first, so a Xamarin compressed module (or any other format a loader
+	/// understands) next to the input resolves like a plain assembly. A file no loader claims
+	/// is loaded as a PE image, as the base resolver does.
+	/// </summary>
+	sealed class FileLoaderAssemblyResolver : UniversalAssemblyResolver
+	{
+		static readonly FileLoadContext context = new FileLoadContext(ApplyWinRTProjections: true, null);
+
+		public FileLoaderAssemblyResolver(string mainAssemblyFileName, string targetFramework)
+			: base(mainAssemblyFileName, throwOnError: false, targetFramework)
+		{
+		}
+
+		protected override MetadataFile LoadModuleFromFile(string fileName)
+		{
+			return InputFileLoader.LoadFile(fileName, context)?.MetadataFile ?? base.LoadModuleFromFile(fileName);
 		}
 	}
 }


### PR DESCRIPTION
> _Written by Claude (agent), posted on behalf of @christophwille._

Fixes #2362.

## What was actually broken

#2362 stayed open with the note that `ilspycmd` still lacked the Xamarin compressed-DLL ("XALZ") support the UI has had since #2137. Looking at it after #4101, there are two separate things in play:

1. **Passing an XALZ file as the input already works.** #4101 made every CLI mode load its input through ILSpyX's `FileLoaderRegistry`, and `XamarinCompressedFileLoader` is the first loader in that registry. So `ilspycmd Foo.dll` with a compressed module decompresses on the fly today. Nothing pinned that with a test, so this PR adds one.
2. **References were the real gap.** The stack trace in the issue is inside `UniversalAssemblyResolver.Resolve`: the *referenced* sibling DLL was still compressed. A Xamarin app folder holds every assembly compressed, and the CLI builds `UniversalAssemblyResolver` directly, whose private load step does `new PEFile(fileName, stream)`. With `throwOnError: false` the resulting `BadImageFormatException` is swallowed, the reference resolves to null, and the output degrades silently. For example, an enum from the referenced assembly prints as a cast of the raw value:

   ```csharp
   return (int)id == 1;          // reference unresolved
   return id == TargetFrameworkIdentifier.NETCoreApp;   // reference resolved
   ```

   The UI does not have this problem because `LoadedAssembly.MyAssemblyResolver` only asks the universal resolver for the *file name* and then loads that file through the registry.

## Approach

Constraints from the request: keep the XALZ code in ILSpyX (no duplication), and do not add detection logic to `ilspycmd` (the registry order already handles it).

- `UniversalAssemblyResolver` gains one `protected virtual MetadataFile LoadModuleFromFile(string fileName)`, extracted from the existing private `CreatePEFileFromFileName`. Both `Resolve` and `ResolveModule` already funnel through that method, so the hook covers assemblies and netmodules. This is an additive public-API change on a non-sealed class; no existing caller changes.
- `ilspycmd` adds `FileLoaderAssemblyResolver : UniversalAssemblyResolver` (15 lines, in `InputFileLoader.cs`) that overrides the hook to run the same loader loop the input file uses, and falls back to the base PE path for anything no loader claims. A corrupt XALZ or a package (bundle/zip) therefore ends up exactly where it did before: an unresolved reference.
- The three duplicated resolver-construction blocks in `IlspyCmdProgram.cs` (`GetDecompiler`, `ExtractResource`, `DecompileAsProject`) collapse into one `CreateResolver` helper. Net fewer lines there.

No new CLI option, no README regeneration, `-d|--dump-package` untouched, no `packages.lock.json` changes (`K4os.Compression.LZ4` reaches the test project transitively via ILSpyX, as it already does for `ICSharpCode.Decompiler.Tests`).

## Rejected alternatives

- **Wrap `UniversalAssemblyResolver` in a CLI-side `IAssemblyResolver` built on the public `FindAssemblyFile`.** Avoids touching the Decompiler, but means re-implementing `Resolve`, `ResolveModule`, and both async variants, plus delegating `IsGacAssembly`/`IsSharedAssembly`, because `WholeProjectDecompiler` and `BamlAwareWholeProjectDecompiler` take the resolver as the `AssemblyReferenceClassifier` too. Roughly three times the code of the hook, all of it duplicating logic that already exists.
- **Use ILSpyX's `AssemblyList`/`LoadedAssembly` stack in `ilspycmd`.** Gives full parity with the UI (including bundle-sibling resolution and `ParentBundle` context), but drags in `AssemblyListManager`, a settings provider, and event plumbing, and changes error semantics for every CLI mode. Out of proportion for the problem.
- **Sniff the XALZ magic in `ilspycmd` and decompress there.** Duplicates `XamarinCompressedFileLoader`, and does nothing for references, which is where the issue actually fails.
- **Inject a `Func<string, MetadataFile?>` into the resolver constructor instead of a virtual method.** Same effect, more surface: another constructor overload on a class that already has six optional parameters.

## Tests

`ICSharpCode.ILSpyCmd.Tests/XamarinCompressedInputTests.cs` builds a temp folder the way a Xamarin app ships: the test assembly and the `ICSharpCode.Decompiler.dll` it references, both LZ4-compressed behind the 12-byte XALZ header (same synthesis as the existing `XamarinCompressedFileLoaderTests`, no binary fixture).

- `CompressedInputIsDecompiled`: pins the input path from #4101.
- `CompressedReferenceIsResolved`: red before this change (`return (int)id == 1;`), green after.

All 44 `ilspycmd` tests pass; the resolver, error-recovery, XALZ loader, and isolated-decompilation fixtures in `ICSharpCode.Decompiler.Tests` pass unchanged.

## Not in this PR

`ICSharpCode.Decompiler.PowerShell` also constructs `UniversalAssemblyResolver` directly and keeps the old behavior for compressed references. Same fix would apply if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
