### PR TITLE
Fix #2930: follow references past the ones a document's assembly names

### DIFF
--- a/ICSharpCode.BamlDecompiler/BamlDecompilerTypeSystem.cs
+++ b/ICSharpCode.BamlDecompiler/BamlDecompilerTypeSystem.cs
@@ -126,6 +126,15 @@ namespace ICSharpCode.BamlDecompiler
 				if (asm != null)
 				{
 					referencedAssemblies.Add(asm);
+					// Whether an element is a markup extension is decided by walking its base types,
+					// and a base type can sit in an assembly the document's own assembly never names.
+					// Stopping at the assemblies it does name leaves such a type unresolved, the
+					// extension unrecognised, and the decompiler's placeholder namespace in the XAML
+					// (issue #2930).
+					foreach (var indirectReference in asm.AssemblyReferences)
+					{
+						assemblyReferenceQueue.Enqueue((true, asm, indirectReference));
+					}
 					var metadata = asm.Metadata;
 					foreach (var h in metadata.ExportedTypes)
 					{

--- a/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
+++ b/ILSpy.BamlDecompiler.Tests/ILSpy.BamlDecompiler.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="FacadeAssemblyTests.cs" />
     <Compile Include="InvalidXmlCharacterTests.cs" />
     <Compile Include="MissingReferencesTests.cs" />
+    <Compile Include="TransitiveReferenceTests.cs" />
     <Compile Include="MarkupExtensionQuotingTests.cs" />
     <Compile Include="RuntimeNamePropertyTests.cs" />
     <Compile Include="StartupUriTests.cs" />

--- a/ILSpy.BamlDecompiler.Tests/TransitiveReferenceTests.cs
+++ b/ILSpy.BamlDecompiler.Tests/TransitiveReferenceTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Siegfried Pammer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this
+// software and associated documentation files (the "Software"), to deal in the Software
+// without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+// to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+// PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+// FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+
+using ICSharpCode.BamlDecompiler;
+using ICSharpCode.Decompiler.Metadata;
+using ICSharpCode.Decompiler.TypeSystem;
+
+using NUnit.Framework;
+
+namespace ILSpy.BamlDecompiler.Tests
+{
+	/// <summary>
+	/// Deciding whether an element is a markup extension means walking its base types, and those
+	/// leave the assemblies a document's own assembly names. A base type landing in an assembly
+	/// nobody loaded resolves to nothing, the extension is not recognised, and it goes out as an
+	/// element tree carrying the decompiler's own placeholder namespace,
+	/// "https://github.com/icsharpcode/ILSpy", into the XAML (issue #2930).
+	/// </summary>
+	[TestFixture]
+	public class TransitiveReferenceTests
+	{
+		/// <summary>
+		/// ICSharpCode.BamlDecompiler stands in for a document's assembly here: it has references of
+		/// its own, and those references have references it does not name itself.
+		/// </summary>
+		static readonly string MainModulePath = Path.Combine(
+			Path.GetDirectoryName(typeof(TransitiveReferenceTests).Assembly.Location),
+			"ICSharpCode.BamlDecompiler.dll");
+
+		static PEFile Load(string path)
+		{
+			using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+			return new PEFile(path, stream, streamOptions: PEStreamOptions.PrefetchEntireImage);
+		}
+
+		static ICompilation TypeSystemOf(PEFile file)
+		{
+			var resolver = new UniversalAssemblyResolver(file.FileName, throwOnError: false,
+				file.DetectTargetFrameworkId(), file.DetectRuntimePack());
+			return new BamlDecompilerTypeSystem(file, resolver);
+		}
+
+		/// <summary>
+		/// An assembly the main module reaches only through one of its own references. Derived from
+		/// the metadata rather than named here, so that changing what either assembly references
+		/// cannot quietly turn this test into one that proves nothing.
+		/// </summary>
+		static string IndirectlyReferencedAssembly(PEFile mainModule)
+		{
+			var direct = new HashSet<string>(mainModule.AssemblyReferences.Select(r => r.Name));
+			foreach (var reference in mainModule.AssemblyReferences)
+			{
+				if (reference.Name != "ICSharpCode.Decompiler")
+					continue;
+				using var referenced = Load(Path.Combine(
+					Path.GetDirectoryName(mainModule.FileName), reference.Name + ".dll"));
+				string indirect = referenced.AssemblyReferences
+					.Select(r => r.Name)
+					.FirstOrDefault(name => !direct.Contains(name));
+				Assert.That(indirect, Is.Not.Null,
+					"the premise of this test is gone: every assembly ICSharpCode.Decompiler "
+					+ "references is now referenced by ICSharpCode.BamlDecompiler as well");
+				return indirect;
+			}
+			Assert.Fail("ICSharpCode.BamlDecompiler no longer references ICSharpCode.Decompiler");
+			return null;
+		}
+
+		[Test]
+		public void AnAssemblyReachedOnlyThroughAReferenceIsLoaded()
+		{
+			using var mainModule = Load(MainModulePath);
+			string indirect = IndirectlyReferencedAssembly(mainModule);
+
+			var compilation = TypeSystemOf(mainModule);
+
+			Assert.That(compilation.Modules.Select(m => m.AssemblyName), Does.Contain(indirect));
+		}
+
+		[Test]
+		public void TheAssembliesTheModuleNamesItselfAreStillLoaded()
+		{
+			using var mainModule = Load(MainModulePath);
+
+			var compilation = TypeSystemOf(mainModule);
+
+			Assert.That(compilation.Modules.Select(m => m.AssemblyName),
+				Does.Contain("ICSharpCode.Decompiler"));
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2930.

Whether an element is a markup extension is decided by walking its base types, and that walk leaves
the assemblies the document's own assembly references. In the report, `LocExtension` comes from
`WPFLocalizeExtension`, which the application does reference, but it derives from
`NestedMarkupExtension` in `XAMLMarkupExtensions`, which it does not. The BAML type system loaded
only the assemblies the module names, so the base type resolved to nothing, the extension was not
recognised, and it went out as an element tree carrying the decompiler's own placeholder namespace
into the XAML:

```xml
<lex:LocExtension>
  <Ctor xmlns="https://github.com/icsharpcode/ILSpy">WizardPrevious</Ctor>
</lex:LocExtension>
```

The reference closure is now followed transitively.

## Reproduction

Three assemblies, built for this: an application referencing `Mid`, whose `LocExtension` derives
from `Base.NestedMarkupExtension`, which the application never references. The shape matters - an
earlier attempt had the application not referencing `Mid` at all, which reproduces the same symptom
through a different mechanism and would have proved the fix against the wrong thing.

```
source      <TextBlock Text="{mid:Loc WizardPrevious}" />
before      <TextBlock><TextBlock.Text><mid:LocExtension>
              <Ctor xmlns="https://github.com/icsharpcode/ILSpy">WizardPrevious</Ctor>
            </mid:LocExtension></TextBlock.Text></TextBlock>
after       <TextBlock Text="{mid:Loc WizardPrevious}" />
```

## What it costs

The type system is built once per assembly, not per document. Measured:

| | modules | build time |
|---|---|---|
| .NET 8 WPF application, before | 87 | 92 ms |
| .NET 8 WPF application, after | 158 | 118 ms |
| .NET Framework assembly, before | 9 | 39 ms |
| .NET Framework assembly, after | 24 | 44 ms |

Working set grows by about 5 MB. Over the 1158 BAML documents of a real DevExpress theme assembly
the output is byte-identical to master: this only decides cases that used to resolve to nothing.

## Tests

`TransitiveReferenceTests` asserts that an assembly reached only through a reference is loaded. The
assembly it looks for is derived from the metadata rather than named in the test, so that changing
what either assembly references cannot quietly turn it into a test that proves nothing.

`ILSpy.BamlDecompiler.Tests` 12, `ICSharpCode.Decompiler.Tests` 3552, `ILSpy.Tests` 1259, no
failures.

*Prepared by an AI agent (Claude, claude-opus-5, via Claude Code) and reviewed by @siegfriedpammer.*
