### PR TITLE
Fix #4059: treat a Deconstruct out argument as a definition

### DIFF
--- a/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
+++ b/ICSharpCode.Decompiler.Tests/TestCases/Pretty/DeconstructionTests.cs
@@ -1240,17 +1240,15 @@ namespace ICSharpCode.Decompiler.Tests.TestCases.Pretty
 			Console.WriteLine(value2);
 		}
 
-		// #4059: csc reuses the same out-slot temporaries for both calls, and hands them to the
-		// second one in the opposite order, so neither deconstruction is recognized.
-		//public void TwoBackToBackDeconstructs_Custom()
-		//{
-		//	var (value, value2) = GetSource<string, string>();
-		//	Console.WriteLine(value);
-		//	Console.WriteLine(value2);
-		//	var (value3, value4) = GetSource<string, string>();
-		//	Console.WriteLine(value3);
-		//	Console.WriteLine(value4);
-		//}
+		public void TwoBackToBackDeconstructs_Custom()
+		{
+			var (value, value2) = GetSource<string, string>();
+			Console.WriteLine(value);
+			Console.WriteLine(value2);
+			var (value3, value4) = GetSource<string, string>();
+			Console.WriteLine(value3);
+			Console.WriteLine(value4);
+		}
 
 	}
 }

--- a/ICSharpCode.Decompiler/FlowAnalysis/ReachingDefinitionsVisitor.cs
+++ b/ICSharpCode.Decompiler/FlowAnalysis/ReachingDefinitionsVisitor.cs
@@ -39,7 +39,9 @@ namespace ICSharpCode.Decompiler.FlowAnalysis
 	/// * <c>StLoc</c>
 	/// * <c>TryCatchHandler</c> (for the exception variable)
 	/// * <c>ReachingDefinitionsVisitor.UninitializedVariable</c> for uninitialized variables.
-	/// Note that we do not keep track of <c>LdLoca</c>/references/pointers.
+	/// * <c>LdLoca</c>, but only where the address is known to be assigned without being read
+	///   first, see <c>IsDefiniteAssignment</c>.
+	/// Note that we do not otherwise keep track of <c>LdLoca</c>/references/pointers.
 	/// The analysis will likely be wrong/incomplete for variables with <c>AddressCount != 0</c>.
 	/// 
 	/// Note: this class does not store the computed information, because doing so
@@ -304,6 +306,8 @@ namespace ICSharpCode.Decompiler.FlowAnalysis
 					int expectedStoreCount = scope.Variables[vi].StoreInstructions.Count;
 					// Extra store for the uninitialized state.
 					expectedStoreCount += 1;
+					// Extra store for every address load that is a definite assignment.
+					expectedStoreCount += scope.Variables[vi].AddressInstructions.Count(IsDefiniteAssignment);
 					Debug.Assert(stores.Count == expectedStoreCount);
 					stores.CopyTo(allStores, si);
 					// Add all stores except for the first (representing the uninitialized state)
@@ -335,7 +339,7 @@ namespace ICSharpCode.Decompiler.FlowAnalysis
 			}
 			foreach (var inst in scope.Descendants)
 			{
-				if (inst.HasDirectFlag(InstructionFlags.MayWriteLocals))
+				if (inst.HasDirectFlag(InstructionFlags.MayWriteLocals) || IsDefiniteAssignment(inst))
 				{
 					cancellationToken.ThrowIfCancellationRequested();
 					ILVariable v = ((IInstructionWithVariableOperand)inst).Variable;
@@ -393,6 +397,33 @@ namespace ICSharpCode.Decompiler.FlowAnalysis
 		{
 			inst.Value.AcceptVisitor(this);
 			HandleStore(inst, inst.Variable);
+		}
+
+		protected internal override void VisitLdLoca(LdLoca inst)
+		{
+			if (IsDefiniteAssignment(inst))
+				HandleStore(inst, inst.Variable);
+			else
+				base.VisitLdLoca(inst);
+		}
+
+		/// <summary>
+		/// Gets whether an address load definitely assigns the variable without reading it first,
+		/// which makes it a definition, just like a store.
+		/// <para>
+		/// IL has no such instruction - 'out' is a C# convention over 'ref' - so this holds only
+		/// for the out arguments of a Deconstruct method, where C#'s definite assignment rules
+		/// rule out a read. A Deconstruct method written in IL could read the argument, and the
+		/// possibility is ignored here: without it, two deconstructions that the compiler lowered
+		/// onto the same temporaries stay in one live range and neither can be recognized.
+		/// </para>
+		/// </summary>
+		static bool IsDefiniteAssignment(ILInstruction inst)
+		{
+			// Argument 0 is the receiver of an instance method or the 'this' argument of an
+			// extension method; IsDeconstructMethod requires every parameter after it to be out.
+			return inst is LdLoca { ChildIndex: > 0, Parent: CallInstruction call }
+				&& MatchInstruction.IsDeconstructMethod(call.Method);
 		}
 
 		protected override void HandleMatchStore(MatchInstruction inst)


### PR DESCRIPTION
Fixes #4059.

Two deconstructions of the same source type in one method are not recognized: the first one alone
decompiles correctly, but as soon as a second follows, both fall back to raw `Deconstruct` calls,
because csc reuses the same two out-slot temporaries and hands them to the second call in the
opposite order.

## Why splitting the temporaries did not happen

`ReachingDefinitionsVisitor` does not track address loads, so a variable that is only ever written
through its address - which is every `out` slot - stays potentially uninitialized for its whole
life. `SplitVariables.GroupStores` merges all such loads of one variable into a single
representative, so the two deconstructions end up in one live range and neither can be matched.

The same holds for `out` arguments in general; it only becomes visible for `Deconstruct`, where
pattern matching depends on the split.

## The fix

An `ldloca` in argument position > 0 of a `Deconstruct` call is treated as a definition: it kills
the definitions reaching it and becomes the one that reaches the following loads. That reuses the
existing store machinery, so it stays flow-sensitive - where two such calls join, both reach the
load and are merged again, which a flow-insensitive rule would get wrong.

IL cannot express an address that is assigned without being read first; `out` is a C# convention
over `ref`. So the qualifying address loads have to be named one by one, and a `Deconstruct`
method written in IL could read its argument before assigning it. That possibility is knowingly
ignored - C#'s definite assignment rules rule it out for anything a compiler emits.

`SplitVariables` itself is unchanged: its `HandleLoad` on such an `ldloca` now runs against the
post-store state and merges the instruction with itself.

## Tests

The `TwoBackToBackDeconstructs_Custom` case that #4059 was filed from is checked in commented out;
this enables it. It fails on all eight compiler configurations before the change and passes after.

`ICSharpCode.Decompiler.Tests`: 3604 tests, no failures, 45 skipped (Windows-only configurations).

*Prepared by an AI agent (Claude, claude-opus-5, via Claude Code) and reviewed by @siegfriedpammer.*
