### PR TITLE
Ignore nullability when comparing backing field and property type of auto properties

### DIFF
--- a/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
+++ b/ICSharpCode.Decompiler/CSharp/Transforms/PatternStatementTransform.cs
@@ -949,7 +949,7 @@ namespace ICSharpCode.Decompiler.CSharp.Transforms
 					// structurally; arbitrary accessor bodies do not. A field of a different
 					// type is not this property's storage, and removing it while printing
 					// `field` would substitute storage of the property's type instead.
-					&& candidate.Type.Equals(propertyType)
+					&& NormalizeTypeVisitor.IgnoreNullability.EquivalentTypes(candidate.ReturnType, propertyType)
 					&& NameCouldBeBackingFieldOfAutomaticProperty(candidate.Name, out var propertyName)
 					&& propertyName == property.Name)
 				{


### PR DESCRIPTION
This fixes a bunch ugliness found by nugetfuzz

<img width="1669" height="641" alt="image" src="https://github.com/user-attachments/assets/43974dc5-b612-4b86-9025-a365d09c2155" />
